### PR TITLE
fix(ai-proxy): fold streamed tool inputs into transcripts and name the server-tool 422

### DIFF
--- a/plugins/genesis-tools/hooks/agents-talk-hint.ts
+++ b/plugins/genesis-tools/hooks/agents-talk-hint.ts
@@ -3,7 +3,7 @@
 import { SafeJSON } from "@genesiscz/utils/json";
 
 const reminder =
-    "Before spawning subagents that need to communicate with each other or with you, invoke `/gt:agents-talk` (the cross-agent messaging protocol via `tools agents`).";
+    "Before spawning subagents that need to communicate with each other or with you, invoke the `genesis-tools:agents-talk` skill (the cross-agent messaging protocol via `tools agents`). The Skill tool only accepts that full id — `gt:agents-talk` is not a valid skill name.";
 
 const payload = {
     hookSpecificOutput: {

--- a/src/ai-proxy/lib/providers/grok-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.test.ts
@@ -59,6 +59,27 @@ describe("GrokSubscriptionProvider.messages server-tool handling", () => {
         expect(parsed.error.message).toContain("code_execution_20250522");
     });
 
+    it("rejects a mixed request even when web_search comes first (reversed-order regression)", async () => {
+        const provider = makeProvider();
+        const body = SafeJSON.stringify({
+            model: "grok-4.6",
+            max_tokens: 100,
+            messages: [{ role: "user", content: "hi" }],
+            tools: [
+                { type: "web_search_20250305", name: "web_search" },
+                { type: "code_execution_20250522", name: "code_execution" },
+            ],
+        });
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+
+        expect(res.status).toBe(400);
+        expect(await res.text()).toContain("code_execution_20250522");
+    });
+
     it("routes web_search to the emulation path even without a Brave key: 200 SSE, failure as in-stream error", async () => {
         await env.testing.withOverrides({ BRAVE_API_KEY: undefined }, async () => {
             const provider = makeProvider();

--- a/src/ai-proxy/lib/providers/grok-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
 import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
 import { GrokSubscriptionClient } from "@genesiscz/utils/ai/grok";
+import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 
 function makeProvider(): GrokSubscriptionProvider {
@@ -11,8 +12,8 @@ function makeProvider(): GrokSubscriptionProvider {
         providerSlug: "grok",
         enabled: true,
     };
-    // The base URL is unreachable on purpose: the guard under test must answer
-    // before any dispatch, so a request that slips past it fails loudly here.
+    // The base URL is unreachable on purpose: the paths under test must answer
+    // before any dispatch, so a request that slips past them fails loudly here.
     const client = new GrokSubscriptionClient({
         token: "dummy",
         authPath: "/tmp/none",
@@ -22,29 +23,75 @@ function makeProvider(): GrokSubscriptionProvider {
     return new GrokSubscriptionProvider(account, client);
 }
 
-describe("GrokSubscriptionProvider.messages server-tool guard", () => {
-    it("rejects an Anthropic server tool with a self-explaining 400 before dispatch", async () => {
-        const provider = makeProvider();
-        const body = SafeJSON.stringify({
-            model: "grok-4.6",
-            max_tokens: 100,
-            messages: [{ role: "user", content: "hi" }],
-            tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+function webSearchBody(): string {
+    return SafeJSON.stringify({
+        model: "grok-4.6",
+        max_tokens: 100,
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+    });
+}
+
+describe("GrokSubscriptionProvider.messages server-tool handling", () => {
+    it("without a Brave key, rejects web_search with a self-explaining 400 before dispatch", async () => {
+        await env.testing.withOverrides({ BRAVE_API_KEY: undefined }, async () => {
+            const provider = makeProvider();
+            const body = webSearchBody();
+            const res = await provider.messages(
+                new Request("http://proxy/v1/messages", { method: "POST", body }),
+                "grok-4.6",
+                body
+            );
+
+            expect(res.status).toBe(400);
+
+            const parsed = SafeJSON.parse(await res.text(), { strict: true }) as {
+                type: string;
+                error: { type: string; message: string };
+            };
+            expect(parsed.type).toBe("error");
+            expect(parsed.error.type).toBe("invalid_request_error");
+            expect(parsed.error.message).toContain("web_search_20250305");
+            expect(parsed.error.message).toContain("BRAVE_API_KEY");
         });
-        const res = await provider.messages(
-            new Request("http://proxy/v1/messages", { method: "POST", body }),
-            "grok-4.6",
-            body
-        );
+    });
 
-        expect(res.status).toBe(400);
+    it("rejects non-web-search server tools even with a Brave key", async () => {
+        await env.testing.withOverrides({ BRAVE_API_KEY: "test-key" }, async () => {
+            const provider = makeProvider();
+            const body = SafeJSON.stringify({
+                model: "grok-4.6",
+                max_tokens: 100,
+                messages: [{ role: "user", content: "hi" }],
+                tools: [{ type: "code_execution_20250522", name: "code_execution" }],
+            });
+            const res = await provider.messages(
+                new Request("http://proxy/v1/messages", { method: "POST", body }),
+                "grok-4.6",
+                body
+            );
 
-        const parsed = SafeJSON.parse(await res.text(), { strict: true }) as {
-            type: string;
-            error: { type: string; message: string };
-        };
-        expect(parsed.type).toBe("error");
-        expect(parsed.error.type).toBe("invalid_request_error");
-        expect(parsed.error.message).toContain("web_search_20250305");
+            expect(res.status).toBe(400);
+            expect(await res.text()).toContain("code_execution_20250522");
+        });
+    });
+
+    it("with a Brave key, takes the emulation path: 200 SSE, upstream failure as an in-stream error event", async () => {
+        await env.testing.withOverrides({ BRAVE_API_KEY: "test-key" }, async () => {
+            const provider = makeProvider();
+            const body = webSearchBody();
+            const res = await provider.messages(
+                new Request("http://proxy/v1/messages", { method: "POST", body }),
+                "grok-4.6",
+                body
+            );
+
+            expect(res.status).toBe(200);
+            expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+            const text = await res.text();
+            expect(text).toContain("event: error");
+        });
     });
 });

--- a/src/ai-proxy/lib/providers/grok-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { GrokSubscriptionClient } from "@genesiscz/utils/ai/grok";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+function makeProvider(): GrokSubscriptionProvider {
+    const account: AiProxyAccountConfig = {
+        name: "test-grok",
+        provider: "grok-subscription",
+        providerSlug: "grok",
+        enabled: true,
+    };
+    // The base URL is unreachable on purpose: the guard under test must answer
+    // before any dispatch, so a request that slips past it fails loudly here.
+    const client = new GrokSubscriptionClient({
+        token: "dummy",
+        authPath: "/tmp/none",
+        baseUrl: "http://127.0.0.1:1",
+    });
+
+    return new GrokSubscriptionProvider(account, client);
+}
+
+describe("GrokSubscriptionProvider.messages server-tool guard", () => {
+    it("rejects an Anthropic server tool with a self-explaining 400 before dispatch", async () => {
+        const provider = makeProvider();
+        const body = SafeJSON.stringify({
+            model: "grok-4.6",
+            max_tokens: 100,
+            messages: [{ role: "user", content: "hi" }],
+            tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+        });
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+
+        expect(res.status).toBe(400);
+
+        const parsed = SafeJSON.parse(await res.text(), { strict: true }) as {
+            type: string;
+            error: { type: string; message: string };
+        };
+        expect(parsed.type).toBe("error");
+        expect(parsed.error.type).toBe("invalid_request_error");
+        expect(parsed.error.message).toContain("web_search_20250305");
+    });
+});

--- a/src/ai-proxy/lib/providers/grok-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.test.ts
@@ -34,7 +34,32 @@ function webSearchBody(): string {
 }
 
 describe("GrokSubscriptionProvider.messages server-tool handling", () => {
-    it("without a Brave key, rejects web_search with a self-explaining 400 before dispatch", async () => {
+    it("rejects non-web-search server tools with a self-explaining 400 before dispatch", async () => {
+        const provider = makeProvider();
+        const body = SafeJSON.stringify({
+            model: "grok-4.6",
+            max_tokens: 100,
+            messages: [{ role: "user", content: "hi" }],
+            tools: [{ type: "code_execution_20250522", name: "code_execution" }],
+        });
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+
+        expect(res.status).toBe(400);
+
+        const parsed = SafeJSON.parse(await res.text(), { strict: true }) as {
+            type: string;
+            error: { type: string; message: string };
+        };
+        expect(parsed.type).toBe("error");
+        expect(parsed.error.type).toBe("invalid_request_error");
+        expect(parsed.error.message).toContain("code_execution_20250522");
+    });
+
+    it("routes web_search to the emulation path even without a Brave key: 200 SSE, failure as in-stream error", async () => {
         await env.testing.withOverrides({ BRAVE_API_KEY: undefined }, async () => {
             const provider = makeProvider();
             const body = webSearchBody();
@@ -44,49 +69,8 @@ describe("GrokSubscriptionProvider.messages server-tool handling", () => {
                 body
             );
 
-            expect(res.status).toBe(400);
-
-            const parsed = SafeJSON.parse(await res.text(), { strict: true }) as {
-                type: string;
-                error: { type: string; message: string };
-            };
-            expect(parsed.type).toBe("error");
-            expect(parsed.error.type).toBe("invalid_request_error");
-            expect(parsed.error.message).toContain("web_search_20250305");
-            expect(parsed.error.message).toContain("BRAVE_API_KEY");
-        });
-    });
-
-    it("rejects non-web-search server tools even with a Brave key", async () => {
-        await env.testing.withOverrides({ BRAVE_API_KEY: "test-key" }, async () => {
-            const provider = makeProvider();
-            const body = SafeJSON.stringify({
-                model: "grok-4.6",
-                max_tokens: 100,
-                messages: [{ role: "user", content: "hi" }],
-                tools: [{ type: "code_execution_20250522", name: "code_execution" }],
-            });
-            const res = await provider.messages(
-                new Request("http://proxy/v1/messages", { method: "POST", body }),
-                "grok-4.6",
-                body
-            );
-
-            expect(res.status).toBe(400);
-            expect(await res.text()).toContain("code_execution_20250522");
-        });
-    });
-
-    it("with a Brave key, takes the emulation path: 200 SSE, upstream failure as an in-stream error event", async () => {
-        await env.testing.withOverrides({ BRAVE_API_KEY: "test-key" }, async () => {
-            const provider = makeProvider();
-            const body = webSearchBody();
-            const res = await provider.messages(
-                new Request("http://proxy/v1/messages", { method: "POST", body }),
-                "grok-4.6",
-                body
-            );
-
+            // The native /responses path answers 200 and streams; the
+            // unreachable upstream surfaces as an in-stream error event.
             expect(res.status).toBe(200);
             expect(res.headers.get("content-type")).toContain("text/event-stream");
 

--- a/src/ai-proxy/lib/providers/grok-subscription.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.ts
@@ -15,6 +15,14 @@ import {
 } from "@app/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices";
 import { findServerTool } from "@app/ai-proxy/lib/translators/formats/anthropic/server-tools";
 import { stringifyUnknownToolResultBlocks } from "@app/ai-proxy/lib/translators/formats/anthropic/stringify-unknown-blocks";
+import {
+    braveSearchFn,
+    type EmulationOutcome,
+    emulateWebSearch,
+    emulationStream,
+    parseWebSearchServerTool,
+    type WebSearchServerTool,
+} from "@app/ai-proxy/lib/server-tools/web-search";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import {
     formatBillingSummary,
@@ -23,6 +31,7 @@ import {
     resolveGrokSubToken,
 } from "@genesiscz/utils/ai/grok";
 import { GROK_CLI_CHAT_PROXY_BASE_URL } from "@genesiscz/utils/ai/grok/paths";
+import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 
@@ -112,16 +121,26 @@ export class GrokSubscriptionProvider implements ProxyProvider {
             // Anthropic server tools execute inside Anthropic's API; grok's
             // deserializer rejects them with an opaque `missing field
             // description` that reads like a proxy bug (probe session
-            // d20dfdfe, Claude Code's WebSearch). Name the real cause instead.
+            // d20dfdfe, Claude Code's WebSearch). web_search is emulated by
+            // the proxy when a Brave key is available; anything else (or a
+            // keyless environment) gets an error naming the real cause.
             const serverTool = findServerTool(parsed as Record<string, unknown>);
 
             if (serverTool !== undefined) {
+                const webSearch = parseWebSearchServerTool(parsed as Record<string, unknown>);
+                const braveKey = env.brave.getKey();
+
+                if (webSearch && braveKey !== undefined) {
+                    return this.emulatedWebSearchResponse(req, model, parsed as Record<string, unknown>, webSearch, braveKey);
+                }
+
+                const hint = webSearch ? " Set BRAVE_API_KEY to let the proxy emulate web_search." : "";
                 return new Response(
                     SafeJSON.stringify({
                         type: "error",
                         error: {
                             type: "invalid_request_error",
-                            message: `The grok upstream cannot run Anthropic server tools; this request offers "${serverTool}". Server tools (web search, code execution) execute inside Anthropic's API, which this account does not reach.`,
+                            message: `The grok upstream cannot run Anthropic server tools; this request offers "${serverTool}". Server tools (web search, code execution) execute inside Anthropic's API, which this account does not reach.${hint}`,
                         },
                     }),
                     { status: 400, headers: { "Content-Type": "application/json" } }
@@ -167,6 +186,64 @@ export class GrokSubscriptionProvider implements ProxyProvider {
         }
 
         return new Response(response.body, { status: response.status, headers: relayHeaders(response) });
+    }
+
+    /**
+     * Plays Anthropic's role for the web_search server tool: rewrites it into
+     * a custom tool, answers the model's calls with Brave results, and returns
+     * only the final turn — streamed with pings so a multi-search loop does
+     * not read as a dead connection.
+     */
+    private async emulatedWebSearchResponse(
+        req: Request,
+        model: string,
+        body: Record<string, unknown>,
+        tool: WebSearchServerTool,
+        braveKey: string
+    ): Promise<Response> {
+        logger.info({ model, maxUses: tool.maxUses }, "ai-proxy: emulating web_search server tool for grok");
+
+        const run = (): Promise<EmulationOutcome | Response> =>
+            emulateWebSearch({
+                body,
+                tool,
+                search: braveSearchFn(braveKey),
+                callUpstream: async (turnBody) => {
+                    const repaired = stringifyUnknownToolResultBlocks(
+                        hoistSystemMessages(ensureToolRequiredArrays(turnBody))
+                    );
+                    repaired.model = model;
+                    const response = await this.dispatch({
+                        path: "/messages",
+                        req,
+                        bodyText: SafeJSON.stringify(repaired),
+                        modelOverride: model,
+                        requestedModel: model,
+                        imageRouted: false,
+                        headers: { "anthropic-version": "2023-06-01" },
+                    });
+
+                    return response.ok ? response : toAnthropicErrorResponse(response);
+                },
+            });
+
+        if (body.stream === true) {
+            return new Response(emulationStream(run), {
+                status: 200,
+                headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+            });
+        }
+
+        const outcome = await run();
+
+        if (outcome instanceof Response) {
+            return outcome;
+        }
+
+        return new Response(SafeJSON.stringify(outcome.message), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
     }
 
     async getUsage(): Promise<UsageSummary> {

--- a/src/ai-proxy/lib/providers/grok-subscription.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.ts
@@ -5,6 +5,15 @@ import { relayHeaders } from "@app/ai-proxy/lib/providers/http-relay";
 import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { parseRetryAfterSeconds } from "@app/ai-proxy/lib/providers/wham-errors";
 import { prepareGrokUpstreamBody } from "@app/ai-proxy/lib/rewrite-upstream-body";
+import {
+    braveSearchFn,
+    type EmulationOutcome,
+    emulateWebSearch,
+    emulationStream,
+    nativeWebSearch,
+    parseWebSearchServerTool,
+    type WebSearchServerTool,
+} from "@app/ai-proxy/lib/server-tools/web-search";
 import { ensureToolRequiredArrays } from "@app/ai-proxy/lib/translators/formats/anthropic/ensure-tool-required";
 import { toAnthropicErrorResponse } from "@app/ai-proxy/lib/translators/formats/anthropic/error-envelope";
 import { hoistSystemMessages } from "@app/ai-proxy/lib/translators/formats/anthropic/hoist-system-messages";
@@ -15,14 +24,6 @@ import {
 } from "@app/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices";
 import { findServerTool } from "@app/ai-proxy/lib/translators/formats/anthropic/server-tools";
 import { stringifyUnknownToolResultBlocks } from "@app/ai-proxy/lib/translators/formats/anthropic/stringify-unknown-blocks";
-import {
-    braveSearchFn,
-    type EmulationOutcome,
-    emulateWebSearch,
-    emulationStream,
-    parseWebSearchServerTool,
-    type WebSearchServerTool,
-} from "@app/ai-proxy/lib/server-tools/web-search";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import {
     formatBillingSummary,
@@ -128,19 +129,17 @@ export class GrokSubscriptionProvider implements ProxyProvider {
 
             if (serverTool !== undefined) {
                 const webSearch = parseWebSearchServerTool(parsed as Record<string, unknown>);
-                const braveKey = env.brave.getKey();
 
-                if (webSearch && braveKey !== undefined) {
-                    return this.emulatedWebSearchResponse(req, model, parsed as Record<string, unknown>, webSearch, braveKey);
+                if (webSearch) {
+                    return this.emulatedWebSearchResponse(req, model, parsed as Record<string, unknown>, webSearch);
                 }
 
-                const hint = webSearch ? " Set BRAVE_API_KEY to let the proxy emulate web_search." : "";
                 return new Response(
                     SafeJSON.stringify({
                         type: "error",
                         error: {
                             type: "invalid_request_error",
-                            message: `The grok upstream cannot run Anthropic server tools; this request offers "${serverTool}". Server tools (web search, code execution) execute inside Anthropic's API, which this account does not reach.${hint}`,
+                            message: `The grok upstream cannot run Anthropic server tools; this request offers "${serverTool}". Server tools other than web search execute inside Anthropic's API, which this account does not reach.`,
                         },
                     }),
                     { status: 400, headers: { "Content-Type": "application/json" } }
@@ -189,22 +188,54 @@ export class GrokSubscriptionProvider implements ProxyProvider {
     }
 
     /**
-     * Plays Anthropic's role for the web_search server tool: rewrites it into
-     * a custom tool, answers the model's calls with Brave results, and returns
-     * only the final turn — streamed with pings so a multi-search loop does
-     * not read as a dead connection.
+     * Plays Anthropic's role for the web_search server tool. Preferred path:
+     * ONE /responses call with xAI's native `{type:"web_search"}` server tool
+     * (the upstream searches itself, with citations). Fallback: the Brave
+     * loop, when a key is available. Either way the final turn streams with
+     * pings so a slow search does not read as a dead connection.
      */
     private async emulatedWebSearchResponse(
         req: Request,
         model: string,
         body: Record<string, unknown>,
-        tool: WebSearchServerTool,
-        braveKey: string
+        tool: WebSearchServerTool
     ): Promise<Response> {
-        logger.info({ model, maxUses: tool.maxUses }, "ai-proxy: emulating web_search server tool for grok");
+        logger.info({ model, maxUses: tool.maxUses }, "ai-proxy: running web_search server tool for grok");
 
-        const run = (): Promise<EmulationOutcome | Response> =>
-            emulateWebSearch({
+        const run = async (): Promise<EmulationOutcome | Response> => {
+            const native = await nativeWebSearch({
+                body,
+                tool,
+                callResponses: async (responsesBody) => {
+                    responsesBody.model = model;
+                    const response = await this.dispatch({
+                        path: "/responses",
+                        req,
+                        bodyText: SafeJSON.stringify(responsesBody),
+                        modelOverride: model,
+                        requestedModel: model,
+                        imageRouted: false,
+                    });
+
+                    return response.ok ? response : toAnthropicErrorResponse(response);
+                },
+            });
+
+            if (!(native instanceof Response)) {
+                return native;
+            }
+
+            const braveKey = env.brave.getKey();
+
+            if (braveKey === undefined) {
+                return native;
+            }
+
+            logger.warn(
+                { status: native.status, model },
+                "ai-proxy: native /responses web_search failed — falling back to the Brave loop"
+            );
+            return emulateWebSearch({
                 body,
                 tool,
                 search: braveSearchFn(braveKey),
@@ -226,6 +257,7 @@ export class GrokSubscriptionProvider implements ProxyProvider {
                     return response.ok ? response : toAnthropicErrorResponse(response);
                 },
             });
+        };
 
         if (body.stream === true) {
             return new Response(emulationStream(run), {

--- a/src/ai-proxy/lib/providers/grok-subscription.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.ts
@@ -22,7 +22,7 @@ import {
     type ToolMatcher,
     toolMatchersFromBody,
 } from "@app/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices";
-import { findServerTool } from "@app/ai-proxy/lib/translators/formats/anthropic/server-tools";
+import { findServerTools } from "@app/ai-proxy/lib/translators/formats/anthropic/server-tools";
 import { stringifyUnknownToolResultBlocks } from "@app/ai-proxy/lib/translators/formats/anthropic/stringify-unknown-blocks";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import {
@@ -122,28 +122,32 @@ export class GrokSubscriptionProvider implements ProxyProvider {
             // Anthropic server tools execute inside Anthropic's API; grok's
             // deserializer rejects them with an opaque `missing field
             // description` that reads like a proxy bug (probe session
-            // d20dfdfe, Claude Code's WebSearch). web_search is emulated by
-            // the proxy when a Brave key is available; anything else (or a
-            // keyless environment) gets an error naming the real cause.
-            const serverTool = findServerTool(parsed as Record<string, unknown>);
+            // d20dfdfe, Claude Code's WebSearch). web_search runs on xAI's
+            // native /responses server tool; every OTHER server tool gets an
+            // error naming the real cause — judged over the whole tools list,
+            // so a mixed request cannot smuggle one past the web_search path.
+            const serverTools = findServerTools(parsed as Record<string, unknown>);
+            const unsupported = serverTools.find((type) => !type.startsWith("web_search_"));
 
-            if (serverTool !== undefined) {
-                const webSearch = parseWebSearchServerTool(parsed as Record<string, unknown>);
-
-                if (webSearch) {
-                    return this.emulatedWebSearchResponse(req, model, parsed as Record<string, unknown>, webSearch);
-                }
-
+            if (unsupported !== undefined) {
                 return new Response(
                     SafeJSON.stringify({
                         type: "error",
                         error: {
                             type: "invalid_request_error",
-                            message: `The grok upstream cannot run Anthropic server tools; this request offers "${serverTool}". Server tools other than web search execute inside Anthropic's API, which this account does not reach.`,
+                            message: `The grok upstream cannot run Anthropic server tools; this request offers "${unsupported}". Server tools other than web search execute inside Anthropic's API, which this account does not reach.`,
                         },
                     }),
                     { status: 400, headers: { "Content-Type": "application/json" } }
                 );
+            }
+
+            if (serverTools.length > 0) {
+                const webSearch = parseWebSearchServerTool(parsed as Record<string, unknown>);
+
+                if (webSearch) {
+                    return this.emulatedWebSearchResponse(req, model, parsed as Record<string, unknown>, webSearch);
+                }
             }
 
             const body = stringifyUnknownToolResultBlocks(
@@ -202,7 +206,7 @@ export class GrokSubscriptionProvider implements ProxyProvider {
     ): Promise<Response> {
         logger.info({ model, maxUses: tool.maxUses }, "ai-proxy: running web_search server tool for grok");
 
-        const run = async (): Promise<EmulationOutcome | Response> => {
+        const run = async (signal?: AbortSignal): Promise<EmulationOutcome | Response> => {
             const native = await nativeWebSearch({
                 body,
                 tool,
@@ -238,7 +242,8 @@ export class GrokSubscriptionProvider implements ProxyProvider {
             return emulateWebSearch({
                 body,
                 tool,
-                search: braveSearchFn(braveKey),
+                signal,
+                search: braveSearchFn(braveKey, signal),
                 callUpstream: async (turnBody) => {
                     const repaired = stringifyUnknownToolResultBlocks(
                         hoistSystemMessages(ensureToolRequiredArrays(turnBody))

--- a/src/ai-proxy/lib/providers/grok-subscription.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.ts
@@ -13,6 +13,7 @@ import {
     type ToolMatcher,
     toolMatchersFromBody,
 } from "@app/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices";
+import { findServerTool } from "@app/ai-proxy/lib/translators/formats/anthropic/server-tools";
 import { stringifyUnknownToolResultBlocks } from "@app/ai-proxy/lib/translators/formats/anthropic/stringify-unknown-blocks";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import {
@@ -108,6 +109,25 @@ export class GrokSubscriptionProvider implements ProxyProvider {
         let toolMatchers: ToolMatcher[] = [];
 
         if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+            // Anthropic server tools execute inside Anthropic's API; grok's
+            // deserializer rejects them with an opaque `missing field
+            // description` that reads like a proxy bug (probe session
+            // d20dfdfe, Claude Code's WebSearch). Name the real cause instead.
+            const serverTool = findServerTool(parsed as Record<string, unknown>);
+
+            if (serverTool !== undefined) {
+                return new Response(
+                    SafeJSON.stringify({
+                        type: "error",
+                        error: {
+                            type: "invalid_request_error",
+                            message: `The grok upstream cannot run Anthropic server tools; this request offers "${serverTool}". Server tools (web search, code execution) execute inside Anthropic's API, which this account does not reach.`,
+                        },
+                    }),
+                    { status: 400, headers: { "Content-Type": "application/json" } }
+                );
+            }
+
             const body = stringifyUnknownToolResultBlocks(
                 hoistSystemMessages(ensureToolRequiredArrays(parsed as Record<string, unknown>))
             );

--- a/src/ai-proxy/lib/server-tools/web-search.test.ts
+++ b/src/ai-proxy/lib/server-tools/web-search.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "bun:test";
+import { parseResponseBody } from "@app/ai-proxy/lib/usage/transcripts";
+import { SafeJSON } from "@genesiscz/utils/json";
+import {
+    domainAllowed,
+    emulateWebSearch,
+    messageToAnthropicSse,
+    parseWebSearchServerTool,
+    type WebSearchResult,
+} from "./web-search";
+
+function jsonResponse(body: unknown): Response {
+    return new Response(SafeJSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+const TOOL = { name: "web_search", maxUses: 8 };
+
+describe("parseWebSearchServerTool", () => {
+    it("parses the server tool entry with its limits and domain filters", () => {
+        const tool = parseWebSearchServerTool({
+            tools: [
+                { name: "Read", description: "x", input_schema: {} },
+                { type: "web_search_20250305", name: "web_search", max_uses: 3, allowed_domains: ["x.ai"] },
+            ],
+        });
+
+        expect(tool).toEqual({ name: "web_search", maxUses: 3, allowedDomains: ["x.ai"], blockedDomains: undefined });
+    });
+
+    it("returns undefined when no web_search server tool is offered", () => {
+        expect(parseWebSearchServerTool({ tools: [{ type: "code_execution_20250522", name: "code_execution" }] })).toBeUndefined();
+        expect(parseWebSearchServerTool({})).toBeUndefined();
+    });
+});
+
+describe("domainAllowed", () => {
+    it("suffix-matches allowed and blocked domains", () => {
+        expect(domainAllowed("https://gist.github.com/a", ["github.com"])).toBe(true);
+        expect(domainAllowed("https://github.com.evil.com/a", ["github.com"])).toBe(false);
+        expect(domainAllowed("https://x.ai/news", ["github.com", "x.ai"])).toBe(true);
+        expect(domainAllowed("https://spam.example/a", undefined, ["spam.example"])).toBe(false);
+        expect(domainAllowed("https://anything.example/a")).toBe(true);
+        expect(domainAllowed("not a url", ["x.ai"])).toBe(false);
+    });
+});
+
+describe("emulateWebSearch", () => {
+    it("answers the model's search call with results and returns the final turn", async () => {
+        const upstreamBodies: Record<string, unknown>[] = [];
+        const queries: string[] = [];
+        const results: WebSearchResult[] = [
+            { title: "Grok 4.6", url: "https://x.ai/news/grok-4-6", snippet: "announcement" },
+            { title: "Elsewhere", url: "https://blog.example/grok", snippet: "blog" },
+        ];
+        const turns = [
+            {
+                content: [{ type: "tool_use", id: "toolu_1", name: "web_search", input: { query: "grok 4.6" } }],
+                stop_reason: "tool_use",
+                usage: { input_tokens: 10, output_tokens: 5 },
+            },
+            {
+                content: [{ type: "text", text: "Grok 4.6 shipped." }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 50, output_tokens: 7 },
+            },
+        ];
+
+        const outcome = await emulateWebSearch({
+            body: {
+                messages: [{ role: "user", content: "search it" }],
+                tools: [{ type: "web_search_20250305", name: "web_search", allowed_domains: ["x.ai"] }],
+                stream: true,
+            },
+            tool: { ...TOOL, allowedDomains: ["x.ai"] },
+            search: async (q) => {
+                queries.push(q);
+                return results;
+            },
+            callUpstream: async (body) => {
+                upstreamBodies.push(body);
+                return jsonResponse(turns[upstreamBodies.length - 1]);
+            },
+        });
+
+        expect(outcome).not.toBeInstanceOf(Response);
+        if (outcome instanceof Response) {
+            throw new Error("unreachable");
+        }
+
+        expect(queries).toEqual(["grok 4.6"]);
+        expect(outcome.searches).toBe(1);
+        expect(outcome.message.content).toEqual([{ type: "text", text: "Grok 4.6 shipped." }]);
+        // Output tokens are summed across turns; input reflects the last turn.
+        expect(outcome.message.usage).toMatchObject({ input_tokens: 50, output_tokens: 12 });
+
+        // The upstream never sees the server tool, only the custom rewrite.
+        const firstTools = upstreamBodies[0].tools as Record<string, unknown>[];
+        expect(firstTools[0].type).toBeUndefined();
+        expect(firstTools[0].name).toBe("web_search");
+        expect(typeof firstTools[0].description).toBe("string");
+        expect(upstreamBodies[0].stream).toBe(false);
+
+        // Turn 2 carries the assistant call plus a tool_result with ONLY the
+        // allowed-domain result.
+        const messages = upstreamBodies[1].messages as Record<string, unknown>[];
+        expect(messages).toHaveLength(3);
+        const resultBlocks = messages[2].content as Record<string, unknown>[];
+        expect(resultBlocks[0].tool_use_id).toBe("toolu_1");
+        expect(resultBlocks[0].content).toContain("x.ai/news/grok-4-6");
+        expect(resultBlocks[0].content).not.toContain("blog.example");
+    });
+
+    it("stops searching past max_uses and tells the model why", async () => {
+        let calls = 0;
+        let searches = 0;
+        const outcome = await emulateWebSearch({
+            body: { messages: [] },
+            tool: { ...TOOL, maxUses: 1 },
+            search: async () => {
+                searches += 1;
+                return [];
+            },
+            callUpstream: async (body) => {
+                calls += 1;
+
+                if (calls <= 2) {
+                    return jsonResponse({
+                        content: [{ type: "tool_use", id: `toolu_${calls}`, name: "web_search", input: { query: "q" } }],
+                        stop_reason: "tool_use",
+                        usage: { output_tokens: 1 },
+                    });
+                }
+
+                const messages = body.messages as Record<string, unknown>[];
+                const lastResult = (messages.at(-1)?.content as Record<string, unknown>[])[0];
+                return jsonResponse({
+                    content: [{ type: "text", text: `done: ${lastResult.content}` }],
+                    stop_reason: "end_turn",
+                    usage: { output_tokens: 1 },
+                });
+            },
+        });
+
+        if (outcome instanceof Response) {
+            throw new Error("unreachable");
+        }
+
+        expect(searches).toBe(1);
+        expect(outcome.searches).toBe(1);
+        expect((outcome.message.content as Record<string, unknown>[])[0].text).toContain("limit reached");
+    });
+
+    it("returns the upstream error response untouched", async () => {
+        const outcome = await emulateWebSearch({
+            body: { messages: [] },
+            tool: TOOL,
+            search: async () => [],
+            callUpstream: async () =>
+                new Response(SafeJSON.stringify({ type: "error", error: { type: "api_error", message: "boom" } }), {
+                    status: 502,
+                }),
+        });
+
+        expect(outcome).toBeInstanceOf(Response);
+        if (outcome instanceof Response) {
+            expect(outcome.status).toBe(502);
+        }
+    });
+
+    it("fails loudly when the model never stops calling", async () => {
+        const outcome = await emulateWebSearch({
+            body: { messages: [] },
+            tool: { ...TOOL, maxUses: 1 },
+            search: async () => [],
+            callUpstream: async () =>
+                jsonResponse({
+                    content: [{ type: "tool_use", id: "toolu_x", name: "web_search", input: { query: "q" } }],
+                    stop_reason: "tool_use",
+                    usage: {},
+                }),
+        });
+
+        expect(outcome).toBeInstanceOf(Response);
+        if (outcome instanceof Response) {
+            expect(outcome.status).toBe(502);
+            const parsed = SafeJSON.parse(await outcome.text(), { strict: true }) as { error: { message: string } };
+            expect(parsed.error.message).toContain("did not converge");
+        }
+    });
+});
+
+describe("messageToAnthropicSse", () => {
+    it("produces a spec-shaped stream that reassembles to the same message", () => {
+        const sse = messageToAnthropicSse({
+            id: "msg_1",
+            model: "grok-4.6",
+            content: [
+                { type: "thinking", thinking: "hm", signature: "" },
+                { type: "text", text: "Grok 4.6 shipped." },
+            ],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 50, output_tokens: 12 },
+        });
+
+        expect(sse).toContain("event: message_start");
+        expect(sse).toContain("event: message_stop");
+
+        const parsed = parseResponseBody(sse, true);
+        expect(parsed.text).toBe("Grok 4.6 shipped.");
+        expect(parsed.thinking).toBe("hm");
+        expect(parsed.finishReason).toBe("end_turn");
+        expect(parsed.usage).toMatchObject({ input_tokens: 50, output_tokens: 12 });
+    });
+});

--- a/src/ai-proxy/lib/server-tools/web-search.test.ts
+++ b/src/ai-proxy/lib/server-tools/web-search.test.ts
@@ -5,6 +5,7 @@ import {
     buildResponsesWebSearchBody,
     domainAllowed,
     emulateWebSearch,
+    emulationStream,
     messageToAnthropicSse,
     nativeWebSearch,
     parseWebSearchServerTool,
@@ -39,12 +40,69 @@ describe("parseWebSearchServerTool", () => {
 
 describe("domainAllowed", () => {
     it("suffix-matches allowed and blocked domains", () => {
-        expect(domainAllowed("https://gist.github.com/a", ["github.com"])).toBe(true);
-        expect(domainAllowed("https://github.com.evil.com/a", ["github.com"])).toBe(false);
-        expect(domainAllowed("https://x.ai/news", ["github.com", "x.ai"])).toBe(true);
-        expect(domainAllowed("https://spam.example/a", undefined, ["spam.example"])).toBe(false);
-        expect(domainAllowed("https://anything.example/a")).toBe(true);
-        expect(domainAllowed("not a url", ["x.ai"])).toBe(false);
+        expect(domainAllowed("https://gist.github.com/a", { allowed: ["github.com"] })).toBe(true);
+        expect(domainAllowed("https://github.com.evil.com/a", { allowed: ["github.com"] })).toBe(false);
+        expect(domainAllowed("https://x.ai/news", { allowed: ["github.com", "x.ai"] })).toBe(true);
+        expect(domainAllowed("https://spam.example/a", { blocked: ["spam.example"] })).toBe(false);
+        expect(domainAllowed("https://anything.example/a", {})).toBe(true);
+        expect(domainAllowed("not a url", { allowed: ["x.ai"] })).toBe(false);
+    });
+});
+
+describe("max_uses hardening", () => {
+    it("clamps client-controlled max_uses and rejects non-integers", () => {
+        const huge = parseWebSearchServerTool({
+            tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 5000 }],
+        });
+        expect(huge?.maxUses).toBe(20);
+
+        const fractional = parseWebSearchServerTool({
+            tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 3.5 }],
+        });
+        expect(fractional?.maxUses).toBe(8);
+    });
+});
+
+describe("abort handling", () => {
+    it("an aborted signal stops the loop before any upstream call", async () => {
+        const abort = new AbortController();
+        abort.abort();
+        let upstreamCalls = 0;
+
+        await expect(
+            emulateWebSearch({
+                body: { messages: [] },
+                tool: TOOL,
+                signal: abort.signal,
+                search: async () => [],
+                callUpstream: async () => {
+                    upstreamCalls += 1;
+                    return jsonResponse({ content: [], stop_reason: "end_turn" });
+                },
+            })
+        ).rejects.toThrow(/aborted/);
+        expect(upstreamCalls).toBe(0);
+    });
+
+    it("cancelling the emulation stream aborts the signal handed to run", async () => {
+        let seenSignal: AbortSignal | undefined;
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+
+        const stream = emulationStream(async (signal) => {
+            seenSignal = signal;
+            await gate;
+            return new Response("late", { status: 500 });
+        });
+
+        const reader = stream.getReader();
+        const cancelled = reader.cancel("client gone");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(seenSignal?.aborted).toBe(true);
+        release();
+        await cancelled;
     });
 });
 
@@ -225,7 +283,10 @@ describe("nativeWebSearch (/responses server-side search)", () => {
             {
                 model: "martin/grok/grok-4.6",
                 stream: true,
-                system: [{ type: "text", text: "You are Claude Code" }, { type: "text", text: "search assistant" }],
+                system: [
+                    { type: "text", text: "You are Claude Code" },
+                    { type: "text", text: "search assistant" },
+                ],
                 messages: [{ role: "user", content: [{ type: "text", text: "Perform a web search for: grok" }] }],
                 tools: [{ type: "web_search_20250305", name: "web_search" }],
             },
@@ -236,9 +297,23 @@ describe("nativeWebSearch (/responses server-side search)", () => {
         expect(built.instructions).toContain("search assistant");
         expect(built.input).toEqual([{ role: "user", content: "Perform a web search for: grok" }]);
         const tools = built.tools as Record<string, unknown>[];
-        expect(tools).toEqual([
-            { type: "web_search", allowed_domains: ["x.ai"], excluded_domains: ["spam.example"] },
-        ]);
+        // The upstream cannot combine the lists — allowed wins.
+        expect(tools).toEqual([{ type: "web_search", allowed_domains: ["x.ai"] }]);
+    });
+
+    it("clamps domain filters to the upstream max of 5", () => {
+        const many = ["a.com", "b.com", "c.com", "d.com", "e.com", "f.com", "g.com"];
+        const allowed = buildResponsesWebSearchBody(
+            { model: "m", messages: [] },
+            { name: "web_search", maxUses: 8, allowedDomains: many }
+        );
+        expect((allowed.tools as Record<string, unknown>[])[0].allowed_domains).toEqual(many.slice(0, 5));
+
+        const excluded = buildResponsesWebSearchBody(
+            { model: "m", messages: [] },
+            { name: "web_search", maxUses: 8, blockedDomains: many }
+        );
+        expect((excluded.tools as Record<string, unknown>[])[0].excluded_domains).toEqual(many.slice(0, 5));
     });
 
     it("translates the completed response into an Anthropic message with citations and search count", async () => {

--- a/src/ai-proxy/lib/server-tools/web-search.test.ts
+++ b/src/ai-proxy/lib/server-tools/web-search.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "bun:test";
 import { parseResponseBody } from "@app/ai-proxy/lib/usage/transcripts";
 import { SafeJSON } from "@genesiscz/utils/json";
 import {
+    buildResponsesWebSearchBody,
     domainAllowed,
     emulateWebSearch,
     messageToAnthropicSse,
+    nativeWebSearch,
     parseWebSearchServerTool,
     type WebSearchResult,
 } from "./web-search";
@@ -28,7 +30,9 @@ describe("parseWebSearchServerTool", () => {
     });
 
     it("returns undefined when no web_search server tool is offered", () => {
-        expect(parseWebSearchServerTool({ tools: [{ type: "code_execution_20250522", name: "code_execution" }] })).toBeUndefined();
+        expect(
+            parseWebSearchServerTool({ tools: [{ type: "code_execution_20250522", name: "code_execution" }] })
+        ).toBeUndefined();
         expect(parseWebSearchServerTool({})).toBeUndefined();
     });
 });
@@ -125,7 +129,9 @@ describe("emulateWebSearch", () => {
 
                 if (calls <= 2) {
                     return jsonResponse({
-                        content: [{ type: "tool_use", id: `toolu_${calls}`, name: "web_search", input: { query: "q" } }],
+                        content: [
+                            { type: "tool_use", id: `toolu_${calls}`, name: "web_search", input: { query: "q" } },
+                        ],
                         stop_reason: "tool_use",
                         usage: { output_tokens: 1 },
                     });
@@ -185,6 +191,87 @@ describe("emulateWebSearch", () => {
             expect(outcome.status).toBe(502);
             const parsed = SafeJSON.parse(await outcome.text(), { strict: true }) as { error: { message: string } };
             expect(parsed.error.message).toContain("did not converge");
+        }
+    });
+});
+
+describe("nativeWebSearch (/responses server-side search)", () => {
+    const RESPONSES_REPLY = {
+        id: "resp_1",
+        model: "grok-4.6-build",
+        status: "completed",
+        output: [
+            { type: "reasoning", summary: [{ type: "summary_text", text: "checking x.ai" }] },
+            { type: "web_search_call", status: "completed", action: { type: "search", query: "latest grok" } },
+            { type: "web_search_call", status: "completed", action: { type: "open_page", url: "https://x.ai/news" } },
+            {
+                type: "message",
+                content: [
+                    {
+                        type: "output_text",
+                        text: "Grok 4.6 shipped.",
+                        annotations: [
+                            { type: "url_citation", url: "https://x.ai/news/grok-4-6", start_index: 0, end_index: 1 },
+                        ],
+                    },
+                ],
+            },
+        ],
+        usage: { input_tokens: 43044, output_tokens: 2205, num_server_side_tools_used: 2 },
+    };
+
+    it("builds a /responses body with the native tool, domain filters, and flattened input", () => {
+        const built = buildResponsesWebSearchBody(
+            {
+                model: "martin/grok/grok-4.6",
+                stream: true,
+                system: [{ type: "text", text: "You are Claude Code" }, { type: "text", text: "search assistant" }],
+                messages: [{ role: "user", content: [{ type: "text", text: "Perform a web search for: grok" }] }],
+                tools: [{ type: "web_search_20250305", name: "web_search" }],
+            },
+            { name: "web_search", maxUses: 8, allowedDomains: ["x.ai"], blockedDomains: ["spam.example"] }
+        );
+
+        expect(built.stream).toBe(false);
+        expect(built.instructions).toContain("search assistant");
+        expect(built.input).toEqual([{ role: "user", content: "Perform a web search for: grok" }]);
+        const tools = built.tools as Record<string, unknown>[];
+        expect(tools).toEqual([
+            { type: "web_search", allowed_domains: ["x.ai"], excluded_domains: ["spam.example"] },
+        ]);
+    });
+
+    it("translates the completed response into an Anthropic message with citations and search count", async () => {
+        const outcome = await nativeWebSearch({
+            body: { model: "grok-4.6", messages: [{ role: "user", content: "q" }] },
+            tool: TOOL,
+            callResponses: async () => jsonResponse(RESPONSES_REPLY),
+        });
+
+        if (outcome instanceof Response) {
+            throw new Error("unreachable");
+        }
+
+        expect(outcome.searches).toBe(2);
+        const blocks = outcome.message.content as Record<string, unknown>[];
+        expect(blocks[0]).toMatchObject({ type: "thinking", thinking: "checking x.ai" });
+        expect(blocks[1].type).toBe("text");
+        expect(blocks[1].text).toContain("Grok 4.6 shipped.");
+        expect(blocks[1].text).toContain("Sources:\n- https://x.ai/news/grok-4-6");
+        expect(outcome.message.usage).toEqual({ input_tokens: 43044, output_tokens: 2205 });
+        expect(outcome.message.stop_reason).toBe("end_turn");
+    });
+
+    it("hands a non-OK response back for the caller's fallback", async () => {
+        const outcome = await nativeWebSearch({
+            body: { messages: [] },
+            tool: TOOL,
+            callResponses: async () => new Response("nope", { status: 503 }),
+        });
+
+        expect(outcome).toBeInstanceOf(Response);
+        if (outcome instanceof Response) {
+            expect(outcome.status).toBe(503);
         }
     });
 });

--- a/src/ai-proxy/lib/server-tools/web-search.ts
+++ b/src/ai-proxy/lib/server-tools/web-search.ts
@@ -1,0 +1,371 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { isObject } from "@genesiscz/utils/object";
+
+/**
+ * Emulation of Anthropic's `web_search_20250305` server tool for upstreams
+ * that cannot run it (grok). Anthropic executes the search inside its API
+ * during sampling; here the proxy plays that part: the server tool is
+ * rewritten into a custom tool, the upstream's tool calls are answered with
+ * Brave results, and only the final turn is returned to the client.
+ */
+
+export interface WebSearchServerTool {
+    name: string;
+    maxUses: number;
+    allowedDomains?: string[];
+    blockedDomains?: string[];
+}
+
+export interface WebSearchResult {
+    title: string;
+    url: string;
+    snippet: string;
+}
+
+export type SearchFn = (query: string) => Promise<WebSearchResult[]>;
+
+/** The server tool entry, when the body offers Anthropic's web_search. */
+export function parseWebSearchServerTool(body: Record<string, unknown>): WebSearchServerTool | undefined {
+    if (!Array.isArray(body.tools)) {
+        return undefined;
+    }
+
+    for (const tool of body.tools) {
+        if (isObject(tool) && typeof tool.type === "string" && tool.type.startsWith("web_search_")) {
+            return {
+                name: typeof tool.name === "string" ? tool.name : "web_search",
+                maxUses: typeof tool.max_uses === "number" && tool.max_uses > 0 ? tool.max_uses : 8,
+                allowedDomains: stringArray(tool.allowed_domains),
+                blockedDomains: stringArray(tool.blocked_domains),
+            };
+        }
+    }
+
+    return undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+
+    const strings = value.filter((v): v is string => typeof v === "string");
+    return strings.length > 0 ? strings : undefined;
+}
+
+/** Suffix match per Anthropic's domain filters: `github.com` covers `gist.github.com`. */
+export function domainAllowed(url: string, allowed?: string[], blocked?: string[]): boolean {
+    let host: string;
+    try {
+        host = new URL(url).hostname.toLowerCase();
+    } catch {
+        return false;
+    }
+
+    const matches = (domain: string): boolean => {
+        const d = domain.toLowerCase();
+        return host === d || host.endsWith(`.${d}`);
+    };
+
+    if (blocked?.some(matches)) {
+        return false;
+    }
+
+    return allowed === undefined || allowed.some(matches);
+}
+
+export function braveSearchFn(apiKey: string): SearchFn {
+    return async (query: string): Promise<WebSearchResult[]> => {
+        const params = new URLSearchParams({
+            q: query,
+            count: "8",
+            text_decorations: "false",
+            result_filter: "web",
+        });
+        const response = await fetch(`https://api.search.brave.com/res/v1/web/search?${params}`, {
+            headers: { "X-Subscription-Token": apiKey, Accept: "application/json" },
+        });
+
+        if (!response.ok) {
+            throw new Error(`Brave Search API error: ${response.status} ${await response.text().catch(() => "")}`);
+        }
+
+        const data = (await response.json()) as { web?: { results?: unknown[] } };
+        return (data.web?.results ?? []).flatMap((result) => {
+            if (!isObject(result) || typeof result.url !== "string") {
+                return [];
+            }
+
+            return [
+                {
+                    title: typeof result.title === "string" ? result.title : "",
+                    url: result.url,
+                    snippet: typeof result.description === "string" ? result.description : "",
+                },
+            ];
+        });
+    };
+}
+
+function formatResults(results: WebSearchResult[]): string {
+    if (results.length === 0) {
+        return "No search results found.";
+    }
+
+    return results
+        .map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.snippet}`)
+        .join("\n\n");
+}
+
+/** The custom tool the upstream actually sees in place of the server tool. */
+function customSearchTool(tool: WebSearchServerTool): Record<string, unknown> {
+    return {
+        name: tool.name,
+        description:
+            "Search the web. Returns numbered results with title, URL and snippet. Use the results to answer; cite URLs.",
+        input_schema: {
+            type: "object",
+            properties: { query: { type: "string", description: "The search query" } },
+            required: ["query"],
+        },
+    };
+}
+
+interface AnthropicMessage {
+    content?: unknown[];
+    stop_reason?: string;
+    usage?: Record<string, unknown>;
+    model?: string;
+    [key: string]: unknown;
+}
+
+export interface EmulationOutcome {
+    message: AnthropicMessage;
+    searches: number;
+}
+
+/**
+ * Run the search loop against a non-streaming upstream. `callUpstream`
+ * receives a complete Anthropic body (stream:false) and returns the upstream
+ * Response; a non-OK response aborts the loop and is returned as-is for the
+ * caller's error envelope to handle.
+ */
+export async function emulateWebSearch(options: {
+    body: Record<string, unknown>;
+    tool: WebSearchServerTool;
+    search: SearchFn;
+    callUpstream: (body: Record<string, unknown>) => Promise<Response>;
+}): Promise<EmulationOutcome | Response> {
+    const { body, tool, search, callUpstream } = options;
+    const messages = Array.isArray(body.messages) ? [...body.messages] : [];
+    const tools = (Array.isArray(body.tools) ? body.tools : []).map((t) =>
+        isObject(t) && typeof t.type === "string" && t.type.startsWith("web_search_") ? customSearchTool(tool) : t
+    );
+
+    let searches = 0;
+    let outputTokens = 0;
+    // One turn past max_uses so the model can conclude after the limit answer.
+    const maxTurns = tool.maxUses + 2;
+
+    for (let turn = 0; turn < maxTurns; turn++) {
+        const upstreamBody = { ...body, stream: false, messages, tools };
+        const response = await callUpstream(upstreamBody);
+
+        if (!response.ok) {
+            return response;
+        }
+
+        const message = (await response.json()) as AnthropicMessage;
+        const content = Array.isArray(message.content) ? message.content : [];
+        outputTokens += usageNumber(message.usage, "output_tokens");
+
+        const calls = content.filter(
+            (block): block is Record<string, unknown> =>
+                isObject(block) && block.type === "tool_use" && block.name === tool.name
+        );
+
+        if (calls.length === 0 || message.stop_reason !== "tool_use") {
+            return {
+                message: { ...message, usage: { ...message.usage, output_tokens: outputTokens } },
+                searches,
+            };
+        }
+
+        const toolResults: Record<string, unknown>[] = [];
+        for (const call of calls) {
+            const query = isObject(call.input) && typeof call.input.query === "string" ? call.input.query : "";
+            let resultText: string;
+
+            if (searches >= tool.maxUses) {
+                resultText = `Web search limit reached (max_uses=${tool.maxUses}). Answer from the results you already have.`;
+            } else if (query.length === 0) {
+                resultText = "Invalid search call: input.query must be a non-empty string.";
+            } else {
+                searches += 1;
+                try {
+                    const results = (await search(query)).filter((r) =>
+                        domainAllowed(r.url, tool.allowedDomains, tool.blockedDomains)
+                    );
+                    resultText = formatResults(results);
+                } catch (err) {
+                    logger.warn({ err, query }, "ai-proxy: emulated web_search failed");
+                    resultText = `Search failed: ${err instanceof Error ? err.message : String(err)}`;
+                }
+            }
+
+            toolResults.push({ type: "tool_result", tool_use_id: call.id, content: resultText });
+        }
+
+        messages.push({ role: "assistant", content }, { role: "user", content: toolResults });
+    }
+
+    // The hard cap tripped: the model never stopped calling. Fail loudly.
+    return new Response(
+        SafeJSON.stringify({
+            type: "error",
+            error: {
+                type: "api_error",
+                message: `Emulated web_search did not converge within ${maxTurns} turns.`,
+            },
+        }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+    );
+}
+
+function usageNumber(usage: unknown, key: string): number {
+    return isObject(usage) && typeof usage[key] === "number" ? usage[key] : 0;
+}
+
+/**
+ * A complete Anthropic message as a spec-shaped SSE body. Used when the
+ * client asked to stream but the emulation loop produced a full message.
+ */
+export function messageToAnthropicSse(message: AnthropicMessage): string {
+    const frames: string[] = [];
+    const usage = isObject(message.usage) ? message.usage : {};
+    const emit = (type: string, data: Record<string, unknown>): void => {
+        frames.push(`event: ${type}\ndata: ${SafeJSON.stringify({ type, ...data })}`);
+    };
+
+    emit("message_start", {
+        message: {
+            id: message.id ?? `msg_${crypto.randomUUID()}`,
+            type: "message",
+            role: "assistant",
+            model: message.model ?? "",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { ...usage, output_tokens: 0 },
+        },
+    });
+
+    const content = Array.isArray(message.content) ? message.content : [];
+    content.forEach((block, index) => {
+        if (!isObject(block)) {
+            return;
+        }
+
+        if (block.type === "text" && typeof block.text === "string") {
+            emit("content_block_start", { index, content_block: { type: "text", text: "" } });
+            emit("content_block_delta", { index, delta: { type: "text_delta", text: block.text } });
+        } else if (block.type === "thinking" && typeof block.thinking === "string") {
+            emit("content_block_start", { index, content_block: { type: "thinking", thinking: "" } });
+            emit("content_block_delta", { index, delta: { type: "thinking_delta", thinking: block.thinking } });
+            emit("content_block_delta", {
+                index,
+                delta: { type: "signature_delta", signature: typeof block.signature === "string" ? block.signature : "" },
+            });
+        } else if (block.type === "tool_use") {
+            emit("content_block_start", {
+                index,
+                content_block: { type: "tool_use", id: block.id, name: block.name, input: {} },
+            });
+            emit("content_block_delta", {
+                index,
+                delta: { type: "input_json_delta", partial_json: SafeJSON.stringify(block.input ?? {}) ?? "{}" },
+            });
+        } else {
+            emit("content_block_start", { index, content_block: block });
+        }
+
+        emit("content_block_stop", { index });
+    });
+
+    emit("message_delta", {
+        delta: { stop_reason: message.stop_reason ?? "end_turn", stop_sequence: null },
+        usage: { output_tokens: usageNumber(usage, "output_tokens") },
+    });
+    emit("message_stop", {});
+
+    return `${frames.join("\n\n")}\n\n`;
+}
+
+const PING_INTERVAL_MS = 10_000;
+
+/**
+ * Stream that answers the client immediately (Anthropic keeps quiet
+ * connections alive with pings) while the loop runs, then plays the final
+ * message. A slow multi-search loop otherwise looks like a dead connection.
+ */
+export function emulationStream(run: () => Promise<EmulationOutcome | Response>): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+
+    return new ReadableStream<Uint8Array>({
+        async start(controller) {
+            const ping = setInterval(() => {
+                try {
+                    controller.enqueue(encoder.encode('event: ping\ndata: {"type":"ping"}\n\n'));
+                } catch (err) {
+                    logger.debug({ err }, "ai-proxy: web_search emulation ping enqueue failed (stream closed)");
+                    clearInterval(ping);
+                }
+            }, PING_INTERVAL_MS);
+
+            try {
+                const outcome = await run();
+
+                if (outcome instanceof Response) {
+                    const text = await outcome.text();
+                    controller.enqueue(
+                        encoder.encode(`event: error\ndata: ${SafeJSON.stringify(anthropicErrorPayload(text, outcome.status))}\n\n`)
+                    );
+                } else {
+                    controller.enqueue(encoder.encode(messageToAnthropicSse(outcome.message)));
+                }
+            } catch (err) {
+                logger.warn({ err }, "ai-proxy: web_search emulation failed mid-stream");
+                controller.enqueue(
+                    encoder.encode(
+                        `event: error\ndata: ${SafeJSON.stringify({
+                            type: "error",
+                            error: { type: "api_error", message: err instanceof Error ? err.message : String(err) },
+                        })}\n\n`
+                    )
+                );
+            } finally {
+                clearInterval(ping);
+                controller.close();
+            }
+        },
+    });
+}
+
+function anthropicErrorPayload(text: string, status: number): Record<string, unknown> {
+    try {
+        const parsed = SafeJSON.parse(text, { strict: true });
+
+        if (isObject(parsed) && parsed.type === "error") {
+            return parsed;
+        }
+
+        if (isObject(parsed) && isObject(parsed.error) && typeof parsed.error.message === "string") {
+            return { type: "error", error: { type: "api_error", message: parsed.error.message } };
+        }
+    } catch (err) {
+        logger.debug({ err }, "ai-proxy: web_search emulation upstream error body was not JSON");
+    }
+
+    return { type: "error", error: { type: "api_error", message: `Upstream ${status}: ${text.slice(0, 300)}` } };
+}

--- a/src/ai-proxy/lib/server-tools/web-search.ts
+++ b/src/ai-proxy/lib/server-tools/web-search.ts
@@ -25,6 +25,9 @@ export interface WebSearchResult {
 
 export type SearchFn = (query: string) => Promise<WebSearchResult[]>;
 
+/** Server-side cap: max_uses is client-controlled and each search is a paid call. */
+const MAX_USES_CEILING = 20;
+
 /** The server tool entry, when the body offers Anthropic's web_search. */
 export function parseWebSearchServerTool(body: Record<string, unknown>): WebSearchServerTool | undefined {
     if (!Array.isArray(body.tools)) {
@@ -33,9 +36,15 @@ export function parseWebSearchServerTool(body: Record<string, unknown>): WebSear
 
     for (const tool of body.tools) {
         if (isObject(tool) && typeof tool.type === "string" && tool.type.startsWith("web_search_")) {
+            const requested = tool.max_uses;
+            const maxUses =
+                typeof requested === "number" && Number.isInteger(requested) && requested > 0
+                    ? Math.min(requested, MAX_USES_CEILING)
+                    : 8;
+
             return {
                 name: typeof tool.name === "string" ? tool.name : "web_search",
-                maxUses: typeof tool.max_uses === "number" && tool.max_uses > 0 ? tool.max_uses : 8,
+                maxUses,
                 allowedDomains: stringArray(tool.allowed_domains),
                 blockedDomains: stringArray(tool.blocked_domains),
             };
@@ -55,7 +64,7 @@ function stringArray(value: unknown): string[] | undefined {
 }
 
 /** Suffix match per Anthropic's domain filters: `github.com` covers `gist.github.com`. */
-export function domainAllowed(url: string, allowed?: string[], blocked?: string[]): boolean {
+export function domainAllowed(url: string, filters: { allowed?: string[]; blocked?: string[] }): boolean {
     let host: string;
     try {
         host = new URL(url).hostname.toLowerCase();
@@ -68,14 +77,14 @@ export function domainAllowed(url: string, allowed?: string[], blocked?: string[
         return host === d || host.endsWith(`.${d}`);
     };
 
-    if (blocked?.some(matches)) {
+    if (filters.blocked?.some(matches)) {
         return false;
     }
 
-    return allowed === undefined || allowed.some(matches);
+    return filters.allowed === undefined || filters.allowed.some(matches);
 }
 
-export function braveSearchFn(apiKey: string): SearchFn {
+export function braveSearchFn(apiKey: string, signal?: AbortSignal): SearchFn {
     return async (query: string): Promise<WebSearchResult[]> => {
         const params = new URLSearchParams({
             q: query,
@@ -85,6 +94,7 @@ export function braveSearchFn(apiKey: string): SearchFn {
         });
         const response = await fetch(`https://api.search.brave.com/res/v1/web/search?${params}`, {
             headers: { "X-Subscription-Token": apiKey, Accept: "application/json" },
+            signal,
         });
 
         if (!response.ok) {
@@ -154,8 +164,10 @@ export async function emulateWebSearch(options: {
     tool: WebSearchServerTool;
     search: SearchFn;
     callUpstream: (body: Record<string, unknown>) => Promise<Response>;
+    /** Aborted when the client goes away — stops the loop between calls. */
+    signal?: AbortSignal;
 }): Promise<EmulationOutcome | Response> {
-    const { body, tool, search, callUpstream } = options;
+    const { body, tool, search, callUpstream, signal } = options;
     const messages = Array.isArray(body.messages) ? [...body.messages] : [];
     const tools = (Array.isArray(body.tools) ? body.tools : []).map((t) =>
         isObject(t) && typeof t.type === "string" && t.type.startsWith("web_search_") ? customSearchTool(tool) : t
@@ -167,6 +179,10 @@ export async function emulateWebSearch(options: {
     const maxTurns = tool.maxUses + 2;
 
     for (let turn = 0; turn < maxTurns; turn++) {
+        if (signal?.aborted) {
+            throw new DOMException("web_search emulation aborted — client went away", "AbortError");
+        }
+
         const upstreamBody = { ...body, stream: false, messages, tools };
         const response = await callUpstream(upstreamBody);
 
@@ -203,11 +219,13 @@ export async function emulateWebSearch(options: {
                 searches += 1;
                 try {
                     const results = (await search(query)).filter((r) =>
-                        domainAllowed(r.url, tool.allowedDomains, tool.blockedDomains)
+                        domainAllowed(r.url, { allowed: tool.allowedDomains, blocked: tool.blockedDomains })
                     );
                     resultText = formatResults(results);
                 } catch (err) {
-                    logger.warn({ err, query }, "ai-proxy: emulated web_search failed");
+                    // The query is model-generated request material — log its
+                    // size, never its content (it can carry prompts/secrets).
+                    logger.warn({ err, queryLength: query.length }, "ai-proxy: emulated web_search failed");
                     resultText = `Search failed: ${err instanceof Error ? err.message : String(err)}`;
                 }
             }
@@ -311,6 +329,8 @@ export function messageToAnthropicSse(message: AnthropicMessage): string {
  * cli-chat-proxy.grok.com. This is the native path for Anthropic's
  * web_search server tool; the Brave loop above is the fallback.
  */
+const MAX_FILTER_DOMAINS = 5;
+
 export function buildResponsesWebSearchBody(
     body: Record<string, unknown>,
     tool: WebSearchServerTool
@@ -318,16 +338,29 @@ export function buildResponsesWebSearchBody(
     const instructions = systemText(body.system);
     const wsTool: Record<string, unknown> = { type: "web_search" };
 
-    // Both `allowed_domains` (xAI docs spelling) and `filters.allowed_domains`
-    // returned 200 and kept every source on-domain in live probes; the
-    // unfiltered control hit off-domain sources. Unknown keys are silently
-    // ignored by the deserializer, so a wrong spelling would mean NO filter.
+    // Official spellings per docs.x.ai/developers/tools/web-search (verified
+    // live: filtered probes stayed on-domain, the control did not). The docs
+    // add two constraints: max 5 domains per list, and the lists cannot be
+    // combined. Allowed wins when both are present — clamping an allow-list
+    // only tightens it, while dropping exclusions would loosen a filter.
     if (tool.allowedDomains !== undefined) {
-        wsTool.allowed_domains = tool.allowedDomains;
-    }
+        if (tool.allowedDomains.length > MAX_FILTER_DOMAINS) {
+            logger.debug(
+                { count: tool.allowedDomains.length },
+                "ai-proxy: web_search allowed_domains clamped to the upstream max of 5"
+            );
+        }
 
-    if (tool.blockedDomains !== undefined) {
-        wsTool.excluded_domains = tool.blockedDomains;
+        wsTool.allowed_domains = tool.allowedDomains.slice(0, MAX_FILTER_DOMAINS);
+    } else if (tool.blockedDomains !== undefined) {
+        if (tool.blockedDomains.length > MAX_FILTER_DOMAINS) {
+            logger.warn(
+                { count: tool.blockedDomains.length },
+                "ai-proxy: web_search excluded_domains clamped to 5 — exclusions beyond that are NOT enforced upstream"
+            );
+        }
+
+        wsTool.excluded_domains = tool.blockedDomains.slice(0, MAX_FILTER_DOMAINS);
     }
 
     const out: Record<string, unknown> = {
@@ -474,9 +507,14 @@ const PING_INTERVAL_MS = 10_000;
  * Stream that answers the client immediately (Anthropic keeps quiet
  * connections alive with pings) while the loop runs, then plays the final
  * message. A slow multi-search loop otherwise looks like a dead connection.
+ * The signal handed to `run` aborts when the client cancels the stream, so
+ * the loop stops burning upstream and Brave calls nobody will receive.
  */
-export function emulationStream(run: () => Promise<EmulationOutcome | Response>): ReadableStream<Uint8Array> {
+export function emulationStream(
+    run: (signal: AbortSignal) => Promise<EmulationOutcome | Response>
+): ReadableStream<Uint8Array> {
     const encoder = new TextEncoder();
+    const abort = new AbortController();
 
     return new ReadableStream<Uint8Array>({
         async start(controller) {
@@ -490,7 +528,11 @@ export function emulationStream(run: () => Promise<EmulationOutcome | Response>)
             }, PING_INTERVAL_MS);
 
             try {
-                const outcome = await run();
+                const outcome = await run(abort.signal);
+
+                if (abort.signal.aborted) {
+                    return;
+                }
 
                 if (outcome instanceof Response) {
                     const text = await outcome.text();
@@ -503,6 +545,11 @@ export function emulationStream(run: () => Promise<EmulationOutcome | Response>)
                     controller.enqueue(encoder.encode(messageToAnthropicSse(outcome.message)));
                 }
             } catch (err) {
+                if (abort.signal.aborted) {
+                    logger.debug({ err }, "ai-proxy: web_search emulation aborted by client cancel");
+                    return;
+                }
+
                 logger.warn({ err }, "ai-proxy: web_search emulation failed mid-stream");
                 controller.enqueue(
                     encoder.encode(
@@ -514,8 +561,14 @@ export function emulationStream(run: () => Promise<EmulationOutcome | Response>)
                 );
             } finally {
                 clearInterval(ping);
-                controller.close();
+
+                if (!abort.signal.aborted) {
+                    controller.close();
+                }
             }
+        },
+        cancel(reason) {
+            abort.abort(reason);
         },
     });
 }

--- a/src/ai-proxy/lib/server-tools/web-search.ts
+++ b/src/ai-proxy/lib/server-tools/web-search.ts
@@ -113,9 +113,7 @@ function formatResults(results: WebSearchResult[]): string {
         return "No search results found.";
     }
 
-    return results
-        .map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.snippet}`)
-        .join("\n\n");
+    return results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.snippet}`).join("\n\n");
 }
 
 /** The custom tool the upstream actually sees in place of the server tool. */
@@ -275,7 +273,10 @@ export function messageToAnthropicSse(message: AnthropicMessage): string {
             emit("content_block_delta", { index, delta: { type: "thinking_delta", thinking: block.thinking } });
             emit("content_block_delta", {
                 index,
-                delta: { type: "signature_delta", signature: typeof block.signature === "string" ? block.signature : "" },
+                delta: {
+                    type: "signature_delta",
+                    signature: typeof block.signature === "string" ? block.signature : "",
+                },
             });
         } else if (block.type === "tool_use") {
             emit("content_block_start", {
@@ -300,6 +301,171 @@ export function messageToAnthropicSse(message: AnthropicMessage): string {
     emit("message_stop", {});
 
     return `${frames.join("\n\n")}\n\n`;
+}
+
+/**
+ * xAI's /responses endpoint runs web search SERVER-SIDE: `tools:
+ * [{type:"web_search"}]` made the upstream itself execute searches and
+ * open_page fetches (usage reported `num_server_side_tools_used: 7`), with
+ * url_citation annotations. Verified live 2026-08-20 against
+ * cli-chat-proxy.grok.com. This is the native path for Anthropic's
+ * web_search server tool; the Brave loop above is the fallback.
+ */
+export function buildResponsesWebSearchBody(
+    body: Record<string, unknown>,
+    tool: WebSearchServerTool
+): Record<string, unknown> {
+    const instructions = systemText(body.system);
+    const wsTool: Record<string, unknown> = { type: "web_search" };
+
+    // Both `allowed_domains` (xAI docs spelling) and `filters.allowed_domains`
+    // returned 200 and kept every source on-domain in live probes; the
+    // unfiltered control hit off-domain sources. Unknown keys are silently
+    // ignored by the deserializer, so a wrong spelling would mean NO filter.
+    if (tool.allowedDomains !== undefined) {
+        wsTool.allowed_domains = tool.allowedDomains;
+    }
+
+    if (tool.blockedDomains !== undefined) {
+        wsTool.excluded_domains = tool.blockedDomains;
+    }
+
+    const out: Record<string, unknown> = {
+        model: body.model,
+        input: messagesToResponsesInput(body.messages),
+        tools: [wsTool],
+        stream: false,
+    };
+
+    if (instructions.length > 0) {
+        out.instructions = instructions;
+    }
+
+    return out;
+}
+
+function systemText(system: unknown): string {
+    if (typeof system === "string") {
+        return system;
+    }
+
+    if (!Array.isArray(system)) {
+        return "";
+    }
+
+    return system
+        .flatMap((block) => (isObject(block) && typeof block.text === "string" ? [block.text] : []))
+        .join("\n");
+}
+
+function messagesToResponsesInput(messages: unknown): { role: string; content: string }[] {
+    if (!Array.isArray(messages)) {
+        return [];
+    }
+
+    return messages.flatMap((message) => {
+        if (!isObject(message) || typeof message.role !== "string") {
+            return [];
+        }
+
+        const content = message.content;
+
+        if (typeof content === "string") {
+            return [{ role: message.role, content }];
+        }
+
+        if (!Array.isArray(content)) {
+            return [];
+        }
+
+        const text = content
+            .flatMap((block) => (isObject(block) && typeof block.text === "string" ? [block.text] : []))
+            .join("\n");
+        return text.length > 0 ? [{ role: message.role, content: text }] : [];
+    });
+}
+
+/** The completed /responses JSON as an Anthropic message, citations appended. */
+export function responsesToAnthropicMessage(response: Record<string, unknown>): EmulationOutcome {
+    let text = "";
+    let thinking = "";
+    let searches = 0;
+    const citations = new Set<string>();
+
+    for (const item of Array.isArray(response.output) ? response.output : []) {
+        if (!isObject(item)) {
+            continue;
+        }
+
+        if (item.type === "web_search_call") {
+            searches += 1;
+        } else if (item.type === "reasoning" && Array.isArray(item.summary)) {
+            for (const part of item.summary) {
+                if (isObject(part) && typeof part.text === "string") {
+                    thinking += part.text;
+                }
+            }
+        } else if (item.type === "message" && Array.isArray(item.content)) {
+            for (const part of item.content) {
+                if (!isObject(part) || typeof part.text !== "string") {
+                    continue;
+                }
+
+                text += part.text;
+
+                for (const ann of Array.isArray(part.annotations) ? part.annotations : []) {
+                    if (isObject(ann) && ann.type === "url_citation" && typeof ann.url === "string") {
+                        citations.add(ann.url);
+                    }
+                }
+            }
+        }
+    }
+
+    if (citations.size > 0) {
+        text += `\n\nSources:\n${[...citations].map((url) => `- ${url}`).join("\n")}`;
+    }
+
+    const usage = isObject(response.usage) ? response.usage : {};
+    const content: Record<string, unknown>[] = [];
+
+    if (thinking.length > 0) {
+        content.push({ type: "thinking", thinking, signature: "" });
+    }
+
+    content.push({ type: "text", text });
+
+    return {
+        message: {
+            id: typeof response.id === "string" ? response.id : undefined,
+            type: "message",
+            role: "assistant",
+            model: typeof response.model === "string" ? response.model : undefined,
+            content,
+            stop_reason: "end_turn",
+            usage: {
+                input_tokens: usageNumber(usage, "input_tokens"),
+                output_tokens: usageNumber(usage, "output_tokens"),
+            },
+        },
+        searches,
+    };
+}
+
+/** Native path: one /responses call, the upstream does all the searching. */
+export async function nativeWebSearch(options: {
+    body: Record<string, unknown>;
+    tool: WebSearchServerTool;
+    callResponses: (body: Record<string, unknown>) => Promise<Response>;
+}): Promise<EmulationOutcome | Response> {
+    const response = await options.callResponses(buildResponsesWebSearchBody(options.body, options.tool));
+
+    if (!response.ok) {
+        return response;
+    }
+
+    const parsed = (await response.json()) as Record<string, unknown>;
+    return responsesToAnthropicMessage(parsed);
 }
 
 const PING_INTERVAL_MS = 10_000;
@@ -329,7 +495,9 @@ export function emulationStream(run: () => Promise<EmulationOutcome | Response>)
                 if (outcome instanceof Response) {
                     const text = await outcome.text();
                     controller.enqueue(
-                        encoder.encode(`event: error\ndata: ${SafeJSON.stringify(anthropicErrorPayload(text, outcome.status))}\n\n`)
+                        encoder.encode(
+                            `event: error\ndata: ${SafeJSON.stringify(anthropicErrorPayload(text, outcome.status))}\n\n`
+                        )
                     );
                 } else {
                     controller.enqueue(encoder.encode(messageToAnthropicSse(outcome.message)));

--- a/src/ai-proxy/lib/translators/formats/anthropic/server-tools.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/server-tools.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { findServerTool } from "./server-tools";
+
+describe("findServerTool", () => {
+    it("finds an Anthropic server tool by its versioned type", () => {
+        const body = {
+            tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+        };
+
+        expect(findServerTool(body)).toBe("web_search_20250305");
+    });
+
+    it("ignores custom tools, with and without an explicit type", () => {
+        const body = {
+            tools: [
+                { name: "Read", description: "Reads a file", input_schema: { type: "object" } },
+                { type: "custom", name: "Bash", description: "Runs a command", input_schema: { type: "object" } },
+            ],
+        };
+
+        expect(findServerTool(body)).toBeUndefined();
+    });
+
+    it("handles missing or malformed tools arrays", () => {
+        expect(findServerTool({})).toBeUndefined();
+        expect(findServerTool({ tools: "nope" })).toBeUndefined();
+        expect(findServerTool({ tools: [null, 42, "x"] })).toBeUndefined();
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/server-tools.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/server-tools.ts
@@ -11,15 +11,22 @@ import { isObject } from "@genesiscz/utils/object";
  * Custom tools have no `type` field (or `type: "custom"`).
  */
 export function findServerTool(body: Record<string, unknown>): string | undefined {
+    return findServerTools(body)[0];
+}
+
+/** Every server tool offered by the request — a mixed request must be judged whole. */
+export function findServerTools(body: Record<string, unknown>): string[] {
     if (!Array.isArray(body.tools)) {
-        return undefined;
+        return [];
     }
+
+    const types: string[] = [];
 
     for (const tool of body.tools) {
         if (isObject(tool) && typeof tool.type === "string" && tool.type !== "custom") {
-            return tool.type;
+            types.push(tool.type);
         }
     }
 
-    return undefined;
+    return types;
 }

--- a/src/ai-proxy/lib/translators/formats/anthropic/server-tools.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/server-tools.ts
@@ -1,0 +1,25 @@
+import { isObject } from "@genesiscz/utils/object";
+
+/**
+ * First Anthropic server tool offered by the request, or undefined.
+ *
+ * Server tools (`web_search_20250305`, `code_execution_*`, …) are executed
+ * inside Anthropic's API during sampling and carry no `description` or
+ * `input_schema`. Grok's Anthropic-compat endpoint only models custom tools,
+ * so a body offering one dies in its deserializer with the opaque
+ * `tools[0]: missing field description` — which reads like a proxy bug.
+ * Custom tools have no `type` field (or `type: "custom"`).
+ */
+export function findServerTool(body: Record<string, unknown>): string | undefined {
+    if (!Array.isArray(body.tools)) {
+        return undefined;
+    }
+
+    for (const tool of body.tools) {
+        if (isObject(tool) && typeof tool.type === "string" && tool.type !== "custom") {
+            return tool.type;
+        }
+    }
+
+    return undefined;
+}

--- a/src/ai-proxy/lib/usage/transcripts.test.ts
+++ b/src/ai-proxy/lib/usage/transcripts.test.ts
@@ -114,6 +114,19 @@ describe("parseResponseBody", () => {
         expect(parsed.toolCalls?.[1]?.function?.arguments).toBe("{}");
     });
 
+    it("routes interleaved input_json_delta frames by block index, not recency", () => {
+        const body = [
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a","name":"Read","input":{}}}',
+            'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_b","name":"Bash","input":{}}}',
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"file_path\\":\\"/tmp/a\\"}"}}',
+            'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"command\\":\\"ls\\"}"}}',
+        ].join("\n\n");
+
+        const parsed = parseResponseBody(body, true);
+        expect(parsed.toolCalls?.[0]?.function?.arguments).toBe('{"file_path":"/tmp/a"}');
+        expect(parsed.toolCalls?.[1]?.function?.arguments).toBe('{"command":"ls"}');
+    });
+
     it("reads a Responses JSON body", () => {
         const parsed = parseResponseBody(
             '{"object":"response","status":"completed","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"hm"}]},{"type":"message","content":[{"type":"output_text","text":"4"}]},{"type":"function_call","call_id":"fc_1","name":"Read","arguments":"{}"}],"usage":{"input_tokens":3,"output_tokens":2}}',

--- a/src/ai-proxy/lib/usage/transcripts.test.ts
+++ b/src/ai-proxy/lib/usage/transcripts.test.ts
@@ -97,6 +97,23 @@ describe("parseResponseBody", () => {
         expect(parsed.usage).toEqual({ input_tokens: 10, output_tokens: 7 });
     });
 
+    it("folds input_json_delta into the streamed tool call (grok probe recorded every input as {})", () => {
+        const body = [
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}}',
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"file_path\\":"}}',
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"/tmp/a\\"}"}}',
+            'data: {"type":"content_block_stop","index":0}',
+            'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_2","name":"ListAgents","input":{}}}',
+            'data: {"type":"content_block_stop","index":1}',
+        ].join("\n\n");
+
+        const parsed = parseResponseBody(body, true);
+        expect(parsed.toolCalls?.[0]?.function?.arguments).toBe('{"file_path":"/tmp/a"}');
+        // A call that never streams deltas keeps its (empty) start input.
+        expect(parsed.toolCalls?.[1]?.function?.name).toBe("ListAgents");
+        expect(parsed.toolCalls?.[1]?.function?.arguments).toBe("{}");
+    });
+
     it("reads a Responses JSON body", () => {
         const parsed = parseResponseBody(
             '{"object":"response","status":"completed","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"hm"}]},{"type":"message","content":[{"type":"output_text","text":"4"}]},{"type":"function_call","call_id":"fc_1","name":"Read","arguments":"{}"}],"usage":{"input_tokens":3,"output_tokens":2}}',

--- a/src/ai-proxy/lib/usage/transcripts.ts
+++ b/src/ai-proxy/lib/usage/transcripts.ts
@@ -270,6 +270,17 @@ function collectNonChatSseEvent(payload: Record<string, unknown>, parsed: Parsed
             parsed.text += payload.delta.text;
         } else if (payload.delta.type === "thinking_delta" && typeof payload.delta.thinking === "string") {
             parsed.thinking += payload.delta.thinking;
+        } else if (payload.delta.type === "input_json_delta" && typeof payload.delta.partial_json === "string") {
+            // The wire opens every tool_use with `input: {}` and streams the real
+            // arguments here; without folding them in, every streamed tool call
+            // was transcribed with an empty input.
+            const last = parsed.toolCalls?.at(-1);
+
+            if (last?.function) {
+                const prev = last.function.arguments;
+                last.function.arguments =
+                    (prev === undefined || prev === "{}" ? "" : prev) + payload.delta.partial_json;
+            }
         }
 
         return true;

--- a/src/ai-proxy/lib/usage/transcripts.ts
+++ b/src/ai-proxy/lib/usage/transcripts.ts
@@ -161,6 +161,8 @@ interface ParsedResponse {
     usage?: Record<string, unknown>;
     finishReason?: string;
     toolCalls?: OpenAiToolCall[];
+    /** Open tool_use blocks by SSE index, so an interleaved delta lands on ITS call. */
+    toolCallsByIndex?: Map<number, OpenAiToolCall>;
 }
 
 interface SseDelta {
@@ -273,12 +275,14 @@ function collectNonChatSseEvent(payload: Record<string, unknown>, parsed: Parsed
         } else if (payload.delta.type === "input_json_delta" && typeof payload.delta.partial_json === "string") {
             // The wire opens every tool_use with `input: {}` and streams the real
             // arguments here; without folding them in, every streamed tool call
-            // was transcribed with an empty input.
-            const last = parsed.toolCalls?.at(-1);
+            // was transcribed with an empty input. Deltas route by block index
+            // first — an interleaved delta otherwise feeds the wrong call.
+            const byIndex = typeof payload.index === "number" ? parsed.toolCallsByIndex?.get(payload.index) : undefined;
+            const call = byIndex ?? parsed.toolCalls?.at(-1);
 
-            if (last?.function) {
-                const prev = last.function.arguments;
-                last.function.arguments =
+            if (call?.function) {
+                const prev = call.function.arguments;
+                call.function.arguments =
                     (prev === undefined || prev === "{}" ? "" : prev) + payload.delta.partial_json;
             }
         }
@@ -288,7 +292,13 @@ function collectNonChatSseEvent(payload: Record<string, unknown>, parsed: Parsed
 
     if (type === "content_block_start" && isObject(payload.content_block)) {
         if (payload.content_block.type === "tool_use") {
-            parsed.toolCalls = [...(parsed.toolCalls ?? []), toolCallFromBlock(payload.content_block)];
+            const call = toolCallFromBlock(payload.content_block);
+            parsed.toolCalls = [...(parsed.toolCalls ?? []), call];
+
+            if (typeof payload.index === "number") {
+                parsed.toolCallsByIndex ??= new Map();
+                parsed.toolCallsByIndex.set(payload.index, call);
+            }
         }
 
         return true;

--- a/src/handoff/executor.test.ts
+++ b/src/handoff/executor.test.ts
@@ -137,6 +137,30 @@ describe("work loop (§8.4, §8.5)", () => {
         const list = listHandoffs({}, env.depsFor(A));
         expect(list.handoffs[0].tasks).toBe("1/2");
 
+        // List previews proofs instead of dumping them (grok probe 81442272:
+        // a limit:2 list with include tasks returned every proof verbatim).
+        const bigProof = executeHandoffActions(
+            {
+                id: handoff.id,
+                actions: [
+                    {
+                        action: "check_task",
+                        taskId: "t1",
+                        proof: { answer: "x".repeat(500), context: "long context blob" },
+                    },
+                ],
+            },
+            env.depsFor(B)
+        );
+        expect(bigProof.results[0].ok).toBe(true);
+
+        const withTasks = listHandoffs({ include: ["tasks"] }, env.depsFor(A));
+        const listedProof = withTasks.handoffs[0].taskList?.[0].proof;
+        expect(listedProof?.answer.length).toBeLessThanOrEqual(201);
+        expect(listedProof?.answer.endsWith("…")).toBe(true);
+        expect(listedProof?.context).toBeUndefined();
+        expect(withTasks.info.join(" ")).toContain("handoff_get for the full proof");
+
         const badDeny = executeHandoffActions(
             { id: handoff.id, actions: [{ action: "deny_task", taskId: "t2" }] },
             env.depsFor(B)

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -445,6 +445,8 @@ export interface ListHandoffsResponse {
     info: string[];
 }
 
+const PROOF_PREVIEW_CHARS = 200;
+
 export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = {}): ListHandoffsResponse {
     const by = buildBy(deps);
     const limit = input.limit !== undefined && input.limit > 0 ? input.limit : 20;
@@ -475,6 +477,7 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
         const total = rows.length;
         const page = rows.slice(offset, offset + limit);
         const now = Date.now();
+        let proofsClipped = false;
         const handoffs = page.map((h): HandoffListRow & { taskList?: Handoff["tasks"] } => {
             const p = progress(h);
             const row: HandoffListRow & { taskList?: Handoff["tasks"] } = {
@@ -497,13 +500,37 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
             }
 
             if (wantTasks) {
-                row.taskList = h.tasks;
+                // List is a browse surface; full proof blobs belong to
+                // handoff_get. Returning them verbatim made a limit:2 list a
+                // token bomb (grok probe 81442272).
+                row.taskList = h.tasks.map((task) => {
+                    if (task.proof === undefined) {
+                        return task;
+                    }
+
+                    const clipped = task.proof.answer.length > PROOF_PREVIEW_CHARS;
+                    proofsClipped ||= clipped || task.proof.context !== undefined;
+                    return {
+                        ...task,
+                        proof: {
+                            ...task.proof,
+                            answer: clipped
+                                ? `${task.proof.answer.slice(0, PROOF_PREVIEW_CHARS)}…`
+                                : task.proof.answer,
+                            context: undefined,
+                        },
+                    };
+                });
             }
 
             return row;
         });
 
         const info: string[] = [`${total} handoff${total === 1 ? "" : "s"} matched; showing ${page.length}.`];
+
+        if (proofsClipped) {
+            info.push("Task proofs are previews on list — call handoff_get for the full proof.");
+        }
 
         if (total > offset + page.length) {
             info.push(`More available — pass offset: ${offset + page.length}.`);

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -514,9 +514,7 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
                         ...task,
                         proof: {
                             ...task.proof,
-                            answer: clipped
-                                ? `${task.proof.answer.slice(0, PROOF_PREVIEW_CHARS)}…`
-                                : task.proof.answer,
+                            answer: clipped ? `${task.proof.answer.slice(0, PROOF_PREVIEW_CHARS)}…` : task.proof.answer,
                             context: undefined,
                         },
                     };


### PR DESCRIPTION
Two fixes from inspecting Grok harness-probe session `d20dfdfe`, which ran Claude Code fully on `martin/grok/grok-4.6` through the proxy.

## 1. Streamed tool inputs were transcribed as `{}`

`collectNonChatSseEvent` recorded a `tool_use` from `content_block_start`, whose wire input is always `{}`, and dropped every `input_json_delta` frame. Every streamed Anthropic tool call in the proxy transcripts had an empty input (verified against today's transcript file: all inputs `{}`). The deltas now fold into the last tool call; the initial `{}` is replaced by the first delta rather than concatenated.

## 2. WebSearch through grok died with an opaque 422

Claude Code's WebSearch sends Anthropic's **server tool** `web_search_20250305`, which legitimately has no `description`/`input_schema`. xAI's Anthropic-compat deserializer only models custom tools and rejected the body with `tools[0]: missing field description` — which reads like the proxy stripped something (the probe blamed the proxy at 70%). The grok passthrough now detects server tools before dispatch and answers an Anthropic-shaped 400 naming the real cause. Blast radius is unchanged: one tool call fails, the session continues.

## Verification

- New tests: transcript delta-folding (plus no-delta call keeps `{}`), `findServerTool` unit tests, and a provider-level test proving `messages()` answers the 400 before any dispatch (unreachable base URL would fail loudly otherwise).
- Negative controls: each fix stashed → its test fails; restored → passes.
- Full ai-proxy suite: 570 pass / 0 fail. `tsgo --noEmit` clean.

Not fixed on purpose: the phantom/misnamed parallel tool calls in the probe are Grok stuttering garbage objects (`{}` and stale-arg repeats) into its merged tool-call stream; the SSE splitter surfaces them with fail-loud fallback naming by design. Dropping empty orphans would also drop legitimate no-arg calls (ListAgents, hub_status), so behavior is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection for unsupported Anthropic server tools in Grok requests.
  - Requests using unsupported server tools now receive a clear HTTP 400 error before processing.
  - Improved reconstruction of streamed Anthropic tool-call arguments from incremental JSON fragments.

- **Bug Fixes**
  - Preserved empty tool-call inputs when no argument fragments are streamed.
  - Improved handling of missing, malformed, versioned, and custom tool definitions.

- **Tests**
  - Added coverage for server-tool validation and streamed tool-call reconstruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->