### PR TITLE
feat: 2026-08-20 enhancements (web search, handoff, ms-teams markdown)

### DIFF
--- a/docs/ai-proxy/FlowMatrix.md
+++ b/docs/ai-proxy/FlowMatrix.md
@@ -66,11 +66,42 @@ Anthropic-shaped bodies — see the known gap below.
 
 ## Translation paths
 
+### Anthropic in, grok upstream — the /responses translation (grok's DEFAULT since 2026-08-21)
+
+```text
+Claude Code --Anthropic--> /v1/messages --anthropic-to-responses--> cli-chat-proxy /responses
+/responses SSE --grok-responses-to-anthropic--> Anthropic SSE --> client
+```
+
+The shim passthrough below merges parallel tool calls into one block; `/responses` streams every
+call as its own named output item, so the whole repair class (index repair, routing tags) is
+structurally unnecessary on this route. This is the translation every other xAI proxy ships
+(sub2api, fleet-harness, 9router: an `output_index → content-block-index` map), plus the piece
+none of them has:
+
+- **Reasoning continuity is preserved, and it is STRONGER than the shim's.** Every request sends
+  `store: false` + `include: ["reasoning.encrypted_content"]`; the returned blob rides the
+  thinking block's `signature` as `grokrs1:<id>:<blob>`, which Anthropic clients replay verbatim.
+  The upstream decrypts and consumes the replay — a tampered blob is rejected with a decrypt
+  error (verified live 2026-08-21), so this is real state restoration, not tolerated noise. The
+  shim replays only plaintext summaries.
+- **Decrypt-retry:** a signature from another conversation (or truncated by a client) fails
+  decryption for the whole request; the proxy retries once without reasoning items, losing
+  continuity for that turn instead of failing it.
+- **Terminal-frame reconciliation:** items that appear only in the `response.completed` snapshot
+  are synthesized as full blocks; a stream that ends without the terminal frame still closes
+  cleanly (fleet-harness measured 1 dropped terminal frame in 38 calls against this upstream).
+- **Known losses, all deliberate:** `stop_sequences`, `metadata`, `top_k`, the `thinking` budget
+  (grok reasons regardless), `cache_control` breakpoints (a no-op — grok caches implicitly,
+  measured), and unknown content block types become stringified text.
+- **Instant fallback:** `AI_PROXY_GROK_MESSAGES_ROUTE=shim` restores the passthrough below.
+
 ### Anthropic in, Anthropic upstream — passthrough (no reshape)
 
 Used when the provider implements `ProxyProvider.messages()`. Today: `anthropic-subscription`
-and `grok-subscription` (added 2026-08-19; preserves reasoning continuity — Grok accepts its own
-`thinking` blocks replayed). The grok passthrough performs four spec repairs, not translations:
+always, and `grok-subscription` only behind `AI_PROXY_GROK_MESSAGES_ROUTE=shim` (it was grok's
+default 2026-08-19 → 2026-08-21). The grok passthrough performs five spec repairs, not
+translations:
 
 - `ensureToolRequiredArrays` — Grok rejects a tool whose `input_schema` omits `required`.
 - `hoistSystemMessages` — Claude Code sometimes puts a `role:"system"` entry inside `messages[]`;
@@ -85,6 +116,18 @@ and `grok-subscription` (added 2026-08-19; preserves reasoning continuity — Gr
   deltas (Anthropic SDKs would overwrite the thinking block with the text block), and it merges
   several parallel tool calls into ONE `tool_use` block. The extra calls are re-emitted as their
   own blocks, each named by matching its argument keys against the request's tool schemas.
+- `tagConfusableTools` — key matching cannot separate two tools that can share an argument
+  object (`A.required ∪ B.required ⊆ A.properties ∩ B.properties`): two no-arg tools both fit
+  `{}`, Glob and Grep both fit `{"pattern":…}`. On STREAMING requests every tool in such a pair
+  gets one required property whose only legal value is its own name; the splitter routes by the
+  tag's value (order-proof, since two tagged objects share the same KEY) and strips it before the
+  client sees the call. Raw wire capture 2026-08-21 confirmed the names are absent from the
+  stream and that no request variant restores them — nine arms tried (`tool_choice`,
+  `disable_parallel_tool_use`, `stream_options`, the fine-grained-streaming beta header,
+  `stream_tool_calls` both ways, `streamToolCalls`, a spoofed `x-grok-client-identifier`): each
+  one `content_block_start`, four argument objects. The grok CLI never hits this: its own binary
+  defaults to `/chat/completions` (with `/responses` as the alternate), formats that carry a name
+  on every tool-call delta; `/v1/messages` is a compatibility shim xAI does not dogfood.
 
 ```text
 Claude Code --Anthropic--> /v1/messages --Anthropic (verbatim)--> api.anthropic.com

--- a/plugins/genesis-tools/hooks/agents-talk-hint.ts
+++ b/plugins/genesis-tools/hooks/agents-talk-hint.ts
@@ -3,7 +3,7 @@
 import { SafeJSON } from "@genesiscz/utils/json";
 
 const reminder =
-    "Before spawning subagents that need to communicate with each other or with you, invoke `/gt:agents-talk` (the cross-agent messaging protocol via `tools agents`).";
+    "Before spawning subagents that need to communicate with each other or with you, invoke the `genesis-tools:agents-talk` skill (the cross-agent messaging protocol via `tools agents`). The Skill tool only accepts that full id — `gt:agents-talk` is not a valid skill name.";
 
 const payload = {
     hookSpecificOutput: {

--- a/plugins/genesis-tools/skills/agents-talk/SKILL.md
+++ b/plugins/genesis-tools/skills/agents-talk/SKILL.md
@@ -110,6 +110,28 @@ Empirically verified 2026-07-13 (two live probe tests + teammate-transcript fore
 
 Never put the payload only in `SendMessage` (not durable, not cursor-tracked) and never rely on the agents channel alone to wake an idle teammate. A teammate that is mid-turn WILL receive Monitor events normally between tool calls — the nudge is only load-bearing for idle recipients, but since the sender can't know, always send it.
 
+## 🛑 Protocol JSON on `SendMessage` is LIVE CONTROL, never a test payload
+
+Observed 2026-08-20 in a probe session. `SendMessage` carrying
+`{"type":"shutdown_request"}` was treated by the harness as a real shutdown:
+the recipient approved it and terminated. A second teammate emitted
+`shutdown_approved` and terminated as well, without ever being sent a shutdown.
+A teammate that received no shutdown at all answered with eight
+`shutdown_rejected` messages in 105 seconds.
+
+- **Never send harness protocol JSON to "see what happens".** There is no dry
+  run. The shape IS the command, so a probe payload kills the agent.
+- To test message delivery, send prose, or send JSON under a key of your own
+  (`{"probe": {...}}`) that no harness verb matches.
+- Protocol replies are also positional: a `shutdown_response` is rejected
+  unless it is addressed to `team-lead`, while other reply shapes are accepted
+  from anywhere. Do not infer one rule from the other.
+- This concerns the harness `SendMessage` tool only. **`tools agents` never
+  does this**: `message`/`request` bodies are opaque strings, the receiver only
+  prints them (`src/agents/lib/filter.ts`), and shutdown is triggered solely by
+  OS signals (`src/agents/lib/lifecycle.ts`). Nothing you put in an agents-channel
+  body can terminate a peer.
+
 `login` writes received events to stdout as JSONL lines. Each line is one event you should react to.
 
 ```bash

--- a/plugins/genesis-tools/skills/wrap-up/SKILL.md
+++ b/plugins/genesis-tools/skills/wrap-up/SKILL.md
@@ -32,15 +32,40 @@ Work through these tiers in order. Stop at the first that yields a directory.
 If this session already read from or wrote to a specific Obsidian vault directory (a plan, a handoff, notes for this project), that is the target. You know this from your own session history — no lookup needed. Prefer it over the registry: it reflects where the work actually lived today.
 
 ### Tier 2 — the registry
-Otherwise consult `~/.claude/handoff-registry.json`, which maps projects/branches/worktrees to their Obsidian home. Run:
+Otherwise consult `~/.claude/handoff-registry.json`, which maps projects/branches/worktrees to their Obsidian home. **Always pass `--project`** — the absolute path of the repo this session actually worked in:
 
 ```bash
-bun "${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/scripts/resolve.ts" resolve
+bun "${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/scripts/resolve.ts" resolve --project "<repo you worked in>"
 ```
+
+Without `--project` the answer comes from the shell's current directory, and the shell's directory is not reliably your session's project: the Bash tool keeps its cwd between calls, worktrees move it, and a single earlier `cd` makes every later `resolve` answer for a different repo. That failure is silent — you get a confident path into another project's vault folder. Pin it.
+
+Any path inside the checkout works. A subdirectory is normalized to the checkout root, and a worktree path (nested or sibling) reports its own branch plus `worktreeOf`, the main checkout it belongs to. Entries registered against the main checkout still match from inside a worktree; an entry that names this exact `worktreeDir` outranks them.
 
 Claude Code substitutes the plugin-root placeholder into this document at load time; it is NOT a shell variable. If any command in this document still shows a literal unsubstituted `CLAUDE_PLUGIN_ROOT` placeholder, do not run it through the shell — build the path yourself from the "Base directory for this skill" line printed when this skill loaded (the plugin root is that directory minus the trailing `skills/wrap-up`).
 
-It reads your current git toplevel + branch + cwd, matches the most specific entry, and prints `{ found, obsidianDir, docPath, ... }`. If `found:true`, use that `docPath`. The registry shape:
+#### 🛑 Check the answer before you write anything
+
+`resolve` prints the context it used and every doubt it has. Read these four fields first:
+
+- **`project` / `branch` / `cwd`** — must be the repo and branch you worked in. If not, re-run with the correct `--project` (and `--branch` if you are wrapping up work on a branch you already left).
+- **`exact`** — `true` only when a registry entry pins your exact branch, or the doc path was derived per branch from config. `false` means a project-wide entry claimed you.
+- **`warnings`** — non-empty means something may be wrong. Read every line.
+- **`alternatives`** — other entries that also matched, most specific first.
+
+`nextSteps` then spells out what to do with that verdict, with the exact commands filled in. Follow it instead of improvising a procedure.
+
+**If `exact` is `false` or `warnings` is non-empty, confirm the target with the user (`AskUserQuestion`) before writing.** Offer the resolved `docPath`, the `alternatives`, and a fresh per-branch doc. A wrap-up appended to the wrong project's doc corrupts an audit trail that is append-only by design, so a single question is much cheaper than the repair.
+
+To see every target registered for the project (including entries for other branches), so you can offer real choices:
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/scripts/resolve.ts" entries --project "<repo you worked in>"
+```
+
+After the user picks, persist it with `register` (see Tier 3) so the next session resolves `exact:true` with no question.
+
+It reads your git toplevel + branch + cwd, matches the most specific entry, and prints `{ found, exact, obsidianDir, docPath, docExists, warnings, alternatives, registerHint, ... }`. The registry shape:
 
 ```json
 {
@@ -55,7 +80,24 @@ It reads your current git toplevel + branch + cwd, matches the most specific ent
 }
 ```
 
-`branch` and `worktreeDir` are optional — omit `branch` for a project-wide entry that matches any branch. `docPath` is optional; when absent the resolver derives `<obsidianDir>/<project>-<branch-slug>.wrapup.md` so each branch accumulates its own file.
+`branch` and `worktreeDir` are optional. `docPath` is optional; when absent the resolver derives `<obsidianDir>/<project>-<branch-slug>.wrapup.md` so each branch accumulates its own file.
+
+⚠️ **A branch-less entry claims every branch of that project, forever.** It is the main way this skill resolves wrong: one old session registers a project-wide target, and months later every new branch of that repo still resolves to that session's doc. Worse when it also pins `docPath` — then all branches append into one file.
+
+This is not hypothetical. `register --obsidian "<dir>"` with no other flag created exactly such an entry for GenesisTools on 2026-07-28, and at least five later sessions each resolved to that unrelated security-incident doc and had to detect the mismatch by hand. So:
+
+- `register` pins the current branch unless you pass `--all-branches`, and creating a catch-all prints a warning saying what it will claim.
+- `resolve` reports `exact:false` plus a warning whenever a branch-less entry wins.
+- Two entries of equal specificity are broken by registration order, newest first.
+- **Do not register a catch-all to silence a question.** Register the branch, or ask the user.
+
+Audit the registry any time a resolution looks off:
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/scripts/resolve.ts" doctor
+```
+
+It is read-only. It lists catch-all entries, entries where several branches share one `docPath`, and entries pointing at deleted projects, deleted worktrees or missing vault folders — each with the command that fixes it.
 
 ### Tier 2.5 — shared plugin config (automatic)
 `resolve` falls back to `~/.genesis-tools/plugins/config.json` by itself when the registry has no match — the result then carries `"source": "config"` and you just use its `docPath`, no user interaction needed. The file is a per-skill map shared by all genesis-tools plugin skills:
@@ -79,8 +121,13 @@ If neither registry nor config yields a target (`found:false`), don't guess sile
 2. **Propose a target** to the user via `AskUserQuestion` — offer the inferred path as the recommended option plus one or two alternatives, so they confirm or redirect in one click.
 3. **Persist the choice** so it's never asked again for this project/branch:
    ```bash
-   bun "${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/scripts/resolve.ts" register --obsidian "<confirmed dir>" --branch "<branch>" --worktree "<worktree or omit>"
+   bun "${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/scripts/resolve.ts" register \
+       --obsidian "<confirmed dir>" \
+       --project "<repo you worked in>" \
+       --branch "<branch>" \
+       --worktree "<worktree or omit>"
    ```
+   `--branch` defaults to the current branch, so omitting it still gives a branch-pinned entry. Pass `--all-branches` only when the user wants one doc for the whole project across every branch. `resolve` prints this exact command as `registerHint`, already filled in.
 4. Then write the doc there.
 
 ## Part 2 — Write the doc
@@ -205,7 +252,7 @@ The header's own **Read to resume** line tells you how much of the log below to 
 - **Header rewrites in place; log is append-only — and you ALWAYS do both.** Every invocation: rewrite the `YOU-ARE-HERE` block (the single mutable region) AND append one new dated `##` log section. Never header-only. Log sections are permanent audit trail — never delete or rewrite them.
 - **Every log section header carries the full datetime** (`## YYYY-MM-DD HH:MM — topic`), never date-only. Get it from `date '+%Y-%m-%d %H:%M'`.
 - **Every git-touching section attaches its commit SHA(s)** inline.
-- **Resolve before writing.** Don't dump wrap-ups in an arbitrary directory — walk the three tiers, and register the target once so it's automatic next time.
+- **Resolve before writing, then check the answer.** Don't dump wrap-ups in an arbitrary directory — walk the three tiers, pass `--project`, and read `project` / `branch` / `exact` / `warnings` back. Confirm with the user whenever `exact` is `false` or a warning fired, then register the target so it's automatic next time.
 - **Keep it honest.** Record what actually happened — failed steps, skipped checks, open bugs. A wrap-up that only lists wins misleads the next session.
 - **Err long, not terse.** The log section is the permanent audit trail — write it exhaustively (goal, full chronological narrative including dead-ends, files+why, decisions+rejected alternatives, bugs, verification output, open items). A substantive session's log runs long by design; a one-paragraph summary of a multi-commit session is a defect, not brevity.
 - **Always end your response with the full absolute path to the wrap-up file as the last line** — after writing or appending, the final line of your reply must be the complete `docPath` (e.g. `/path/to/Vault/ProjectRepo/Plans/....wrapup.md`), so the user can open it in one click. Nothing after it.

--- a/plugins/genesis-tools/skills/wrap-up/scripts/resolve.test.ts
+++ b/plugins/genesis-tools/skills/wrap-up/scripts/resolve.test.ts
@@ -3,14 +3,20 @@ import { chmod, mkdir, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/pro
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+    auditRegistry,
     blockquote,
     buildLogBody,
     derivedDocPath,
     type Entry,
+    entryBranch,
     expandHome,
     innerBlock,
     matches,
+    nextSteps,
     parseFlags,
+    parsePorcelainMain,
+    rankEntries,
+    resolutionWarnings,
     sh,
     slug,
     splitSentinels,
@@ -100,6 +106,199 @@ describe("matches", () => {
     it("does not match a sibling dir sharing a name prefix", () => {
         const sibling = { toplevel: "/repos/ProjOther", branch: "feat/x", cwd: "/repos/ProjOther" };
         expect(matches({ projectDir: "/repos/Proj", obsidianDir: "/v" }, sibling)).toBe(0);
+    });
+
+    it("does not match a nested git checkout under a parent projectDir", () => {
+        const nestedGit = {
+            toplevel: "/repos/parent/child",
+            branch: "main",
+            cwd: "/repos/parent/child",
+        };
+        expect(matches({ projectDir: "/repos/parent", obsidianDir: "/v" }, nestedGit)).toBe(0);
+    });
+});
+
+describe("matches — linked worktrees", () => {
+    const sibling = {
+        toplevel: "/repos/Proj-wt-feature",
+        branch: "feat/x",
+        cwd: "/repos/Proj-wt-feature",
+        mainProject: "/repos/Proj",
+    };
+
+    it("matches an entry registered against the main checkout", () => {
+        expect(matches({ projectDir: "/repos/Proj", obsidianDir: "/v", branch: "feat/x" }, sibling)).toBeGreaterThan(0);
+    });
+
+    it("still respects the entry's branch pin from a worktree", () => {
+        expect(matches({ projectDir: "/repos/Proj", obsidianDir: "/v", branch: "feat/other" }, sibling)).toBe(0);
+    });
+
+    it("ranks the worktree-specific entry above the main-checkout one", () => {
+        const viaMain = matches({ projectDir: "/repos/Proj", obsidianDir: "/v", branch: "feat/x" }, sibling);
+        const viaWorktree = matches(
+            {
+                projectDir: "/repos/Proj",
+                obsidianDir: "/v",
+                branch: "feat/x",
+                worktreeDir: "/repos/Proj-wt-feature",
+            },
+            sibling
+        );
+        expect(viaWorktree).toBeGreaterThan(viaMain);
+    });
+
+    it("does not match another project just because we are in a worktree", () => {
+        expect(matches({ projectDir: "/repos/Other", obsidianDir: "/v" }, sibling)).toBe(0);
+    });
+});
+
+describe("nextSteps", () => {
+    const cmds = { registerCmd: "REGISTER", entriesCmd: "ENTRIES" };
+
+    it("walks Tier 1 → entries → confirm → register when nothing resolved", () => {
+        const steps = nextSteps({ found: false, exact: false, docExists: false, docPath: "", ...cmds });
+        expect(steps[0]).toContain("Tier 1");
+        expect(steps.some((s) => s.includes("ENTRIES"))).toBe(true);
+        expect(steps.some((s) => s.includes("REGISTER"))).toBe(true);
+    });
+
+    it("blocks writing and offers the pin command on a non-exact match", () => {
+        const steps = nextSteps({ found: true, exact: false, docExists: true, docPath: "/v/d.md", ...cmds });
+        expect(steps[0]).toContain("Do not write yet");
+        expect(steps[1]).toContain("REGISTER");
+    });
+
+    it("goes straight to here/log on an exact match with an existing doc", () => {
+        const steps = nextSteps({ found: true, exact: true, docExists: true, docPath: "/v/d.md", ...cmds });
+        expect(steps).toHaveLength(1);
+        expect(steps[0]).toContain("here");
+        expect(steps[0]).toContain("log");
+    });
+
+    it("says to create the file first when the doc is missing", () => {
+        const steps = nextSteps({ found: true, exact: true, docExists: false, docPath: "/v/d.md", ...cmds });
+        expect(steps[0]).toContain("template");
+    });
+});
+
+describe("auditRegistry", () => {
+    const allPresent = () => true;
+
+    it("reports a branch-less entry as a catch-all", () => {
+        const issues = auditRegistry([{ projectDir: "/repos/Proj", obsidianDir: "/v" }], allPresent);
+        expect(issues.map((i) => i.kind)).toEqual(["catch-all"]);
+    });
+
+    it("reports a catch-all with a pinned docPath as sharing one file", () => {
+        const issues = auditRegistry(
+            [{ projectDir: "/repos/Proj", obsidianDir: "/v", docPath: "/v/one.md" }],
+            allPresent
+        );
+        expect(issues.map((i) => i.kind)).toEqual(["catch-all", "shared-doc"]);
+    });
+
+    it("stays silent on a healthy branch-pinned entry", () => {
+        const issues = auditRegistry([{ projectDir: "/repos/Proj", obsidianDir: "/v", branch: "feat/x" }], allPresent);
+        expect(issues).toEqual([]);
+    });
+
+    it("reports deleted project, worktree and vault directories", () => {
+        const entry: Entry = {
+            projectDir: "/gone/Proj",
+            obsidianDir: "/gone/vault",
+            branch: "feat/x",
+            worktreeDir: "/gone/wt",
+        };
+        const issues = auditRegistry([entry], () => false);
+        expect(issues.map((i) => i.kind).sort()).toEqual(["missing-project", "missing-vault-dir", "missing-worktree"]);
+    });
+
+    it("carries a fix command on every issue", () => {
+        const issues = auditRegistry([{ projectDir: "/repos/Proj", obsidianDir: "/v" }], allPresent);
+        expect(issues.every((i) => i.fix.length > 0)).toBe(true);
+    });
+});
+
+describe("rankEntries", () => {
+    const ctx = { toplevel: "/repos/Proj", branch: "feat/x", cwd: "/repos/Proj" };
+
+    it("puts the branch-pinned entry above the project-wide one", () => {
+        const wide: Entry = { projectDir: "/repos/Proj", obsidianDir: "/v/wide" };
+        const pinned: Entry = { projectDir: "/repos/Proj", obsidianDir: "/v/pinned", branch: "feat/x" };
+        expect(rankEntries([wide, pinned], ctx)[0].entry.obsidianDir).toBe("/v/pinned");
+    });
+
+    it("breaks an equal-specificity tie with the newest registration", () => {
+        const old: Entry = { projectDir: "/repos/Proj", obsidianDir: "/v/old" };
+        const recent: Entry = { projectDir: "/repos/Proj", obsidianDir: "/v/recent" };
+        expect(rankEntries([old, recent], ctx)[0].entry.obsidianDir).toBe("/v/recent");
+    });
+
+    it("drops entries for other projects and other branches", () => {
+        const foreign: Entry = { projectDir: "/repos/Other", obsidianDir: "/v/foreign" };
+        const otherBranch: Entry = { projectDir: "/repos/Proj", obsidianDir: "/v/other", branch: "feat/y" };
+        const mine: Entry = { projectDir: "/repos/Proj", obsidianDir: "/v/mine", branch: "feat/x" };
+        expect(rankEntries([foreign, otherBranch, mine], ctx).map((r) => r.entry.obsidianDir)).toEqual(["/v/mine"]);
+    });
+});
+
+describe("resolutionWarnings", () => {
+    const ctx = { toplevel: "/repos/Proj", branch: "feat/x", cwd: "/repos/Proj" };
+
+    it("flags a project-wide entry as claiming every branch", () => {
+        const warnings = resolutionWarnings({
+            entry: { projectDir: "/repos/Proj", obsidianDir: "/v" },
+            ctx,
+            alternatives: [],
+            docExists: true,
+        });
+        expect(warnings.some((w) => w.includes("project-wide entry"))).toBe(true);
+    });
+
+    it("flags a project-wide entry that also pins a shared docPath", () => {
+        const warnings = resolutionWarnings({
+            entry: { projectDir: "/repos/Proj", obsidianDir: "/v", docPath: "/v/one.md" },
+            ctx,
+            alternatives: [],
+            docExists: true,
+        });
+        expect(warnings.some((w) => w.includes("same file"))).toBe(true);
+    });
+
+    it("stays silent for a branch-exact match whose doc exists", () => {
+        const warnings = resolutionWarnings({
+            entry: { projectDir: "/repos/Proj", obsidianDir: "/v", branch: "feat/x" },
+            ctx,
+            alternatives: [],
+            docExists: true,
+        });
+        expect(warnings).toEqual([]);
+    });
+
+    it("counts the other matching entries and the missing doc", () => {
+        const warnings = resolutionWarnings({
+            entry: { projectDir: "/repos/Proj", obsidianDir: "/v", branch: "feat/x" },
+            ctx,
+            alternatives: [{ entry: { projectDir: "/repos/Proj", obsidianDir: "/v2" }, score: 1 }],
+            docExists: false,
+        });
+        expect(warnings.some((w) => w.includes("1 other registry entry"))).toBe(true);
+        expect(warnings.some((w) => w.includes("does not exist yet"))).toBe(true);
+    });
+});
+
+describe("entryBranch", () => {
+    it("pins the current branch when none is given", () => {
+        expect(entryBranch({ obsidian: "/v" }, "feat/x")).toBe("feat/x");
+    });
+
+    it("keeps an explicit branch", () => {
+        expect(entryBranch({ branch: "feat/y" }, "feat/x")).toBe("feat/y");
+    });
+
+    it("makes a catch-all only when --all-branches is passed", () => {
+        expect(entryBranch({ "all-branches": "" }, "feat/x")).toBe("");
     });
 });
 
@@ -269,6 +468,28 @@ describe("parseFlags", () => {
 
     it("ignores positional noise", () => {
         expect(parseFlags(["stray", "--branch", "feat/x"])).toEqual({ branch: "feat/x" });
+    });
+
+    it("does not let a boolean flag swallow the next flag's value", () => {
+        expect(parseFlags(["--all-branches", "--obsidian", "/vault"])).toEqual({
+            "all-branches": "",
+            obsidian: "/vault",
+        });
+    });
+});
+
+describe("parsePorcelainMain", () => {
+    it("returns the first worktree path when it is not this checkout", () => {
+        const text = "worktree /repos/Proj\nHEAD abc\n\nworktree /repos/Proj-wt\nHEAD def\n";
+        expect(parsePorcelainMain(text, "/repos/Proj-wt")).toBe("/repos/Proj");
+    });
+
+    it("returns empty when this checkout is already the main one", () => {
+        expect(parsePorcelainMain("worktree /repos/Proj\nHEAD abc\n", "/repos/Proj")).toBe("");
+    });
+
+    it("returns empty on blank git output", () => {
+        expect(parsePorcelainMain("", "/repos/Proj")).toBe("");
     });
 });
 

--- a/plugins/genesis-tools/skills/wrap-up/scripts/resolve.ts
+++ b/plugins/genesis-tools/skills/wrap-up/scripts/resolve.ts
@@ -6,7 +6,13 @@
  * Owns the deterministic half of "where does the wrap-up doc live?":
  *   - resolve : match the current project/branch/worktree against the registry,
  *               print the obsidian dir + the derived doc path (or found:false).
+ *               Context comes from the shell cwd unless --project/--branch/--cwd
+ *               pin it, and is always echoed back with `warnings` naming every
+ *               reason the top match may be the wrong doc.
+ *   - entries : list every registered target for a project (the redirect menu).
  *   - register: append/update a registry entry after the user confirms a target.
+ *               The entry is pinned to the current branch unless --branch or
+ *               --all-branches says otherwise.
  *   - here    : print ONLY the YOU-ARE-HERE block of a wrap-up file (cheap read).
  *   - log     : atomically append a log section AND rewrite the YOU-ARE-HERE block,
  *               auto-stamping the datetime and auto-generating the before→after
@@ -187,20 +193,66 @@ export function derivedDocPath(entry: Entry, branch: string): string {
     return join(entry.obsidianDir, `${project}-${slug(branch)}.wrapup.md`);
 }
 
-async function gitContext() {
-    const toplevel = await sh(["git", "rev-parse", "--show-toplevel"]);
-    const branch = await sh(["git", "rev-parse", "--abbrev-ref", "HEAD"]);
-    // In a worktree, common-dir differs from git-dir; the "main" checkout's
-    // toplevel is what a project-level entry keys on.
-    const cwd = process.cwd();
-    return { toplevel: toplevel || cwd, branch: branch || "", cwd };
+export interface Ctx {
+    toplevel: string;
+    branch: string;
+    cwd: string;
+    /** The main checkout, when `toplevel` is a linked worktree. Empty otherwise. */
+    mainProject?: string;
 }
 
-export function matches(entry: Entry, ctx: { toplevel: string; branch: string; cwd: string }): number {
+/**
+ * First porcelain `worktree ` line is the main checkout. Empty / same-path
+ * means we ARE the main checkout (or git said nothing).
+ */
+export function parsePorcelainMain(text: string, toplevel: string): string {
+    const first = text.split("\n")[0] ?? "";
+    const main = first.startsWith("worktree ") ? first.slice("worktree ".length).trim() : "";
+    return main && main !== toplevel ? main : "";
+}
+
+/**
+ * `git worktree list` prints the main checkout first. A linked worktree can live
+ * anywhere — a sibling directory as often as a nested one — so without this a
+ * sibling worktree path-matches nothing and every project-level entry is missed.
+ */
+async function mainCheckout(toplevel: string): Promise<string> {
+    return parsePorcelainMain(await sh(["git", "-C", toplevel, "worktree", "list", "--porcelain"]), toplevel);
+}
+
+/**
+ * Everything below keys off this context, so getting it from the ambient shell
+ * alone is how a wrap-up lands in another project's vault folder: the agent's
+ * shell cwd persists across calls and is not necessarily the repo the session
+ * worked in. `--project` / `--branch` / `--cwd` let the caller pin it, and the
+ * pinned values are echoed back in every `resolve` result so a wrong one is
+ * visible instead of silent.
+ */
+async function gitContext(args: Record<string, string> = {}): Promise<Ctx> {
+    const pinnedProject = args.project ? expandHome(args.project) : "";
+    // A pinned project implies its own cwd: keeping the ambient one would let a
+    // stale directory still path-match a foreign registry entry.
+    const cwd = args.cwd ? expandHome(args.cwd) : pinnedProject || process.cwd();
+    // Normalize whatever was pinned to the checkout root. --project is routinely
+    // given a subdirectory or a worktree path, and echoing that raw path back as
+    // "project" is how a wrong target survives review.
+    const toplevel = (await sh(["git", "-C", cwd, "rev-parse", "--show-toplevel"])) || pinnedProject || cwd;
+    const branch = args.branch || (await sh(["git", "-C", toplevel, "rev-parse", "--abbrev-ref", "HEAD"]));
+    return { toplevel, branch: branch || "", cwd, mainProject: await mainCheckout(toplevel) };
+}
+
+export function matches(entry: Entry, ctx: Ctx): number {
     // Higher score = more specific match. 0 = no match.
+    // Do not prefix-match cwd against another repository: a nested git checkout
+    // at /parent/child would otherwise steal the parent's wrap-up. Same-repo
+    // subdirectories still match because gitContext sets toplevel to the root.
     const paths = [entry.worktreeDir, entry.projectDir].filter(Boolean) as string[];
-    const pathHit = paths.some((p) => ctx.toplevel === p || ctx.cwd === p || ctx.cwd.startsWith(`${p}/`));
-    if (!pathHit) {
+    const direct = paths.some((p) => ctx.toplevel === p || ctx.cwd === p);
+    // From a linked worktree, an entry registered against the main checkout is
+    // still this project's entry — a sibling worktree shares no path prefix with
+    // it, so without this the correct target resolves to found:false.
+    const viaMain = !direct && Boolean(ctx.mainProject) && paths.some((p) => p === ctx.mainProject);
+    if (!direct && !viaMain) {
         return 0;
     }
 
@@ -220,13 +272,194 @@ export function matches(entry: Entry, ctx: { toplevel: string; branch: string; c
     return score;
 }
 
-async function cmdResolve() {
-    const ctx = await gitContext();
-    const reg = await loadRegistry();
-    const ranked = reg.entries
-        .map((e) => ({ e, score: matches(e, ctx) }))
+export interface Ranked {
+    entry: Entry;
+    score: number;
+}
+
+/**
+ * Rank the matching entries, most specific first. Equal specificity is broken by
+ * registration order, newest first: `register` appends, so the later entry is the
+ * one the user set up most recently, and a months-old catch-all must not outrank it.
+ */
+export function rankEntries(entries: Entry[], ctx: Ctx): Ranked[] {
+    return entries
+        .map((entry, index) => ({ entry, score: matches(entry, ctx), index }))
         .filter((x) => x.score > 0)
-        .sort((a, b) => b.score - a.score);
+        .sort((a, b) => b.score - a.score || b.index - a.index)
+        .map(({ entry, score }) => ({ entry, score }));
+}
+
+/**
+ * The failure this skill actually hits is a confident wrong answer, not a missing
+ * one. These warnings name every reason the top match may not be the target the
+ * session wants, so the caller can stop and confirm instead of appending a session
+ * log to an unrelated project's doc.
+ */
+export function resolutionWarnings({
+    entry,
+    ctx,
+    alternatives,
+    docExists,
+}: {
+    entry: Entry;
+    ctx: Ctx;
+    alternatives: Ranked[];
+    docExists: boolean;
+}): string[] {
+    const warnings: string[] = [];
+    if (!entry.branch) {
+        warnings.push(
+            `matched a project-wide entry (no branch pinned): it claims EVERY branch of ${basename(entry.projectDir)}, not just "${ctx.branch}" — confirm this is the right doc before writing`
+        );
+    }
+
+    if (!entry.branch && entry.docPath) {
+        warnings.push(
+            `that entry also pins docPath, so every branch of this project appends into the same file (${entry.docPath})`
+        );
+    }
+
+    if (alternatives.length) {
+        warnings.push(
+            `${alternatives.length} other registry entr${alternatives.length === 1 ? "y" : "ies"} also match — see "alternatives"`
+        );
+    }
+
+    if (!docExists) {
+        warnings.push("docPath does not exist yet — create it from the SKILL.md template before calling `log`");
+    }
+
+    return warnings;
+}
+
+function registerHint(ctx: Ctx, obsidianDir = "<dir>"): string {
+    const worktree = ctx.mainProject ? ` --worktree "${ctx.toplevel}"` : "";
+    const project = ctx.mainProject || ctx.toplevel;
+    return `bun "${import.meta.path}" register --obsidian "${obsidianDir}" --project "${project}" --branch "${ctx.branch}"${worktree}`;
+}
+
+function entriesHint(ctx: Ctx): string {
+    return `bun "${import.meta.path}" entries --project "${ctx.toplevel}"`;
+}
+
+/**
+ * The guide half of this script. A caller that only gets a path has to invent the
+ * procedure; spelling out the next commands is what keeps a doubtful match from
+ * being written anyway, and it replaces the habit of registering a catch-all
+ * entry just to make the question go away.
+ */
+export function nextSteps({
+    found,
+    exact,
+    docExists,
+    docPath,
+    registerCmd,
+    entriesCmd,
+}: {
+    found: boolean;
+    exact: boolean;
+    docExists: boolean;
+    docPath: string;
+    registerCmd: string;
+    entriesCmd: string;
+}): string[] {
+    if (!found) {
+        return [
+            "1. Tier 1 wins if it applies: a vault folder this session already read or wrote for this project IS the target, no lookup needed.",
+            `2. Otherwise see what is already registered for this project: ${entriesCmd}`,
+            "3. Infer the vault layout with one or two `ls` calls, then ask the user to confirm the directory (AskUserQuestion).",
+            `4. Pin the confirmed directory so it is never asked again: ${registerCmd}`,
+            "5. Create the doc from the SKILL.md template, then append with `log`.",
+        ];
+    }
+
+    const steps: string[] = [];
+    if (!exact) {
+        steps.push(
+            `1. Do not write yet. No entry claims this branch specifically, so show the user this docPath plus "alternatives" and let them confirm (AskUserQuestion). Full list: ${entriesCmd}`,
+            `2. Once confirmed, pin it to this branch — do NOT register a catch-all: ${registerCmd}`
+        );
+    }
+
+    steps.push(
+        docExists
+            ? `${steps.length + 1}. Read the current state cheaply with \`here "${docPath}"\`, then append this session with \`log "${docPath}"\`.`
+            : `${steps.length + 1}. Create "${docPath}" from the SKILL.md template (header + first log section), then use \`log\` for every later session.`
+    );
+
+    return steps;
+}
+
+export interface RegistryIssue {
+    kind: "catch-all" | "shared-doc" | "missing-project" | "missing-worktree" | "missing-vault-dir";
+    entry: Entry;
+    detail: string;
+    fix: string;
+}
+
+/**
+ * Read-only audit of the registry. Every issue here has already cost a session:
+ * branch-less entries hijack unrelated branches, and entries pointing at deleted
+ * worktrees resolve to a checkout that no longer exists.
+ */
+export function auditRegistry(entries: Entry[], exists: (path: string) => boolean): RegistryIssue[] {
+    const issues: RegistryIssue[] = [];
+    for (const entry of entries) {
+        const pin = `register --obsidian "${entry.obsidianDir}" --project "${entry.projectDir}" --branch "<branch this doc belongs to>"`;
+        if (!entry.branch) {
+            issues.push({
+                kind: "catch-all",
+                entry,
+                detail: `no branch pinned: this entry claims every branch of ${basename(entry.projectDir)}`,
+                fix: `re-register it against the branch it was written for: ${pin}`,
+            });
+        }
+
+        if (!entry.branch && entry.docPath) {
+            issues.push({
+                kind: "shared-doc",
+                entry,
+                detail: `every branch of ${basename(entry.projectDir)} appends into ${entry.docPath}`,
+                fix: "drop docPath (so each branch derives its own file), or pin the entry to one branch",
+            });
+        }
+
+        if (!exists(entry.projectDir)) {
+            issues.push({
+                kind: "missing-project",
+                entry,
+                detail: `projectDir no longer exists: ${entry.projectDir}`,
+                fix: "delete this entry from the registry file by hand",
+            });
+        }
+
+        if (entry.worktreeDir && !exists(entry.worktreeDir)) {
+            issues.push({
+                kind: "missing-worktree",
+                entry,
+                detail: `worktreeDir no longer exists: ${entry.worktreeDir}`,
+                fix: "delete this entry, or re-register it without --worktree",
+            });
+        }
+
+        if (!exists(entry.obsidianDir)) {
+            issues.push({
+                kind: "missing-vault-dir",
+                entry,
+                detail: `obsidianDir does not exist: ${entry.obsidianDir}`,
+                fix: "create the directory, or re-register the entry against the real vault folder",
+            });
+        }
+    }
+
+    return issues;
+}
+
+async function cmdResolve(args: Record<string, string> = {}) {
+    const ctx = await gitContext(args);
+    const reg = await loadRegistry();
+    const ranked = rankEntries(reg.entries, ctx);
 
     if (ranked.length === 0) {
         // Fallback tier: shared plugin config. docDir (absolute or project-relative)
@@ -243,17 +476,35 @@ async function cmdResolve() {
 
         if (docDir) {
             const entry: Entry = { projectDir: ctx.toplevel, obsidianDir: docDir };
+            const docPath = derivedDocPath(entry, ctx.branch);
             console.log(
                 // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
                 JSON.stringify(
                     {
                         found: true,
                         source: "config",
+                        // The config fallback derives a per-branch filename, so it is
+                        // branch-exact by construction.
+                        exact: true,
                         obsidianDir: docDir,
-                        docPath: derivedDocPath(entry, ctx.branch),
+                        docPath,
+                        docExists: await Bun.file(docPath).exists(),
                         project: ctx.toplevel,
                         branch: ctx.branch,
+                        cwd: ctx.cwd,
+                        worktreeOf: ctx.mainProject || null,
                         worktree: null,
+                        alternatives: [],
+                        warnings: [],
+                        registerHint: registerHint(ctx, docDir),
+                        nextSteps: nextSteps({
+                            found: true,
+                            exact: true,
+                            docExists: await Bun.file(docPath).exists(),
+                            docPath,
+                            registerCmd: registerHint(ctx, docDir),
+                            entriesCmd: entriesHint(ctx),
+                        }),
                     },
                     null,
                     2
@@ -262,23 +513,74 @@ async function cmdResolve() {
             return;
         }
 
-        // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
-        console.log(JSON.stringify({ found: false, project: ctx.toplevel, branch: ctx.branch, cwd: ctx.cwd }, null, 2));
+        console.log(
+            // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+            JSON.stringify(
+                {
+                    found: false,
+                    project: ctx.toplevel,
+                    branch: ctx.branch,
+                    cwd: ctx.cwd,
+                    worktreeOf: ctx.mainProject || null,
+                    registerHint: registerHint(ctx),
+                    nextSteps: nextSteps({
+                        found: false,
+                        exact: false,
+                        docExists: false,
+                        docPath: "",
+                        registerCmd: registerHint(ctx),
+                        entriesCmd: entriesHint(ctx),
+                    }),
+                },
+                null,
+                2
+            )
+        );
         return;
     }
 
-    const { e } = ranked[0];
+    const { entry } = ranked[0];
+    const docPath = derivedDocPath(entry, ctx.branch);
+    const docExists = await Bun.file(docPath).exists();
+    const alternatives = ranked.slice(1);
+    const exact = Boolean(entry.branch) && entry.branch === ctx.branch;
+    // Only pre-fill the resolved directory once it is trustworthy: pre-filling a
+    // doubtful match turns "confirm this" into a one-key rubber stamp of the
+    // wrong target.
+    const hint = registerHint(ctx, exact ? entry.obsidianDir : "<dir the user confirms>");
     console.log(
         // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
         JSON.stringify(
             {
                 found: true,
                 source: "registry",
-                obsidianDir: e.obsidianDir,
-                docPath: derivedDocPath(e, ctx.branch),
+                exact,
+                obsidianDir: entry.obsidianDir,
+                docPath,
+                docExists,
                 project: ctx.toplevel,
                 branch: ctx.branch,
-                worktree: e.worktreeDir ?? null,
+                cwd: ctx.cwd,
+                worktreeOf: ctx.mainProject || null,
+                worktree: entry.worktreeDir ?? null,
+                matchedEntry: entry,
+                alternatives: alternatives.map(({ entry: alt, score }) => ({
+                    obsidianDir: alt.obsidianDir,
+                    docPath: derivedDocPath(alt, ctx.branch),
+                    branch: alt.branch ?? null,
+                    worktreeDir: alt.worktreeDir ?? null,
+                    score,
+                })),
+                warnings: resolutionWarnings({ entry, ctx, alternatives, docExists }),
+                registerHint: hint,
+                nextSteps: nextSteps({
+                    found: true,
+                    exact,
+                    docExists,
+                    docPath,
+                    registerCmd: hint,
+                    entriesCmd: entriesHint(ctx),
+                }),
             },
             null,
             2
@@ -286,19 +588,126 @@ async function cmdResolve() {
     );
 }
 
+/** Read-only registry audit: names every entry that can resolve wrong, and how
+ * to fix it. Never mutates — a diagnostic that repairs would hide the cause. */
+async function cmdDoctor() {
+    const reg = await loadRegistry();
+    const paths = new Set<string>();
+    for (const e of reg.entries) {
+        paths.add(e.projectDir);
+        paths.add(e.obsidianDir);
+        if (e.worktreeDir) {
+            paths.add(e.worktreeDir);
+        }
+    }
+
+    const present = new Set<string>();
+    await Promise.all(
+        [...paths].map(async (p) => {
+            // Bun.file().exists() is false for directories, so stat instead.
+            const ok = await stat(p).then(
+                (info) => info.isDirectory(),
+                () => false
+            );
+            if (ok) {
+                present.add(p);
+            }
+        })
+    );
+
+    const issues = auditRegistry(reg.entries, (p) => present.has(p));
+    console.log(
+        // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+        JSON.stringify(
+            {
+                registry: await registryPath(),
+                entries: reg.entries.length,
+                healthy: issues.length === 0,
+                issues,
+            },
+            null,
+            2
+        )
+    );
+}
+
+/** Every registry entry for this project, branch-matching or not — the menu to
+ * offer the user when the top match is wrong or missing. */
+async function cmdEntries(args: Record<string, string> = {}) {
+    const ctx = await gitContext(args);
+    const reg = await loadRegistry();
+    const roots = [ctx.toplevel, ctx.mainProject].filter((p): p is string => Boolean(p));
+    const forProject = reg.entries.filter(
+        (e) => roots.includes(e.projectDir) || (e.worktreeDir !== undefined && roots.includes(e.worktreeDir))
+    );
+
+    console.log(
+        // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+        JSON.stringify(
+            {
+                project: ctx.toplevel,
+                branch: ctx.branch,
+                cwd: ctx.cwd,
+                registry: await registryPath(),
+                entries: forProject.map((e) => ({
+                    obsidianDir: e.obsidianDir,
+                    // Derive with the entry's OWN branch: showing a non-matching
+                    // entry under the current branch's filename invents a path
+                    // that entry would never produce.
+                    docPath: derivedDocPath(e, e.branch || ctx.branch),
+                    branch: e.branch ?? null,
+                    worktreeDir: e.worktreeDir ?? null,
+                    matchesCurrent: matches(e, ctx) > 0,
+                })),
+            },
+            null,
+            2
+        )
+    );
+}
+
+export function entryBranch(args: Record<string, string>, ctxBranch: string): string {
+    // A branch-less entry claims every branch of the project forever, which is
+    // how an old session's doc keeps winning months later. Pin the current branch
+    // by default; `--all-branches` is the explicit opt-in to the catch-all.
+    if (args.branch) {
+        return args.branch;
+    }
+
+    return "all-branches" in args ? "" : ctxBranch;
+}
+
 async function cmdRegister(args: Record<string, string>) {
-    const ctx = await gitContext();
+    const ctx = await gitContext(args);
+    const branch = entryBranch(args, ctx.branch);
     const entry: Entry = {
-        projectDir: args.project ?? ctx.toplevel,
-        obsidianDir: args.obsidian,
-        ...(args.branch ? { branch: args.branch } : {}),
-        ...(args.worktree ? { worktreeDir: args.worktree } : {}),
-        ...(args.doc ? { docPath: args.doc } : {}),
+        projectDir: ctx.toplevel,
+        obsidianDir: expandHome(args.obsidian ?? ""),
+        ...(branch ? { branch } : {}),
+        ...(args.worktree ? { worktreeDir: expandHome(args.worktree) } : {}),
+        ...(args.doc ? { docPath: expandHome(args.doc) } : {}),
     };
 
     if (!entry.obsidianDir) {
         console.error("register: --obsidian <dir> is required");
         process.exit(1);
+    }
+
+    if (!entry.branch) {
+        // The catch-all is the single biggest source of wrong wrap-up targets, so
+        // creating one says out loud what it will do to every future branch.
+        console.error(
+            [
+                `wrap-up: registering a CATCH-ALL entry for ${entry.projectDir}.`,
+                `  It will claim EVERY branch of that project, forever, including branches that do not exist yet.`,
+                `  Prefer one entry per branch: drop --all-branches and the current branch is pinned for you.`,
+                entry.docPath
+                    ? `  With docPath set, every branch will also append into the same file: ${entry.docPath}`
+                    : "",
+            ]
+                .filter(Boolean)
+                .join("\n")
+        );
     }
 
     const reg = await loadRegistry();
@@ -497,8 +906,15 @@ export function parseFlags(argv: string[]): Record<string, string> {
     const out: Record<string, string> = {};
     for (let i = 0; i < argv.length; i++) {
         if (argv[i].startsWith("--")) {
-            out[argv[i].slice(2)] = argv[i + 1] ?? "";
-            i++;
+            const next = argv[i + 1];
+            // A boolean flag (--all-branches) must not swallow the flag that
+            // follows it, or `--all-branches --obsidian /vault` would silently
+            // drop the target directory.
+            const isBoolean = next === undefined || next.startsWith("--");
+            out[argv[i].slice(2)] = isBoolean ? "" : next;
+            if (!isBoolean) {
+                i++;
+            }
         }
     }
     return out;
@@ -510,7 +926,13 @@ if (import.meta.main) {
     const [cmd, ...rest] = process.argv.slice(2);
     switch (cmd) {
         case "resolve":
-            await cmdResolve();
+            await cmdResolve(parseFlags(rest));
+            break;
+        case "entries":
+            await cmdEntries(parseFlags(rest));
+            break;
+        case "doctor":
+            await cmdDoctor();
             break;
         case "register":
             await cmdRegister(parseFlags(rest));
@@ -523,7 +945,21 @@ if (import.meta.main) {
             break;
         default:
             console.error(
-                "usage: resolve.ts <resolve | register --obsidian <dir> [--branch b] [--worktree w] [--project p] [--doc path] | here <file> | log <file>  (log reads stdin: @@HERE@@ … @@LOG@@ …)>"
+                [
+                    "usage: resolve.ts <command>",
+                    "",
+                    "  resolve  [--project <dir>] [--branch <b>] [--cwd <dir>]",
+                    "           where does the wrap-up doc live? Pin --project to the repo the session",
+                    "           actually worked in; without it the ambient shell cwd decides. Any path",
+                    "           inside the checkout works (subdirectory or worktree). The result carries",
+                    "           `warnings` and `nextSteps` — read them before writing anything.",
+                    "  entries  [--project <dir>]   every registered target for that project",
+                    "  doctor                       audit the registry for entries that resolve wrong",
+                    "  register --obsidian <dir> [--project p] [--branch b | --all-branches] [--worktree w] [--doc path]",
+                    "           branch defaults to the current one; --all-branches makes a catch-all",
+                    "  here     <file>              print only the YOU-ARE-HERE block",
+                    "  log      <file>              stdin: @@HERE@@ … @@LOG@@ …",
+                ].join("\n")
             );
             process.exit(1);
     }

--- a/src/agents/commands/login.ts
+++ b/src/agents/commands/login.ts
@@ -467,6 +467,15 @@ async function runLoginImpl(opts: LoginOpts): Promise<void> {
             const initialEmitted = await drainPending(active);
 
             if (initialEmitted === 0) {
+                // Nothing queued: this blocks until a message arrives, for up
+                // to the cap. Say so on stderr, or a caller that times out
+                // sees an empty stdout and a live process and cannot tell
+                // "waiting" from "crashed before it printed anything".
+                out.log.info(
+                    `${record.agent_name}: mailbox empty — waiting for the first message (up to ${Math.round(
+                        LISTEN_CAP_MS / 3_600_000
+                    )}h). Nothing will print until one arrives.`
+                );
                 const deadline = Date.now() + LISTEN_CAP_MS;
                 await watchUntilDeadline(active, deadline, true);
             }

--- a/src/agents/lib/paths.ts
+++ b/src/agents/lib/paths.ts
@@ -5,6 +5,13 @@ import { FriendlyError } from "./errors";
 import type { SessionPaths } from "./types";
 
 const UNSAFE_SEGMENT_RE = /[/\\]|^\.\.?$/;
+// Escape codes, newlines, tabs. Captured terminal output passed as --session
+// created real directories under agentsRoot() whose names carry ANSI colour
+// codes and line breaks: unlistable, untypeable, and awkward to clean up.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: rejecting control characters is the point
+const CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/;
+/** A session id is a UUID (36 chars) and an agent id is shorter. */
+const MAX_SEGMENT_LENGTH = 128;
 
 /**
  * Reject path-traversal/absolute-escape segments before they're joined into a
@@ -17,6 +24,27 @@ export function assertSafePathSegment(value: string, label: string): string {
         throw new FriendlyError(
             `${label} "${value}" is not a valid path segment`,
             `${label} must not contain "/", "\\", or be "." / "..".`
+        );
+    }
+
+    if (CONTROL_CHAR_RE.test(value)) {
+        throw new FriendlyError(
+            `${label} contains a control character`,
+            `${label} must be plain text. This usually means captured terminal output (escape codes or a newline) was passed instead of an id.`
+        );
+    }
+
+    if (value.length > MAX_SEGMENT_LENGTH) {
+        throw new FriendlyError(
+            `${label} is ${value.length} characters long`,
+            `${label} must be at most ${MAX_SEGMENT_LENGTH} characters. This usually means a whole command output was passed instead of an id.`
+        );
+    }
+
+    if (value !== value.trim()) {
+        throw new FriendlyError(
+            `${label} "${value}" has leading or trailing whitespace`,
+            `${label} must not start or end with whitespace.`
         );
     }
 

--- a/src/agents/tests/paths.test.ts
+++ b/src/agents/tests/paths.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { assertSafePathSegment } from "@app/agents/lib/paths";
+
+/** ESC, built rather than typed, so this file stays plain text. */
+const ESC = String.fromCharCode(27);
+
+describe("assertSafePathSegment", () => {
+    test("accepts the ids this system actually uses", () => {
+        expect(assertSafePathSegment("c5922f36-0edf-4746-96b8-048940a43461", "session")).toBe(
+            "c5922f36-0edf-4746-96b8-048940a43461"
+        );
+        expect(assertSafePathSegment("main_c5922f360edf", "agent id")).toBe("main_c5922f360edf");
+        expect(assertSafePathSegment("agents-talk-smoke-019f1573", "session")).toBe("agents-talk-smoke-019f1573");
+    });
+
+    test("still rejects traversal and separators", () => {
+        expect(() => assertSafePathSegment("..", "session")).toThrow();
+        expect(() => assertSafePathSegment("a/b", "session")).toThrow();
+        expect(() => assertSafePathSegment("", "session")).toThrow();
+    });
+
+    test("rejects captured terminal output, which created real unlistable directories", () => {
+        // The shape that landed in ~/.genesis-tools/agents: an ANSI colour
+        // code wrapped around a tick, plus the echoed test name.
+        const ansi = `${ESC}[32m ok ${ESC}[0m discover lists lead`;
+        expect(() => assertSafePathSegment(ansi, "session")).toThrow(/control character/);
+
+        // Multi-line capture is the same mistake with a newline in it.
+        expect(() => assertSafePathSegment("===\n  ok discover lists lead", "session")).toThrow(/control character/);
+        expect(() => assertSafePathSegment("has\ttab", "session")).toThrow(/control character/);
+    });
+
+    test("rejects a whole command output pasted as an id, and stray whitespace", () => {
+        expect(() => assertSafePathSegment("x".repeat(129), "session")).toThrow(/129 characters/);
+        expect(assertSafePathSegment("x".repeat(128), "session")).toHaveLength(128);
+        expect(() => assertSafePathSegment(" leading", "session")).toThrow(/whitespace/);
+        expect(() => assertSafePathSegment("trailing ", "session")).toThrow(/whitespace/);
+    });
+});

--- a/src/ai-proxy/lib/providers/grok-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.test.ts
@@ -1,0 +1,406 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { GrokSubscriptionProvider } from "@app/ai-proxy/lib/providers/grok-subscription";
+import { TOOL_ROUTING_TAG } from "@app/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag";
+import type { AiProxyAccountConfig } from "@app/ai-proxy/lib/types";
+import { GrokSubscriptionClient } from "@genesiscz/utils/ai/grok";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+function makeProvider(): GrokSubscriptionProvider {
+    const account: AiProxyAccountConfig = {
+        name: "test-grok",
+        provider: "grok-subscription",
+        providerSlug: "grok",
+        enabled: true,
+    };
+    // The base URL is unreachable on purpose: the paths under test must answer
+    // before any dispatch, so a request that slips past them fails loudly here.
+    const client = new GrokSubscriptionClient({
+        token: "dummy",
+        authPath: "/tmp/none",
+        baseUrl: "http://127.0.0.1:1",
+    });
+
+    return new GrokSubscriptionProvider(account, client);
+}
+
+function webSearchBody(): string {
+    return SafeJSON.stringify({
+        model: "grok-4.6",
+        max_tokens: 100,
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+    });
+}
+
+describe("GrokSubscriptionProvider.messages server-tool handling", () => {
+    it("rejects non-web-search server tools with a self-explaining 400 before dispatch", async () => {
+        const provider = makeProvider();
+        const body = SafeJSON.stringify({
+            model: "grok-4.6",
+            max_tokens: 100,
+            messages: [{ role: "user", content: "hi" }],
+            tools: [{ type: "code_execution_20250522", name: "code_execution" }],
+        });
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+
+        expect(res.status).toBe(400);
+
+        const parsed = SafeJSON.parse(await res.text(), { strict: true }) as {
+            type: string;
+            error: { type: string; message: string };
+        };
+        expect(parsed.type).toBe("error");
+        expect(parsed.error.type).toBe("invalid_request_error");
+        expect(parsed.error.message).toContain("code_execution_20250522");
+    });
+
+    it("rejects a mixed request even when web_search comes first (reversed-order regression)", async () => {
+        const provider = makeProvider();
+        const body = SafeJSON.stringify({
+            model: "grok-4.6",
+            max_tokens: 100,
+            messages: [{ role: "user", content: "hi" }],
+            tools: [
+                { type: "web_search_20250305", name: "web_search" },
+                { type: "code_execution_20250522", name: "code_execution" },
+            ],
+        });
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+
+        expect(res.status).toBe(400);
+        expect(await res.text()).toContain("code_execution_20250522");
+    });
+
+    it("routes web_search to the emulation path even without a Brave key: 200 SSE, failure as in-stream error", async () => {
+        await env.testing.withOverrides({ BRAVE_API_KEY: undefined }, async () => {
+            const provider = makeProvider();
+            const body = webSearchBody();
+            const res = await provider.messages(
+                new Request("http://proxy/v1/messages", { method: "POST", body }),
+                "grok-4.6",
+                body
+            );
+
+            // The native /responses path answers 200 and streams; the
+            // unreachable upstream surfaces as an in-stream error event.
+            expect(res.status).toBe(200);
+            expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+            const text = await res.text();
+            expect(text).toContain("event: error");
+        });
+    });
+
+    it("cancelling the SSE stream aborts the in-flight native /responses call", async () => {
+        const provider = makeProvider();
+        const client = provider as unknown as {
+            client: { fetch: (path: string, init: RequestInit) => Promise<Response> };
+        };
+        let seen: AbortSignal | undefined;
+        let markDispatched: () => void = () => {};
+        const dispatched = new Promise<void>((resolve) => {
+            markDispatched = resolve;
+        });
+        // A native search that never answers on its own: only the client's
+        // cancellation can end it, which is exactly the leak under test.
+        client.client.fetch = async (_path, init) => {
+            seen = init.signal ?? undefined;
+            markDispatched();
+            return await new Promise<Response>((_resolve, reject) => {
+                init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+            });
+        };
+
+        const body = webSearchBody();
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+        const reader = res.body?.getReader();
+        await dispatched;
+        // The stream stays quiet until the first ping, so cancel without
+        // reading — that is what a client walking away looks like.
+        await reader?.cancel("client gone");
+
+        // Wait on the abort itself rather than a fixed delay, so a loaded
+        // machine cannot make this pass or fail by timing.
+        if (seen?.aborted === false) {
+            await new Promise<void>((resolve) => seen?.addEventListener("abort", () => resolve()));
+        }
+
+        expect(seen?.aborted).toBe(true);
+    });
+
+    it("never sends a request the native translation would truncate: no Brave key → self-explaining error", async () => {
+        await env.testing.withOverrides({ BRAVE_API_KEY: undefined }, async () => {
+            const provider = makeProvider();
+            // web_search plus a client tool: the /responses body carries
+            // web_search only, so answering natively would drop Read.
+            const body = SafeJSON.stringify({
+                model: "grok-4.6",
+                max_tokens: 100,
+                stream: false,
+                messages: [{ role: "user", content: "hi" }],
+                tools: [
+                    { type: "web_search_20250305", name: "web_search" },
+                    { name: "Read", description: "read a file", input_schema: { type: "object" } },
+                ],
+            });
+            const res = await provider.messages(
+                new Request("http://proxy/v1/messages", { method: "POST", body }),
+                "grok-4.6",
+                body
+            );
+
+            // 400, not the ConnectionRefused a dispatched native call would
+            // give against the unreachable base URL — proof it never dispatched.
+            expect(res.status).toBe(400);
+
+            const text = await res.text();
+            expect(text).toContain("1 client tool");
+            expect(text).toContain("BRAVE_API_KEY");
+        });
+    });
+});
+
+describe("GrokSubscriptionProvider.messages tool tagging", () => {
+    // These tests pin the SHIM fallback (AI_PROXY_GROK_MESSAGES_ROUTE=shim).
+    // The default route translates to /responses and never tags a schema.
+    beforeAll(() => {
+        env.testing.set("AI_PROXY_GROK_MESSAGES_ROUTE", "shim");
+    });
+
+    afterAll(() => {
+        env.testing.unset("AI_PROXY_GROK_MESSAGES_ROUTE");
+    });
+
+    const noArg = (name: string) => ({
+        name,
+        description: "x",
+        input_schema: { type: "object", properties: {}, required: [] },
+    });
+    const withArg = (name: string) => ({
+        name,
+        description: "x",
+        input_schema: { type: "object", properties: { q: { type: "string" } }, required: ["q"] },
+    });
+
+    /** The body this provider actually put on the wire. */
+    async function dispatchedBody(requestBody: Record<string, unknown>): Promise<Record<string, unknown>> {
+        const provider = makeProvider();
+        const client = provider as unknown as {
+            client: { fetch: (path: string, init: RequestInit) => Promise<Response> };
+        };
+        let sent = "";
+        client.client.fetch = async (_path, init) => {
+            sent = String(init.body);
+            return new Response("", { status: 200, headers: { "content-type": "text/event-stream" } });
+        };
+
+        const body = SafeJSON.stringify(requestBody);
+        await provider.messages(new Request("http://proxy/v1/messages", { method: "POST", body }), "grok-4.6", body);
+        return SafeJSON.parse(sent, { strict: true }) as Record<string, unknown>;
+    }
+
+    function schemaOf(body: Record<string, unknown>, name: string): Record<string, unknown> {
+        const tools = body.tools as Record<string, unknown>[];
+        const tool = tools.find((t) => t.name === name);
+        return tool?.input_schema as Record<string, unknown>;
+    }
+
+    it("tags every no-arg tool when two or more are offered, so a merged `{}` names itself", async () => {
+        const sent = await dispatchedBody({
+            model: "grok-4.6",
+            max_tokens: 100,
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+            tools: [noArg("ListAgents"), noArg("TaskList"), withArg("Bash")],
+        });
+
+        for (const name of ["ListAgents", "TaskList"]) {
+            const schema = schemaOf(sent, name);
+            expect(schema.required).toEqual([TOOL_ROUTING_TAG]);
+            expect((schema.properties as Record<string, unknown>)[TOOL_ROUTING_TAG]).toMatchObject({ enum: [name] });
+        }
+
+        // The tool that already carries arguments is left exactly as the client wrote it.
+        expect(schemaOf(sent, "Bash")).toEqual({
+            type: "object",
+            properties: { q: { type: "string" } },
+            required: ["q"],
+        });
+    });
+
+    it("leaves schemas untouched when nothing is ambiguous, and when not streaming", async () => {
+        // One no-arg tool resolves by key matching; tagging it would change the
+        // model's view of the schema for no gain.
+        const single = await dispatchedBody({
+            model: "grok-4.6",
+            max_tokens: 100,
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+            tools: [noArg("ListAgents"), withArg("Bash")],
+        });
+        expect(schemaOf(single, "ListAgents").required).toEqual([]);
+
+        // Non-streaming replies name every call already — nothing to repair.
+        const nonStreaming = await dispatchedBody({
+            model: "grok-4.6",
+            max_tokens: 100,
+            stream: false,
+            messages: [{ role: "user", content: "hi" }],
+            tools: [noArg("ListAgents"), noArg("TaskList")],
+        });
+        expect(schemaOf(nonStreaming, "ListAgents").required).toEqual([]);
+        expect(schemaOf(nonStreaming, "TaskList").required).toEqual([]);
+    });
+});
+
+describe("GrokSubscriptionProvider.messages /responses route (default)", () => {
+    interface Sent {
+        path: string;
+        body: Record<string, unknown>;
+    }
+
+    function stubbedProvider(respond: (sent: Sent[]) => Response): {
+        provider: GrokSubscriptionProvider;
+        sent: Sent[];
+    } {
+        const provider = makeProvider();
+        const client = provider as unknown as {
+            client: { fetch: (path: string, init: { body?: unknown }) => Promise<Response> };
+        };
+        const sent: Sent[] = [];
+        client.client.fetch = async (path, init) => {
+            sent.push({ path, body: SafeJSON.parse(String(init.body), { strict: true }) as Record<string, unknown> });
+            return respond(sent);
+        };
+
+        return { provider, sent };
+    }
+
+    const envelope = SafeJSON.stringify({
+        id: "resp_1",
+        status: "completed",
+        output: [{ type: "message", content: [{ type: "output_text", text: "4" }] }],
+        usage: { input_tokens: 10, output_tokens: 1, total_tokens: 11 },
+    });
+
+    it("translates the Anthropic body onto the /responses wire and the reply back", async () => {
+        const { provider, sent } = stubbedProvider(
+            () => new Response(envelope, { status: 200, headers: { "content-type": "application/json" } })
+        );
+
+        const body = SafeJSON.stringify({
+            model: "grok-4.6",
+            max_tokens: 100,
+            system: "be terse",
+            messages: [{ role: "user", content: "2+2?" }],
+            tools: [{ name: "Read", description: "read", input_schema: { type: "object" } }],
+        });
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+
+        expect(sent).toHaveLength(1);
+        expect(sent[0].path).toBe("/responses");
+        expect(sent[0].body.store).toBe(false);
+        expect(sent[0].body.instructions).toBe("be terse");
+        expect(sent[0].body.max_output_tokens).toBe(100);
+        // ensureToolRequiredArrays ran before the translation.
+        expect((sent[0].body.tools as Record<string, unknown>[])[0].parameters).toEqual({
+            type: "object",
+            required: [],
+        });
+
+        const message = SafeJSON.parse(await res.text(), { strict: true }) as Record<string, unknown>;
+        expect(message.type).toBe("message");
+        expect(message.content).toEqual([{ type: "text", text: "4" }]);
+        expect(message.stop_reason).toBe("end_turn");
+    });
+
+    it("retries once without reasoning items when the upstream cannot decrypt them", async () => {
+        const { provider, sent } = stubbedProvider((calls) =>
+            calls.length === 1
+                ? new Response(
+                      SafeJSON.stringify({
+                          code: "invalid-argument",
+                          error: "Could not decrypt the provided encrypted_content. Ensure the value is the unmodified encrypted_content from a previous response.",
+                      }),
+                      { status: 400, headers: { "content-type": "application/json" } }
+                  )
+                : new Response(envelope, { status: 200, headers: { "content-type": "application/json" } })
+        );
+
+        const body = SafeJSON.stringify({
+            model: "grok-4.6",
+            max_tokens: 100,
+            messages: [
+                { role: "user", content: "hi" },
+                {
+                    role: "assistant",
+                    content: [
+                        { type: "thinking", thinking: "old reasoning", signature: "grokrs1:rs_x:STALEENC==" },
+                        { type: "text", text: "earlier answer" },
+                    ],
+                },
+                { role: "user", content: "again?" },
+            ],
+        });
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+
+        expect(sent).toHaveLength(2);
+        const firstItems = (sent[0].body.input as Record<string, unknown>[]).map((item) => item.type ?? item.role);
+        const retryItems = (sent[1].body.input as Record<string, unknown>[]).map((item) => item.type ?? item.role);
+        expect(firstItems).toContain("reasoning");
+        expect(retryItems).not.toContain("reasoning");
+
+        expect(res.status).toBe(200);
+    });
+
+    it("does not retry on unrelated errors", async () => {
+        const { provider, sent } = stubbedProvider(
+            () =>
+                new Response(SafeJSON.stringify({ code: "invalid-argument", error: "some other problem" }), {
+                    status: 400,
+                    headers: { "content-type": "application/json" },
+                })
+        );
+
+        const body = SafeJSON.stringify({
+            model: "grok-4.6",
+            max_tokens: 100,
+            messages: [{ role: "user", content: "hi" }],
+        });
+        const res = await provider.messages(
+            new Request("http://proxy/v1/messages", { method: "POST", body }),
+            "grok-4.6",
+            body
+        );
+
+        expect(sent).toHaveLength(1);
+        expect(res.status).toBe(400);
+
+        // The client speaks Anthropic, so the error must be Anthropic-shaped.
+        const parsed = SafeJSON.parse(await res.text(), { strict: true }) as Record<string, unknown>;
+        expect(parsed.type).toBe("error");
+        expect((parsed.error as Record<string, unknown>).message).toContain("some other problem");
+    });
+});

--- a/src/ai-proxy/lib/providers/grok-subscription.ts
+++ b/src/ai-proxy/lib/providers/grok-subscription.ts
@@ -5,15 +5,35 @@ import { relayHeaders } from "@app/ai-proxy/lib/providers/http-relay";
 import type { OpenAiModel, ProxyProvider } from "@app/ai-proxy/lib/providers/types";
 import { parseRetryAfterSeconds } from "@app/ai-proxy/lib/providers/wham-errors";
 import { prepareGrokUpstreamBody } from "@app/ai-proxy/lib/rewrite-upstream-body";
+import {
+    braveSearchFn,
+    type EmulationOutcome,
+    emulateWebSearch,
+    emulationStream,
+    nativeTranslationLoss,
+    nativeWebSearch,
+    parseWebSearchServerTool,
+    type WebSearchServerTool,
+} from "@app/ai-proxy/lib/server-tools/web-search";
+import {
+    anthropicToGrokResponses,
+    stripReasoningInput,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/anthropic-to-responses";
 import { ensureToolRequiredArrays } from "@app/ai-proxy/lib/translators/formats/anthropic/ensure-tool-required";
 import { toAnthropicErrorResponse } from "@app/ai-proxy/lib/translators/formats/anthropic/error-envelope";
+import {
+    grokResponsesSseToAnthropic,
+    grokResponsesToAnthropicMessage,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/grok-responses-to-anthropic";
 import { hoistSystemMessages } from "@app/ai-proxy/lib/translators/formats/anthropic/hoist-system-messages";
 import {
     repairAnthropicSseIndices,
     type ToolMatcher,
     toolMatchersFromBody,
 } from "@app/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices";
+import { findServerTools } from "@app/ai-proxy/lib/translators/formats/anthropic/server-tools";
 import { stringifyUnknownToolResultBlocks } from "@app/ai-proxy/lib/translators/formats/anthropic/stringify-unknown-blocks";
+import { tagConfusableTools } from "@app/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag";
 import type { AiProxyAccountConfig, UsageSummary } from "@app/ai-proxy/lib/types";
 import {
     formatBillingSummary,
@@ -22,6 +42,7 @@ import {
     resolveGrokSubToken,
 } from "@genesiscz/utils/ai/grok";
 import { GROK_CLI_CHAT_PROXY_BASE_URL } from "@genesiscz/utils/ai/grok/paths";
+import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 
@@ -106,12 +127,66 @@ export class GrokSubscriptionProvider implements ProxyProvider {
 
         let outBody = bodyText;
         let toolMatchers: ToolMatcher[] = [];
+        let taggedTools = new Set<string>();
 
         if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+            // Anthropic server tools execute inside Anthropic's API; grok's
+            // deserializer rejects them with an opaque `missing field
+            // description` that reads like a proxy bug (probe session
+            // d20dfdfe, Claude Code's WebSearch). web_search runs on xAI's
+            // native /responses server tool; every OTHER server tool gets an
+            // error naming the real cause — judged over the whole tools list,
+            // so a mixed request cannot smuggle one past the web_search path.
+            const serverTools = findServerTools(parsed as Record<string, unknown>);
+            const unsupported = serverTools.find((type) => !type.startsWith("web_search_"));
+
+            if (unsupported !== undefined) {
+                return new Response(
+                    SafeJSON.stringify({
+                        type: "error",
+                        error: {
+                            type: "invalid_request_error",
+                            message: `The grok upstream models custom tools only; this request offers "${unsupported}", a typed Anthropic tool it cannot deserialize. Server tools such as code_execution run inside Anthropic's API, which this account does not reach; client-executed typed tools (bash, text_editor) carry no description or input_schema, which is the field the upstream rejects. Web search is the one typed tool this proxy serves, on xAI's native server-side search.`,
+                        },
+                    }),
+                    { status: 400, headers: { "Content-Type": "application/json" } }
+                );
+            }
+
+            if (serverTools.length > 0) {
+                const webSearch = parseWebSearchServerTool(parsed as Record<string, unknown>);
+
+                if (webSearch) {
+                    return this.emulatedWebSearchResponse(req, model, parsed as Record<string, unknown>, webSearch);
+                }
+            }
+
+            // Default route: the /responses wire. The shim merges parallel
+            // tool calls into ONE block (raw wire capture 2026-08-21, nine
+            // request variants tried); /responses streams every call as its
+            // own named item, and reasoning survives via encrypted reasoning
+            // items round-tripped through thinking signatures.
+            // AI_PROXY_GROK_MESSAGES_ROUTE=shim restores the passthrough
+            // below instantly.
+            if (env.aiProxy.getGrokMessagesRoute() === "responses") {
+                return this.messagesViaResponses(req, model, parsed as Record<string, unknown>);
+            }
+
             const body = stringifyUnknownToolResultBlocks(
                 hoistSystemMessages(ensureToolRequiredArrays(parsed as Record<string, unknown>))
             );
             body.model = model;
+
+            // Grok's STREAMING /messages merges parallel calls into one block
+            // and keeps only the first name, so a `{}` orphan matches every
+            // no-argument tool equally and the splitter has nothing to go on.
+            // Tagging those schemas puts the name back INTO the arguments,
+            // which keeps the stream a stream — the tag never reaches the
+            // client. Non-streaming replies name every call already.
+            if (body.stream === true) {
+                taggedTools = tagConfusableTools(body);
+            }
+
             outBody = SafeJSON.stringify(body);
             toolMatchers = toolMatchersFromBody(body);
         }
@@ -140,13 +215,182 @@ export class GrokSubscriptionProvider implements ProxyProvider {
         // which makes Anthropic SDKs overwrite the thinking block with the text
         // block. Verified live 2026-08-19; repaired, not translated.
         if (response.body && contentType.includes("text/event-stream")) {
-            return new Response(repairAnthropicSseIndices(response.body, { tools: toolMatchers }), {
+            return new Response(repairAnthropicSseIndices(response.body, { tools: toolMatchers, taggedTools }), {
                 status: response.status,
                 headers: relayHeaders(response),
             });
         }
 
         return new Response(response.body, { status: response.status, headers: relayHeaders(response) });
+    }
+
+    /**
+     * Anthropic body → /responses wire → Anthropic reply. One upstream output
+     * item maps to one content block, so the shim's merge defect cannot occur,
+     * and `encrypted_content` reasoning replay is stronger than the shim's
+     * plaintext thinking (grok decrypts and consumes it — a tampered blob is
+     * rejected).
+     */
+    private async messagesViaResponses(
+        req: Request,
+        model: string,
+        parsed: Record<string, unknown>
+    ): Promise<Response> {
+        const anthropicBody = hoistSystemMessages(ensureToolRequiredArrays(parsed));
+        const responsesBody = anthropicToGrokResponses(anthropicBody, model);
+
+        const send = (bodyText: string): Promise<Response> =>
+            this.dispatch({
+                path: "/responses",
+                req,
+                bodyText,
+                modelOverride: model,
+                requestedModel: model,
+                imageRouted: false,
+            });
+
+        let response = await send(SafeJSON.stringify(responsesBody));
+
+        if (!response.ok) {
+            const errorText = await response.text();
+
+            // A signature packed by a different conversation (or truncated by
+            // the client) fails decryption for the WHOLE request. Replaying
+            // once without reasoning items loses continuity for one turn
+            // instead of failing it.
+            if (response.status === 400 && errorText.includes("Could not decrypt")) {
+                logger.warn({ model }, "ai-proxy: grok rejected replayed reasoning — retrying without reasoning items");
+                response = await send(SafeJSON.stringify(stripReasoningInput(responsesBody)));
+
+                if (!response.ok) {
+                    return toAnthropicErrorResponse(response);
+                }
+            } else {
+                return toAnthropicErrorResponse(
+                    new Response(errorText, { status: response.status, headers: response.headers })
+                );
+            }
+        }
+
+        const contentType = response.headers.get("content-type") ?? "";
+
+        if (response.body && contentType.includes("text/event-stream")) {
+            return new Response(grokResponsesSseToAnthropic(response.body, { model }), {
+                status: response.status,
+                headers: relayHeaders(response),
+            });
+        }
+
+        const envelope = SafeJSON.parse(await response.text(), { strict: true });
+        const message = grokResponsesToAnthropicMessage(
+            typeof envelope === "object" && envelope !== null && !Array.isArray(envelope)
+                ? (envelope as Record<string, unknown>)
+                : {},
+            { model }
+        );
+
+        return new Response(SafeJSON.stringify(message), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+
+    /**
+     * Plays Anthropic's role for the web_search server tool. Preferred path:
+     * ONE /responses call with xAI's native `{type:"web_search"}` server tool
+     * (the upstream searches itself, with citations). Fallback: the Brave
+     * loop, when a key is available. Either way the final turn streams with
+     * pings so a slow search does not read as a dead connection.
+     */
+    private async emulatedWebSearchResponse(
+        req: Request,
+        model: string,
+        body: Record<string, unknown>,
+        tool: WebSearchServerTool
+    ): Promise<Response> {
+        logger.info({ model, maxUses: tool.maxUses }, "ai-proxy: running web_search server tool for grok");
+
+        const loss = nativeTranslationLoss(body, tool);
+        const run = async (signal?: AbortSignal): Promise<EmulationOutcome | Response> => {
+            const native =
+                loss === undefined
+                    ? await nativeWebSearch({
+                          body,
+                          tool,
+                          callResponses: async (responsesBody) => {
+                              responsesBody.model = model;
+                              const response = await this.dispatch({
+                                  path: "/responses",
+                                  req,
+                                  bodyText: SafeJSON.stringify(responsesBody),
+                                  modelOverride: model,
+                                  requestedModel: model,
+                                  imageRouted: false,
+                                  signal,
+                              });
+
+                              return response.ok ? response : toAnthropicErrorResponse(response);
+                          },
+                      })
+                    : unsupportedNativeResponse(loss);
+
+            if (!(native instanceof Response)) {
+                return native;
+            }
+
+            const braveKey = env.brave.getKey();
+
+            if (braveKey === undefined) {
+                return native;
+            }
+
+            logger.warn(
+                { status: native.status, model, loss },
+                "ai-proxy: native /responses web_search unavailable — falling back to the Brave loop"
+            );
+            return emulateWebSearch({
+                body,
+                tool,
+                signal,
+                search: braveSearchFn(braveKey, signal),
+                callUpstream: async (turnBody) => {
+                    const repaired = stringifyUnknownToolResultBlocks(
+                        hoistSystemMessages(ensureToolRequiredArrays(turnBody))
+                    );
+                    repaired.model = model;
+                    const response = await this.dispatch({
+                        path: "/messages",
+                        req,
+                        bodyText: SafeJSON.stringify(repaired),
+                        modelOverride: model,
+                        requestedModel: model,
+                        imageRouted: false,
+                        headers: { "anthropic-version": "2023-06-01" },
+                        signal,
+                    });
+
+                    return response.ok ? response : toAnthropicErrorResponse(response);
+                },
+            });
+        };
+
+        if (body.stream === true) {
+            return new Response(emulationStream(run), {
+                status: 200,
+                headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+            });
+        }
+
+        const outcome = await run();
+
+        if (outcome instanceof Response) {
+            return outcome;
+        }
+
+        return new Response(SafeJSON.stringify(outcome.message), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
     }
 
     async getUsage(): Promise<UsageSummary> {
@@ -188,6 +432,7 @@ export class GrokSubscriptionProvider implements ProxyProvider {
         requestedModel,
         imageRouted,
         headers,
+        signal,
     }: {
         path: string;
         req: Request;
@@ -196,6 +441,8 @@ export class GrokSubscriptionProvider implements ProxyProvider {
         requestedModel: string;
         imageRouted: boolean;
         headers?: Record<string, string>;
+        /** Extra abort source (the emulation stream's), composed with the client's. */
+        signal?: AbortSignal;
     }): Promise<Response> {
         const started = performance.now();
 
@@ -204,7 +451,7 @@ export class GrokSubscriptionProvider implements ProxyProvider {
                 method: "POST",
                 body: bodyText,
                 modelOverride,
-                signal: req.signal,
+                signal: signal === undefined ? req.signal : AbortSignal.any([req.signal, signal]),
                 headers: {
                     Accept: req.headers.get("Accept") ?? "application/json",
                     ...headers,
@@ -300,4 +547,24 @@ export class GrokSubscriptionProvider implements ProxyProvider {
             throw err;
         }
     }
+}
+
+/**
+ * Stands in for a failed native call when the /responses translation would
+ * drop part of the request, so the Brave fallback (which keeps the original
+ * Anthropic body) is chosen instead. Without a Brave key this is what the
+ * client sees, and it names what is unsupported rather than answering from a
+ * silently truncated conversation.
+ */
+function unsupportedNativeResponse(loss: string): Response {
+    return new Response(
+        SafeJSON.stringify({
+            type: "error",
+            error: {
+                type: "invalid_request_error",
+                message: `web_search on grok cannot be combined with ${loss}: xAI's native server-side search takes plain text only. Set BRAVE_API_KEY to run the emulated search loop, which keeps the full request.`,
+            },
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+    );
 }

--- a/src/ai-proxy/lib/server-tools/web-search.test.ts
+++ b/src/ai-proxy/lib/server-tools/web-search.test.ts
@@ -1,0 +1,534 @@
+import { describe, expect, it } from "bun:test";
+import { parseResponseBody } from "@app/ai-proxy/lib/usage/transcripts";
+import { SafeJSON } from "@genesiscz/utils/json";
+import {
+    buildResponsesWebSearchBody,
+    domainAllowed,
+    type EmulationOutcome,
+    emulateWebSearch,
+    emulationStream,
+    messageToAnthropicSse,
+    nativeTranslationLoss,
+    nativeWebSearch,
+    parseWebSearchServerTool,
+    type WebSearchResult,
+} from "./web-search";
+
+function jsonResponse(body: unknown): Response {
+    return new Response(SafeJSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+const TOOL = { name: "web_search", maxUses: 8 };
+
+describe("parseWebSearchServerTool", () => {
+    it("parses the server tool entry with its limits and domain filters", () => {
+        const tool = parseWebSearchServerTool({
+            tools: [
+                { name: "Read", description: "x", input_schema: {} },
+                { type: "web_search_20250305", name: "web_search", max_uses: 3, allowed_domains: ["x.ai"] },
+            ],
+        });
+
+        expect(tool).toEqual({ name: "web_search", maxUses: 3, allowedDomains: ["x.ai"], blockedDomains: undefined });
+    });
+
+    it("returns undefined when no web_search server tool is offered", () => {
+        expect(
+            parseWebSearchServerTool({ tools: [{ type: "code_execution_20250522", name: "code_execution" }] })
+        ).toBeUndefined();
+        expect(parseWebSearchServerTool({})).toBeUndefined();
+    });
+});
+
+describe("nativeTranslationLoss", () => {
+    it("clears a request the /responses translation carries faithfully", () => {
+        // Text-only, web_search-only: the shape Claude Code actually sends.
+        expect(
+            nativeTranslationLoss(
+                {
+                    tools: [{ type: "web_search_20250305", name: "web_search" }],
+                    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+                },
+                TOOL
+            )
+        ).toBeUndefined();
+        expect(nativeTranslationLoss({ messages: [{ role: "user", content: "hi" }] })).toBeUndefined();
+    });
+
+    it("names client tools and blocks the flattener would drop", () => {
+        expect(
+            nativeTranslationLoss({
+                tools: [{ type: "web_search_20250305" }, { name: "Read", description: "x", input_schema: {} }],
+                messages: [],
+            })
+        ).toBe("1 client tool");
+
+        expect(
+            nativeTranslationLoss({
+                messages: [
+                    {
+                        role: "user",
+                        content: [
+                            { type: "text", text: "and now" },
+                            { type: "tool_result", tool_use_id: "toolu_1", content: "42" },
+                            { type: "image", source: {} },
+                        ],
+                    },
+                ],
+            })
+        ).toBe("image, tool_result content blocks");
+    });
+
+    it("names domain filters the upstream cannot express", () => {
+        // One list of at most five: pairing the two would silently drop every
+        // exclusion, so a request excluding gist.github.com while allowing
+        // github.com must not take this path.
+        expect(
+            nativeTranslationLoss(
+                { messages: [] },
+                { ...TOOL, allowedDomains: ["github.com"], blockedDomains: ["gist.github.com"] }
+            )
+        ).toBe("both allowed_domains and blocked_domains");
+
+        expect(
+            nativeTranslationLoss({ messages: [] }, { ...TOOL, blockedDomains: ["a", "b", "c", "d", "e", "f"] })
+        ).toBe("6 blocked_domains (the upstream takes 5)");
+
+        // An over-long ALLOW list only tightens the request, so it stays native.
+        expect(
+            nativeTranslationLoss({ messages: [] }, { ...TOOL, allowedDomains: ["a", "b", "c", "d", "e", "f"] })
+        ).toBeUndefined();
+    });
+});
+
+describe("domainAllowed", () => {
+    it("suffix-matches allowed and blocked domains", () => {
+        expect(domainAllowed("https://gist.github.com/a", { allowed: ["github.com"] })).toBe(true);
+        expect(domainAllowed("https://github.com.evil.com/a", { allowed: ["github.com"] })).toBe(false);
+        expect(domainAllowed("https://x.ai/news", { allowed: ["github.com", "x.ai"] })).toBe(true);
+        expect(domainAllowed("https://spam.example/a", { blocked: ["spam.example"] })).toBe(false);
+        expect(domainAllowed("https://anything.example/a", {})).toBe(true);
+        expect(domainAllowed("not a url", { allowed: ["x.ai"] })).toBe(false);
+    });
+});
+
+describe("max_uses hardening", () => {
+    it("clamps client-controlled max_uses and rejects non-integers", () => {
+        const huge = parseWebSearchServerTool({
+            tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 5000 }],
+        });
+        expect(huge?.maxUses).toBe(20);
+
+        const fractional = parseWebSearchServerTool({
+            tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 3.5 }],
+        });
+        expect(fractional?.maxUses).toBe(8);
+    });
+});
+
+describe("abort handling", () => {
+    it("an aborted signal stops the loop before any upstream call", async () => {
+        const abort = new AbortController();
+        abort.abort();
+        let upstreamCalls = 0;
+
+        await expect(
+            emulateWebSearch({
+                body: { messages: [] },
+                tool: TOOL,
+                signal: abort.signal,
+                search: async () => [],
+                callUpstream: async () => {
+                    upstreamCalls += 1;
+                    return jsonResponse({ content: [], stop_reason: "end_turn" });
+                },
+            })
+        ).rejects.toThrow(/aborted/);
+        expect(upstreamCalls).toBe(0);
+    });
+
+    it("cancelling the emulation stream aborts the signal handed to run", async () => {
+        let seenSignal: AbortSignal | undefined;
+        let release: () => void = () => {};
+        const gate = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+
+        const stream = emulationStream(async (signal) => {
+            seenSignal = signal;
+            await gate;
+            return new Response("late", { status: 500 });
+        });
+
+        const reader = stream.getReader();
+        const cancelled = reader.cancel("client gone");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(seenSignal?.aborted).toBe(true);
+        release();
+        await cancelled;
+    });
+});
+
+describe("emulateWebSearch", () => {
+    it("answers the model's search call with results and returns the final turn", async () => {
+        const upstreamBodies: Record<string, unknown>[] = [];
+        const queries: string[] = [];
+        const results: WebSearchResult[] = [
+            { title: "Grok 4.6", url: "https://x.ai/news/grok-4-6", snippet: "announcement" },
+            { title: "Elsewhere", url: "https://blog.example/grok", snippet: "blog" },
+        ];
+        const turns = [
+            {
+                content: [{ type: "tool_use", id: "toolu_1", name: "web_search", input: { query: "grok 4.6" } }],
+                stop_reason: "tool_use",
+                usage: { input_tokens: 10, output_tokens: 5 },
+            },
+            {
+                content: [{ type: "text", text: "Grok 4.6 shipped." }],
+                stop_reason: "end_turn",
+                usage: { input_tokens: 50, output_tokens: 7 },
+            },
+        ];
+
+        const outcome = await emulateWebSearch({
+            body: {
+                messages: [{ role: "user", content: "search it" }],
+                tools: [{ type: "web_search_20250305", name: "web_search", allowed_domains: ["x.ai"] }],
+                stream: true,
+            },
+            tool: { ...TOOL, allowedDomains: ["x.ai"] },
+            search: async (q) => {
+                queries.push(q);
+                return results;
+            },
+            callUpstream: async (body) => {
+                upstreamBodies.push(body);
+                return jsonResponse(turns[upstreamBodies.length - 1]);
+            },
+        });
+
+        expect(outcome).not.toBeInstanceOf(Response);
+        if (outcome instanceof Response) {
+            throw new Error("unreachable");
+        }
+
+        expect(queries).toEqual(["grok 4.6"]);
+        expect(outcome.searches).toBe(1);
+        expect(outcome.message.content).toEqual([{ type: "text", text: "Grok 4.6 shipped." }]);
+        // Output tokens are summed across turns; input reflects the last turn.
+        expect(outcome.message.usage).toMatchObject({ input_tokens: 50, output_tokens: 12 });
+
+        // The upstream never sees the server tool, only the custom rewrite.
+        const firstTools = upstreamBodies[0].tools as Record<string, unknown>[];
+        expect(firstTools[0].type).toBeUndefined();
+        expect(firstTools[0].name).toBe("web_search");
+        expect(typeof firstTools[0].description).toBe("string");
+        expect(upstreamBodies[0].stream).toBe(false);
+
+        // Turn 2 carries the assistant call plus a tool_result with ONLY the
+        // allowed-domain result.
+        const messages = upstreamBodies[1].messages as Record<string, unknown>[];
+        expect(messages).toHaveLength(3);
+        const resultBlocks = messages[2].content as Record<string, unknown>[];
+        expect(resultBlocks[0].tool_use_id).toBe("toolu_1");
+        expect(resultBlocks[0].content).toContain("x.ai/news/grok-4-6");
+        expect(resultBlocks[0].content).not.toContain("blog.example");
+    });
+
+    it("stops searching past max_uses and tells the model why", async () => {
+        let calls = 0;
+        let searches = 0;
+        const outcome = await emulateWebSearch({
+            body: { messages: [] },
+            tool: { ...TOOL, maxUses: 1 },
+            search: async () => {
+                searches += 1;
+                return [];
+            },
+            callUpstream: async (body) => {
+                calls += 1;
+
+                if (calls <= 2) {
+                    return jsonResponse({
+                        content: [
+                            { type: "tool_use", id: `toolu_${calls}`, name: "web_search", input: { query: "q" } },
+                        ],
+                        stop_reason: "tool_use",
+                        usage: { output_tokens: 1 },
+                    });
+                }
+
+                const messages = body.messages as Record<string, unknown>[];
+                const lastResult = (messages.at(-1)?.content as Record<string, unknown>[])[0];
+                return jsonResponse({
+                    content: [{ type: "text", text: `done: ${lastResult.content}` }],
+                    stop_reason: "end_turn",
+                    usage: { output_tokens: 1 },
+                });
+            },
+        });
+
+        if (outcome instanceof Response) {
+            throw new Error("unreachable");
+        }
+
+        expect(searches).toBe(1);
+        expect(outcome.searches).toBe(1);
+        expect((outcome.message.content as Record<string, unknown>[])[0].text).toContain("limit reached");
+    });
+
+    it("returns the upstream error response untouched", async () => {
+        const outcome = await emulateWebSearch({
+            body: { messages: [] },
+            tool: TOOL,
+            search: async () => [],
+            callUpstream: async () =>
+                new Response(SafeJSON.stringify({ type: "error", error: { type: "api_error", message: "boom" } }), {
+                    status: 502,
+                }),
+        });
+
+        expect(outcome).toBeInstanceOf(Response);
+        if (outcome instanceof Response) {
+            expect(outcome.status).toBe(502);
+        }
+    });
+
+    it("fails loudly when the model never stops calling", async () => {
+        const outcome = await emulateWebSearch({
+            body: { messages: [] },
+            tool: { ...TOOL, maxUses: 1 },
+            search: async () => [],
+            callUpstream: async () =>
+                jsonResponse({
+                    content: [{ type: "tool_use", id: "toolu_x", name: "web_search", input: { query: "q" } }],
+                    stop_reason: "tool_use",
+                    usage: {},
+                }),
+        });
+
+        expect(outcome).toBeInstanceOf(Response);
+        if (outcome instanceof Response) {
+            expect(outcome.status).toBe(502);
+            const parsed = SafeJSON.parse(await outcome.text(), { strict: true }) as { error: { message: string } };
+            expect(parsed.error.message).toContain("did not converge");
+        }
+    });
+});
+
+describe("nativeWebSearch (/responses server-side search)", () => {
+    const RESPONSES_REPLY = {
+        id: "resp_1",
+        model: "grok-4.6-build",
+        status: "completed",
+        output: [
+            { type: "reasoning", summary: [{ type: "summary_text", text: "checking x.ai" }] },
+            { type: "web_search_call", status: "completed", action: { type: "search", query: "latest grok" } },
+            { type: "web_search_call", status: "completed", action: { type: "open_page", url: "https://x.ai/news" } },
+            {
+                type: "message",
+                content: [
+                    {
+                        type: "output_text",
+                        text: "Grok 4.6 shipped.",
+                        annotations: [
+                            { type: "url_citation", url: "https://x.ai/news/grok-4-6", start_index: 0, end_index: 1 },
+                        ],
+                    },
+                ],
+            },
+        ],
+        usage: { input_tokens: 43044, output_tokens: 2205, num_server_side_tools_used: 2 },
+    };
+
+    it("builds a /responses body with the native tool, domain filters, and flattened input", () => {
+        const built = buildResponsesWebSearchBody(
+            {
+                model: "martin/grok/grok-4.6",
+                stream: true,
+                system: [
+                    { type: "text", text: "You are Claude Code" },
+                    { type: "text", text: "search assistant" },
+                ],
+                messages: [{ role: "user", content: [{ type: "text", text: "Perform a web search for: grok" }] }],
+                tools: [{ type: "web_search_20250305", name: "web_search" }],
+            },
+            { name: "web_search", maxUses: 8, allowedDomains: ["x.ai"], blockedDomains: ["spam.example"] }
+        );
+
+        expect(built.stream).toBe(false);
+        expect(built.instructions).toContain("search assistant");
+        expect(built.input).toEqual([{ role: "user", content: "Perform a web search for: grok" }]);
+        const tools = built.tools as Record<string, unknown>[];
+        // The upstream cannot combine the lists — allowed wins.
+        expect(tools).toEqual([{ type: "web_search", allowed_domains: ["x.ai"] }]);
+    });
+
+    it("carries the caller's output cap and honours tool_choice none", () => {
+        const capped = buildResponsesWebSearchBody({ model: "m", messages: [], max_tokens: 512 }, TOOL);
+        expect(capped.max_output_tokens).toBe(512);
+        expect(capped.tools).toEqual([{ type: "web_search" }]);
+
+        // `none` forbids tool calls, so no billed search may run.
+        const forbidden = buildResponsesWebSearchBody(
+            { model: "m", messages: [], max_tokens: 512, tool_choice: { type: "none" } },
+            TOOL
+        );
+        expect(forbidden.tools).toEqual([]);
+        expect(forbidden.tool_choice).toBeUndefined();
+    });
+
+    it("forces the search when tool_choice makes it mandatory", () => {
+        // `any` and `tool` naming it both mean the model must call it; the
+        // upstream would otherwise default to auto and could skip it.
+        expect(buildResponsesWebSearchBody({ messages: [], tool_choice: { type: "any" } }, TOOL).tool_choice).toBe(
+            "required"
+        );
+        expect(
+            buildResponsesWebSearchBody({ messages: [], tool_choice: { type: "tool", name: "web_search" } }, TOOL)
+                .tool_choice
+        ).toBe("required");
+
+        // A different tool name is not this tool, and auto stays the default.
+        expect(
+            buildResponsesWebSearchBody({ messages: [], tool_choice: { type: "tool", name: "Read" } }, TOOL).tool_choice
+        ).toBeUndefined();
+        expect(
+            buildResponsesWebSearchBody({ messages: [], tool_choice: { type: "auto" } }, TOOL).tool_choice
+        ).toBeUndefined();
+    });
+
+    it("clamps domain filters to the upstream max of 5", () => {
+        const many = ["a.com", "b.com", "c.com", "d.com", "e.com", "f.com", "g.com"];
+        const allowed = buildResponsesWebSearchBody(
+            { model: "m", messages: [] },
+            { name: "web_search", maxUses: 8, allowedDomains: many }
+        );
+        expect((allowed.tools as Record<string, unknown>[])[0].allowed_domains).toEqual(many.slice(0, 5));
+
+        const excluded = buildResponsesWebSearchBody(
+            { model: "m", messages: [] },
+            { name: "web_search", maxUses: 8, blockedDomains: many }
+        );
+        expect((excluded.tools as Record<string, unknown>[])[0].excluded_domains).toEqual(many.slice(0, 5));
+    });
+
+    it("translates the completed response into an Anthropic message with citations and search count", async () => {
+        const outcome = await nativeWebSearch({
+            body: { model: "grok-4.6", messages: [{ role: "user", content: "q" }] },
+            tool: TOOL,
+            callResponses: async () => jsonResponse(RESPONSES_REPLY),
+        });
+
+        if (outcome instanceof Response) {
+            throw new Error("unreachable");
+        }
+
+        expect(outcome.searches).toBe(2);
+        const blocks = outcome.message.content as Record<string, unknown>[];
+        expect(blocks[0]).toMatchObject({ type: "thinking", thinking: "checking x.ai" });
+        expect(blocks[1].type).toBe("text");
+        expect(blocks[1].text).toContain("Grok 4.6 shipped.");
+        expect(blocks[1].text).toContain("Sources:\n- https://x.ai/news/grok-4-6");
+        // The count the upstream actually spent, in the field Anthropic
+        // reports it in — max_uses cannot bound it, so it must be visible.
+        expect(outcome.message.usage).toEqual({
+            input_tokens: 43044,
+            output_tokens: 2205,
+            server_tool_use: { web_search_requests: 2 },
+        });
+        expect(outcome.message.stop_reason).toBe("end_turn");
+    });
+
+    it("reports a reply cut short by the output cap as max_tokens, not end_turn", async () => {
+        // Live shape: the upstream honours max_output_tokens by answering
+        // status "incomplete". Calling that end_turn tells the client a
+        // truncated answer finished normally.
+        const cut = await nativeWebSearch({
+            body: { messages: [], max_tokens: 64 },
+            tool: TOOL,
+            callResponses: async () =>
+                jsonResponse({
+                    status: "incomplete",
+                    incomplete_details: { reason: "max_output_tokens" },
+                    output: [{ type: "message", content: [{ type: "output_text", text: "half an ans" }] }],
+                    usage: {},
+                }),
+        });
+
+        if (cut instanceof Response) {
+            throw new Error("unreachable");
+        }
+
+        expect(cut.message.stop_reason).toBe("max_tokens");
+
+        // An incomplete reply for any OTHER reason is not a cap hit.
+        const other = await nativeWebSearch({
+            body: { messages: [] },
+            tool: TOOL,
+            callResponses: async () =>
+                jsonResponse({
+                    status: "incomplete",
+                    incomplete_details: { reason: "content_filter" },
+                    output: [],
+                    usage: {},
+                }),
+        });
+
+        expect((other as EmulationOutcome).message.stop_reason).toBe("end_turn");
+    });
+
+    it("always carries an id and a model, which Anthropic SDKs read as required", async () => {
+        const outcome = await nativeWebSearch({
+            body: { messages: [] },
+            tool: TOOL,
+            // A reply with neither field: undefined would be dropped by
+            // SafeJSON and reach the client as a message missing both keys.
+            callResponses: async () => jsonResponse({ output: [], usage: {} }),
+        });
+
+        if (outcome instanceof Response) {
+            throw new Error("unreachable");
+        }
+
+        expect(outcome.message.id).toMatch(/^msg_/);
+        expect(outcome.message.model).toBe("");
+    });
+
+    it("hands a non-OK response back for the caller's fallback", async () => {
+        const outcome = await nativeWebSearch({
+            body: { messages: [] },
+            tool: TOOL,
+            callResponses: async () => new Response("nope", { status: 503 }),
+        });
+
+        expect(outcome).toBeInstanceOf(Response);
+        if (outcome instanceof Response) {
+            expect(outcome.status).toBe(503);
+        }
+    });
+});
+
+describe("messageToAnthropicSse", () => {
+    it("produces a spec-shaped stream that reassembles to the same message", () => {
+        const sse = messageToAnthropicSse({
+            id: "msg_1",
+            model: "grok-4.6",
+            content: [
+                { type: "thinking", thinking: "hm", signature: "" },
+                { type: "text", text: "Grok 4.6 shipped." },
+            ],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 50, output_tokens: 12 },
+        });
+
+        expect(sse).toContain("event: message_start");
+        expect(sse).toContain("event: message_stop");
+
+        const parsed = parseResponseBody(sse, true);
+        expect(parsed.text).toBe("Grok 4.6 shipped.");
+        expect(parsed.thinking).toBe("hm");
+        expect(parsed.finishReason).toBe("end_turn");
+        expect(parsed.usage).toMatchObject({ input_tokens: 50, output_tokens: 12 });
+    });
+});

--- a/src/ai-proxy/lib/server-tools/web-search.ts
+++ b/src/ai-proxy/lib/server-tools/web-search.ts
@@ -1,0 +1,707 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { isObject } from "@genesiscz/utils/object";
+
+/**
+ * Emulation of Anthropic's `web_search_20250305` server tool for upstreams
+ * that cannot run it (grok). Anthropic executes the search inside its API
+ * during sampling; here the proxy plays that part: the server tool is
+ * rewritten into a custom tool, the upstream's tool calls are answered with
+ * Brave results, and only the final turn is returned to the client.
+ */
+
+export interface WebSearchServerTool {
+    name: string;
+    maxUses: number;
+    allowedDomains?: string[];
+    blockedDomains?: string[];
+}
+
+export interface WebSearchResult {
+    title: string;
+    url: string;
+    snippet: string;
+}
+
+export type SearchFn = (query: string) => Promise<WebSearchResult[]>;
+
+/** Server-side cap: max_uses is client-controlled and each search is a paid call. */
+const MAX_USES_CEILING = 20;
+
+/** The server tool entry, when the body offers Anthropic's web_search. */
+export function parseWebSearchServerTool(body: Record<string, unknown>): WebSearchServerTool | undefined {
+    if (!Array.isArray(body.tools)) {
+        return undefined;
+    }
+
+    for (const tool of body.tools) {
+        if (isObject(tool) && typeof tool.type === "string" && tool.type.startsWith("web_search_")) {
+            const requested = tool.max_uses;
+            const maxUses =
+                typeof requested === "number" && Number.isInteger(requested) && requested > 0
+                    ? Math.min(requested, MAX_USES_CEILING)
+                    : 8;
+
+            return {
+                name: typeof tool.name === "string" ? tool.name : "web_search",
+                maxUses,
+                allowedDomains: stringArray(tool.allowed_domains),
+                blockedDomains: stringArray(tool.blocked_domains),
+            };
+        }
+    }
+
+    return undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+
+    const strings = value.filter((v): v is string => typeof v === "string");
+    return strings.length > 0 ? strings : undefined;
+}
+
+/** Suffix match per Anthropic's domain filters: `github.com` covers `gist.github.com`. */
+export function domainAllowed(url: string, filters: { allowed?: string[]; blocked?: string[] }): boolean {
+    let host: string;
+    try {
+        host = new URL(url).hostname.toLowerCase();
+    } catch {
+        return false;
+    }
+
+    const matches = (domain: string): boolean => {
+        const d = domain.toLowerCase();
+        return host === d || host.endsWith(`.${d}`);
+    };
+
+    if (filters.blocked?.some(matches)) {
+        return false;
+    }
+
+    return filters.allowed === undefined || filters.allowed.some(matches);
+}
+
+/** A Brave call that never answers would stall the loop behind SSE pings forever. */
+const BRAVE_TIMEOUT_MS = 15_000;
+
+export function braveSearchFn(apiKey: string, signal?: AbortSignal): SearchFn {
+    return async (query: string): Promise<WebSearchResult[]> => {
+        const params = new URLSearchParams({
+            q: query,
+            count: "8",
+            text_decorations: "false",
+            result_filter: "web",
+        });
+        const timeout = AbortSignal.timeout(BRAVE_TIMEOUT_MS);
+        const response = await fetch(`https://api.search.brave.com/res/v1/web/search?${params}`, {
+            headers: { "X-Subscription-Token": apiKey, Accept: "application/json" },
+            signal: signal === undefined ? timeout : AbortSignal.any([signal, timeout]),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Brave Search API error: ${response.status} ${await response.text().catch(() => "")}`);
+        }
+
+        const data = (await response.json()) as { web?: { results?: unknown[] } };
+        return (data.web?.results ?? []).flatMap((result) => {
+            if (!isObject(result) || typeof result.url !== "string") {
+                return [];
+            }
+
+            return [
+                {
+                    title: typeof result.title === "string" ? result.title : "",
+                    url: result.url,
+                    snippet: typeof result.description === "string" ? result.description : "",
+                },
+            ];
+        });
+    };
+}
+
+function formatResults(results: WebSearchResult[]): string {
+    if (results.length === 0) {
+        return "No search results found.";
+    }
+
+    return results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.snippet}`).join("\n\n");
+}
+
+/** The custom tool the upstream actually sees in place of the server tool. */
+function customSearchTool(tool: WebSearchServerTool): Record<string, unknown> {
+    return {
+        name: tool.name,
+        description:
+            "Search the web. Returns numbered results with title, URL and snippet. Use the results to answer; cite URLs.",
+        input_schema: {
+            type: "object",
+            properties: { query: { type: "string", description: "The search query" } },
+            required: ["query"],
+        },
+    };
+}
+
+interface AnthropicMessage {
+    content?: unknown[];
+    stop_reason?: string;
+    usage?: Record<string, unknown>;
+    model?: string;
+    [key: string]: unknown;
+}
+
+export interface EmulationOutcome {
+    message: AnthropicMessage;
+    searches: number;
+}
+
+/**
+ * Run the search loop against a non-streaming upstream. `callUpstream`
+ * receives a complete Anthropic body (stream:false) and returns the upstream
+ * Response; a non-OK response aborts the loop and is returned as-is for the
+ * caller's error envelope to handle.
+ */
+export async function emulateWebSearch(options: {
+    body: Record<string, unknown>;
+    tool: WebSearchServerTool;
+    search: SearchFn;
+    callUpstream: (body: Record<string, unknown>) => Promise<Response>;
+    /** Aborted when the client goes away — stops the loop between calls. */
+    signal?: AbortSignal;
+}): Promise<EmulationOutcome | Response> {
+    const { body, tool, search, callUpstream, signal } = options;
+    const messages = Array.isArray(body.messages) ? [...body.messages] : [];
+    const tools = (Array.isArray(body.tools) ? body.tools : []).map((t) =>
+        isObject(t) && typeof t.type === "string" && t.type.startsWith("web_search_") ? customSearchTool(tool) : t
+    );
+
+    let searches = 0;
+    let outputTokens = 0;
+    // One turn past max_uses so the model can conclude after the limit answer.
+    const maxTurns = tool.maxUses + 2;
+
+    for (let turn = 0; turn < maxTurns; turn++) {
+        if (signal?.aborted) {
+            throw new DOMException("web_search emulation aborted — client went away", "AbortError");
+        }
+
+        const upstreamBody = { ...body, stream: false, messages, tools };
+        const response = await callUpstream(upstreamBody);
+
+        if (!response.ok) {
+            return response;
+        }
+
+        const message = (await response.json()) as AnthropicMessage;
+        const content = Array.isArray(message.content) ? message.content : [];
+        outputTokens += usageNumber(message.usage, "output_tokens");
+
+        const calls = content.filter(
+            (block): block is Record<string, unknown> =>
+                isObject(block) && block.type === "tool_use" && block.name === tool.name
+        );
+
+        if (calls.length === 0 || message.stop_reason !== "tool_use") {
+            return {
+                message: { ...message, usage: { ...message.usage, output_tokens: outputTokens } },
+                searches,
+            };
+        }
+
+        const toolResults: Record<string, unknown>[] = [];
+        for (const call of calls) {
+            const query = isObject(call.input) && typeof call.input.query === "string" ? call.input.query : "";
+            let resultText: string;
+
+            if (searches >= tool.maxUses) {
+                resultText = `Web search limit reached (max_uses=${tool.maxUses}). Answer from the results you already have.`;
+            } else if (query.length === 0) {
+                resultText = "Invalid search call: input.query must be a non-empty string.";
+            } else {
+                searches += 1;
+                try {
+                    const results = (await search(query)).filter((r) =>
+                        domainAllowed(r.url, { allowed: tool.allowedDomains, blocked: tool.blockedDomains })
+                    );
+                    resultText = formatResults(results);
+                } catch (err) {
+                    // The query is model-generated request material — log its
+                    // size, never its content (it can carry prompts/secrets).
+                    logger.warn({ err, queryLength: query.length }, "ai-proxy: emulated web_search failed");
+                    resultText = `Search failed: ${err instanceof Error ? err.message : String(err)}`;
+                }
+            }
+
+            toolResults.push({ type: "tool_result", tool_use_id: call.id, content: resultText });
+        }
+
+        messages.push({ role: "assistant", content }, { role: "user", content: toolResults });
+    }
+
+    // The hard cap tripped: the model never stopped calling. Fail loudly.
+    return new Response(
+        SafeJSON.stringify({
+            type: "error",
+            error: {
+                type: "api_error",
+                message: `Emulated web_search did not converge within ${maxTurns} turns.`,
+            },
+        }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+    );
+}
+
+function usageNumber(usage: unknown, key: string): number {
+    return isObject(usage) && typeof usage[key] === "number" ? usage[key] : 0;
+}
+
+/**
+ * A complete Anthropic message as a spec-shaped SSE body. Used when the
+ * client asked to stream but the emulation loop produced a full message.
+ */
+export function messageToAnthropicSse(message: AnthropicMessage): string {
+    const frames: string[] = [];
+    const usage = isObject(message.usage) ? message.usage : {};
+    const emit = (type: string, data: Record<string, unknown>): void => {
+        frames.push(`event: ${type}\ndata: ${SafeJSON.stringify({ type, ...data })}`);
+    };
+
+    emit("message_start", {
+        message: {
+            id: message.id ?? `msg_${crypto.randomUUID()}`,
+            type: "message",
+            role: "assistant",
+            model: message.model ?? "",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { ...usage, output_tokens: 0 },
+        },
+    });
+
+    const content = Array.isArray(message.content) ? message.content : [];
+    content.forEach((block, index) => {
+        if (!isObject(block)) {
+            return;
+        }
+
+        if (block.type === "text" && typeof block.text === "string") {
+            emit("content_block_start", { index, content_block: { type: "text", text: "" } });
+            emit("content_block_delta", { index, delta: { type: "text_delta", text: block.text } });
+        } else if (block.type === "thinking" && typeof block.thinking === "string") {
+            emit("content_block_start", { index, content_block: { type: "thinking", thinking: "" } });
+            emit("content_block_delta", { index, delta: { type: "thinking_delta", thinking: block.thinking } });
+            emit("content_block_delta", {
+                index,
+                delta: {
+                    type: "signature_delta",
+                    signature: typeof block.signature === "string" ? block.signature : "",
+                },
+            });
+        } else if (block.type === "tool_use") {
+            emit("content_block_start", {
+                index,
+                content_block: { type: "tool_use", id: block.id, name: block.name, input: {} },
+            });
+            emit("content_block_delta", {
+                index,
+                delta: { type: "input_json_delta", partial_json: SafeJSON.stringify(block.input ?? {}) ?? "{}" },
+            });
+        } else {
+            emit("content_block_start", { index, content_block: block });
+        }
+
+        emit("content_block_stop", { index });
+    });
+
+    emit("message_delta", {
+        delta: { stop_reason: message.stop_reason ?? "end_turn", stop_sequence: null },
+        usage: { output_tokens: usageNumber(usage, "output_tokens") },
+    });
+    emit("message_stop", {});
+
+    return `${frames.join("\n\n")}\n\n`;
+}
+
+/**
+ * xAI's /responses endpoint runs web search SERVER-SIDE: `tools:
+ * [{type:"web_search"}]` made the upstream itself execute searches and
+ * open_page fetches (usage reported `num_server_side_tools_used: 7`), with
+ * url_citation annotations. Verified live 2026-08-20 against
+ * cli-chat-proxy.grok.com. This is the native path for Anthropic's
+ * web_search server tool; the Brave loop above is the fallback.
+ */
+const MAX_FILTER_DOMAINS = 5;
+
+/**
+ * Why the native path would lose part of the request, or undefined when it
+ * carries it faithfully. The /responses translation below sends text only and
+ * the web_search tool only, so a body offering client-executed tools or
+ * carrying tool_use / tool_result / image blocks must take the Brave loop,
+ * which keeps the original Anthropic body intact. Dropping them silently
+ * would answer a search using context the model never saw.
+ */
+export function nativeTranslationLoss(body: Record<string, unknown>, tool?: WebSearchServerTool): string | undefined {
+    // Domain filters the upstream cannot express. It takes ONE list of at most
+    // five domains, so a request pairing an allow-list with exclusions, or
+    // excluding more than five domains, would come back with sources it asked
+    // to avoid. Slicing an over-long ALLOW list only tightens the request, so
+    // that case stays on the native path.
+    if (tool?.allowedDomains !== undefined && tool.blockedDomains !== undefined) {
+        return "both allowed_domains and blocked_domains";
+    }
+
+    if ((tool?.blockedDomains?.length ?? 0) > MAX_FILTER_DOMAINS) {
+        return `${tool?.blockedDomains?.length} blocked_domains (the upstream takes ${MAX_FILTER_DOMAINS})`;
+    }
+
+    const custom = Array.isArray(body.tools)
+        ? body.tools.filter((tool) => isObject(tool) && (tool.type === undefined || tool.type === "custom")).length
+        : 0;
+
+    if (custom > 0) {
+        return `${custom} client tool${custom === 1 ? "" : "s"}`;
+    }
+
+    const kinds = new Set<string>();
+
+    for (const message of Array.isArray(body.messages) ? body.messages : []) {
+        if (!isObject(message) || !Array.isArray(message.content)) {
+            continue;
+        }
+
+        for (const block of message.content) {
+            if (isObject(block) && typeof block.type === "string" && typeof block.text !== "string") {
+                kinds.add(block.type);
+            }
+        }
+    }
+
+    return kinds.size > 0 ? `${[...kinds].sort().join(", ")} content blocks` : undefined;
+}
+
+export function buildResponsesWebSearchBody(
+    body: Record<string, unknown>,
+    tool: WebSearchServerTool
+): Record<string, unknown> {
+    const instructions = systemText(body.system);
+    const wsTool: Record<string, unknown> = { type: "web_search" };
+
+    // max_uses is deliberately NOT sent: the upstream decides how many
+    // searches to run and offers no cap. Probed live 2026-08-20 —
+    // `max_tool_calls: 1` was accepted (HTTP 200) and ignored, the reply still
+    // carried 9 web_search_call items against the uncapped control's 10. Only
+    // the Brave loop can honour max_uses; here it bounds nothing, so
+    // nativeWebSearch logs when the upstream exceeds what the client asked.
+
+    // Official spellings per docs.x.ai/developers/tools/web-search (verified
+    // live: filtered probes stayed on-domain, the control did not). The docs
+    // add two constraints: max 5 domains per list, and the lists cannot be
+    // combined. Allowed wins when both are present — clamping an allow-list
+    // only tightens it, while dropping exclusions would loosen a filter.
+    if (tool.allowedDomains !== undefined) {
+        if (tool.allowedDomains.length > MAX_FILTER_DOMAINS) {
+            logger.debug(
+                { count: tool.allowedDomains.length },
+                "ai-proxy: web_search allowed_domains clamped to the upstream max of 5"
+            );
+        }
+
+        wsTool.allowed_domains = tool.allowedDomains.slice(0, MAX_FILTER_DOMAINS);
+    } else if (tool.blockedDomains !== undefined) {
+        if (tool.blockedDomains.length > MAX_FILTER_DOMAINS) {
+            logger.warn(
+                { count: tool.blockedDomains.length },
+                "ai-proxy: web_search excluded_domains clamped to 5 — exclusions beyond that are NOT enforced upstream"
+            );
+        }
+
+        wsTool.excluded_domains = tool.blockedDomains.slice(0, MAX_FILTER_DOMAINS);
+    }
+
+    // tool_choice `none` forbids tool calls. Offering the server tool anyway
+    // would run a billed search the caller explicitly ruled out, so the turn
+    // goes up with no tools at all.
+    const forbidden = isObject(body.tool_choice) && body.tool_choice.type === "none";
+    const out: Record<string, unknown> = {
+        model: body.model,
+        input: messagesToResponsesInput(body.messages),
+        tools: forbidden ? [] : [wsTool],
+        stream: false,
+    };
+
+    if (forbidden) {
+        logger.debug({}, "ai-proxy: web_search offered with tool_choice none — answering without searching");
+    }
+
+    // `any` and `tool` naming this tool both mean "you must call it". The
+    // upstream defaults to auto, which may skip the only offered tool.
+    const mandatory =
+        isObject(body.tool_choice) &&
+        (body.tool_choice.type === "any" || (body.tool_choice.type === "tool" && body.tool_choice.name === tool.name));
+
+    if (mandatory) {
+        out.tool_choice = "required";
+    }
+
+    // The caller's output cap, in the name /responses uses. Forwarded because
+    // it is the caller's stated limit, but do NOT rely on it here: probed live
+    // 2026-08-20, three runs per arm, same prompt and max_output_tokens of 48.
+    // With NO tools every run came back "incomplete" (reason
+    // max_output_tokens); with the web_search tool every run came back
+    // "completed" at 5.4k-6.2k output tokens. The upstream drops the cap once
+    // a server tool is in play, exactly like max_tool_calls above.
+    if (typeof body.max_tokens === "number") {
+        out.max_output_tokens = body.max_tokens;
+    }
+
+    if (instructions.length > 0) {
+        out.instructions = instructions;
+    }
+
+    return out;
+}
+
+function systemText(system: unknown): string {
+    if (typeof system === "string") {
+        return system;
+    }
+
+    if (!Array.isArray(system)) {
+        return "";
+    }
+
+    return system
+        .flatMap((block) => (isObject(block) && typeof block.text === "string" ? [block.text] : []))
+        .join("\n");
+}
+
+function messagesToResponsesInput(messages: unknown): { role: string; content: string }[] {
+    if (!Array.isArray(messages)) {
+        return [];
+    }
+
+    return messages.flatMap((message) => {
+        if (!isObject(message) || typeof message.role !== "string") {
+            return [];
+        }
+
+        const content = message.content;
+
+        if (typeof content === "string") {
+            return [{ role: message.role, content }];
+        }
+
+        if (!Array.isArray(content)) {
+            return [];
+        }
+
+        const text = content
+            .flatMap((block) => (isObject(block) && typeof block.text === "string" ? [block.text] : []))
+            .join("\n");
+        return text.length > 0 ? [{ role: message.role, content: text }] : [];
+    });
+}
+
+function truncatedByCap(response: Record<string, unknown>): boolean {
+    if (response.status !== "incomplete") {
+        return false;
+    }
+
+    const details = response.incomplete_details;
+    return isObject(details) && details.reason === "max_output_tokens";
+}
+
+/** The completed /responses JSON as an Anthropic message, citations appended. */
+export function responsesToAnthropicMessage(response: Record<string, unknown>): EmulationOutcome {
+    let text = "";
+    let thinking = "";
+    let searches = 0;
+    const citations = new Set<string>();
+
+    for (const item of Array.isArray(response.output) ? response.output : []) {
+        if (!isObject(item)) {
+            continue;
+        }
+
+        if (item.type === "web_search_call") {
+            searches += 1;
+        } else if (item.type === "reasoning" && Array.isArray(item.summary)) {
+            for (const part of item.summary) {
+                if (isObject(part) && typeof part.text === "string") {
+                    thinking += part.text;
+                }
+            }
+        } else if (item.type === "message" && Array.isArray(item.content)) {
+            for (const part of item.content) {
+                if (!isObject(part) || typeof part.text !== "string") {
+                    continue;
+                }
+
+                text += part.text;
+
+                for (const ann of Array.isArray(part.annotations) ? part.annotations : []) {
+                    if (isObject(ann) && ann.type === "url_citation" && typeof ann.url === "string") {
+                        citations.add(ann.url);
+                    }
+                }
+            }
+        }
+    }
+
+    if (citations.size > 0) {
+        text += `\n\nSources:\n${[...citations].map((url) => `- ${url}`).join("\n")}`;
+    }
+
+    const usage = isObject(response.usage) ? response.usage : {};
+    const content: Record<string, unknown>[] = [];
+
+    if (thinking.length > 0) {
+        content.push({ type: "thinking", thinking, signature: "" });
+    }
+
+    content.push({ type: "text", text });
+
+    return {
+        message: {
+            // Anthropic SDKs read id and model as required; SafeJSON drops
+            // undefined keys, so the non-streaming path must not leave holes.
+            id: typeof response.id === "string" ? response.id : `msg_${crypto.randomUUID()}`,
+            type: "message",
+            role: "assistant",
+            model: typeof response.model === "string" ? response.model : "",
+            content,
+            // A reply cut short by the output cap must not read as a finished
+            // one. Verified live 2026-08-20: the upstream honours
+            // max_output_tokens by answering status "incomplete" with
+            // incomplete_details.reason "max_output_tokens".
+            stop_reason: truncatedByCap(response) ? "max_tokens" : "end_turn",
+            usage: {
+                input_tokens: usageNumber(usage, "input_tokens"),
+                output_tokens: usageNumber(usage, "output_tokens"),
+                // What the upstream actually spent. max_uses cannot bound it
+                // (see buildResponsesWebSearchBody), so the caller at least
+                // sees the count in the field Anthropic reports it in.
+                server_tool_use: { web_search_requests: searches },
+            },
+        },
+        searches,
+    };
+}
+
+/** Native path: one /responses call, the upstream does all the searching. */
+export async function nativeWebSearch(options: {
+    body: Record<string, unknown>;
+    tool: WebSearchServerTool;
+    callResponses: (body: Record<string, unknown>) => Promise<Response>;
+}): Promise<EmulationOutcome | Response> {
+    const response = await options.callResponses(buildResponsesWebSearchBody(options.body, options.tool));
+
+    if (!response.ok) {
+        return response;
+    }
+
+    const parsed = (await response.json()) as Record<string, unknown>;
+    const outcome = responsesToAnthropicMessage(parsed);
+
+    if (outcome.searches > options.tool.maxUses) {
+        logger.warn(
+            { searches: outcome.searches, maxUses: options.tool.maxUses },
+            "ai-proxy: native web_search ran more searches than max_uses — the upstream enforces no cap, each search is billed"
+        );
+    }
+
+    return outcome;
+}
+
+const PING_INTERVAL_MS = 10_000;
+
+/**
+ * Stream that answers the client immediately (Anthropic keeps quiet
+ * connections alive with pings) while the loop runs, then plays the final
+ * message. A slow multi-search loop otherwise looks like a dead connection.
+ * The signal handed to `run` aborts when the client cancels the stream, so
+ * the loop stops burning upstream and Brave calls nobody will receive.
+ */
+export function emulationStream(
+    run: (signal: AbortSignal) => Promise<EmulationOutcome | Response>
+): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    const abort = new AbortController();
+
+    return new ReadableStream<Uint8Array>({
+        async start(controller) {
+            const ping = setInterval(() => {
+                try {
+                    controller.enqueue(encoder.encode('event: ping\ndata: {"type":"ping"}\n\n'));
+                } catch (err) {
+                    logger.debug({ err }, "ai-proxy: web_search emulation ping enqueue failed (stream closed)");
+                    clearInterval(ping);
+                }
+            }, PING_INTERVAL_MS);
+
+            try {
+                const outcome = await run(abort.signal);
+
+                if (abort.signal.aborted) {
+                    return;
+                }
+
+                if (outcome instanceof Response) {
+                    const text = await outcome.text();
+                    controller.enqueue(
+                        encoder.encode(
+                            `event: error\ndata: ${SafeJSON.stringify(anthropicErrorPayload(text, outcome.status))}\n\n`
+                        )
+                    );
+                } else {
+                    controller.enqueue(encoder.encode(messageToAnthropicSse(outcome.message)));
+                }
+            } catch (err) {
+                if (abort.signal.aborted) {
+                    logger.debug({ err }, "ai-proxy: web_search emulation aborted by client cancel");
+                    return;
+                }
+
+                logger.warn({ err }, "ai-proxy: web_search emulation failed mid-stream");
+                controller.enqueue(
+                    encoder.encode(
+                        `event: error\ndata: ${SafeJSON.stringify({
+                            type: "error",
+                            error: { type: "api_error", message: err instanceof Error ? err.message : String(err) },
+                        })}\n\n`
+                    )
+                );
+            } finally {
+                clearInterval(ping);
+
+                if (!abort.signal.aborted) {
+                    controller.close();
+                }
+            }
+        },
+        cancel(reason) {
+            abort.abort(reason);
+        },
+    });
+}
+
+function anthropicErrorPayload(text: string, status: number): Record<string, unknown> {
+    try {
+        const parsed = SafeJSON.parse(text, { strict: true });
+
+        if (isObject(parsed) && parsed.type === "error") {
+            return parsed;
+        }
+
+        if (isObject(parsed) && isObject(parsed.error) && typeof parsed.error.message === "string") {
+            return { type: "error", error: { type: "api_error", message: parsed.error.message } };
+        }
+    } catch (err) {
+        logger.debug({ err }, "ai-proxy: web_search emulation upstream error body was not JSON");
+    }
+
+    return { type: "error", error: { type: "api_error", message: `Upstream ${status}: ${text.slice(0, 300)}` } };
+}

--- a/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-responses.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-responses.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "bun:test";
+import {
+    anthropicToGrokResponses,
+    packReasoningSignature,
+    REASONING_SIGNATURE_PREFIX,
+    stripReasoningInput,
+    unpackReasoningSignature,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/anthropic-to-responses";
+
+describe("packReasoningSignature / unpackReasoningSignature", () => {
+    it("round-trips id and encrypted content", () => {
+        const packed = packReasoningSignature("rs_abc-123", "R2E1Hmij6U3KWy+skp8Z==");
+
+        expect(packed.startsWith(REASONING_SIGNATURE_PREFIX)).toBe(true);
+        expect(unpackReasoningSignature(packed)).toEqual({
+            id: "rs_abc-123",
+            encryptedContent: "R2E1Hmij6U3KWy+skp8Z==",
+        });
+    });
+
+    it("rejects foreign and empty signatures", () => {
+        expect(unpackReasoningSignature("")).toBeUndefined();
+        expect(unpackReasoningSignature(undefined)).toBeUndefined();
+        // A real Anthropic signature is opaque base64 with no prefix.
+        expect(unpackReasoningSignature("EqQBCkgIBBAC")).toBeUndefined();
+        expect(unpackReasoningSignature(`${REASONING_SIGNATURE_PREFIX}no-separator`)).toBeUndefined();
+        expect(unpackReasoningSignature(`${REASONING_SIGNATURE_PREFIX}id:`)).toBeUndefined();
+    });
+});
+
+describe("anthropicToGrokResponses", () => {
+    it("always requests stateless encrypted reasoning", () => {
+        const out = anthropicToGrokResponses({ messages: [] }, "grok-4.6");
+
+        expect(out.model).toBe("grok-4.6");
+        expect(out.store).toBe(false);
+        expect(out.include).toEqual(["reasoning.encrypted_content"]);
+    });
+
+    it("joins system blocks into instructions", () => {
+        const out = anthropicToGrokResponses(
+            {
+                system: [
+                    { type: "text", text: "You are terse." },
+                    { type: "text", text: "Answer in Czech." },
+                ],
+            },
+            "grok-4.6"
+        );
+
+        expect(out.instructions).toBe("You are terse.\n\nAnswer in Czech.");
+    });
+
+    it("maps user content and hoists tool_result blocks to function_call_output items", () => {
+        const out = anthropicToGrokResponses(
+            {
+                messages: [
+                    { role: "user", content: "plain string" },
+                    {
+                        role: "user",
+                        content: [
+                            {
+                                type: "tool_result",
+                                tool_use_id: "call-1",
+                                content: [{ type: "text", text: "ok" }],
+                            },
+                            {
+                                type: "tool_result",
+                                tool_use_id: "call-2",
+                                is_error: true,
+                                content: "boom",
+                            },
+                            { type: "text", text: "continue please" },
+                        ],
+                    },
+                ],
+            },
+            "grok-4.6"
+        );
+
+        expect(out.input).toEqual([
+            { role: "user", content: [{ type: "input_text", text: "plain string" }] },
+            { type: "function_call_output", call_id: "call-1", output: "ok" },
+            { type: "function_call_output", call_id: "call-2", output: "[Tool call failed] boom" },
+            { role: "user", content: [{ type: "input_text", text: "continue please" }] },
+        ]);
+    });
+
+    it("replays a packed thinking block as a reasoning item, in block order", () => {
+        const out = anthropicToGrokResponses(
+            {
+                messages: [
+                    {
+                        role: "assistant",
+                        content: [
+                            {
+                                type: "thinking",
+                                thinking: "the summary text",
+                                signature: packReasoningSignature("rs_1", "ENCRYPTED=="),
+                            },
+                            { type: "text", text: "calling the tool now" },
+                            { type: "tool_use", id: "call-9", name: "run_command", input: { command: "date" } },
+                        ],
+                    },
+                ],
+            },
+            "grok-4.6"
+        );
+
+        expect(out.input).toEqual([
+            {
+                type: "reasoning",
+                id: "rs_1",
+                summary: [{ type: "summary_text", text: "the summary text" }],
+                encrypted_content: "ENCRYPTED==",
+            },
+            { role: "assistant", content: [{ type: "output_text", text: "calling the tool now" }] },
+            { type: "function_call", call_id: "call-9", name: "run_command", arguments: '{"command":"date"}' },
+        ]);
+    });
+
+    it("drops thinking blocks the shim produced (signature is empty) instead of failing the turn", () => {
+        const out = anthropicToGrokResponses(
+            {
+                messages: [
+                    {
+                        role: "assistant",
+                        content: [
+                            { type: "thinking", thinking: "shim-era reasoning", signature: "" },
+                            { type: "text", text: "answer" },
+                        ],
+                    },
+                ],
+            },
+            "grok-4.6"
+        );
+
+        expect(out.input).toEqual([{ role: "assistant", content: [{ type: "output_text", text: "answer" }] }]);
+    });
+
+    it("maps tools, tool_choice and parallel-call opt-out", () => {
+        const out = anthropicToGrokResponses(
+            {
+                tools: [
+                    {
+                        name: "Glob",
+                        description: "find files",
+                        input_schema: { type: "object", properties: { pattern: {} }, required: ["pattern"] },
+                    },
+                ],
+                tool_choice: { type: "tool", name: "Glob", disable_parallel_tool_use: true },
+            },
+            "grok-4.6"
+        );
+
+        expect(out.tools).toEqual([
+            {
+                type: "function",
+                name: "Glob",
+                description: "find files",
+                parameters: { type: "object", properties: { pattern: {} }, required: ["pattern"] },
+            },
+        ]);
+        expect(out.tool_choice).toEqual({ type: "function", name: "Glob" });
+        expect(out.parallel_tool_calls).toBe(false);
+
+        expect(anthropicToGrokResponses({ tool_choice: { type: "any" } }, "m").tool_choice).toBe("required");
+        expect(anthropicToGrokResponses({ tool_choice: { type: "auto" } }, "m").tool_choice).toBe("auto");
+    });
+
+    it("carries the sampling and effort fields and renames max_tokens", () => {
+        const out = anthropicToGrokResponses(
+            { max_tokens: 4096, stream: true, temperature: 0.2, top_p: 0.9, reasoning_effort: "xhigh" },
+            "grok-4.6"
+        );
+
+        expect(out.max_output_tokens).toBe(4096);
+        expect(out.max_tokens).toBeUndefined();
+        expect(out.stream).toBe(true);
+        expect(out.temperature).toBe(0.2);
+        expect(out.top_p).toBe(0.9);
+        expect(out.reasoning_effort).toBe("xhigh");
+    });
+});
+
+describe("stripReasoningInput", () => {
+    it("removes only reasoning items", () => {
+        const body = {
+            input: [
+                { role: "user", content: [{ type: "input_text", text: "hi" }] },
+                { type: "reasoning", id: "rs_1", summary: [], encrypted_content: "X" },
+                { type: "function_call", call_id: "c1", name: "t", arguments: "{}" },
+            ],
+        };
+
+        expect(stripReasoningInput(body).input).toEqual([
+            { role: "user", content: [{ type: "input_text", text: "hi" }] },
+            { type: "function_call", call_id: "c1", name: "t", arguments: "{}" },
+        ]);
+        // The original body is untouched — the retry needs both variants.
+        expect(body.input).toHaveLength(3);
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-responses.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/anthropic-to-responses.ts
@@ -1,0 +1,368 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { isObject } from "@genesiscz/utils/object";
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * Anthropic Messages request → xAI Responses request. Grok's native
+ * `/v1/messages` shim merges parallel tool calls into one block and keeps only
+ * the first name (raw wire capture 2026-08-21, nine request variants tried);
+ * its `/responses` wire names every call. This translator is how the Anthropic
+ * door reaches that reliable wire without losing reasoning continuity.
+ *
+ * Reasoning continuity: with `store: false` + `include:
+ * ["reasoning.encrypted_content"]` grok returns reasoning items whose
+ * `encrypted_content` it decrypts and consumes on replay (verified: a tampered
+ * blob is rejected with a decrypt error, so replay is real, not tolerated).
+ * The Anthropic wire has no slot for it, so it rides inside the thinking
+ * block's `signature`, which Anthropic clients replay verbatim and never
+ * inspect. Thinking blocks without a packed signature (another provider's
+ * history, the shim's `signature: ""`) are dropped, exactly as the OpenAI
+ * translation drops them.
+ */
+
+export const REASONING_SIGNATURE_PREFIX = "grokrs1:";
+
+export function packReasoningSignature(id: string, encryptedContent: string): string {
+    return `${REASONING_SIGNATURE_PREFIX}${id}:${encryptedContent}`;
+}
+
+export function unpackReasoningSignature(signature: unknown): { id: string; encryptedContent: string } | undefined {
+    if (typeof signature !== "string" || !signature.startsWith(REASONING_SIGNATURE_PREFIX)) {
+        return undefined;
+    }
+
+    const rest = signature.slice(REASONING_SIGNATURE_PREFIX.length);
+    const separator = rest.indexOf(":");
+
+    if (separator <= 0 || separator === rest.length - 1) {
+        return undefined;
+    }
+
+    return { id: rest.slice(0, separator), encryptedContent: rest.slice(separator + 1) };
+}
+
+function systemToInstructions(system: unknown): string | undefined {
+    if (typeof system === "string" && system.length > 0) {
+        return system;
+    }
+
+    if (!Array.isArray(system)) {
+        return undefined;
+    }
+
+    const parts: string[] = [];
+
+    for (const entry of system) {
+        if (typeof entry === "string") {
+            parts.push(entry);
+        } else if (isObject(entry) && typeof entry.text === "string") {
+            parts.push(entry.text);
+        }
+    }
+
+    return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+/** Same flattening the OpenAI translation applies to `tool_result.content`. */
+function flattenToolResult(result: JsonRecord): string {
+    const failedPrefix = result.is_error === true ? "[Tool call failed] " : "";
+    const content = result.content;
+
+    if (typeof content === "string") {
+        return `${failedPrefix}${content}`;
+    }
+
+    if (!Array.isArray(content)) {
+        return `${failedPrefix}${content === undefined ? "" : SafeJSON.stringify(content)}`;
+    }
+
+    const flattened = content
+        .map((part) => {
+            if (!isObject(part)) {
+                return "";
+            }
+
+            if (part.type === "text") {
+                return String(part.text ?? "");
+            }
+
+            if (part.type === "image" || (isObject(part.source) && part.source.type === "base64")) {
+                return "[Image Omitted]";
+            }
+
+            return SafeJSON.stringify(part);
+        })
+        .join("\n");
+
+    return `${failedPrefix}${flattened}`;
+}
+
+function userContentPart(part: JsonRecord): JsonRecord | null {
+    if (part.type === "text" && typeof part.text === "string") {
+        return { type: "input_text", text: part.text };
+    }
+
+    if (part.type === "image" && isObject(part.source)) {
+        const source = part.source;
+
+        if (source.type === "base64") {
+            return { type: "input_image", image_url: `data:${source.media_type};base64,${source.data}` };
+        }
+
+        if (source.type === "url" && typeof source.url === "string") {
+            return { type: "input_image", image_url: source.url };
+        }
+    }
+
+    if (part.type === "tool_use" || part.type === "thinking" || part.type === "redacted_thinking") {
+        return null;
+    }
+
+    return { type: "input_text", text: SafeJSON.stringify(part) };
+}
+
+function pushUserMessage(input: JsonRecord[], parts: JsonRecord[]): void {
+    if (parts.length > 0) {
+        input.push({ role: "user", content: parts.splice(0) });
+    }
+}
+
+function pushAssistantText(input: JsonRecord[], parts: string[]): void {
+    if (parts.length > 0) {
+        input.push({
+            role: "assistant",
+            content: [{ type: "output_text", text: parts.splice(0).join("\n") }],
+        });
+    }
+}
+
+function appendUserMessage(input: JsonRecord[], content: unknown): void {
+    if (typeof content === "string") {
+        if (content.length > 0) {
+            input.push({ role: "user", content: [{ type: "input_text", text: content }] });
+        }
+
+        return;
+    }
+
+    if (!Array.isArray(content)) {
+        return;
+    }
+
+    // Tool outputs become their own top-level items; everything else stays one
+    // user message. Claude Code orders results before commentary, so emitting
+    // the outputs first preserves the conversation order.
+    const parts: JsonRecord[] = [];
+
+    for (const part of content) {
+        if (!isObject(part)) {
+            continue;
+        }
+
+        if (part.type === "tool_result") {
+            input.push({
+                type: "function_call_output",
+                call_id: part.tool_use_id,
+                output: flattenToolResult(part),
+            });
+            continue;
+        }
+
+        const mapped = userContentPart(part);
+
+        if (mapped !== null) {
+            parts.push(mapped);
+        }
+    }
+
+    pushUserMessage(input, parts);
+}
+
+function appendAssistantMessage(input: JsonRecord[], content: unknown, dropped: { thinking: number }): void {
+    if (typeof content === "string") {
+        if (content.length > 0) {
+            input.push({ role: "assistant", content: [{ type: "output_text", text: content }] });
+        }
+
+        return;
+    }
+
+    if (!Array.isArray(content)) {
+        return;
+    }
+
+    const textParts: string[] = [];
+
+    for (const part of content) {
+        if (!isObject(part)) {
+            continue;
+        }
+
+        if (part.type === "thinking") {
+            const packed = unpackReasoningSignature(part.signature);
+
+            if (packed === undefined) {
+                dropped.thinking += 1;
+                continue;
+            }
+
+            pushAssistantText(input, textParts);
+            input.push({
+                type: "reasoning",
+                id: packed.id,
+                summary: [{ type: "summary_text", text: String(part.thinking ?? "") }],
+                encrypted_content: packed.encryptedContent,
+            });
+            continue;
+        }
+
+        if (part.type === "tool_use") {
+            pushAssistantText(input, textParts);
+            input.push({
+                type: "function_call",
+                call_id: part.id,
+                name: part.name,
+                arguments: typeof part.input === "string" ? part.input : SafeJSON.stringify(part.input ?? {}),
+            });
+            continue;
+        }
+
+        if (part.type === "text" && typeof part.text === "string") {
+            textParts.push(part.text);
+        }
+    }
+
+    pushAssistantText(input, textParts);
+}
+
+function responsesTools(tools: unknown): JsonRecord[] | undefined {
+    if (!Array.isArray(tools)) {
+        return undefined;
+    }
+
+    const mapped: JsonRecord[] = [];
+
+    for (const tool of tools) {
+        if (!isObject(tool) || typeof tool.name !== "string") {
+            continue;
+        }
+
+        mapped.push({
+            type: "function",
+            name: tool.name,
+            description: tool.description ?? "",
+            parameters: tool.input_schema ?? { type: "object", properties: {}, required: [] },
+        });
+    }
+
+    return mapped.length > 0 ? mapped : undefined;
+}
+
+function responsesToolChoice(choice: unknown): unknown {
+    if (!isObject(choice)) {
+        return undefined;
+    }
+
+    if (choice.type === "auto") {
+        return "auto";
+    }
+
+    if (choice.type === "none") {
+        return "none";
+    }
+
+    if (choice.type === "any") {
+        return "required";
+    }
+
+    if (choice.type === "tool" && typeof choice.name === "string") {
+        return { type: "function", name: choice.name };
+    }
+
+    return undefined;
+}
+
+/**
+ * The decrypt-failure retry: a signature packed by a different conversation
+ * (or truncated by a client) fails upstream decryption for the WHOLE request,
+ * so the retry replays the same body minus every reasoning item.
+ */
+export function stripReasoningInput(body: JsonRecord): JsonRecord {
+    if (!Array.isArray(body.input)) {
+        return body;
+    }
+
+    return {
+        ...body,
+        input: body.input.filter((item) => !(isObject(item) && item.type === "reasoning")),
+    };
+}
+
+export function anthropicToGrokResponses(body: JsonRecord, model: string): JsonRecord {
+    const input: JsonRecord[] = [];
+    const dropped = { thinking: 0 };
+
+    if (Array.isArray(body.messages)) {
+        for (const message of body.messages) {
+            if (!isObject(message)) {
+                continue;
+            }
+
+            if (message.role === "assistant") {
+                appendAssistantMessage(input, message.content, dropped);
+            } else {
+                appendUserMessage(input, message.content);
+            }
+        }
+    }
+
+    if (dropped.thinking > 0) {
+        logger.debug(
+            { dropped: dropped.thinking, model },
+            "ai-proxy: dropped thinking blocks without a grok reasoning signature"
+        );
+    }
+
+    const out: JsonRecord = {
+        model,
+        input,
+        store: false,
+        include: ["reasoning.encrypted_content"],
+    };
+
+    const instructions = systemToInstructions(body.system);
+
+    if (instructions !== undefined) {
+        out.instructions = instructions;
+    }
+
+    const tools = responsesTools(body.tools);
+
+    if (tools !== undefined) {
+        out.tools = tools;
+    }
+
+    const toolChoice = responsesToolChoice(body.tool_choice);
+
+    if (toolChoice !== undefined) {
+        out.tool_choice = toolChoice;
+    }
+
+    if (isObject(body.tool_choice) && body.tool_choice.disable_parallel_tool_use === true) {
+        out.parallel_tool_calls = false;
+    }
+
+    if (typeof body.max_tokens === "number") {
+        out.max_output_tokens = body.max_tokens;
+    }
+
+    for (const field of ["stream", "temperature", "top_p", "reasoning_effort"] as const) {
+        if (body[field] !== undefined) {
+            out[field] = body[field];
+        }
+    }
+
+    return out;
+}

--- a/src/ai-proxy/lib/translators/formats/anthropic/grok-responses-to-anthropic.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/grok-responses-to-anthropic.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from "bun:test";
+import {
+    packReasoningSignature,
+    unpackReasoningSignature,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/anthropic-to-responses";
+import {
+    grokResponsesSseToAnthropic,
+    grokResponsesToAnthropicMessage,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/grok-responses-to-anthropic";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+interface Frame {
+    event: string;
+    data: Record<string, unknown>;
+}
+
+function sse(events: Array<Record<string, unknown>>): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    const text = events.map((event) => `event: ${event.type}\ndata: ${SafeJSON.stringify(event)}\n\n`).join("");
+
+    return new ReadableStream({
+        start(controller) {
+            controller.enqueue(encoder.encode(text));
+            controller.close();
+        },
+    });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<{ raw: string; frames: Frame[] }> {
+    const raw = await new Response(stream).text();
+    const frames: Frame[] = [];
+
+    for (const chunk of raw.split("\n\n")) {
+        const eventLine = chunk.split("\n").find((line) => line.startsWith("event: "));
+        const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
+
+        if (eventLine && dataLine) {
+            frames.push({
+                event: eventLine.slice(7),
+                data: SafeJSON.parse(dataLine.slice(6), { strict: true }) as Record<string, unknown>,
+            });
+        }
+    }
+
+    return { raw, frames };
+}
+
+function frameSummary(frames: Frame[]): string[] {
+    return frames.map((frame) => {
+        if (frame.event === "content_block_start") {
+            const block = frame.data.content_block as Record<string, unknown>;
+            return `start[${frame.data.index}]:${block.type}${block.name ? `:${block.name}` : ""}`;
+        }
+
+        if (frame.event === "content_block_delta") {
+            const delta = frame.data.delta as Record<string, unknown>;
+            return `delta[${frame.data.index}]:${delta.type}`;
+        }
+
+        if (frame.event === "content_block_stop") {
+            return `stop[${frame.data.index}]`;
+        }
+
+        return frame.event;
+    });
+}
+
+// The wire shape captured live 2026-08-21: one reasoning item (summary deltas,
+// encrypted_content on the done frame), then each function_call as its own
+// output item with its name on the added frame.
+const REASONING_DONE = {
+    type: "reasoning",
+    id: "rs_1",
+    summary: [{ type: "summary_text", text: "I should call both tools." }],
+    status: "completed",
+    encrypted_content: "ENC==",
+};
+
+const CALL_A_DONE = {
+    type: "function_call",
+    call_id: "call-a-0",
+    name: "list_agents",
+    arguments: "{}",
+    status: "completed",
+};
+
+const CALL_B_DONE = {
+    type: "function_call",
+    call_id: "call-a-1",
+    name: "run_command",
+    arguments: '{"command":"date"}',
+    status: "completed",
+};
+
+const COMPLETED = {
+    type: "response.completed",
+    response: {
+        id: "resp_1",
+        status: "completed",
+        output: [REASONING_DONE, CALL_A_DONE, CALL_B_DONE],
+        usage: {
+            input_tokens: 1000,
+            input_tokens_details: { cached_tokens: 384 },
+            output_tokens: 50,
+            total_tokens: 1050,
+        },
+    },
+};
+
+describe("grokResponsesSseToAnthropic", () => {
+    it("gives every output item its own named content block", async () => {
+        const { frames } = await collect(
+            grokResponsesSseToAnthropic(
+                sse([
+                    { type: "response.created", response: { id: "resp_1" } },
+                    { type: "response.output_item.added", output_index: 0, item: { type: "reasoning", id: "rs_1" } },
+                    { type: "response.reasoning_summary_part.added", output_index: 0 },
+                    { type: "response.reasoning_summary_text.delta", output_index: 0, delta: "I should call " },
+                    { type: "response.reasoning_summary_text.delta", output_index: 0, delta: "both tools." },
+                    { type: "response.output_item.done", output_index: 0, item: REASONING_DONE },
+                    {
+                        type: "response.output_item.added",
+                        output_index: 1,
+                        item: { type: "function_call", call_id: "call-a-0", name: "list_agents", arguments: "" },
+                    },
+                    { type: "response.function_call_arguments.delta", output_index: 1, delta: "{}" },
+                    { type: "response.output_item.done", output_index: 1, item: CALL_A_DONE },
+                    {
+                        type: "response.output_item.added",
+                        output_index: 2,
+                        item: { type: "function_call", call_id: "call-a-1", name: "run_command", arguments: "" },
+                    },
+                    { type: "response.function_call_arguments.delta", output_index: 2, delta: '{"command":' },
+                    { type: "response.function_call_arguments.delta", output_index: 2, delta: '"date"}' },
+                    { type: "response.output_item.done", output_index: 2, item: CALL_B_DONE },
+                    COMPLETED,
+                ]),
+                { model: "grok-4.6" }
+            )
+        );
+
+        expect(frameSummary(frames)).toEqual([
+            "message_start",
+            "start[0]:thinking",
+            "delta[0]:thinking_delta",
+            "delta[0]:thinking_delta",
+            "delta[0]:signature_delta",
+            "stop[0]",
+            "start[1]:tool_use:list_agents",
+            "delta[1]:input_json_delta",
+            "stop[1]",
+            "start[2]:tool_use:run_command",
+            "delta[2]:input_json_delta",
+            "delta[2]:input_json_delta",
+            "stop[2]",
+            "message_delta",
+            "message_stop",
+        ]);
+
+        const starts = frames.filter((frame) => frame.event === "content_block_start");
+        expect((starts[1].data.content_block as Record<string, unknown>).id).toBe("call-a-0");
+        expect((starts[2].data.content_block as Record<string, unknown>).id).toBe("call-a-1");
+
+        // The signature round-trips the encrypted reasoning verbatim.
+        const signatureDelta = frames.find(
+            (frame) =>
+                frame.event === "content_block_delta" &&
+                (frame.data.delta as Record<string, unknown>).type === "signature_delta"
+        );
+        const signature = (signatureDelta?.data.delta as Record<string, unknown>).signature;
+        expect(unpackReasoningSignature(signature)).toEqual({ id: "rs_1", encryptedContent: "ENC==" });
+
+        const messageDelta = frames.find((frame) => frame.event === "message_delta");
+        expect((messageDelta?.data.delta as Record<string, unknown>).stop_reason).toBe("tool_use");
+        expect(messageDelta?.data.usage).toEqual({
+            input_tokens: 616,
+            output_tokens: 50,
+            cache_read_input_tokens: 384,
+        });
+    });
+
+    it("synthesizes an item that only appears in the terminal snapshot", async () => {
+        const { frames } = await collect(
+            grokResponsesSseToAnthropic(
+                sse([
+                    { type: "response.created", response: { id: "resp_1" } },
+                    { type: "response.output_item.added", output_index: 0, item: { type: "reasoning", id: "rs_1" } },
+                    { type: "response.reasoning_summary_text.delta", output_index: 0, delta: "thinking…" },
+                    { type: "response.output_item.done", output_index: 0, item: REASONING_DONE },
+                    // call-a-0 streamed; call-a-1 arrives ONLY in the snapshot.
+                    {
+                        type: "response.output_item.added",
+                        output_index: 1,
+                        item: { type: "function_call", call_id: "call-a-0", name: "list_agents", arguments: "" },
+                    },
+                    { type: "response.function_call_arguments.delta", output_index: 1, delta: "{}" },
+                    { type: "response.output_item.done", output_index: 1, item: CALL_A_DONE },
+                    COMPLETED,
+                ]),
+                { model: "grok-4.6" }
+            )
+        );
+
+        const summary = frameSummary(frames);
+        expect(summary).toContain("start[2]:tool_use:run_command");
+        expect(summary.filter((entry) => entry === "delta[2]:input_json_delta")).toHaveLength(1);
+
+        const salvaged = frames.find(
+            (frame) =>
+                frame.event === "content_block_delta" &&
+                frame.data.index === 2 &&
+                (frame.data.delta as Record<string, unknown>).type === "input_json_delta"
+        );
+        expect((salvaged?.data.delta as Record<string, unknown>).partial_json).toBe('{"command":"date"}');
+    });
+
+    it("closes the message when the stream ends without a terminal frame", async () => {
+        const { frames } = await collect(
+            grokResponsesSseToAnthropic(
+                sse([
+                    { type: "response.created", response: { id: "resp_1" } },
+                    {
+                        type: "response.output_item.added",
+                        output_index: 0,
+                        item: { type: "function_call", call_id: "call-a-0", name: "list_agents", arguments: "" },
+                    },
+                    { type: "response.function_call_arguments.delta", output_index: 0, delta: "{}" },
+                    // no output_item.done, no response.completed — the 1-in-38 case
+                ]),
+                { model: "grok-4.6" }
+            )
+        );
+
+        expect(frameSummary(frames)).toEqual([
+            "message_start",
+            "start[0]:tool_use:list_agents",
+            "delta[0]:input_json_delta",
+            "stop[0]",
+            "message_delta",
+            "message_stop",
+        ]);
+
+        const messageDelta = frames.find((frame) => frame.event === "message_delta");
+        expect((messageDelta?.data.delta as Record<string, unknown>).stop_reason).toBe("tool_use");
+    });
+
+    it("forwards keepalive comments and turns response.failed into an Anthropic error frame", async () => {
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(encoder.encode(": keepalive\n"));
+                controller.enqueue(
+                    encoder.encode(
+                        `data: ${SafeJSON.stringify({
+                            type: "response.failed",
+                            response: { error: { message: "upstream exploded" } },
+                        })}\n\n`
+                    )
+                );
+                controller.close();
+            },
+        });
+
+        const { raw, frames } = await collect(grokResponsesSseToAnthropic(stream, { model: "grok-4.6" }));
+
+        expect(raw).toContain(": keepalive");
+        const error = frames.find((frame) => frame.event === "error");
+        expect((error?.data.error as Record<string, unknown>).message).toBe("upstream exploded");
+        // A failed response never fabricates a message_stop.
+        expect(frames.some((frame) => frame.event === "message_stop")).toBe(false);
+    });
+
+    it("streams text deltas into a text block", async () => {
+        const { frames } = await collect(
+            grokResponsesSseToAnthropic(
+                sse([
+                    { type: "response.created", response: { id: "resp_1" } },
+                    {
+                        type: "response.output_item.added",
+                        output_index: 0,
+                        item: { type: "message", role: "assistant" },
+                    },
+                    { type: "response.output_text.delta", output_index: 0, delta: "Hello " },
+                    { type: "response.output_text.delta", output_index: 0, delta: "world" },
+                    {
+                        type: "response.output_item.done",
+                        output_index: 0,
+                        item: { type: "message", content: [{ type: "output_text", text: "Hello world" }] },
+                    },
+                    {
+                        type: "response.completed",
+                        response: {
+                            id: "resp_1",
+                            status: "completed",
+                            output: [{ type: "message", content: [{ type: "output_text", text: "Hello world" }] }],
+                            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+                        },
+                    },
+                ]),
+                { model: "grok-4.6" }
+            )
+        );
+
+        expect(frameSummary(frames)).toEqual([
+            "message_start",
+            "start[0]:text",
+            "delta[0]:text_delta",
+            "delta[0]:text_delta",
+            "stop[0]",
+            "message_delta",
+            "message_stop",
+        ]);
+
+        const messageDelta = frames.find((frame) => frame.event === "message_delta");
+        expect((messageDelta?.data.delta as Record<string, unknown>).stop_reason).toBe("end_turn");
+    });
+});
+
+describe("grokResponsesToAnthropicMessage", () => {
+    it("maps the whole envelope, packing the reasoning signature", () => {
+        const message = grokResponsesToAnthropicMessage(
+            {
+                id: "resp_9",
+                status: "completed",
+                output: [
+                    REASONING_DONE,
+                    { type: "message", content: [{ type: "output_text", text: "running it" }] },
+                    CALL_B_DONE,
+                ],
+                usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120 },
+            },
+            { model: "grok-4.6" }
+        );
+
+        expect(message.content).toEqual([
+            {
+                type: "thinking",
+                thinking: "I should call both tools.",
+                signature: packReasoningSignature("rs_1", "ENC=="),
+            },
+            { type: "text", text: "running it" },
+            { type: "tool_use", id: "call-a-1", name: "run_command", input: { command: "date" } },
+        ]);
+        expect(message.stop_reason).toBe("tool_use");
+        expect(message.usage).toEqual({ input_tokens: 100, output_tokens: 20 });
+    });
+
+    it("reports max_tokens when the response is incomplete for that reason", () => {
+        const message = grokResponsesToAnthropicMessage(
+            {
+                id: "resp_9",
+                status: "incomplete",
+                incomplete_details: { reason: "max_output_tokens" },
+                output: [{ type: "message", content: [{ type: "output_text", text: "truncat" }] }],
+            },
+            { model: "grok-4.6" }
+        );
+
+        expect(message.stop_reason).toBe("max_tokens");
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/grok-responses-to-anthropic.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/grok-responses-to-anthropic.ts
@@ -1,0 +1,528 @@
+import { safeStreamControllerError } from "@app/ai-proxy/lib/safe-stream-controller";
+import { packReasoningSignature } from "@app/ai-proxy/lib/translators/formats/anthropic/anthropic-to-responses";
+import {
+    type AnthropicStopReason,
+    type AnthropicUsage,
+    anthropicSseFrame,
+    parsedToolInput,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { isObject } from "@genesiscz/utils/object";
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * xAI Responses output → Anthropic Messages, streaming and not. The mirror of
+ * anthropic-to-responses.ts. One Responses output item becomes one Anthropic
+ * content block, keyed by `output_index` — the merge defect the shim has is
+ * structurally impossible here.
+ *
+ * Terminal-frame reconciliation: grok occasionally streams an item only in the
+ * final `response.completed` snapshot (fleet-harness measured 1 dropped
+ * terminal frame in 38 calls against the same upstream, in the OTHER
+ * direction — items streamed but the terminal frame missing). Both gaps are
+ * covered: items never streamed are synthesized from the snapshot, and a
+ * stream that ends without a terminal frame still closes with what it saw.
+ */
+
+function usageFromResponses(raw: unknown): AnthropicUsage | null {
+    if (!isObject(raw)) {
+        return null;
+    }
+
+    const inputTokens = typeof raw.input_tokens === "number" ? raw.input_tokens : 0;
+    const outputTokens = typeof raw.output_tokens === "number" ? raw.output_tokens : 0;
+
+    // Same folds as the chat-completions mapping: reasoning is added only when
+    // the totals prove it was excluded, cache reads move OUTSIDE input_tokens.
+    const outputDetails = isObject(raw.output_tokens_details) ? raw.output_tokens_details : undefined;
+    const reasoningTokens =
+        outputDetails && typeof outputDetails.reasoning_tokens === "number" ? outputDetails.reasoning_tokens : 0;
+    const totalTokens = typeof raw.total_tokens === "number" ? raw.total_tokens : undefined;
+    const reasoningExcluded = reasoningTokens > 0 && totalTokens != null && inputTokens + outputTokens < totalTokens;
+
+    const usage: AnthropicUsage = {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens + (reasoningExcluded ? reasoningTokens : 0),
+    };
+
+    const inputDetails = isObject(raw.input_tokens_details) ? raw.input_tokens_details : undefined;
+
+    if (inputDetails && typeof inputDetails.cached_tokens === "number" && inputDetails.cached_tokens > 0) {
+        usage.cache_read_input_tokens = inputDetails.cached_tokens;
+        usage.input_tokens = Math.max(0, inputTokens - inputDetails.cached_tokens);
+    }
+
+    return usage;
+}
+
+function reasoningSummaryText(item: JsonRecord): string {
+    if (!Array.isArray(item.summary)) {
+        return "";
+    }
+
+    return item.summary
+        .map((part) => (isObject(part) && typeof part.text === "string" ? part.text : ""))
+        .filter((text) => text.length > 0)
+        .join("\n\n");
+}
+
+function reasoningSignature(item: JsonRecord): string {
+    if (typeof item.encrypted_content !== "string" || item.encrypted_content.length === 0) {
+        return "";
+    }
+
+    const id = typeof item.id === "string" ? item.id : `rs_${crypto.randomUUID()}`;
+    return packReasoningSignature(id, item.encrypted_content);
+}
+
+function messageText(item: JsonRecord): string {
+    if (!Array.isArray(item.content)) {
+        return "";
+    }
+
+    return item.content.map((part) => (isObject(part) && typeof part.text === "string" ? part.text : "")).join("");
+}
+
+function stopReasonFor(response: JsonRecord, sawFunctionCall: boolean): AnthropicStopReason {
+    const incomplete = isObject(response.incomplete_details) ? response.incomplete_details : undefined;
+
+    if (response.status === "incomplete" && incomplete?.reason === "max_output_tokens") {
+        return "max_tokens";
+    }
+
+    const output = Array.isArray(response.output) ? response.output : [];
+    const hasCall = sawFunctionCall || output.some((item) => isObject(item) && item.type === "function_call");
+
+    return hasCall ? "tool_use" : "end_turn";
+}
+
+/** Non-streaming: a Responses envelope → an Anthropic message object. */
+export function grokResponsesToAnthropicMessage(response: JsonRecord, options: { model: string }): JsonRecord {
+    const output = Array.isArray(response.output) ? response.output : [];
+    const content: JsonRecord[] = [];
+
+    for (const item of output) {
+        if (!isObject(item)) {
+            continue;
+        }
+
+        if (item.type === "reasoning") {
+            content.push({
+                type: "thinking",
+                thinking: reasoningSummaryText(item),
+                signature: reasoningSignature(item),
+            });
+            continue;
+        }
+
+        if (item.type === "message") {
+            content.push({ type: "text", text: messageText(item) });
+            continue;
+        }
+
+        if (item.type === "function_call") {
+            content.push({
+                type: "tool_use",
+                id: typeof item.call_id === "string" ? item.call_id : `toolu_${crypto.randomUUID()}`,
+                name: typeof item.name === "string" ? item.name : "unknown",
+                input: parsedToolInput(item.arguments),
+            });
+        }
+    }
+
+    if (content.length === 0) {
+        content.push({ type: "text", text: "" });
+    }
+
+    return {
+        id: `msg_${typeof response.id === "string" ? response.id.replace(/^resp_/, "") : crypto.randomUUID()}`,
+        type: "message",
+        role: "assistant",
+        model: options.model,
+        content,
+        stop_reason: stopReasonFor(response, false),
+        stop_sequence: null,
+        usage: usageFromResponses(response.usage) ?? { input_tokens: 0, output_tokens: 0 },
+    };
+}
+
+type BlockKind = "thinking" | "text" | "tool_use";
+
+interface ItemState {
+    /** Anthropic content-block index this output item was assigned. */
+    blockIndex: number;
+    kind: BlockKind;
+    /** Characters already streamed for this block (dedupes the done-frame salvage). */
+    streamedChars: number;
+    summaryParts: number;
+    closed: boolean;
+}
+
+interface StreamState {
+    model: string;
+    messageId: string;
+    started: boolean;
+    nextBlockIndex: number;
+    /** Responses output_index → block state. Ignored item types are absent. */
+    items: Map<number, ItemState>;
+    sawFunctionCall: boolean;
+    usage: AnthropicUsage | null;
+    outputChars: number;
+    finished: boolean;
+}
+
+function frameStart(state: StreamState): string {
+    if (state.started) {
+        return "";
+    }
+
+    state.started = true;
+
+    return anthropicSseFrame("message_start", {
+        message: {
+            id: state.messageId,
+            type: "message",
+            role: "assistant",
+            model: state.model,
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 0, output_tokens: 0 },
+        },
+    });
+}
+
+function contentBlockFor(item: JsonRecord): { kind: BlockKind; block: JsonRecord } | null {
+    if (item.type === "reasoning") {
+        return { kind: "thinking", block: { type: "thinking", thinking: "" } };
+    }
+
+    if (item.type === "message") {
+        return { kind: "text", block: { type: "text", text: "" } };
+    }
+
+    if (item.type === "function_call") {
+        return {
+            kind: "tool_use",
+            block: {
+                type: "tool_use",
+                id: typeof item.call_id === "string" ? item.call_id : `toolu_${crypto.randomUUID()}`,
+                name: typeof item.name === "string" ? item.name : "unknown",
+                input: {},
+            },
+        };
+    }
+
+    return null;
+}
+
+function openItem(state: StreamState, outputIndex: number, item: JsonRecord): string {
+    const mapped = contentBlockFor(item);
+
+    if (mapped === null) {
+        return "";
+    }
+
+    const blockIndex = state.nextBlockIndex++;
+    state.items.set(outputIndex, {
+        blockIndex,
+        kind: mapped.kind,
+        streamedChars: 0,
+        summaryParts: 0,
+        closed: false,
+    });
+
+    if (mapped.kind === "tool_use") {
+        state.sawFunctionCall = true;
+    }
+
+    return (
+        frameStart(state) + anthropicSseFrame("content_block_start", { index: blockIndex, content_block: mapped.block })
+    );
+}
+
+function deltaFrame(state: StreamState, outputIndex: number, delta: JsonRecord, chars: number): string {
+    const item = state.items.get(outputIndex);
+
+    if (item === undefined || item.closed) {
+        return "";
+    }
+
+    item.streamedChars += chars;
+    state.outputChars += chars;
+
+    return anthropicSseFrame("content_block_delta", { index: item.blockIndex, delta });
+}
+
+function closeItem(state: StreamState, outputIndex: number, doneItem: JsonRecord | undefined): string {
+    const item = state.items.get(outputIndex);
+
+    if (item === undefined || item.closed) {
+        return "";
+    }
+
+    let out = "";
+
+    if (doneItem !== undefined) {
+        // The done frame carries the complete item; anything the stream never
+        // delivered as deltas is salvaged here.
+        if (item.kind === "thinking") {
+            const summary = reasoningSummaryText(doneItem);
+
+            if (item.streamedChars === 0 && summary.length > 0) {
+                out += deltaFrame(state, outputIndex, { type: "thinking_delta", thinking: summary }, summary.length);
+            }
+
+            const signature = reasoningSignature(doneItem);
+
+            if (signature.length > 0) {
+                out += anthropicSseFrame("content_block_delta", {
+                    index: item.blockIndex,
+                    delta: { type: "signature_delta", signature },
+                });
+            }
+        }
+
+        if (item.kind === "text") {
+            const text = messageText(doneItem);
+
+            if (item.streamedChars === 0 && text.length > 0) {
+                out += deltaFrame(state, outputIndex, { type: "text_delta", text }, text.length);
+            }
+        }
+
+        if (item.kind === "tool_use" && typeof doneItem.arguments === "string" && doneItem.arguments.length > 0) {
+            if (item.streamedChars === 0) {
+                out += deltaFrame(
+                    state,
+                    outputIndex,
+                    { type: "input_json_delta", partial_json: doneItem.arguments },
+                    doneItem.arguments.length
+                );
+            }
+        }
+    }
+
+    item.closed = true;
+    out += anthropicSseFrame("content_block_stop", { index: item.blockIndex });
+
+    return out;
+}
+
+function finishFrames(state: StreamState, response: JsonRecord | undefined): string {
+    if (state.finished) {
+        return "";
+    }
+
+    state.finished = true;
+
+    let out = frameStart(state);
+
+    // Items the stream never opened (terminal-snapshot-only) are synthesized
+    // whole; open items are closed with their snapshot for salvage.
+    const output = response !== undefined && Array.isArray(response.output) ? response.output : [];
+
+    for (const [i, raw] of output.entries()) {
+        if (!isObject(raw)) {
+            continue;
+        }
+
+        if (!state.items.has(i)) {
+            out += openItem(state, i, raw);
+        }
+
+        out += closeItem(state, i, raw);
+    }
+
+    for (const [outputIndex, item] of state.items) {
+        if (!item.closed) {
+            out += closeItem(state, outputIndex, undefined);
+        }
+    }
+
+    if (response !== undefined) {
+        state.usage = usageFromResponses(response.usage) ?? state.usage;
+    }
+
+    const stopReason =
+        response !== undefined
+            ? stopReasonFor(response, state.sawFunctionCall)
+            : state.sawFunctionCall
+              ? "tool_use"
+              : "end_turn";
+
+    out += anthropicSseFrame("message_delta", {
+        delta: { stop_reason: stopReason, stop_sequence: null },
+        usage: state.usage ?? { input_tokens: 0, output_tokens: Math.ceil(state.outputChars / 4) },
+    });
+    out += anthropicSseFrame("message_stop", {});
+
+    return out;
+}
+
+function handleEvent(state: StreamState, event: JsonRecord): string {
+    const type = event.type;
+    const outputIndex = typeof event.output_index === "number" ? event.output_index : 0;
+
+    if (type === "response.output_item.added" && isObject(event.item)) {
+        return openItem(state, outputIndex, event.item);
+    }
+
+    if (type === "response.reasoning_summary_part.added") {
+        const item = state.items.get(outputIndex);
+
+        if (item !== undefined && item.summaryParts > 0) {
+            item.summaryParts += 1;
+            return deltaFrame(state, outputIndex, { type: "thinking_delta", thinking: "\n\n" }, 2);
+        }
+
+        if (item !== undefined) {
+            item.summaryParts += 1;
+        }
+
+        return "";
+    }
+
+    if (type === "response.reasoning_summary_text.delta" && typeof event.delta === "string") {
+        return deltaFrame(state, outputIndex, { type: "thinking_delta", thinking: event.delta }, event.delta.length);
+    }
+
+    if (type === "response.output_text.delta" && typeof event.delta === "string") {
+        return deltaFrame(state, outputIndex, { type: "text_delta", text: event.delta }, event.delta.length);
+    }
+
+    if (type === "response.function_call_arguments.delta" && typeof event.delta === "string") {
+        return deltaFrame(
+            state,
+            outputIndex,
+            { type: "input_json_delta", partial_json: event.delta },
+            event.delta.length
+        );
+    }
+
+    if (type === "response.output_item.done") {
+        return closeItem(state, outputIndex, isObject(event.item) ? event.item : undefined);
+    }
+
+    if (type === "response.completed" || type === "response.incomplete") {
+        return finishFrames(state, isObject(event.response) ? event.response : undefined);
+    }
+
+    if (type === "response.failed" || type === "error") {
+        const err = isObject(event.response) && isObject(event.response.error) ? event.response.error : event.error;
+        const message = isObject(err) && typeof err.message === "string" ? err.message : "upstream response failed";
+        state.finished = true;
+
+        return anthropicSseFrame("error", { error: { type: "api_error", message } });
+    }
+
+    return "";
+}
+
+/** Streaming: a Responses SSE body → an Anthropic SSE body. */
+export function grokResponsesSseToAnthropic(
+    upstream: ReadableStream<Uint8Array>,
+    options: { model: string }
+): ReadableStream<Uint8Array> {
+    const state: StreamState = {
+        model: options.model,
+        messageId: `msg_${crypto.randomUUID()}`,
+        started: false,
+        nextBlockIndex: 0,
+        items: new Map(),
+        sawFunctionCall: false,
+        usage: null,
+        outputChars: 0,
+        finished: false,
+    };
+
+    const reader = upstream.getReader();
+    const decoder = new TextDecoder();
+    const encoder = new TextEncoder();
+    let buffer = "";
+
+    return new ReadableStream<Uint8Array>({
+        async start(controller) {
+            let streamSucceeded = false;
+
+            const emit = (chunk: string): void => {
+                if (chunk.length > 0) {
+                    controller.enqueue(encoder.encode(chunk));
+                }
+            };
+
+            try {
+                while (true) {
+                    const { done, value } = await reader.read();
+
+                    if (done) {
+                        break;
+                    }
+
+                    buffer += decoder.decode(value, { stream: true });
+                    const lines = buffer.split("\n");
+                    buffer = lines.pop() ?? "";
+
+                    for (const line of lines) {
+                        // Grok stalls up to ~15s before the first byte and holds
+                        // the connection with SSE comments; forward them so the
+                        // client's idle timeout sees a live stream.
+                        if (line.startsWith(":")) {
+                            emit(`${line}\n\n`);
+                            continue;
+                        }
+
+                        if (!line.startsWith("data:")) {
+                            continue;
+                        }
+
+                        const payload = line.slice(5).trim();
+
+                        if (!payload || payload === "[DONE]") {
+                            continue;
+                        }
+
+                        try {
+                            const event = SafeJSON.parse(payload, { strict: true });
+
+                            if (isObject(event)) {
+                                emit(handleEvent(state, event));
+                            }
+                        } catch (err) {
+                            logger.debug(
+                                { err, payloadPreview: payload.slice(0, 120) },
+                                "ai-proxy: skipped grok /responses SSE event"
+                            );
+                        }
+                    }
+                }
+
+                // The 1-in-38 case: the stream ended without a terminal frame.
+                // Close with what was seen instead of leaving the message open.
+                emit(finishFrames(state, undefined));
+                streamSucceeded = true;
+            } catch (err) {
+                logger.warn({ err, model: options.model }, "ai-proxy: grok /responses SSE translation failed");
+
+                if (!safeStreamControllerError(controller, err, streamSucceeded)) {
+                    logger.debug({ err }, "ai-proxy: skipped controller.error (client abort or detached)");
+                }
+            } finally {
+                if (streamSucceeded) {
+                    try {
+                        controller.close();
+                    } catch (controllerErr) {
+                        logger.debug({ err: controllerErr }, "ai-proxy: controller.close() threw — client detached");
+                    }
+                }
+            }
+        },
+        cancel(reason) {
+            reader.cancel(reason).catch((err) => {
+                logger.debug({ err }, "ai-proxy: upstream reader cancel failed");
+            });
+        },
+    });
+}

--- a/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/openai-to-anthropic-responses.ts
@@ -79,7 +79,7 @@ function usageFrom(raw: unknown): AnthropicUsage {
     return usage;
 }
 
-function parsedToolInput(rawArguments: unknown): unknown {
+export function parsedToolInput(rawArguments: unknown): unknown {
     if (typeof rawArguments !== "string" || rawArguments.trim().length === 0) {
         return {};
     }
@@ -146,9 +146,11 @@ export function openAiCompletionToAnthropicMessage(
     };
 }
 
-function frame(type: string, data: Record<string, unknown>): string {
+export function anthropicSseFrame(type: string, data: Record<string, unknown>): string {
     return `event: ${type}\ndata: ${SafeJSON.stringify({ type, ...data })}\n\n`;
 }
+
+const frame = anthropicSseFrame;
 
 type BlockKind = "thinking" | "text" | "tool_use";
 

--- a/src/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { repairAnthropicSseIndices } from "@app/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices";
+import { TOOL_ROUTING_TAG } from "@app/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag";
 import { SafeJSON } from "@genesiscz/utils/json";
 
 function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
@@ -253,5 +254,234 @@ describe("repairAnthropicSseIndices", () => {
 
         expect(out).toContain('"type":"content_block_start"');
         expect(out).toContain('"index":0');
+    });
+
+    it("swaps arguments back when grok puts another call's args under the declared name", async () => {
+        // Observed live 2026-08-20: a merged block declaring `Edit` carried
+        // {query, count} first, so Edit was rejected for a missing file_path it
+        // was never given and the search call never ran at all.
+        const tools = [
+            {
+                name: "Edit",
+                required: ["file_path", "old_string"],
+                properties: ["file_path", "old_string", "new_string"],
+            },
+            { name: "brave_web_search", required: ["query"], properties: ["query", "count"] },
+        ];
+        const input = [
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"t1","name":"Edit","input":{}}}\n\n',
+            'data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"query\\":\\"grok bugs\\",\\"count\\":3}"}}\n\n',
+            'data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"file_path\\":\\"/tmp/a\\",\\"old_string\\":\\"x\\"}"}}\n\n',
+            'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+        ];
+
+        const out = await collect(repairAnthropicSseIndices(sseStream(input), { tools }));
+        const frames = out
+            .split("\n")
+            .filter((line) => line.startsWith("data: "))
+            .map((line) => SafeJSON.parse(line.slice("data: ".length), { strict: true }) as Record<string, unknown>);
+
+        const calls = new Map<number, { name?: string; args: string }>();
+        for (const frame of frames) {
+            const index = frame.index as number;
+            if (frame.type === "content_block_start") {
+                calls.set(index, { name: (frame.content_block as Record<string, unknown>).name as string, args: "" });
+            } else if (frame.type === "content_block_delta") {
+                const delta = frame.delta as Record<string, unknown>;
+                if (delta.type === "input_json_delta") {
+                    const call = calls.get(index);
+                    if (call) {
+                        call.args += delta.partial_json as string;
+                    }
+                }
+            }
+        }
+
+        // Edit keeps its name and now receives the Edit arguments; the search
+        // arguments go out under the tool they uniquely match.
+        expect(calls.get(0)?.name).toBe("Edit");
+        expect(SafeJSON.parse(calls.get(0)?.args ?? "", { strict: true })).toEqual({
+            file_path: "/tmp/a",
+            old_string: "x",
+        });
+        expect(calls.get(1)?.name).toBe("brave_web_search");
+        expect(SafeJSON.parse(calls.get(1)?.args ?? "", { strict: true })).toEqual({ query: "grok bugs", count: 3 });
+    });
+
+    describe("no-argument calls in a merged block", () => {
+        const tools = [
+            { name: "run_command", required: ["command"], properties: ["command"] },
+            { name: "list_agents", required: [TOOL_ROUTING_TAG], properties: [TOOL_ROUTING_TAG] },
+            { name: "list_tasks", required: [TOOL_ROUTING_TAG], properties: [TOOL_ROUTING_TAG] },
+            { name: "read_file", required: ["path"], properties: ["path"] },
+        ];
+
+        /** Verbatim shape captured from grok's wire on 2026-08-21: ONE start frame, N complete objects. */
+        function mergedStream(argObjects: string[], blockName = "run_command"): ReadableStream<Uint8Array> {
+            return sseStream([
+                `event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call-abc-0","name":"${blockName}","input":{}}}\n\n`,
+                ...argObjects.map(
+                    (args) =>
+                        `data: ${SafeJSON.stringify({
+                            type: "content_block_delta",
+                            delta: { type: "input_json_delta", partial_json: args },
+                        })}\n\n`
+                ),
+                'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+            ]);
+        }
+
+        async function toolCalls(
+            stream: ReadableStream<Uint8Array>,
+            taggedTools?: Set<string>
+        ): Promise<{ name: string; args: string }[]> {
+            const out = await collect(repairAnthropicSseIndices(stream, { tools, taggedTools }));
+            const calls = new Map<number, { name: string; args: string }>();
+
+            for (const line of out.split("\n")) {
+                if (!line.startsWith("data: ")) {
+                    continue;
+                }
+
+                const frame = SafeJSON.parse(line.slice("data: ".length), { strict: true }) as Record<string, unknown>;
+                const index = frame.index as number;
+                const block = frame.content_block as Record<string, unknown> | undefined;
+
+                if (frame.type === "content_block_start" && block?.type === "tool_use") {
+                    calls.set(index, { name: String(block.name), args: "" });
+                }
+
+                const delta = frame.delta as Record<string, unknown> | undefined;
+
+                if (frame.type === "content_block_delta" && delta?.type === "input_json_delta") {
+                    const call = calls.get(index);
+
+                    if (call) {
+                        call.args += String(delta.partial_json);
+                    }
+                }
+            }
+
+            return [...calls.values()];
+        }
+
+        const tagged = [
+            '{"command":"date"}',
+            `{"${TOOL_ROUTING_TAG}":"list_agents"}`,
+            `{"${TOOL_ROUTING_TAG}":"list_tasks"}`,
+            '{"path":"/etc/hosts"}',
+        ];
+
+        it("names every merged no-arg call from its routing tag and strips the tag", async () => {
+            const calls = await toolCalls(mergedStream(tagged), new Set(["list_agents", "list_tasks"]));
+
+            expect(calls.map((c) => c.name)).toEqual(["run_command", "list_agents", "list_tasks", "read_file"]);
+            // The tag is the proxy's own addition; the client asked for an
+            // empty-object schema and must get exactly that.
+            expect(calls.map((c) => c.args)).toEqual(['{"command":"date"}', "{}", "{}", '{"path":"/etc/hosts"}']);
+        });
+
+        it("negative control: the same stream is unresolvable without the tag", async () => {
+            // Two no-arg tools produce byte-identical `{}` objects, so key
+            // matching has nothing to separate them and both inherit the
+            // block's name. This is the defect the tag exists to remove.
+            const untagged = ['{"command":"date"}', "{}", "{}", '{"path":"/etc/hosts"}'];
+            const calls = await toolCalls(mergedStream(untagged));
+
+            expect(calls.map((c) => c.name)).toEqual(["run_command", "run_command", "run_command", "read_file"]);
+        });
+
+        it("swaps by the tag's VALUE when two tagged objects arrive in the wrong order", async () => {
+            // Both objects carry the tag KEY, so key fitting sees them as
+            // interchangeable — a block declared list_agents whose first object
+            // is tagged list_tasks would silently emit list_tasks's arguments
+            // under list_agents and duplicate list_agents from the orphan.
+            // Only the tag's value can order them.
+            const calls = await toolCalls(
+                mergedStream(
+                    [`{"${TOOL_ROUTING_TAG}":"list_tasks"}`, `{"${TOOL_ROUTING_TAG}":"list_agents"}`],
+                    "list_agents"
+                ),
+                new Set(["list_agents", "list_tasks"])
+            );
+
+            expect(calls.map((c) => c.name)).toEqual(["list_agents", "list_tasks"]);
+            expect(calls.map((c) => c.args)).toEqual(["{}", "{}"]);
+        });
+
+        it("routes a merged Glob/Grep-shaped orphan by its tag, not by its overlapping keys", async () => {
+            // {"pattern":…} fits both glob_search and grep_search, so before
+            // confusability tagging this orphan inherited the block's name.
+            const overlapTools = [
+                {
+                    name: "glob_search",
+                    required: ["pattern", TOOL_ROUTING_TAG],
+                    properties: ["pattern", "path", TOOL_ROUTING_TAG],
+                },
+                {
+                    name: "grep_search",
+                    required: ["pattern", TOOL_ROUTING_TAG],
+                    properties: ["pattern", "path", "output_mode", TOOL_ROUTING_TAG],
+                },
+            ];
+            const stream = mergedStream(
+                [
+                    `{"pattern":"*.ts","${TOOL_ROUTING_TAG}":"glob_search"}`,
+                    `{"pattern":"TODO","${TOOL_ROUTING_TAG}":"grep_search"}`,
+                ],
+                "glob_search"
+            );
+            const out = await collect(
+                repairAnthropicSseIndices(stream, {
+                    tools: overlapTools,
+                    taggedTools: new Set(["glob_search", "grep_search"]),
+                })
+            );
+            const calls = new Map<number, { name: string; args: string }>();
+
+            for (const line of out.split("\n")) {
+                if (!line.startsWith("data: ")) {
+                    continue;
+                }
+
+                const frame = SafeJSON.parse(line.slice("data: ".length), { strict: true }) as Record<string, unknown>;
+                const block = frame.content_block as Record<string, unknown> | undefined;
+
+                if (frame.type === "content_block_start" && block?.type === "tool_use") {
+                    calls.set(frame.index as number, { name: String(block.name), args: "" });
+                }
+
+                const delta = frame.delta as Record<string, unknown> | undefined;
+
+                if (frame.type === "content_block_delta" && delta?.type === "input_json_delta") {
+                    const call = calls.get(frame.index as number);
+
+                    if (call) {
+                        call.args += String(delta.partial_json);
+                    }
+                }
+            }
+
+            const list = [...calls.values()];
+            expect(list.map((c) => c.name)).toEqual(["glob_search", "grep_search"]);
+            expect(list.map((c) => c.args)).toEqual(['{"pattern":"*.ts"}', '{"pattern":"TODO"}']);
+        });
+
+        it("never deletes a same-named property from a request it did not tag", async () => {
+            // A client is free to declare its own `__tool_route` parameter.
+            // With nothing tagged, the proxy injected nothing, so it must not
+            // remove anything either.
+            const calls = await toolCalls(mergedStream([`{"${TOOL_ROUTING_TAG}":"list_agents"}`]));
+
+            expect(calls[0].args).toBe(`{"${TOOL_ROUTING_TAG}":"list_agents"}`);
+        });
+
+        it("ignores a tag naming a tool this request never tagged", async () => {
+            // An empty tagged set means the proxy injected nothing, so a
+            // property that merely looks like the tag must not route a call.
+            const calls = await toolCalls(mergedStream(tagged), new Set());
+
+            expect(calls.map((c) => c.name)).toEqual(["run_command", "run_command", "run_command", "read_file"]);
+        });
     });
 });

--- a/src/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/repair-sse-indices.ts
@@ -1,3 +1,4 @@
+import { routedToolName, stripRoutingTag } from "@app/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 
@@ -45,13 +46,88 @@ export function toolMatchersFromBody(body: JsonRecord): ToolMatcher[] {
  * match is trusted; anything else falls back to the original block's name and
  * fails loudly client-side rather than running the wrong tool.
  */
+function toolFits(tool: ToolMatcher, argKeys: string[]): boolean {
+    return tool.required.every((key) => argKeys.includes(key)) && argKeys.every((key) => tool.properties.includes(key));
+}
+
 function matchToolName(argKeys: string[], tools: ToolMatcher[], fallback: string): string {
-    const matches = tools.filter(
-        (tool) =>
-            tool.required.every((key) => argKeys.includes(key)) && argKeys.every((key) => tool.properties.includes(key))
-    );
+    const matches = tools.filter((tool) => toolFits(tool, argKeys));
 
     return matches.length === 1 ? matches[0].name : fallback;
+}
+
+function parseRecord(text: string): JsonRecord | undefined {
+    try {
+        const parsed = SafeJSON.parse(text, { strict: true });
+        return isJsonRecord(parsed) ? parsed : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Which held object belongs to the name the wire already sent.
+ *
+ * Grok does not only lose the second call's NAME, it also puts the wrong
+ * arguments first: a merged block declaring `Edit` arrived carrying
+ * `{query, count}`, so Edit was rejected for a missing `file_path` while the
+ * search call it belonged to never ran. When the first object does not fit the
+ * declared tool but one orphan does, they are swapped and BOTH calls come out
+ * right. When nothing fits, the order is left alone so the call still fails
+ * loudly rather than being quietly reassigned to a guess.
+ */
+function assignFirstCallArgs(
+    block: ToolBlockState,
+    held: string[],
+    tools: ToolMatcher[],
+    taggedTools: Set<string>
+): { firstArgs: string; leftovers: string[] } {
+    const declared = tools.find((tool) => tool.name === block.toolName);
+    const first = parseRecord(block.firstText);
+
+    if (first === undefined) {
+        return { firstArgs: block.firstText, leftovers: held };
+    }
+
+    // A routing tag is authoritative: two tagged tools share the same KEY, so
+    // key fitting cannot tell their objects apart — only the tag's value can.
+    const firstRouted = routedToolName(first, taggedTools);
+    const firstBelongs =
+        firstRouted !== undefined
+            ? firstRouted === block.toolName
+            : declared === undefined || toolFits(declared, Object.keys(first));
+
+    if (firstBelongs) {
+        return { firstArgs: block.firstText, leftovers: held };
+    }
+
+    const swapIndex = held.findIndex((candidate) => {
+        const parsed = parseRecord(candidate);
+
+        if (parsed === undefined) {
+            return false;
+        }
+
+        const routed = routedToolName(parsed, taggedTools);
+
+        if (routed !== undefined) {
+            return routed === block.toolName;
+        }
+
+        return declared !== undefined && toolFits(declared, Object.keys(parsed));
+    });
+
+    if (swapIndex === -1) {
+        return { firstArgs: block.firstText, leftovers: held };
+    }
+
+    logger.warn(
+        { tool: block.toolName, position: swapIndex + 1 },
+        "ai-proxy: grok put another call's arguments first in a merged block — swapped them back so both calls are valid"
+    );
+    const leftovers = [...held];
+    leftovers[swapIndex] = block.firstText;
+    return { firstArgs: held[swapIndex], leftovers };
 }
 
 /**
@@ -113,6 +189,14 @@ interface ToolBlockState {
     orphanScanner: JsonScanner;
     /** Set when trailing bytes were not a second object — stop interpreting. */
     disabled: boolean;
+    /**
+     * The FIRST object's bytes, held until the block stops. Grok also mismatches
+     * which arguments ride under which name: a merged block declaring `Edit`
+     * arrived carrying `{query, count}`, so Edit was rejected for a missing
+     * file_path it was never given. Holding lets the stop handler hand each
+     * parsed object to the tool whose schema it actually fits.
+     */
+    firstText: string;
 }
 
 /**
@@ -140,12 +224,22 @@ interface ToolBlockState {
  */
 export function repairAnthropicSseIndices(
     upstream: ReadableStream<Uint8Array>,
-    options?: { tools?: ToolMatcher[] }
+    options?: { tools?: ToolMatcher[]; taggedTools?: Set<string> }
 ): ReadableStream<Uint8Array> {
     const reader = upstream.getReader();
     const decoder = new TextDecoder();
     const encoder = new TextEncoder();
     const tools = options?.tools ?? [];
+    const taggedTools = options?.taggedTools ?? new Set<string>();
+
+    /**
+     * Strip the routing tag, but ONLY when this request actually injected it.
+     * A client is free to declare a real parameter of the same name, and
+     * deleting it would corrupt a call this proxy never touched.
+     */
+    function untag(argsText: string): string {
+        return taggedTools.size > 0 ? stripRoutingTag(argsText) : argsText;
+    }
     let buffer = "";
     let nextIndex = 0;
     let currentIndex = 0;
@@ -185,7 +279,9 @@ export function repairAnthropicSseIndices(
             }
 
             if (!block.scanner.complete) {
-                pending += char;
+                // Held, not streamed: which tool these arguments belong to is
+                // not known until the block stops and the orphans are in.
+                block.firstText += char;
                 scanChar(block.scanner, char);
                 continue;
             }
@@ -198,11 +294,15 @@ export function repairAnthropicSseIndices(
 
                 if (char !== "{") {
                     // Not a second call: give up on splitting and hand ALL held
-                    // bytes back verbatim — including orphans already buffered —
-                    // so the ONE call fails loudly instead of pairing a guessed
-                    // split with a corrupted first call.
+                    // bytes back — the held first object and any buffered
+                    // orphans — so the ONE call fails loudly instead of pairing
+                    // a guessed split with a corrupted first call. Each held
+                    // object is still complete JSON, so the routing tag comes
+                    // off here too: giving up on the split is no reason to show
+                    // the client a property this proxy invented.
                     block.disabled = true;
-                    pending += [...block.orphans, char].join("");
+                    pending += [...[block.firstText, ...block.orphans].map(untag), char].join("");
+                    block.firstText = "";
                     block.orphans = [];
                     continue;
                 }
@@ -229,28 +329,74 @@ export function repairAnthropicSseIndices(
 
     /** The real stop closes the original block, then the orphans become blocks. */
     function emitStopAndOrphans(block: ToolBlockState): string {
-        const frames = [frameText("content_block_stop", { index: block.index })];
-        const leftovers = block.orphanText !== null ? [...block.orphans, block.orphanText] : block.orphans;
+        const held = block.orphanText !== null ? [...block.orphans, block.orphanText] : block.orphans;
+        const { firstArgs, leftovers } = assignFirstCallArgs(block, held, tools, taggedTools);
+        const frames: string[] = [];
+
+        // The held first object goes out now, under the name the wire already
+        // sent — possibly swapped with an orphan that actually fits that name.
+        // The routing tag is this proxy's own addition and is stripped here, so
+        // the client only ever sees the schema it asked for.
+        if (firstArgs.length > 0) {
+            frames.push(
+                frameText("content_block_delta", {
+                    index: block.index,
+                    delta: { type: "input_json_delta", partial_json: untag(firstArgs) },
+                })
+            );
+        }
+
+        frames.push(frameText("content_block_stop", { index: block.index }));
 
         for (const orphan of leftovers) {
             currentIndex = nextIndex;
             nextIndex += 1;
 
             let name = block.toolName;
+            let routed = false;
             try {
                 const parsed = SafeJSON.parse(orphan, { strict: true });
 
                 if (isJsonRecord(parsed)) {
-                    name = matchToolName(Object.keys(parsed), tools, block.toolName);
+                    // The routing tag names its own tool, so it settles the
+                    // no-argument case that key matching cannot. Key matching
+                    // still runs for every untagged call.
+                    const tagged = routedToolName(parsed, taggedTools);
+                    routed = tagged !== undefined;
+                    name = tagged ?? matchToolName(Object.keys(parsed), tools, block.toolName);
                 }
             } catch (err) {
                 logger.debug({ err }, "ai-proxy: merged-call orphan did not parse; keeping the original tool name");
             }
 
-            logger.warn(
-                { from: block.toolName, to: name, index: currentIndex },
-                "ai-proxy: grok merged an extra tool call into one block — emitted as its own tool_use"
-            );
+            // An orphan with NO arguments is a no-arg call whose name the wire
+            // destroyed. If the fallback tool requires arguments, the name we
+            // are about to emit is certainly wrong and the client will reject
+            // it — say so here, or the InputValidationError reads as a bug in
+            // the tool being blamed.
+            const noArgs = orphan.trim() === "{}";
+            const fallbackNeedsArgs = tools.some((t) => t.name === name && t.required.length > 0);
+
+            if (routed) {
+                logger.debug(
+                    { from: block.toolName, to: name, index: currentIndex },
+                    "ai-proxy: merged tool call named by its routing tag"
+                );
+            } else if (noArgs && fallbackNeedsArgs) {
+                logger.warn(
+                    {
+                        blamed: name,
+                        candidates: tools.filter((t) => t.required.length === 0).map((t) => t.name),
+                        index: currentIndex,
+                    },
+                    "ai-proxy: grok destroyed the name of a no-arg tool call; no unique match, so it goes out under a tool that requires arguments and the client will reject it"
+                );
+            } else {
+                logger.warn(
+                    { from: block.toolName, to: name, index: currentIndex },
+                    "ai-proxy: grok merged an extra tool call into one block — emitted as its own tool_use"
+                );
+            }
 
             frames.push(
                 frameText("content_block_start", {
@@ -264,7 +410,7 @@ export function repairAnthropicSseIndices(
                 }),
                 frameText("content_block_delta", {
                     index: currentIndex,
-                    delta: { type: "input_json_delta", partial_json: orphan },
+                    delta: { type: "input_json_delta", partial_json: untag(orphan) },
                 }),
                 frameText("content_block_stop", { index: currentIndex })
             );
@@ -312,6 +458,7 @@ export function repairAnthropicSseIndices(
                               orphanText: null,
                               orphanScanner: createJsonScanner(),
                               disabled: false,
+                              firstText: "",
                           }
                         : null;
 
@@ -330,11 +477,11 @@ export function repairAnthropicSseIndices(
                     const block = toolBlock;
                     toolBlock = null;
 
-                    if (block.orphans.length > 0 || block.orphanText !== null) {
-                        // The original data line is replaced wholesale; the stop's
-                        // own event: line already passed through above it.
-                        return emitStopAndOrphans(block).replace(/^event: content_block_stop\n/, "");
-                    }
+                    // Always go through the stop handler: the first call's
+                    // arguments are held until here even when nothing merged.
+                    // The original data line is replaced wholesale; the stop's
+                    // own event: line already passed through above it.
+                    return emitStopAndOrphans(block).replace(/^event: content_block_stop\n/, "");
                 }
             }
 
@@ -380,7 +527,7 @@ export function repairAnthropicSseIndices(
                     // client any merged calls sitting in the buffer — dropping them
                     // here would destroy bytes the client received before this
                     // transformer existed.
-                    if (toolBlock && (toolBlock.orphans.length > 0 || toolBlock.orphanText !== null)) {
+                    if (toolBlock) {
                         const block = toolBlock;
                         toolBlock = null;
                         parts.push(emitStopAndOrphans(block));

--- a/src/ai-proxy/lib/translators/formats/anthropic/server-tools.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/server-tools.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { findServerTool } from "./server-tools";
+
+describe("findServerTool", () => {
+    it("finds an Anthropic server tool by its versioned type", () => {
+        const body = {
+            tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+        };
+
+        expect(findServerTool(body)).toBe("web_search_20250305");
+    });
+
+    it("ignores custom tools, with and without an explicit type", () => {
+        const body = {
+            tools: [
+                { name: "Read", description: "Reads a file", input_schema: { type: "object" } },
+                { type: "custom", name: "Bash", description: "Runs a command", input_schema: { type: "object" } },
+            ],
+        };
+
+        expect(findServerTool(body)).toBeUndefined();
+    });
+
+    it("handles missing or malformed tools arrays", () => {
+        expect(findServerTool({})).toBeUndefined();
+        expect(findServerTool({ tools: "nope" })).toBeUndefined();
+        expect(findServerTool({ tools: [null, 42, "x"] })).toBeUndefined();
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/server-tools.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/server-tools.ts
@@ -1,0 +1,32 @@
+import { isObject } from "@genesiscz/utils/object";
+
+/**
+ * First Anthropic server tool offered by the request, or undefined.
+ *
+ * Server tools (`web_search_20250305`, `code_execution_*`, …) are executed
+ * inside Anthropic's API during sampling and carry no `description` or
+ * `input_schema`. Grok's Anthropic-compat endpoint only models custom tools,
+ * so a body offering one dies in its deserializer with the opaque
+ * `tools[0]: missing field description` — which reads like a proxy bug.
+ * Custom tools have no `type` field (or `type: "custom"`).
+ */
+export function findServerTool(body: Record<string, unknown>): string | undefined {
+    return findServerTools(body)[0];
+}
+
+/** Every server tool offered by the request — a mixed request must be judged whole. */
+export function findServerTools(body: Record<string, unknown>): string[] {
+    if (!Array.isArray(body.tools)) {
+        return [];
+    }
+
+    const types: string[] = [];
+
+    for (const tool of body.tools) {
+        if (isObject(tool) && typeof tool.type === "string" && tool.type !== "custom") {
+            types.push(tool.type);
+        }
+    }
+
+    return types;
+}

--- a/src/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag.test.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import {
+    routedToolName,
+    stripRoutingTag,
+    TOOL_ROUTING_TAG,
+    tagConfusableTools,
+} from "@app/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag";
+
+const noArg = (name: string) => ({
+    name,
+    description: "x",
+    input_schema: { type: "object", properties: {}, required: [] },
+});
+
+describe("tagConfusableTools", () => {
+    it("tags each no-arg tool with an enum of its own name", () => {
+        const body = { tools: [noArg("ListAgents"), noArg("TaskList")] };
+        const tagged = tagConfusableTools(body);
+
+        expect(tagged).toEqual(new Set(["ListAgents", "TaskList"]));
+
+        for (const name of ["ListAgents", "TaskList"]) {
+            const tool = body.tools.find((t) => t.name === name);
+            const schema = tool?.input_schema as Record<string, unknown>;
+            expect(schema.required).toEqual([TOOL_ROUTING_TAG]);
+            expect((schema.properties as Record<string, unknown>)[TOOL_ROUTING_TAG]).toEqual({
+                type: "string",
+                enum: [name],
+                description: `Routing tag required by this endpoint. Always exactly "${name}".`,
+            });
+        }
+    });
+
+    it("tags overlapping arg-taking schemas: Glob and Grep both fit {pattern}", () => {
+        // The live pair from Claude Code's toolset: required ∪ required =
+        // {pattern} ⊆ properties ∩ properties = {pattern, path}, so a merged
+        // `{"pattern":"*.ts"}` orphan fits either and only the tag can say
+        // which call it was.
+        const glob = {
+            name: "Glob",
+            input_schema: {
+                type: "object",
+                properties: { pattern: { type: "string" }, path: { type: "string" } },
+                required: ["pattern"],
+            },
+        };
+        const grep = {
+            name: "Grep",
+            input_schema: {
+                type: "object",
+                properties: { pattern: { type: "string" }, path: { type: "string" }, output_mode: { type: "string" } },
+                required: ["pattern"],
+            },
+        };
+        const bash = {
+            name: "Bash",
+            input_schema: { type: "object", properties: { command: { type: "string" } }, required: ["command"] },
+        };
+        const body = { tools: [glob, grep, bash] };
+
+        expect(tagConfusableTools(body)).toEqual(new Set(["Glob", "Grep"]));
+        // Bash shares no property with either — untouched.
+        expect((bash.input_schema as Record<string, unknown>).required).toEqual(["command"]);
+        // The tag rides ALONGSIDE the real required key, not instead of it.
+        expect((glob.input_schema as Record<string, unknown>).required).toEqual(["pattern", TOOL_ROUTING_TAG]);
+    });
+
+    it("does nothing when no pair of tools can share an argument object", () => {
+        // One no-arg tool is already unique against every argument-taking tool,
+        // so its schema must reach the model exactly as the client wrote it.
+        const single = {
+            tools: [
+                noArg("ListAgents"),
+                { name: "Bash", input_schema: { type: "object", properties: { c: {} }, required: ["c"] } },
+            ],
+        };
+        expect(tagConfusableTools(single)).toEqual(new Set());
+        expect((single.tools[0].input_schema as Record<string, unknown>).required).toEqual([]);
+
+        // Distinct required keys with no shared properties: Edit's object can
+        // never fit Write and vice versa.
+        const distinct = {
+            tools: [
+                {
+                    name: "Edit",
+                    input_schema: {
+                        type: "object",
+                        properties: { file_path: {}, old_string: {}, new_string: {} },
+                        required: ["file_path", "old_string", "new_string"],
+                    },
+                },
+                {
+                    name: "Write",
+                    input_schema: {
+                        type: "object",
+                        properties: { file_path: {}, content: {} },
+                        required: ["file_path", "content"],
+                    },
+                },
+            ],
+        };
+        expect(tagConfusableTools(distinct)).toEqual(new Set());
+
+        expect(tagConfusableTools({})).toEqual(new Set());
+        expect(tagConfusableTools({ tools: [] })).toEqual(new Set());
+    });
+
+    it("keeps the tool's own optional properties callable alongside the tag", () => {
+        const body = {
+            tools: [
+                {
+                    name: "ListAgents",
+                    input_schema: { type: "object", properties: { channel: { type: "string" } }, required: [] },
+                },
+                noArg("TaskList"),
+            ],
+        };
+        tagConfusableTools(body);
+
+        const schema = body.tools[0].input_schema as Record<string, unknown>;
+        expect(Object.keys(schema.properties as Record<string, unknown>)).toEqual(["channel", TOOL_ROUTING_TAG]);
+    });
+});
+
+describe("routedToolName", () => {
+    it("trusts the tag only when it names a tool this request tagged", () => {
+        const tagged = new Set(["ListAgents"]);
+
+        expect(routedToolName({ [TOOL_ROUTING_TAG]: "ListAgents" }, tagged)).toBe("ListAgents");
+
+        // A tool that was never tagged cannot be reached through the tag, so a
+        // coincidental property of the same name cannot redirect a call.
+        expect(routedToolName({ [TOOL_ROUTING_TAG]: "Bash" }, tagged)).toBeUndefined();
+        expect(routedToolName({ [TOOL_ROUTING_TAG]: 7 }, tagged)).toBeUndefined();
+        expect(routedToolName({}, tagged)).toBeUndefined();
+    });
+});
+
+describe("stripRoutingTag", () => {
+    it("removes the proxy's own property and leaves everything else alone", () => {
+        expect(stripRoutingTag(`{"${TOOL_ROUTING_TAG}":"ListAgents"}`)).toBe("{}");
+        expect(stripRoutingTag(`{"${TOOL_ROUTING_TAG}":"ListAgents","channel":"ops"}`)).toBe('{"channel":"ops"}');
+        expect(stripRoutingTag('{"command":"date"}')).toBe('{"command":"date"}');
+    });
+
+    it("returns unparseable text untouched so a bad call still fails on its own terms", () => {
+        expect(stripRoutingTag('{"command":')).toBe('{"command":');
+        expect(stripRoutingTag("")).toBe("");
+    });
+});

--- a/src/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag.ts
+++ b/src/ai-proxy/lib/translators/formats/anthropic/tool-routing-tag.ts
@@ -1,0 +1,142 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+
+type JsonRecord = Record<string, unknown>;
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The property injected into otherwise-empty tool schemas. Namespaced so it
+ * cannot collide with a real parameter, and only ever trusted when its value
+ * names a tool this module actually tagged.
+ */
+export const TOOL_ROUTING_TAG = "__tool_route";
+
+interface SchemaShape {
+    tool: JsonRecord;
+    name: string;
+    required: string[];
+    properties: string[];
+}
+
+function schemaShape(tool: unknown): SchemaShape | undefined {
+    if (!isJsonRecord(tool) || typeof tool.name !== "string" || !isJsonRecord(tool.input_schema)) {
+        return undefined;
+    }
+
+    const schema = tool.input_schema;
+
+    return {
+        tool,
+        name: tool.name,
+        required: Array.isArray(schema.required) ? schema.required.filter((r) => typeof r === "string") : [],
+        properties: isJsonRecord(schema.properties) ? Object.keys(schema.properties) : [],
+    };
+}
+
+/**
+ * Whether one argument object can legally belong to BOTH tools. An object with
+ * key set K fits a tool when required ⊆ K ⊆ properties, so a shared object
+ * exists exactly when `A.required ∪ B.required ⊆ A.properties ∩ B.properties`.
+ * Two no-argument tools are the degenerate case (∅ ⊆ ∅); Glob and Grep are the
+ * live one — both accept `{pattern, path}`, so `{"pattern":"*.ts"}` fits either.
+ */
+function confusable(a: SchemaShape, b: SchemaShape): boolean {
+    const shared = new Set(a.properties.filter((key) => b.properties.includes(key)));
+
+    return [...a.required, ...b.required].every((key) => shared.has(key));
+}
+
+/**
+ * Grok's STREAMING /messages merges parallel tool calls into one block and
+ * keeps only the first call's name (raw wire capture, 2026-08-21: one
+ * `content_block_start` naming `run_command`, then four complete argument
+ * objects as separate `input_json_delta` frames). The splitter recovers a name
+ * by matching argument keys against the request's schemas, which only works
+ * when exactly one tool fits — and fails for every pair of tools that can share
+ * an argument object: two no-argument tools (`{}` fits both), or overlapping
+ * schemas like Glob and Grep (`{"pattern":…}` fits both).
+ *
+ * So make exactly those calls distinguishable at the source: every tool in some
+ * {@link confusable} pair gets one required property whose only legal value is
+ * its own name. The model fills it, the merged stream carries it, the splitter
+ * reads the name straight off the object, and {@link stripRoutingTag} removes
+ * it before the client sees the call. Streaming is untouched, and tools no
+ * other tool can imitate go up verbatim.
+ *
+ * With the tag in place every schema-conforming argument object is uniquely
+ * attributable: an untagged tool's object fits no other tool (else the pair
+ * would be confusable and both tagged), and a tagged tool's object names itself.
+ * Mutates `body.tools` in place and returns the names it tagged.
+ */
+export function tagConfusableTools(body: JsonRecord): Set<string> {
+    const tagged = new Set<string>();
+
+    if (!Array.isArray(body.tools)) {
+        return tagged;
+    }
+
+    const shapes = body.tools.map(schemaShape).filter((shape): shape is SchemaShape => shape !== undefined);
+
+    for (let i = 0; i < shapes.length; i++) {
+        for (let j = i + 1; j < shapes.length; j++) {
+            if (confusable(shapes[i], shapes[j])) {
+                tagged.add(shapes[i].name);
+                tagged.add(shapes[j].name);
+            }
+        }
+    }
+
+    for (const shape of shapes) {
+        if (!tagged.has(shape.name)) {
+            continue;
+        }
+
+        const schema = shape.tool.input_schema as JsonRecord;
+        const properties = isJsonRecord(schema.properties) ? { ...schema.properties } : {};
+
+        properties[TOOL_ROUTING_TAG] = {
+            type: "string",
+            enum: [shape.name],
+            description: `Routing tag required by this endpoint. Always exactly "${shape.name}".`,
+        };
+        shape.tool.input_schema = { ...schema, properties, required: [...shape.required, TOOL_ROUTING_TAG] };
+    }
+
+    return tagged;
+}
+
+/**
+ * The tool named by an argument object's routing tag, when it names one this
+ * request actually tagged. Anything else returns undefined so a coincidental
+ * property of the same name can never redirect a call.
+ */
+export function routedToolName(args: JsonRecord, tagged: Set<string>): string | undefined {
+    const value = args[TOOL_ROUTING_TAG];
+
+    return typeof value === "string" && tagged.has(value) ? value : undefined;
+}
+
+/**
+ * Remove the routing tag from a serialized argument object. The client asked
+ * for its own schema and must never see the property this proxy added. Text
+ * that does not parse is returned untouched, so a malformed call still fails
+ * loudly on its own terms instead of being rewritten.
+ */
+export function stripRoutingTag(argsText: string): string {
+    let parsed: unknown;
+
+    try {
+        parsed = SafeJSON.parse(argsText, { strict: true });
+    } catch {
+        return argsText;
+    }
+
+    if (!isJsonRecord(parsed) || !(TOOL_ROUTING_TAG in parsed)) {
+        return argsText;
+    }
+
+    delete parsed[TOOL_ROUTING_TAG];
+    return SafeJSON.stringify(parsed);
+}

--- a/src/ai-proxy/lib/usage/transcripts.test.ts
+++ b/src/ai-proxy/lib/usage/transcripts.test.ts
@@ -97,6 +97,36 @@ describe("parseResponseBody", () => {
         expect(parsed.usage).toEqual({ input_tokens: 10, output_tokens: 7 });
     });
 
+    it("folds input_json_delta into the streamed tool call (grok probe recorded every input as {})", () => {
+        const body = [
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}}',
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"file_path\\":"}}',
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"/tmp/a\\"}"}}',
+            'data: {"type":"content_block_stop","index":0}',
+            'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_2","name":"ListAgents","input":{}}}',
+            'data: {"type":"content_block_stop","index":1}',
+        ].join("\n\n");
+
+        const parsed = parseResponseBody(body, true);
+        expect(parsed.toolCalls?.[0]?.function?.arguments).toBe('{"file_path":"/tmp/a"}');
+        // A call that never streams deltas keeps its (empty) start input.
+        expect(parsed.toolCalls?.[1]?.function?.name).toBe("ListAgents");
+        expect(parsed.toolCalls?.[1]?.function?.arguments).toBe("{}");
+    });
+
+    it("routes interleaved input_json_delta frames by block index, not recency", () => {
+        const body = [
+            'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a","name":"Read","input":{}}}',
+            'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_b","name":"Bash","input":{}}}',
+            'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"file_path\\":\\"/tmp/a\\"}"}}',
+            'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"command\\":\\"ls\\"}"}}',
+        ].join("\n\n");
+
+        const parsed = parseResponseBody(body, true);
+        expect(parsed.toolCalls?.[0]?.function?.arguments).toBe('{"file_path":"/tmp/a"}');
+        expect(parsed.toolCalls?.[1]?.function?.arguments).toBe('{"command":"ls"}');
+    });
+
     it("reads a Responses JSON body", () => {
         const parsed = parseResponseBody(
             '{"object":"response","status":"completed","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"hm"}]},{"type":"message","content":[{"type":"output_text","text":"4"}]},{"type":"function_call","call_id":"fc_1","name":"Read","arguments":"{}"}],"usage":{"input_tokens":3,"output_tokens":2}}',

--- a/src/ai-proxy/lib/usage/transcripts.ts
+++ b/src/ai-proxy/lib/usage/transcripts.ts
@@ -161,6 +161,8 @@ interface ParsedResponse {
     usage?: Record<string, unknown>;
     finishReason?: string;
     toolCalls?: OpenAiToolCall[];
+    /** Open tool_use blocks by SSE index, so an interleaved delta lands on ITS call. */
+    toolCallsByIndex?: Map<number, OpenAiToolCall>;
 }
 
 interface SseDelta {
@@ -270,6 +272,19 @@ function collectNonChatSseEvent(payload: Record<string, unknown>, parsed: Parsed
             parsed.text += payload.delta.text;
         } else if (payload.delta.type === "thinking_delta" && typeof payload.delta.thinking === "string") {
             parsed.thinking += payload.delta.thinking;
+        } else if (payload.delta.type === "input_json_delta" && typeof payload.delta.partial_json === "string") {
+            // The wire opens every tool_use with `input: {}` and streams the real
+            // arguments here; without folding them in, every streamed tool call
+            // was transcribed with an empty input. Deltas route by block index
+            // first — an interleaved delta otherwise feeds the wrong call.
+            const byIndex = typeof payload.index === "number" ? parsed.toolCallsByIndex?.get(payload.index) : undefined;
+            const call = byIndex ?? parsed.toolCalls?.at(-1);
+
+            if (call?.function) {
+                const prev = call.function.arguments;
+                call.function.arguments =
+                    (prev === undefined || prev === "{}" ? "" : prev) + payload.delta.partial_json;
+            }
         }
 
         return true;
@@ -277,7 +292,13 @@ function collectNonChatSseEvent(payload: Record<string, unknown>, parsed: Parsed
 
     if (type === "content_block_start" && isObject(payload.content_block)) {
         if (payload.content_block.type === "tool_use") {
-            parsed.toolCalls = [...(parsed.toolCalls ?? []), toolCallFromBlock(payload.content_block)];
+            const call = toolCallFromBlock(payload.content_block);
+            parsed.toolCalls = [...(parsed.toolCalls ?? []), call];
+
+            if (typeof payload.index === "number") {
+                parsed.toolCallsByIndex ??= new Map();
+                parsed.toolCallsByIndex.set(payload.index, call);
+            }
         }
 
         return true;

--- a/src/claude/commands/config.ts
+++ b/src/claude/commands/config.ts
@@ -11,6 +11,7 @@ import { UsageHistoryDb } from "@app/claude/lib/usage/history-db";
 import { clearPollGate } from "@app/claude/lib/usage/poll-gate";
 import { invalidateSharedUsage } from "@app/claude/lib/usage/shared-cache";
 import { ensureSubscriptionAnchors, planAllowsClaudeCode } from "@app/claude/lib/usage/subscription";
+import { formatWarmupViaHint } from "@app/claude/lib/warmup/service";
 import * as p from "@clack/prompts";
 import { AIConfig } from "@genesiscz/utils/ai/AIConfig";
 import { claudeOAuth, fetchOAuthProfile, getClaudeJsonAccount } from "@genesiscz/utils/claude/auth";
@@ -822,7 +823,8 @@ async function showConfig(config: ClaudeConfig, aiConfig: AIConfig): Promise<voi
             lines.push("  Today's warmups:");
             for (const evt of w.todayLog.events) {
                 const icon = evt.success ? pc.green("\u2713") : pc.red("\u2717");
-                lines.push(`    ${evt.time}  ${evt.account.padEnd(20)} ${evt.type.padEnd(8)} ${icon}`);
+                const via = pc.dim(formatWarmupViaHint(evt.via));
+                lines.push(`    ${evt.time}  ${evt.account.padEnd(20)} ${evt.type.padEnd(8)} ${icon}${via}`);
             }
         }
     }

--- a/src/claude/commands/start.cmux.test.ts
+++ b/src/claude/commands/start.cmux.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildLaunchArgs, cmuxPermissionArgs } from "./start";
+import { buildLaunchArgs, cmuxPermissionArgs, passthroughHandlesSession } from "./start";
 
 describe("cmuxPermissionArgs", () => {
     test("injects the bypass because cmux claude-teams execs past the ccc wrapper", () => {
@@ -55,5 +55,15 @@ describe("buildLaunchArgs", () => {
         const args = buildLaunchArgs({ resumeArgs: ["--continue"], passthrough: ["-p"], cmux: false });
 
         expect(args).toEqual(["--continue", "-p"]);
+    });
+});
+
+describe("passthroughHandlesSession", () => {
+    test("--agent-id counts so teammate attach does not open the limit-killed picker", () => {
+        expect(passthroughHandlesSession(["--agent-id", "pageobjects-fable@session-8f96d99f"])).toBe(true);
+    });
+
+    test("bare teammate-unrelated flags do not", () => {
+        expect(passthroughHandlesSession(["--model", "fable"])).toBe(false);
     });
 });

--- a/src/claude/commands/start.ts
+++ b/src/claude/commands/start.ts
@@ -711,7 +711,19 @@ function sessionLabel(session: SessionSummary): string {
 /** True when the user already told claude what to open (`--resume`, `-c`, `-p`, …). */
 export function passthroughHandlesSession(passthrough: string[]): boolean {
     return passthrough.some((arg) =>
-        ["--resume", "-r", "--continue", "-c", "--fork-session", "--print", "-p"].includes(arg.split("=")[0])
+        [
+            "--resume",
+            "-r",
+            "--continue",
+            "-c",
+            "--fork-session",
+            "--print",
+            "-p",
+            // Teammate re-attach. Without this, `tools claude teams` attach
+            // with `--agent-id` and no `--resume` pops the unrelated
+            // limit-killed session picker ("Cancelled, nothing launched").
+            "--agent-id",
+        ].includes(arg.split("=")[0])
     );
 }
 

--- a/src/claude/commands/warmup.ts
+++ b/src/claude/commands/warmup.ts
@@ -1,4 +1,4 @@
-import { sendWarmupMessage } from "@app/claude/lib/warmup/service";
+import { formatWarmupViaHint, sendWarmupMessage } from "@app/claude/lib/warmup/service";
 import * as p from "@clack/prompts";
 import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { out } from "@genesiscz/utils/logger";
@@ -55,19 +55,20 @@ export function registerWarmupCommand(program: Command): void {
             selectedNames = selected as string[];
         }
 
-        const results: Array<{ name: string; success: boolean; duration: number }> = [];
+        const results: Array<{ name: string; success: boolean; duration: number; viaHint: string }> = [];
 
         const spinner = p.spinner();
 
         for (const name of selectedNames) {
             spinner.start(`Warming up ${pc.cyan(name)}...`);
             const start = performance.now();
-            const success = await sendWarmupMessage(name);
+            const sent = await sendWarmupMessage(name);
             const duration = Math.round(performance.now() - start);
-            results.push({ name, success, duration });
+            const viaHint = formatWarmupViaHint(sent.via);
+            results.push({ name, success: sent.success, duration, viaHint });
 
-            if (success) {
-                spinner.stop(`${pc.cyan(name)} ${pc.green("\u2713")} ${pc.dim(`${duration}ms`)}`);
+            if (sent.success) {
+                spinner.stop(`${pc.cyan(name)} ${pc.green("\u2713")} ${pc.dim(`${duration}ms`)}${pc.dim(viaHint)}`);
             } else {
                 spinner.stop(`${pc.cyan(name)} ${pc.red("\u2717 failed")} ${pc.dim(`${duration}ms`)}`);
             }
@@ -83,7 +84,7 @@ export function registerWarmupCommand(program: Command): void {
             const icon = r.success ? pc.green("\u2713") : pc.red("\u2717");
             const label = allAccounts.find((a) => a.name === r.name)?.label;
             const hint = label ? pc.dim(` (${label})`) : "";
-            lines.push(`  ${icon} ${r.name}${hint}  ${pc.dim(`${r.duration}ms`)}`);
+            lines.push(`  ${icon} ${r.name}${hint}  ${pc.dim(`${r.duration}ms`)}${pc.dim(r.viaHint)}`);
         }
 
         lines.push("");
@@ -117,12 +118,12 @@ export function registerWarmupCommand(program: Command): void {
 
             for (const name of accountNames) {
                 const start = performance.now();
-                const success = await sendWarmupMessage(name);
+                const sent = await sendWarmupMessage(name);
                 const duration = Math.round(performance.now() - start);
-                const icon = success ? "\u2713" : "\u2717";
-                out.println(`  ${icon} ${name} (${duration}ms)`);
+                const icon = sent.success ? "\u2713" : "\u2717";
+                out.println(`  ${icon} ${name} (${duration}ms)${formatWarmupViaHint(sent.via)}`);
 
-                if (!success) {
+                if (!sent.success) {
                     failures++;
                 }
             }

--- a/src/claude/lib/config/index.ts
+++ b/src/claude/lib/config/index.ts
@@ -53,6 +53,8 @@ export interface WarmupTodayEvent {
     type: "session" | "weekly";
     time: string; // "06:00"
     success: boolean;
+    /** Set when the ping used the login-long oat token instead of the short-lived OAuth pair. */
+    via?: "login-long";
 }
 
 export interface WarmupTodayLog {

--- a/src/claude/lib/teams/launch.test.ts
+++ b/src/claude/lib/teams/launch.test.ts
@@ -1,6 +1,41 @@
 import { describe, expect, test } from "bun:test";
-import { buildTeammateClaudeArgs, buildToolsCcTeammateCommand } from "./launch";
+import {
+    buildTeammateClaudeArgs,
+    buildToolsCcTeammateCommand,
+    isLiveSidechain,
+    LIVE_SIDECHAIN_MS,
+    launchTeammate,
+} from "./launch";
 import type { TeamMemberView, TeamView } from "./types";
+
+/** Runs `fn` with Bun.spawnSync recorded, so a test can prove nothing spawned. */
+async function withSpawnSpy(fn: () => Promise<unknown>): Promise<{ result: unknown; calls: string[][] }> {
+    const original = Bun.spawnSync;
+    const calls: string[][] = [];
+    // A spawn here would be the regression: a second process for a teammate
+    // that is already running inside the lead. Throwing makes it loud.
+    (Bun as { spawnSync: unknown }).spawnSync = (cmd: string[]) => {
+        calls.push(cmd);
+        throw new Error(`unexpected spawn: ${cmd.join(" ")}`);
+    };
+
+    try {
+        return { result: await fn(), calls };
+    } finally {
+        (Bun as { spawnSync: unknown }).spawnSync = original;
+    }
+}
+
+function liveSidechain(): TeamMemberView["transcript"] {
+    return {
+        sessionId: "55a1a95d-4c46-4f3d-8a2d-5b27191ed430",
+        path: "/tmp/55a1a95d/subagents/agent-a1.jsonl",
+        mtimeMs: Date.now() - 2_000,
+        hasLeadAssignment: true,
+        messageCount: 4,
+        sidechain: true,
+    };
+}
 
 function fakeTeam(over: Partial<TeamView> = {}): TeamView {
     return {
@@ -68,6 +103,64 @@ describe("buildTeammateClaudeArgs", () => {
         );
         expect(args).toContain("--resume");
         expect(args).toContain("bad27373-df6b-4e1f-a716-1fcda43f5f01");
+        expect(args).toContain("--agent-id");
+    });
+
+    test("a sidechain resumes the lead session and does not pass --agent-id", () => {
+        const leadId = "3ef3c468-e0f1-4959-8f16-e2d3ce7c4feb";
+        const args = buildTeammateClaudeArgs(
+            fakeTeam(),
+            fakeMate({
+                transcript: {
+                    sessionId: leadId,
+                    path: `/tmp/${leadId}/subagents/agent-apageobjects-fable-629d28c8906398e7.jsonl`,
+                    mtimeMs: Date.now(),
+                    hasLeadAssignment: true,
+                    messageCount: 40,
+                    sidechain: true,
+                },
+            })
+        );
+        expect(args).toEqual(["--resume", leadId]);
+        expect(args).not.toContain("--agent-id");
+    });
+});
+
+describe("isLiveSidechain", () => {
+    test("true when the sidechain jsonl was written in the last 90s", () => {
+        expect(
+            isLiveSidechain({
+                sessionId: "abc",
+                path: "/tmp/x.jsonl",
+                mtimeMs: Date.now() - 5_000,
+                hasLeadAssignment: true,
+                messageCount: 1,
+                sidechain: true,
+            })
+        ).toBe(true);
+    });
+
+    test("false once the sidechain has gone quiet past the age boundary", () => {
+        // The boundary gates whether launchTeammate spawns a second process,
+        // so both sides of it are pinned. `now` is injectable — no real clock.
+        const base = { sessionId: "abc", path: "/tmp/x.jsonl", hasLeadAssignment: true, messageCount: 1 };
+        const now = 1_000_000_000_000;
+
+        expect(isLiveSidechain({ ...base, mtimeMs: now - (LIVE_SIDECHAIN_MS - 1), sidechain: true }, now)).toBe(true);
+        expect(isLiveSidechain({ ...base, mtimeMs: now - LIVE_SIDECHAIN_MS, sidechain: true }, now)).toBe(false);
+        expect(isLiveSidechain({ ...base, mtimeMs: now - LIVE_SIDECHAIN_MS * 3, sidechain: true }, now)).toBe(false);
+    });
+
+    test("false for a standalone transcript even if it is fresh", () => {
+        expect(
+            isLiveSidechain({
+                sessionId: "abc",
+                path: "/tmp/x.jsonl",
+                mtimeMs: Date.now(),
+                hasLeadAssignment: true,
+                messageCount: 1,
+            })
+        ).toBe(false);
     });
 });
 
@@ -78,5 +171,42 @@ describe("buildToolsCcTeammateCommand", () => {
         expect(cmd).toContain("--agent-name");
         expect(cmd).toContain("bm-research-product");
         expect(cmd).toContain("cd '/Users/Martin/Tresors/Projects/GenesisPlayground'");
+    });
+});
+
+describe("launchTeammate with a live in-process teammate", () => {
+    test("attach does not spawn a second process", async () => {
+        const { result, calls } = await withSpawnSpy(() =>
+            launchTeammate({
+                team: fakeTeam(),
+                teammate: fakeMate({ transcript: liveSidechain() }),
+                account: "martin",
+                mode: "attach",
+            })
+        );
+
+        expect((result as { action: string }).action).toBe("noop");
+        expect((result as { detail: string }).detail).toContain("still live");
+        expect(calls).toHaveLength(0);
+    });
+
+    test("focus without a resolvable lead pane hands over the lead session instead of spawning", async () => {
+        // Discovery cannot name the lead pane for a team whose teammates are
+        // all in-process, so this is the common path, not a corner case.
+        const transcript = liveSidechain();
+        const { result, calls } = await withSpawnSpy(() =>
+            launchTeammate({
+                team: fakeTeam({ lead: undefined }),
+                teammate: fakeMate({ transcript }),
+                account: "martin",
+                mode: "focus",
+            })
+        );
+
+        expect((result as { action: string }).action).toBe("noop");
+        // The WHOLE session id: a truncated one still matches a prefix but
+        // produces a focus command that cannot resolve anything.
+        expect((result as { detail: string }).detail).toContain(`tools claude cmux focus ${transcript?.sessionId}`);
+        expect(calls).toHaveLength(0);
     });
 });

--- a/src/claude/lib/teams/launch.ts
+++ b/src/claude/lib/teams/launch.ts
@@ -31,11 +31,31 @@ export interface LaunchResult {
     command?: string;
 }
 
+/** In-process sidechain still being written: do not spawn a second `--agent-id` process. */
+export const LIVE_SIDECHAIN_MS = 90_000;
+
+export function isLiveSidechain(transcript: TeamMemberView["transcript"] | undefined, now = Date.now()): boolean {
+    if (!transcript?.sidechain) {
+        return false;
+    }
+
+    return now - transcript.mtimeMs < LIVE_SIDECHAIN_MS;
+}
+
 /**
  * Build the argv Claude needs to rejoin an agent-team as this teammate.
  * Prefer --resume when a transcript exists (keeps history + first assignment).
+ *
+ * In-process teammates write under `<lead>/subagents/`. That file shares the
+ * lead's session id, so the only honest resume is the lead itself — never a
+ * fresh `--agent-id` spawn, which re-invokes the assignment as a new session.
  */
 export function buildTeammateClaudeArgs(team: TeamView, teammate: TeamMemberView): string[] {
+    const transcript = teammate.transcript;
+    if (transcript?.sidechain && transcript.sessionId) {
+        return ["--resume", transcript.sessionId];
+    }
+
     const m = teammate.member;
     const teamName = team.config.name || team.teamName;
     const args = [
@@ -62,8 +82,8 @@ export function buildTeammateClaudeArgs(team: TeamView, teammate: TeamMemberView
 
     // Resume a prior transcript only when it already has the lead assignment
     // (or any real messages). Empty/auth-fail sessions are better restarted.
-    if (teammate.transcript?.hasLeadAssignment && teammate.transcript.sessionId) {
-        args.push("--resume", teammate.transcript.sessionId);
+    if (transcript?.hasLeadAssignment && transcript.sessionId) {
+        args.push("--resume", transcript.sessionId);
     }
 
     return args;
@@ -253,7 +273,80 @@ export async function launchTeammate(opts: LaunchTeammateOptions): Promise<Launc
     const command = buildToolsCcTeammateCommand(account, opts.team, opts.teammate);
     const cwd = opts.teammate.member.cwd || opts.team.cwd || process.cwd();
     const inject = opts.injectAssignment !== false;
-    const needsInject = inject && Boolean(opts.teammate.member.prompt) && !opts.teammate.transcript?.hasLeadAssignment;
+    const needsInject =
+        inject &&
+        Boolean(opts.teammate.member.prompt) &&
+        !opts.teammate.transcript?.hasLeadAssignment &&
+        !opts.teammate.transcript?.sidechain;
+
+    if (isLiveSidechain(opts.teammate.transcript) && opts.mode !== "focus") {
+        const ageSec = Math.max(0, Math.round((Date.now() - opts.teammate.transcript!.mtimeMs) / 1000));
+        logger.info(
+            { path: opts.teammate.transcript!.path, ageSec, mode: opts.mode },
+            "[teams] refusing to spawn a second process for a live in-process teammate"
+        );
+
+        return {
+            action: "noop",
+            detail:
+                `in-process teammate still live (transcript updated ${ageSec}s ago). ` +
+                `Not spawning a second process — that re-invokes the assignment as a new session. ` +
+                `Tail: tools claude tail -a ${opts.teammate.member.name}` +
+                (opts.teammate.transcript!.sessionId
+                    ? `  Resume lead: tools cc run ${account} -- --resume ${opts.teammate.transcript!.sessionId}`
+                    : ""),
+            command,
+        };
+    }
+
+    // In-process mate: focus the lead pane if we have one. Do not fall through
+    // to a `--agent-id` spawn — that is a new session, not this teammate.
+    if (opts.mode === "focus" && isLiveSidechain(opts.teammate.transcript)) {
+        const leadLive = opts.team.lead?.live;
+        if (leadLive?.tmuxSession && leadLive.tmuxPaneId) {
+            const tmux = resolveTmuxBin();
+            const selected = Bun.spawnSync([tmux, "select-pane", "-t", leadLive.tmuxPaneId], {
+                stdout: "ignore",
+                stderr: "pipe",
+            });
+
+            if (selected.exitCode !== 0) {
+                throw new Error(
+                    `tmux select-pane ${leadLive.tmuxPaneId} failed: ${selected.stderr.toString().trim() || "unknown error"}`
+                );
+            }
+
+            if (!env.get("TMUX")) {
+                Bun.spawnSync([tmux, "attach-session", "-t", leadLive.tmuxSession], {
+                    stdout: "inherit",
+                    stderr: "inherit",
+                    stdin: "inherit",
+                });
+            }
+
+            return {
+                action: "focused",
+                detail: `Focused lead ${leadLive.tmuxSession}:${leadLive.tmuxPaneId} (in-process teammate)`,
+                command,
+            };
+        }
+
+        // Discovery cannot always name the lead's pane for a team whose
+        // teammates are all in-process: lead records carry no teamName or
+        // parentSessionId, and there are no teammate panes to locate it by.
+        // The sidechain transcript still knows the lead SESSION, so hand that
+        // over instead of leaving the user with nothing actionable.
+        const ageSec = Math.max(0, Math.round((Date.now() - opts.teammate.transcript!.mtimeMs) / 1000));
+        const leadSession = opts.teammate.transcript!.sessionId;
+        return {
+            action: "noop",
+            detail:
+                `in-process teammate still live (transcript updated ${ageSec}s ago) with no tmux pane to focus. ` +
+                `Tail: tools claude tail -a ${opts.teammate.member.name}` +
+                (leadSession ? `  Focus the lead: tools claude cmux focus ${leadSession}` : ""),
+            command,
+        };
+    }
 
     // Already running → focus pane
     if (opts.mode === "focus" || (opts.mode === "attach" && opts.teammate.live?.tmuxPaneId)) {
@@ -273,7 +366,7 @@ export async function launchTeammate(opts: LaunchTeammateOptions): Promise<Launc
             }
 
             // If we are inside tmux, also select the window; attach is for outside
-            if (!process.env.TMUX) {
+            if (!env.get("TMUX")) {
                 Bun.spawnSync([tmux, "attach-session", "-t", live.tmuxSession], {
                     stdout: "inherit",
                     stderr: "inherit",
@@ -324,7 +417,7 @@ export async function launchTeammate(opts: LaunchTeammateOptions): Promise<Launc
     }
 
     // attach / launch in current context
-    if (process.env.TMUX) {
+    if (env.get("TMUX")) {
         // Launch in a new window of the current session so we don't clobber the caller
         const tmux = resolveTmuxBin();
         const name = opts.teammate.member.name.slice(0, 20);

--- a/src/claude/lib/teams/transcripts.test.ts
+++ b/src/claude/lib/teams/transcripts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -85,5 +85,166 @@ describe("indexTeamTranscripts with awkward agent names", () => {
         writeTranscript(dir, "elsewhere", "someone");
 
         expect(indexTeamTranscripts(dir, "session-different").size).toBe(0);
+    });
+});
+
+describe("indexTeamTranscripts in-process sidechains", () => {
+    const leadId = "3ef3c468-e0f1-4959-8f16-e2d3ce7c4feb";
+
+    function writeSidechain(dir: string, agentName: string, lastText: string): string {
+        const sub = join(dir, leadId, "subagents");
+        mkdirSync(sub, { recursive: true });
+        const stem = `agent-a${agentName}-629d28c8906398e7`;
+        writeFileSync(
+            join(sub, `${stem}.meta.json`),
+            SafeJSON.stringify({
+                name: agentName,
+                teamName: TEAM,
+                taskKind: "in_process_teammate",
+            })
+        );
+
+        const lines = [
+            {
+                type: "user",
+                sessionId: leadId,
+                timestamp: "2026-08-20T16:50:36.000Z",
+                message: { content: `<teammate-message teammate_id="team-lead">Do the thing</teammate-message>` },
+            },
+            {
+                type: "assistant",
+                sessionId: leadId,
+                timestamp: "2026-08-20T17:12:25.000Z",
+                message: { content: [{ type: "text", text: lastText }] },
+            },
+        ];
+        const path = join(sub, `${stem}.jsonl`);
+        writeFileSync(path, `${lines.map((l) => SafeJSON.stringify(l)).join("\n")}\n`);
+        return path;
+    }
+
+    test("meta.teamName owns the sidechain — transcript text cannot claim it for another team", () => {
+        const dir = mkdtempSync(join(tmpdir(), "teams-sidechain-"));
+        const sub = join(dir, leadId, "subagents");
+        mkdirSync(sub, { recursive: true });
+        const stem = "agent-aborrowed-629d28c8906398e7";
+        writeFileSync(
+            join(sub, `${stem}.meta.json`),
+            SafeJSON.stringify({ name: "borrowed", teamName: "team-alpha", taskKind: "in_process_teammate" })
+        );
+        // The body mentions the other team, which used to be enough to index
+        // this agent under it and later resume the wrong lead session.
+        writeFileSync(
+            join(sub, `${stem}.jsonl`),
+            `${SafeJSON.stringify({
+                type: "assistant",
+                sessionId: leadId,
+                timestamp: "2026-08-20T17:12:25.000Z",
+                message: { content: [{ type: "text", text: `working alongside ${TEAM} on the same repo` }] },
+            })}\n`
+        );
+
+        expect(indexTeamTranscripts(dir, TEAM).get("borrowed")).toBeUndefined();
+        expect(indexTeamTranscripts(dir, "team-alpha").get("borrowed")).toBeDefined();
+    });
+
+    test("an ordinary subagent sidecar is not indexed as a teammate", () => {
+        const dir = mkdtempSync(join(tmpdir(), "teams-sidechain-"));
+        const sub = join(dir, leadId, "subagents");
+        mkdirSync(sub, { recursive: true });
+        const stem = "agent-aexplore-629d28c8906398e7";
+        writeFileSync(
+            join(sub, `${stem}.meta.json`),
+            SafeJSON.stringify({ name: "explore", teamName: TEAM, taskKind: "task" })
+        );
+        writeFileSync(
+            join(sub, `${stem}.jsonl`),
+            `${SafeJSON.stringify({
+                type: "assistant",
+                sessionId: leadId,
+                timestamp: "2026-08-20T17:12:25.000Z",
+                message: { content: [{ type: "text", text: "searched the repo" }] },
+            })}\n`
+        );
+
+        expect(indexTeamTranscripts(dir, TEAM).get("explore")).toBeUndefined();
+    });
+
+    test("indexes <lead>/subagents/agent-*.jsonl via meta.json even without agentName fields", () => {
+        const dir = mkdtempSync(join(tmpdir(), "teams-sidechain-"));
+        writeSidechain(dir, "pageobjects-fable", "While the retry downloads, verifying the MePAS locators.");
+
+        const found = indexTeamTranscripts(dir, TEAM).get("pageobjects-fable");
+        expect(found).toBeDefined();
+        expect(found?.sidechain).toBe(true);
+        expect(found?.sessionId).toBe(leadId);
+        expect(found?.hasLeadAssignment).toBe(true);
+        expect(found?.lastMessage?.text).toContain("MePAS locators");
+        expect(found?.path).toContain(`${leadId}/subagents/`);
+    });
+
+    test("a newer sidechain wins over an older standalone jsonl of the same agent", () => {
+        const dir = mkdtempSync(join(tmpdir(), "teams-sidechain-"));
+        const standaloneId = "b9799f97-ead9-4d25-ada1-51635a3e924f";
+        writeTranscript(dir, standaloneId, "pageobjects-fable");
+        const side = writeSidechain(dir, "pageobjects-fable", "MePAS selectors confirmed correct.");
+        expect(side).toContain("subagents");
+
+        // Back-to-back writes can land on the same mtime, and the standalone
+        // file is indexed first, so a tie would keep it and fail this test for
+        // a reason that has nothing to do with the rule under test.
+        const hour = new Date(Date.now() - 3_600_000);
+        utimesSync(join(dir, `${standaloneId}.jsonl`), hour, hour);
+
+        const found = indexTeamTranscripts(dir, TEAM).get("pageobjects-fable");
+        expect(found?.sidechain).toBe(true);
+        expect(found?.sessionId).toBe(leadId);
+        expect(found?.lastMessage?.text).toContain("MePAS selectors");
+    });
+
+    test("does not treat the filename agent-a… as the --resume id", () => {
+        const dir = mkdtempSync(join(tmpdir(), "teams-sidechain-"));
+        writeSidechain(dir, "pageobjects-fable", "on it");
+
+        const found = indexTeamTranscripts(dir, TEAM).get("pageobjects-fable");
+        expect(found?.sessionId).toBe(leadId);
+        expect(found?.sessionId.startsWith("agent-")).toBe(false);
+    });
+});
+
+describe("indexTeamTranscripts cache invalidation", () => {
+    const leadId = "8b1c1f2e-1111-4222-8333-444455556666";
+
+    test("editing only the sidecar meta re-indexes: the cache key covers it", () => {
+        const dir = mkdtempSync(join(tmpdir(), "teams-cache-"));
+        const sub = join(dir, leadId, "subagents");
+        mkdirSync(sub, { recursive: true });
+        const stem = "agent-amover-629d28c8906398e7";
+        const metaPath = join(sub, `${stem}.meta.json`);
+        const write = (teamName: string): void => {
+            writeFileSync(metaPath, SafeJSON.stringify({ name: "mover", teamName, taskKind: "in_process_teammate" }));
+        };
+
+        write(TEAM);
+        writeFileSync(
+            join(sub, `${stem}.jsonl`),
+            `${SafeJSON.stringify({
+                type: "assistant",
+                sessionId: leadId,
+                timestamp: "2026-08-20T17:12:25.000Z",
+                message: { content: [{ type: "text", text: "on it" }] },
+            })}\n`
+        );
+
+        // Warm the cache for this project dir.
+        expect(indexTeamTranscripts(dir, TEAM).get("mover")).toBeDefined();
+
+        // Hand the sidechain to a different team, touching ONLY the meta. A
+        // fingerprint built from the jsonl alone would keep serving the old
+        // mapping and leave this teammate on the wrong team.
+        write("team-elsewhere");
+
+        expect(indexTeamTranscripts(dir, TEAM).get("mover")).toBeUndefined();
+        expect(indexTeamTranscripts(dir, "team-elsewhere").get("mover")).toBeDefined();
     });
 });

--- a/src/claude/lib/teams/transcripts.ts
+++ b/src/claude/lib/teams/transcripts.ts
@@ -1,5 +1,5 @@
-import { closeSync, fstatSync, openSync, readdirSync, readSync, statSync } from "node:fs";
-import { basename, join } from "node:path";
+import { closeSync, type Dirent, fstatSync, openSync, readdirSync, readFileSync, readSync, statSync } from "node:fs";
+import { basename, join, sep } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import { profiler } from "@genesiscz/utils/profile";
@@ -123,15 +123,61 @@ export function readHeadTail(
     }
 }
 
+function isSidechainPath(path: string): boolean {
+    return path.includes(`${sep}subagents${sep}`);
+}
+
+function parentSessionIdFromSidechainPath(path: string): string | undefined {
+    const parts = path.split(sep);
+    const idx = parts.lastIndexOf("subagents");
+    if (idx <= 0) {
+        return undefined;
+    }
+
+    return parts[idx - 1];
+}
+
+interface AgentMetaFile {
+    name?: string;
+    teamName?: string;
+    taskKind?: string;
+}
+
+function readSidechainMeta(jsonlPath: string): AgentMetaFile | undefined {
+    const metaPath = jsonlPath.replace(/\.jsonl$/, ".meta.json");
+    try {
+        const parsed = SafeJSON.parse(readFileSync(metaPath, "utf8"), { strict: true });
+        if (!parsed || typeof parsed !== "object") {
+            return undefined;
+        }
+
+        const rec = parsed as Record<string, unknown>;
+        return {
+            name: typeof rec.name === "string" ? rec.name : undefined,
+            teamName: typeof rec.teamName === "string" ? rec.teamName : undefined,
+            taskKind: typeof rec.taskKind === "string" ? rec.taskKind : undefined,
+        };
+    } catch (error) {
+        logger.debug({ error, metaPath }, "[teams] sidechain meta missing or unreadable");
+        return undefined;
+    }
+}
+
 function summarizeSlice(
     path: string,
     mtimeMs: number,
     agentName: string | null,
     teamName: string,
     head: string,
-    tail: string
+    tail: string,
+    extra?: { sidechain?: boolean; sessionIdOverride?: string }
 ): TeammateTranscriptRef | undefined {
-    const sessionId = basename(path, ".jsonl");
+    let sessionId =
+        extra?.sessionIdOverride || (isSidechainPath(path) ? parentSessionIdFromSidechainPath(path) : undefined);
+    if (!sessionId) {
+        sessionId = basename(path, ".jsonl");
+    }
+
     let hasLeadAssignment = false;
     let messageCount = 0;
     let lastMessage: TeammateLastMessage | undefined;
@@ -152,6 +198,10 @@ function summarizeSlice(
             // per unparsable line across every transcript in the project.
             logger.trace({ error, path }, "[teams] skipping unparsable transcript line");
             continue;
+        }
+
+        if (typeof obj.sessionId === "string" && obj.sessionId && !extra?.sessionIdOverride) {
+            sessionId = obj.sessionId;
         }
 
         const ag = (obj.agentName ?? obj.agent_name) as string | undefined;
@@ -210,6 +260,7 @@ function summarizeSlice(
         hasLeadAssignment,
         lastMessage,
         messageCount,
+        sidechain: extra?.sidechain || isSidechainPath(path) || undefined,
     };
 }
 
@@ -228,17 +279,97 @@ const indexCache = new Map<string, ProjectIndexCacheEntry>();
 function projectFingerprint(projectDir: string, files: string[], teamNames: string[]): string {
     const parts: string[] = [teamNames.join(",")];
 
-    for (const name of files) {
+    for (const file of files) {
         try {
-            const st = statSync(join(projectDir, name));
-            parts.push(`${name}:${st.mtimeMs}:${st.size}`);
+            const st = statSync(file);
+            parts.push(`${file}:${st.mtimeMs}:${st.size}`);
         } catch (error) {
-            logger.debug({ error, projectDir, name }, "[teams] transcript stat failed; treating index as stale");
+            logger.debug({ error, projectDir, file }, "[teams] transcript stat failed; treating index as stale");
             return `stale-${Date.now()}`;
+        }
+
+        if (!isSidechainPath(file)) {
+            continue;
+        }
+
+        // A sidechain's team and kind come from its sidecar meta, so editing
+        // the meta alone must invalidate the index. Statting only the jsonl
+        // kept serving the previous team mapping until the jsonl also changed.
+        const metaPath = file.replace(/\.jsonl$/, ".meta.json");
+        try {
+            const st = statSync(metaPath);
+            parts.push(`${metaPath}:${st.mtimeMs}:${st.size}`);
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+                logger.debug({ error, metaPath }, "[teams] sidechain meta stat failed");
+            }
+
+            // Absent is a real state: recording it means CREATING a meta later
+            // changes the key too.
+            parts.push(`${metaPath}:none`);
         }
     }
 
     return parts.join("|");
+}
+
+/** Top-level `*.jsonl` plus `<session>/subagents/*.jsonl` (in-process teammates). */
+function listTranscriptFiles(projectDir: string): string[] | null {
+    let entries: Dirent[];
+    try {
+        entries = readdirSync(projectDir, { withFileTypes: true });
+    } catch (error) {
+        logger.debug({ error, projectDir }, "[teams] could not list the project dir; no transcripts indexed");
+        return null;
+    }
+
+    const files: string[] = [];
+    for (const ent of entries) {
+        if (ent.isFile() && ent.name.endsWith(".jsonl")) {
+            files.push(join(projectDir, ent.name));
+            continue;
+        }
+
+        if (!ent.isDirectory()) {
+            continue;
+        }
+
+        const subDir = join(projectDir, ent.name, "subagents");
+        let subEntries: string[];
+        try {
+            subEntries = readdirSync(subDir);
+        } catch (error) {
+            // Most sessions have no subagents dir at all, so a missing one is
+            // not worth a line; anything else (permissions, a broken link) is.
+            if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+                logger.debug({ error, subDir }, "[teams] could not list a subagents dir; its teammates stay unindexed");
+            }
+
+            continue;
+        }
+
+        for (const name of subEntries) {
+            if (name.endsWith(".jsonl")) {
+                files.push(join(subDir, name));
+            }
+        }
+    }
+
+    return files;
+}
+
+function rememberHit(
+    byAgent: Map<string, TeammateTranscriptRef>,
+    agentName: string,
+    parsed: TeammateTranscriptRef
+): boolean {
+    const prev = byAgent.get(agentName);
+    if (!prev || parsed.mtimeMs > prev.mtimeMs) {
+        byAgent.set(agentName, parsed);
+        return true;
+    }
+
+    return false;
 }
 
 /**
@@ -263,11 +394,8 @@ export function indexProjectTranscripts(
         }
 
         const teamSet = new Set(teamNames);
-        let files: string[];
-        try {
-            files = readdirSync(projectDir).filter((f) => f.endsWith(".jsonl"));
-        } catch (error) {
-            logger.debug({ error, projectDir }, "[teams] could not list the project dir; no transcripts indexed");
+        const files = listTranscriptFiles(projectDir);
+        if (files === null) {
             return byTeam;
         }
 
@@ -285,8 +413,7 @@ export function indexProjectTranscripts(
         let skippedLarge = 0;
         let hits = 0;
 
-        for (const name of files) {
-            const path = join(projectDir, name);
+        for (const path of files) {
             const slice = readHeadTail(path);
             if (!slice) {
                 continue;
@@ -295,6 +422,53 @@ export function indexProjectTranscripts(
             scanned++;
             const { head, tail, size, mtimeMs } = slice;
             const hay = `${head}\n${tail}`;
+
+            if (isSidechainPath(path)) {
+                const meta = readSidechainMeta(path);
+                const agentName = meta?.name;
+                const metaTeam = meta?.teamName;
+                if (!agentName || agentName === "team-lead") {
+                    continue;
+                }
+
+                // An ordinary subagent sidecar is not a teammate. Only a
+                // declared kind rules it out; older metas carry none.
+                if (meta?.taskKind !== undefined && meta.taskKind !== "in_process_teammate") {
+                    continue;
+                }
+
+                // Metadata wins when it names a team. Letting the transcript
+                // TEXT also match would index this agent under any other team
+                // whose name merely appears in the head or tail, and a later
+                // reattach would then resume the wrong lead session.
+                const hitTeams =
+                    metaTeam !== undefined && metaTeam.length > 0
+                        ? teamSet.has(metaTeam)
+                            ? [metaTeam]
+                            : []
+                        : [...teamSet].filter((t) => hay.includes(t));
+
+                if (hitTeams.length === 0) {
+                    continue;
+                }
+
+                const parentId = parentSessionIdFromSidechainPath(path);
+                for (const teamName of hitTeams) {
+                    const parsed = summarizeSlice(path, mtimeMs, agentName, teamName, head, tail, {
+                        sidechain: true,
+                        sessionIdOverride: parentId,
+                    });
+                    if (!parsed) {
+                        continue;
+                    }
+
+                    if (rememberHit(byTeam.get(teamName)!, agentName, parsed)) {
+                        hits++;
+                    }
+                }
+
+                continue;
+            }
 
             // Which of our teams appear in this slice?
             const hitTeams: string[] = [];
@@ -336,10 +510,8 @@ export function indexProjectTranscripts(
                         continue;
                     }
 
-                    hits++;
-                    const prev = byAgent.get(agentName);
-                    if (!prev || parsed.mtimeMs > prev.mtimeMs) {
-                        byAgent.set(agentName, parsed);
+                    if (rememberHit(byAgent, agentName, parsed)) {
+                        hits++;
                     }
                 }
             }

--- a/src/claude/lib/teams/types.ts
+++ b/src/claude/lib/teams/types.ts
@@ -38,12 +38,23 @@ export interface TeammateLastMessage {
 }
 
 export interface TeammateTranscriptRef {
+    /**
+     * Id to pass to `claude --resume`. For a standalone teammate jsonl this is
+     * that file's session. For an in-process sidechain it is the LEAD session
+     * (the jsonl lives under `<lead>/subagents/` and shares the lead's id).
+     */
     sessionId: string;
     path: string;
     mtimeMs: number;
     hasLeadAssignment: boolean;
     lastMessage?: TeammateLastMessage;
     messageCount: number;
+    /**
+     * True when this file is `<lead-session>/subagents/agent-*.jsonl` — the
+     * in-process teammate transcript. It is not a session you can --resume as
+     * a new `--agent-id` process.
+     */
+    sidechain?: boolean;
 }
 
 export interface LiveTeammateProcess {

--- a/src/claude/lib/teams/ui.ts
+++ b/src/claude/lib/teams/ui.ts
@@ -7,7 +7,7 @@ import { renderTree, type TreeNode } from "@genesiscz/utils/prompts/p/tree";
 import { stripAnsi } from "@genesiscz/utils/string";
 import pc from "picocolors";
 import { discoverTeam, discoverTeams } from "./discover";
-import { buildToolsCcTeammateCommand, launchTeammate, pickDefaultAccount } from "./launch";
+import { buildToolsCcTeammateCommand, isLiveSidechain, launchTeammate, pickDefaultAccount } from "./launch";
 import { formatStatusBadge, readProcessEnvKeys } from "./status";
 import type { TeamMemberView, TeamView } from "./types";
 
@@ -56,6 +56,32 @@ function colorStatus(status: TeamMemberView["status"], label: string): string {
     }
 }
 
+/** In-process mates write under the lead session. A new `--agent-id` spawn re-invokes. */
+function isInProcessMate(t: TeamMemberView): boolean {
+    return t.backend === "in-process" || Boolean(t.transcript?.sidechain);
+}
+
+function inProcessSpawnWarning(t: TeamMemberView): string | undefined {
+    if (!isInProcessMate(t)) {
+        return undefined;
+    }
+
+    if (isLiveSidechain(t.transcript)) {
+        return "in-process still live: attach/split starts a new session and re-invokes the assignment";
+    }
+
+    return "in-process: attach/split does not restore the last tool call (new session, or lead resume)";
+}
+
+function teamSelectHint(all: boolean | undefined, teams: TeamView[]): string {
+    const scope = all ? "(all projects)" : "(this project)";
+    if (teams.some((t) => t.teammates.some((m) => isInProcessMate(m)))) {
+        return `${scope} in-process attach re-invokes`;
+    }
+
+    return scope;
+}
+
 export function renderTeamsTree(teams: TeamView[]): string[] {
     if (teams.length === 0) {
         return [pc.dim("(no agent teams found)")];
@@ -93,8 +119,13 @@ export function renderTeamsTree(teams: TeamView[]): string[] {
 
             if (t.transcript && !t.transcript.hasLeadAssignment && t.member.prompt) {
                 children.push({
-                    text: pc.yellow("missing lead assignment — attach injects it"),
+                    text: pc.yellow("missing lead assignment: attach injects it"),
                 });
+            }
+
+            const spawnWarn = inProcessSpawnWarning(t);
+            if (spawnWarn) {
+                children.push({ text: pc.yellow(spawnWarn) });
             }
 
             return {
@@ -161,7 +192,7 @@ export async function runTeamsInteractive(opts: { all?: boolean; account?: strin
 
         const teamPick = await tableSelect({
             message: "Select team",
-            hint: opts.all ? "(all projects)" : "(this project)",
+            hint: teamSelectHint(opts.all, teams),
             columns: [
                 { label: "TEAM", minWidth: 16 },
                 { label: "LIVE", minWidth: 4, align: "right" },
@@ -194,6 +225,9 @@ export async function runTeamsInteractive(opts: { all?: boolean; account?: strin
                                     )
                                 ),
                             t.teammates.length > 6 ? pc.dim(`… +${t.teammates.length - 6} more`) : "",
+                            t.teammates.some((m) => isInProcessMate(m))
+                                ? pc.yellow("in-process attach re-invokes: it does not restore the last tool call")
+                                : "",
                         ].filter(Boolean),
                     };
                 }),
@@ -259,7 +293,9 @@ async function runTeamDetail(teamName: string, accountFlag?: string): Promise<"b
 
     const matePick = await tableSelect({
         message: `Teammates · ${fresh.teamName}`,
-        hint: "(enter to act)",
+        hint: fresh.teammates.some((m) => isInProcessMate(m))
+            ? "in-process attach re-invokes, it does not restore the last tool call"
+            : "(enter to act)",
         columns: [
             { label: "NAME", minWidth: 14 },
             { label: "STATUS", minWidth: 12 },
@@ -335,7 +371,12 @@ function buildTeammateDetail(team: TeamView, t: TeamMemberView): string[] {
     }
 
     if (!t.transcript?.hasLeadAssignment && t.member.prompt) {
-        lines.push(pc.yellow("First assignment missing — attach/split will inject prompt"));
+        lines.push(pc.yellow("First assignment missing: attach/split will inject prompt"));
+    }
+
+    const spawnWarn = inProcessSpawnWarning(t);
+    if (spawnWarn) {
+        lines.push(pc.yellow(spawnWarn));
     }
 
     // Do NOT dump the full tools cc run command here — it wraps and wrecks the frame.
@@ -371,49 +412,86 @@ async function resolveAccountForUi(team: TeamView, accountFlag?: string): Promis
     return pickDefaultAccount(team);
 }
 
+function attachPlanDetail(teammate: TeamMemberView): string {
+    const spawnWarn = inProcessSpawnWarning(teammate);
+    if (spawnWarn) {
+        return pc.yellow(spawnWarn);
+    }
+
+    const t = teammate.transcript;
+    if (t?.hasLeadAssignment && t.sessionId) {
+        return pc.dim(`will --resume ${t.sessionId.slice(0, 8)}`);
+    }
+
+    return pc.yellow("will inject lead assignment after boot");
+}
+
+function attachActionLabel(teammate: TeamMemberView): string {
+    if (isLiveSidechain(teammate.transcript)) {
+        return pc.yellow("Do not spawn: in-process still live (attach would re-invoke)");
+    }
+
+    if (isInProcessMate(teammate)) {
+        return pc.yellow("Resume lead only: in-process attach does not restore last tool call");
+    }
+
+    return pc.cyan("Launch / re-attach (new window or foreground)");
+}
+
+function splitActionLabel(teammate: TeamMemberView): string {
+    if (isInProcessMate(teammate)) {
+        return pc.yellow("Do not split-spawn: that starts a new session and re-invokes");
+    }
+
+    return pc.cyan("Split lead tmux pane + launch with OAuth");
+}
+
 async function runTeammateActions(
     team: TeamView,
     teammate: TeamMemberView,
     accountFlag?: string
 ): Promise<"back" | "quit" | "refresh"> {
-    const account = await resolveAccountForUi(team, accountFlag);
-    const cmd = buildToolsCcTeammateCommand(account, team, teammate);
+    const freshTeam = discoverTeam(team.teamName) ?? team;
+    const freshMate = freshTeam.teammates.find((m) => m.member.name === teammate.member.name) ?? teammate;
+    const account = await resolveAccountForUi(freshTeam, accountFlag);
+    const cmd = buildToolsCcTeammateCommand(account, freshTeam, freshMate);
 
     const action = await tableSelect({
-        message: `${teammate.member.name} · ${team.teamName}`,
-        hint: `account ${account}`,
+        message: `${freshMate.member.name} · ${freshTeam.teamName}`,
+        hint: isInProcessMate(freshMate)
+            ? `account ${account} · in-process attach re-invokes, it does not restore the last tool call`
+            : `account ${account}`,
         columns: [{ label: "ACTION", minWidth: 48 }],
         rows: [
             {
                 value: "focus",
                 cells: [
-                    teammate.live
+                    freshMate.live || isLiveSidechain(freshMate.transcript)
                         ? pc.green("Focus live pane (select in tmux)")
                         : pc.dim("Focus live pane (not running)"),
                 ],
                 detail: [
-                    teammate.live ? pc.dim(`${teammate.live.tmuxSession}:${teammate.live.tmuxPaneId}`) : "",
+                    freshMate.live ? pc.dim(`${freshMate.live.tmuxSession}:${freshMate.live.tmuxPaneId}`) : "",
+                    isLiveSidechain(freshMate.transcript)
+                        ? pc.yellow("in-process: focus the lead pane. Do not attach-spawn.")
+                        : "",
                 ].filter(Boolean),
             },
             {
                 value: "split",
-                cells: [pc.cyan("Split lead tmux pane + launch with OAuth")],
+                cells: [splitActionLabel(freshMate)],
                 detail: [
-                    team.tmuxSession
-                        ? pc.dim(`lead tmux ${team.tmuxSession}`)
+                    attachPlanDetail(freshMate),
+                    freshTeam.tmuxSession
+                        ? pc.dim(`lead tmux ${freshTeam.tmuxSession}`)
                         : pc.yellow("No lead tmux session detected"),
                     pc.dim(ellipsize(cmd, 90)),
                 ],
             },
             {
                 value: "attach",
-                cells: [pc.cyan("Launch / re-attach (new window or foreground)")],
-                detail: [
-                    teammate.transcript?.hasLeadAssignment
-                        ? pc.dim(`will --resume ${teammate.transcript.sessionId.slice(0, 8)}`)
-                        : pc.yellow("will inject lead assignment after boot"),
-                    pc.dim(ellipsize(cmd, 90)),
-                ],
+                cells: [attachActionLabel(freshMate)],
+                detail: [attachPlanDetail(freshMate), pc.dim(ellipsize(cmd, 90))],
             },
             {
                 value: "print",
@@ -440,24 +518,30 @@ async function runTeammateActions(
         return "back";
     }
 
-    if (action === "focus" && !teammate.live) {
-        out.println(pc.yellow("Teammate is not running — use split or attach."));
+    if (action === "focus" && !freshMate.live && !isLiveSidechain(freshMate.transcript)) {
+        out.println(pc.yellow("Teammate is not running. Use split or attach."));
         return "back";
     }
 
     try {
         const result = await launchTeammate({
-            team,
-            teammate,
+            team: freshTeam,
+            teammate: freshMate,
             account,
             mode: action as "focus" | "attach" | "split",
         });
-        out.println(pc.green(`✓ ${result.detail}`));
+        const mark = result.action === "noop" ? pc.yellow("•") : pc.green("✓");
+        out.println(`${mark} ${result.detail}`);
         if (result.command && action !== "focus") {
             out.println(pc.dim(result.command));
         }
 
-        if (action === "split" || action === "attach") {
+        if (
+            (action === "split" || action === "attach") &&
+            result.action !== "noop" &&
+            !freshMate.transcript?.hasLeadAssignment &&
+            !freshMate.transcript?.sidechain
+        ) {
             out.println(
                 pc.dim("If the mate boots empty, the lead assignment is injected when missing from the transcript.")
             );

--- a/src/claude/lib/warmup/service.test.ts
+++ b/src/claude/lib/warmup/service.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import { LONG_TOKEN_MIN_LENGTH } from "@genesiscz/utils/claude/token-verify";
+import type { AIAccountTokens } from "@genesiscz/utils/config/ai.types";
+import { formatWarmupViaHint, sendWarmupMessage } from "./service";
+
+const LONG = "x".repeat(LONG_TOKEN_MIN_LENGTH);
+const INVALID_GRANT = "Token expired (invalid_grant). Run: tools claude login bfbc";
+
+function tokens(partial: AIAccountTokens): AIAccountTokens {
+    return partial;
+}
+
+describe("formatWarmupViaHint", () => {
+    test("oauth and missing via print nothing", () => {
+        expect(formatWarmupViaHint()).toBe("");
+        expect(formatWarmupViaHint("oauth")).toBe("");
+    });
+
+    test("login-long is named in the user-facing suffix", () => {
+        expect(formatWarmupViaHint("login-long")).toBe(" used login-long token");
+    });
+});
+
+describe("sendWarmupMessage", () => {
+    test("OAuth success does not touch the login-long token", async () => {
+        const longLivedCalls: string[] = [];
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({ accessToken: "at", refreshToken: "rt", longLivedToken: LONG }),
+            sendOAuth: async () => {},
+            sendLongLived: async (token) => {
+                longLivedCalls.push(token);
+                return "ok";
+            },
+        });
+
+        expect(result).toEqual({ success: true, via: "oauth" });
+        expect(longLivedCalls).toEqual([]);
+    });
+
+    test("invalid_grant falls back to login-long and reports it", async () => {
+        const oauthCalls: string[] = [];
+        const longLivedCalls: string[] = [];
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({ accessToken: "dead", refreshToken: "dead", longLivedToken: LONG }),
+            sendOAuth: async (name) => {
+                oauthCalls.push(name);
+                throw new Error(INVALID_GRANT);
+            },
+            sendLongLived: async (token) => {
+                longLivedCalls.push(token);
+                return "ok";
+            },
+        });
+
+        expect(oauthCalls).toEqual(["bfbc"]);
+        expect(longLivedCalls).toEqual([LONG]);
+        expect(result).toEqual({ success: true, via: "login-long" });
+    });
+
+    test("a 429 on login-long still counts as warmup success", async () => {
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({ accessToken: "dead", refreshToken: "dead", longLivedToken: LONG }),
+            sendOAuth: async () => {
+                throw new Error(INVALID_GRANT);
+            },
+            sendLongLived: async () => "limited",
+        });
+
+        expect(result).toEqual({ success: true, via: "login-long" });
+    });
+
+    test("invalid_grant with no login-long token fails", async () => {
+        let longLivedCalled = false;
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({ accessToken: "dead", refreshToken: "dead" }),
+            sendOAuth: async () => {
+                throw new Error(INVALID_GRANT);
+            },
+            sendLongLived: async () => {
+                longLivedCalled = true;
+                return "ok";
+            },
+        });
+
+        expect(longLivedCalled).toBe(false);
+        expect(result).toEqual({ success: false });
+    });
+
+    test("a truncated login-long token is treated as absent", async () => {
+        let longLivedCalled = false;
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () =>
+                tokens({ accessToken: "dead", refreshToken: "dead", longLivedToken: "sk-ant-oat01-short" }),
+            sendOAuth: async () => {
+                throw new Error(INVALID_GRANT);
+            },
+            sendLongLived: async () => {
+                longLivedCalled = true;
+                return "ok";
+            },
+        });
+
+        expect(longLivedCalled).toBe(false);
+        expect(result).toEqual({ success: false });
+    });
+
+    test("an expired minted login-long token is not used", async () => {
+        let longLivedCalled = false;
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () =>
+                tokens({
+                    accessToken: "dead",
+                    refreshToken: "dead",
+                    longLivedToken: LONG,
+                    longLivedTokenExpiresAt: Date.now() - 1_000,
+                }),
+            sendOAuth: async () => {
+                throw new Error(INVALID_GRANT);
+            },
+            sendLongLived: async () => {
+                longLivedCalled = true;
+                return "ok";
+            },
+        });
+
+        expect(longLivedCalled).toBe(false);
+        expect(result).toEqual({ success: false });
+    });
+
+    test("a non-auth OAuth error does not fall back to login-long", async () => {
+        let longLivedCalled = false;
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({ accessToken: "at", refreshToken: "rt", longLivedToken: LONG }),
+            sendOAuth: async () => {
+                throw new Error("No haiku model available");
+            },
+            sendLongLived: async () => {
+                longLivedCalled = true;
+                return "ok";
+            },
+        });
+
+        expect(longLivedCalled).toBe(false);
+        expect(result).toEqual({ success: false });
+    });
+
+    test("login-long invalid after invalid_grant is a failure", async () => {
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({ accessToken: "dead", refreshToken: "dead", longLivedToken: LONG }),
+            sendOAuth: async () => {
+                throw new Error(INVALID_GRANT);
+            },
+            sendLongLived: async () => "invalid",
+        });
+
+        expect(result).toEqual({ success: false });
+    });
+
+    test("no OAuth pair uses login-long directly", async () => {
+        const oauthCalls: string[] = [];
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({ longLivedToken: LONG }),
+            sendOAuth: async (name) => {
+                oauthCalls.push(name);
+            },
+            sendLongLived: async () => "ok",
+        });
+
+        expect(oauthCalls).toEqual([]);
+        expect(result).toEqual({ success: true, via: "login-long" });
+    });
+
+    test("credential-less accounts fail without sending", async () => {
+        let oauthCalled = false;
+        let longLivedCalled = false;
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({}),
+            sendOAuth: async () => {
+                oauthCalled = true;
+            },
+            sendLongLived: async () => {
+                longLivedCalled = true;
+                return "ok";
+            },
+        });
+
+        expect(oauthCalled).toBe(false);
+        expect(longLivedCalled).toBe(false);
+        expect(result).toEqual({ success: false });
+    });
+
+    test("an unreadable token store fails the warmup without throwing", async () => {
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => {
+                throw new Error("ENOENT config");
+            },
+            sendOAuth: async () => {
+                throw new Error("should not send");
+            },
+            sendLongLived: async () => "ok",
+        });
+
+        expect(result).toEqual({ success: false });
+    });
+
+    test("a 401 from OAuth also falls back to login-long", async () => {
+        const result = await sendWarmupMessage("bfbc", {
+            loadTokens: async () => tokens({ accessToken: "stale", refreshToken: "stale", longLivedToken: LONG }),
+            sendOAuth: async () => {
+                throw new Error("Unauthorized: 401");
+            },
+            sendLongLived: async () => "ok",
+        });
+
+        expect(result).toEqual({ success: true, via: "login-long" });
+    });
+});

--- a/src/claude/lib/warmup/service.ts
+++ b/src/claude/lib/warmup/service.ts
@@ -1,4 +1,10 @@
 import type { AccountUsage, UsageResponse } from "@app/claude/lib/usage/api";
+import {
+    longLivedTokenUsable,
+    sendLongLivedInferencePing,
+    type TokenVerdict,
+} from "@genesiscz/utils/claude/token-verify";
+import type { AIAccountTokens } from "@genesiscz/utils/config/ai.types";
 import { formatLocalDate } from "@genesiscz/utils/date";
 import { logger } from "@genesiscz/utils/logger";
 
@@ -44,37 +50,142 @@ function shouldWarmWeekly(usage: UsageResponse): boolean {
     return new Date(sevenDay.resets_at).getTime() < Date.now();
 }
 
-export async function sendWarmupMessage(accountName: string): Promise<boolean> {
-    try {
-        const { AIAccount } = await import("@genesiscz/utils/ai/AIAccount");
-        const { AIConfig } = await import("@genesiscz/utils/ai/AIConfig");
-        const { ChatEngine } = await import("@ask/chat/ChatEngine");
-        const { AnthropicModelCategory } = await import("@genesiscz/utils/ask/providers/ModelResolver");
+export type WarmupVia = "oauth" | "login-long";
 
-        // Fail fast on credential-less entries (e.g. an aborted login left an
-        // account with empty tokens) instead of spinning through token-refresh
-        // retries and an API call that can only return "Invalid bearer token".
-        const aiConfig = await AIConfig.load();
-        const tokens = aiConfig.getAccount(accountName)?.tokens;
-        if (tokens && !tokens.accessToken && !tokens.refreshToken && !tokens.longLivedToken && !tokens.authFile) {
-            logger.warn(
-                `Warmup skipped for "${accountName}": no credentials stored. Run: tools claude login ${accountName}`
-            );
-            return false;
-        }
+export type WarmupSendResult = {
+    success: boolean;
+    via?: WarmupVia;
+};
 
-        const account = AIAccount.chooseClaude(accountName);
-        await ChatEngine.oneShot({
-            account,
-            model: AnthropicModelCategory.Haiku,
-            message: "hi",
-            maxTokens: 5,
-        });
+export type SendWarmupOptions = {
+    loadTokens?: (accountName: string) => Promise<AIAccountTokens | undefined>;
+    sendOAuth?: (accountName: string) => Promise<void>;
+    sendLongLived?: (token: string) => Promise<TokenVerdict>;
+};
+
+export function formatWarmupViaHint(via?: WarmupVia): string {
+    if (via !== "login-long") {
+        return "";
+    }
+
+    return " used login-long token";
+}
+
+function isOAuthAuthFailure(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+
+    return /invalid_grant|Token expired|Invalid bearer token|unauthorized|\b401\b/i.test(msg);
+}
+
+function hasOAuthCredentials(tokens: AIAccountTokens | undefined): boolean {
+    if (!tokens) {
+        // Unknown account: let the OAuth path raise the not-found error.
         return true;
+    }
+
+    return Boolean(tokens.accessToken || tokens.refreshToken || tokens.authFile);
+}
+
+function hasNoCredentials(tokens: AIAccountTokens): boolean {
+    return !tokens.accessToken && !tokens.refreshToken && !tokens.longLivedToken && !tokens.authFile;
+}
+
+function longLivedSucceeded(verdict: TokenVerdict): boolean {
+    return verdict === "ok" || verdict === "limited";
+}
+
+async function defaultLoadTokens(accountName: string): Promise<AIAccountTokens | undefined> {
+    const { AIConfig } = await import("@genesiscz/utils/ai/AIConfig");
+    const aiConfig = await AIConfig.load();
+    return aiConfig.getAccount(accountName)?.tokens;
+}
+
+async function defaultSendOAuth(accountName: string): Promise<void> {
+    const { AIAccount } = await import("@genesiscz/utils/ai/AIAccount");
+    const { ChatEngine } = await import("@ask/chat/ChatEngine");
+    const { AnthropicModelCategory } = await import("@genesiscz/utils/ask/providers/ModelResolver");
+
+    const account = AIAccount.chooseClaude(accountName);
+    await ChatEngine.oneShot({
+        account,
+        model: AnthropicModelCategory.Haiku,
+        message: "hi",
+        maxTokens: 5,
+    });
+}
+
+async function warmupViaLongLived(
+    accountName: string,
+    token: string,
+    sendLongLived: (token: string) => Promise<TokenVerdict>,
+    oauthErr?: unknown
+): Promise<WarmupSendResult> {
+    const verdict = await sendLongLived(token);
+
+    if (longLivedSucceeded(verdict)) {
+        logger.info(`Warmup for "${accountName}" used login-long token`);
+        return { success: true, via: "login-long" };
+    }
+
+    const oauthPart = oauthErr ? `oauth: ${oauthErr}; ` : "";
+    logger.warn(`Warmup message failed for "${accountName}": ${oauthPart}login-long: ${verdict}`);
+    return { success: false };
+}
+
+export async function sendWarmupMessage(
+    accountName: string,
+    options: SendWarmupOptions = {}
+): Promise<WarmupSendResult> {
+    const loadTokens = options.loadTokens ?? defaultLoadTokens;
+    const sendOAuth = options.sendOAuth ?? defaultSendOAuth;
+    const sendLongLived = options.sendLongLived ?? sendLongLivedInferencePing;
+
+    let tokens: Awaited<ReturnType<typeof loadTokens>>;
+    try {
+        tokens = await loadTokens(accountName);
     } catch (err) {
         logger.warn(`Warmup message failed for "${accountName}": ${err}`);
-        return false;
+        return { success: false };
     }
+
+    // Fail fast on credential-less entries (e.g. an aborted login left an
+    // account with empty tokens) instead of spinning through token-refresh
+    // retries and an API call that can only return "Invalid bearer token".
+    if (tokens && hasNoCredentials(tokens)) {
+        logger.warn(
+            `Warmup skipped for "${accountName}": no credentials stored. Run: tools claude login ${accountName}`
+        );
+        return { success: false };
+    }
+
+    const canLongLived = tokens ? longLivedTokenUsable(tokens) : false;
+
+    if (hasOAuthCredentials(tokens)) {
+        try {
+            await sendOAuth(accountName);
+            return { success: true, via: "oauth" };
+        } catch (err) {
+            if (isOAuthAuthFailure(err) && canLongLived && tokens?.longLivedToken) {
+                logger.info(`Warmup OAuth failed for "${accountName}" (${err}); trying login-long token`);
+                return warmupViaLongLived(accountName, tokens.longLivedToken, sendLongLived, err);
+            }
+
+            const loginLongHint =
+                isOAuthAuthFailure(err) && !canLongLived
+                    ? `. Or attach a long-lived token: tools claude login-long ${accountName}`
+                    : "";
+            logger.warn(`Warmup message failed for "${accountName}": ${err}${loginLongHint}`);
+            return { success: false };
+        }
+    }
+
+    if (canLongLived && tokens?.longLivedToken) {
+        logger.info(`Warmup for "${accountName}": no OAuth pair, using login-long token`);
+        return warmupViaLongLived(accountName, tokens.longLivedToken, sendLongLived);
+    }
+
+    logger.warn(`Warmup skipped for "${accountName}": no credentials stored. Run: tools claude login ${accountName}`);
+    return { success: false };
 }
 
 /**
@@ -113,17 +224,18 @@ export async function processWarmupRules(usageResults: AccountUsage[]): Promise<
                 const wasUnused = !result.usage.five_hour.resets_at || result.usage.five_hour.utilization === 0;
 
                 logger.info(`Session warmup: sending to ${accountName}`);
-                const success = await sendWarmupMessage(accountName);
+                const sent = await sendWarmupMessage(accountName);
 
                 warmup.todayLog.events.push({
                     account: accountName,
                     type: "session",
                     time: formatTime(new Date()),
-                    success,
+                    success: sent.success,
+                    ...(sent.via === "login-long" ? { via: "login-long" as const } : {}),
                 });
                 configChanged = true;
 
-                if (success && warmup.session.notify) {
+                if (sent.success && warmup.session.notify) {
                     const shouldNotify = !warmup.session.notifyOnlyIfUnused || wasUnused;
 
                     if (shouldNotify) {
@@ -131,7 +243,10 @@ export async function processWarmupRules(usageResults: AccountUsage[]): Promise<
                         await dispatchNotification({
                             app: "claude",
                             title: "Claude Warmup",
-                            message: `Session started for ${accountName}`,
+                            message:
+                                sent.via === "login-long"
+                                    ? `Session started for ${accountName} (login-long token)`
+                                    : `Session started for ${accountName}`,
                         });
                     }
                 }
@@ -150,22 +265,26 @@ export async function processWarmupRules(usageResults: AccountUsage[]): Promise<
 
             if (shouldWarmWeekly(result.usage)) {
                 logger.info(`Weekly warmup: sending to ${accountName}`);
-                const success = await sendWarmupMessage(accountName);
+                const sent = await sendWarmupMessage(accountName);
 
                 warmup.todayLog.events.push({
                     account: accountName,
                     type: "weekly",
                     time: formatTime(new Date()),
-                    success,
+                    success: sent.success,
+                    ...(sent.via === "login-long" ? { via: "login-long" as const } : {}),
                 });
                 configChanged = true;
 
-                if (success && warmup.weekly.notify) {
+                if (sent.success && warmup.weekly.notify) {
                     const { dispatchNotification } = await import("@genesiscz/utils/notifications");
                     await dispatchNotification({
                         app: "claude",
                         title: "Claude Warmup",
-                        message: `Weekly session started for ${accountName}`,
+                        message:
+                            sent.via === "login-long"
+                                ? `Weekly session started for ${accountName} (login-long token)`
+                                : `Weekly session started for ${accountName}`,
                     });
                 }
             }

--- a/src/claude/mcp/tools/handoff.ts
+++ b/src/claude/mcp/tools/handoff.ts
@@ -78,7 +78,8 @@ export const HANDOFF_LIST_DESCRIPTION =
     "List recent handoffs, newest-updated first — ALL projects by default; project: '<name>' narrows. " +
     "open: true → only unresolved (not done/cancelled); mine: true → posted by, claimed by, or targeted at " +
     "this session; limit (default 20) + offset page through. Open rows are detailed, claimed rows concise. " +
-    'Optional include: ["tasks"] adds the full task array per row (other include values are ignored with an info line). ' +
+    'Optional include: ["tasks"] adds a task array per row with proof PREVIEWS (answer clipped, context dropped, ' +
+    "id lists capped) — call handoff_get for full proofs. Other include values are ignored with an info line. " +
     "Use the id with handoff_get.";
 
 export const HANDOFF_ACTION_DESCRIPTION =
@@ -179,7 +180,8 @@ export const HANDOFF_LIST_INPUT_SCHEMA = {
         include: {
             type: "array",
             items: { type: "string" },
-            description: 'optional — only "tasks" is honored on list rows (adds full task array as taskList)',
+            description:
+                'optional — only "tasks" is honored on list rows (adds taskList with proof previews; handoff_get returns full proofs)',
         },
     },
 } as const;

--- a/src/handoff/executor.test.ts
+++ b/src/handoff/executor.test.ts
@@ -137,6 +137,37 @@ describe("work loop (§8.4, §8.5)", () => {
         const list = listHandoffs({}, env.depsFor(A));
         expect(list.handoffs[0].tasks).toBe("1/2");
 
+        // List previews proofs instead of dumping them (grok probe 81442272:
+        // a limit:2 list with include tasks returned every proof verbatim).
+        const bigProof = executeHandoffActions(
+            {
+                id: handoff.id,
+                actions: [
+                    {
+                        action: "check_task",
+                        taskId: "t1",
+                        proof: {
+                            answer: "x".repeat(500),
+                            context: "long context blob",
+                            commitIds: ["c1", "c2", "c3", "c4", "c5", "c6", "c7"],
+                        },
+                    },
+                ],
+            },
+            env.depsFor(B)
+        );
+        expect(bigProof.results[0].ok).toBe(true);
+
+        const withTasks = listHandoffs({ include: ["tasks"] }, env.depsFor(A));
+        const listedProof = withTasks.handoffs[0].taskList?.[0].proof;
+        expect(listedProof?.answer.length).toBeLessThanOrEqual(201);
+        expect(listedProof?.answer.endsWith("…")).toBe(true);
+        expect(listedProof?.context).toBeUndefined();
+        // Long id lists are capped on list too — the stored proof keeps all 7.
+        expect(listedProof?.commitIds).toEqual(["c1", "c2", "c3", "c4", "c5"]);
+        expect(bigProof.handoff.tasks[0].proof?.commitIds).toHaveLength(7);
+        expect(withTasks.info.join(" ")).toContain("handoff_get for the full proof");
+
         const badDeny = executeHandoffActions(
             { id: handoff.id, actions: [{ action: "deny_task", taskId: "t2" }] },
             env.depsFor(B)

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -440,10 +440,23 @@ export interface ListHandoffsInput {
     include?: string[];
 }
 
+/**
+ * A task as it appears on a LIST row: the proof is a preview, never the whole
+ * thing. `answer` may be clipped, `context` is always dropped, and the id
+ * arrays hold at most the first few entries. Call handoff_get for the stored
+ * proof — treating this shape as complete loses evidence.
+ */
+export type HandoffTaskPreview = Omit<Handoff["tasks"][number], "proof"> & {
+    proof?: Omit<NonNullable<Handoff["tasks"][number]["proof"]>, "context"> & { context?: undefined };
+};
+
 export interface ListHandoffsResponse {
-    handoffs: (HandoffListRow & { taskList?: Handoff["tasks"] })[];
+    handoffs: (HandoffListRow & { taskList?: HandoffTaskPreview[] })[];
     info: string[];
 }
+
+const PROOF_PREVIEW_CHARS = 200;
+const PROOF_PREVIEW_IDS = 5;
 
 export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = {}): ListHandoffsResponse {
     const by = buildBy(deps);
@@ -475,9 +488,10 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
         const total = rows.length;
         const page = rows.slice(offset, offset + limit);
         const now = Date.now();
-        const handoffs = page.map((h): HandoffListRow & { taskList?: Handoff["tasks"] } => {
+        let proofsClipped = false;
+        const handoffs = page.map((h): HandoffListRow & { taskList?: HandoffTaskPreview[] } => {
             const p = progress(h);
-            const row: HandoffListRow & { taskList?: Handoff["tasks"] } = {
+            const row: HandoffListRow & { taskList?: HandoffTaskPreview[] } = {
                 id: h.id,
                 title: h.title,
                 status: h.status,
@@ -497,13 +511,40 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
             }
 
             if (wantTasks) {
-                row.taskList = h.tasks;
+                // List is a browse surface; full proof blobs belong to
+                // handoff_get. Returning them verbatim made a limit:2 list a
+                // token bomb (grok probe 81442272).
+                row.taskList = h.tasks.map((task): HandoffTaskPreview => {
+                    if (task.proof === undefined) {
+                        return { ...task, proof: undefined };
+                    }
+
+                    const clipped = task.proof.answer.length > PROOF_PREVIEW_CHARS;
+                    const idsClipped =
+                        (task.proof.commitIds?.length ?? 0) > PROOF_PREVIEW_IDS ||
+                        (task.proof.attachmentIds?.length ?? 0) > PROOF_PREVIEW_IDS;
+                    proofsClipped ||= clipped || idsClipped || task.proof.context !== undefined;
+                    return {
+                        ...task,
+                        proof: {
+                            ...task.proof,
+                            answer: clipped ? `${task.proof.answer.slice(0, PROOF_PREVIEW_CHARS)}…` : task.proof.answer,
+                            context: undefined,
+                            commitIds: task.proof.commitIds?.slice(0, PROOF_PREVIEW_IDS),
+                            attachmentIds: task.proof.attachmentIds?.slice(0, PROOF_PREVIEW_IDS),
+                        },
+                    };
+                });
             }
 
             return row;
         });
 
         const info: string[] = [`${total} handoff${total === 1 ? "" : "s"} matched; showing ${page.length}.`];
+
+        if (proofsClipped) {
+            info.push("Task proofs are previews on list — call handoff_get for the full proof.");
+        }
 
         if (total > offset + page.length) {
             info.push(`More available — pass offset: ${offset + page.length}.`);

--- a/src/ms-teams/lib/export/markdown.test.ts
+++ b/src/ms-teams/lib/export/markdown.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { COMPLETENESS_NOTE, type ExportedMessage, type ThreadExport } from "../types";
+import { renderMarkdown } from "./markdown";
+
+const OBJECT_ID = "0-weu-d1-0123456789abcdef01234567";
+const AMS = `https://eu-api.asm.skype.com/v1/objects/${OBJECT_ID}/views/imgo`;
+const LOCAL = `/tmp/${OBJECT_ID}.png`;
+
+function threadWith(message: Partial<ExportedMessage> & Pick<ExportedMessage, "text" | "html">): ThreadExport {
+    const full: ExportedMessage = {
+        id: "m1",
+        sequenceId: 1,
+        time: "2026-08-13T18:04:41.000Z",
+        from: { mri: "8:orgid:me", displayName: "martin.foltyn@tekies.eu", email: null },
+        isFromMe: true,
+        messageType: "RichText/Html",
+        replyToId: null,
+        replyTo: null,
+        reactions: [],
+        mentions: [],
+        links: [],
+        attachments: [],
+        call: null,
+        system: null,
+        ...message,
+    };
+
+    return {
+        conversation: {
+            id: "19:chat@unq.gbl.spaces",
+            type: "chat",
+            title: "Ada Lovelace",
+            topic: null,
+            members: [],
+            cachedFrom: full.time,
+            cachedTo: full.time,
+            messageCount: 1,
+            completenessNote: COMPLETENESS_NOTE,
+        },
+        messages: [full],
+    };
+}
+
+describe("renderMarkdown", () => {
+    test("renders Teams HTML structure instead of the flattened text field", () => {
+        const flat =
+            "A tady ještě summary\n\n\n Flow Summary \n Tým procházel Figmu.\n\n Architektura marketplace stránek \n Bannery a landing pages";
+        const html = `<p>A tady ještě summary</p><h2>Flow Summary</h2><p>Tým procházel Figmu.</p><h3>Architektura marketplace stránek</h3><ul><li>Bannery a landing pages</li></ul>`;
+        const md = renderMarkdown(threadWith({ text: flat, html }));
+        expect(md).toContain("## Flow Summary");
+        expect(md).toContain("### Architektura marketplace stránek");
+        expect(md).toContain("- Bannery a landing pages");
+        expect(md.includes(" Flow Summary ")).toBe(false);
+    });
+
+    test("does not emit a duplicate image when the HTML already inlined it", () => {
+        const html = `<p><img src="${AMS}" itemtype="http://schema.skype.com/AMSImage" itemid="${OBJECT_ID}" alt="image" /></p>`;
+        const md = renderMarkdown(
+            threadWith({
+                text: "",
+                html,
+                attachments: [
+                    {
+                        name: `${OBJECT_ID}.png`,
+                        mimeHint: "png",
+                        url: AMS,
+                        itemId: OBJECT_ID,
+                        localPath: LOCAL,
+                    },
+                ],
+            })
+        );
+        expect(md.split(`![${OBJECT_ID}.png](${LOCAL})`).length - 1).toBe(1);
+        expect(md.includes("eu-api.asm.skype.com")).toBe(false);
+        expect(md.includes("_(no text)_")).toBe(false);
+    });
+
+    test("does not relist a remote inline image that has no localPath or itemId", () => {
+        // A non-AMS image: the body carries it by URL alone, so the
+        // attachment list would otherwise emit it a second time.
+        const remote = "https://cdn.example.com/diagram.png";
+        const md = renderMarkdown(
+            threadWith({
+                text: "",
+                html: `<p><img src="${remote}" alt="diagram" /></p>`,
+                attachments: [{ name: "diagram.png", mimeHint: "png", url: remote, itemId: null, localPath: null }],
+            })
+        );
+
+        expect(md.split(remote).length - 1).toBe(1);
+    });
+
+    test("falls back to plain text when there is no html", () => {
+        const md = renderMarkdown(threadWith({ text: "plain only", html: null }));
+        expect(md).toContain("plain only");
+    });
+});

--- a/src/ms-teams/lib/export/markdown.ts
+++ b/src/ms-teams/lib/export/markdown.ts
@@ -1,6 +1,10 @@
 import { formatDateTime } from "@genesiscz/utils/date";
+import { logger } from "@genesiscz/utils/logger";
+import { teamsHtmlToMarkdown } from "../html-to-markdown";
 import { isImageAttachment } from "../media";
-import type { ThreadExport } from "../types";
+import type { Attachment, ExportedMessage, ThreadExport } from "../types";
+
+const log = logger.scoped("ms-teams").log;
 
 export function renderMarkdown(thread: ThreadExport): string {
     const lines: string[] = [];
@@ -30,10 +34,12 @@ export function renderMarkdown(thread: ThreadExport): string {
             lines.push("");
         }
 
+        const body = message.system ? "" : messageBodyMarkdown(message);
+
         if (message.system) {
             lines.push(`*${message.system}*`);
-        } else if (message.text.trim()) {
-            lines.push(message.text);
+        } else if (body) {
+            lines.push(body);
         } else if (message.attachments.length === 0) {
             lines.push("_(no text)_");
         }
@@ -44,6 +50,10 @@ export function renderMarkdown(thread: ThreadExport): string {
         }
 
         for (const attachment of message.attachments) {
+            if (attachmentShownInMarkdown(body, attachment)) {
+                continue;
+            }
+
             const href = attachment.localPath ?? attachment.url;
 
             if (!href) {
@@ -63,4 +73,38 @@ export function renderMarkdown(thread: ThreadExport): string {
     }
 
     return `${lines.join("\n").trim()}\n`;
+}
+
+function messageBodyMarkdown(message: ExportedMessage): string {
+    if (message.html?.trim()) {
+        try {
+            const converted = teamsHtmlToMarkdown(message.html, message.attachments);
+
+            if (converted) {
+                return converted;
+            }
+        } catch (err) {
+            log.debug({ err, messageId: message.id }, "[ms-teams] html to markdown failed");
+        }
+    }
+
+    return message.text.trim();
+}
+
+function attachmentShownInMarkdown(markdown: string, attachment: Attachment): boolean {
+    if (attachment.localPath && markdown.includes(attachment.localPath)) {
+        return true;
+    }
+
+    if (attachment.itemId && markdown.includes(attachment.itemId)) {
+        return true;
+    }
+
+    // A remote inline image (no localPath, no AMS itemId) is already in the
+    // body by its URL; listing it again below would duplicate it.
+    if (attachment.url && markdown.includes(attachment.url)) {
+        return true;
+    }
+
+    return false;
 }

--- a/src/ms-teams/lib/html-to-markdown.test.ts
+++ b/src/ms-teams/lib/html-to-markdown.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { teamsHtmlToMarkdown } from "./html-to-markdown";
+
+const FLOW_SUMMARY_HTML = `<p>A tady ještě summary </p>
+<p> </p>
+<h2>Flow Summary</h2>
+<p>Tým procházel Figmu a DZ pro nový marketplace v Můj ČEZ kvůli nacenění do zítřka; shodli se, že podklady jsou nedostatečné (nehotová Figma, chybí Figma pro administraci, OPN mimo tým) a přesné nacenění odmítnou, nabídnou jen statickou variantu a otázky.</p>
+<p> </p>
+<h3>Architektura marketplace stránek</h3>
+<ul>
+<li>Bannery a landing pages produktů řídí online platforma (clever chest), layout kategorií přes číselníky s admin UI</li><li>L1 = hierarchie (chybí field pro chip a online bonus), L2 = detail kategorie, L3 = landing page produktu</li><li>Marketing banner na dashboardu i marketplace bude sdílet stejné DTO (MarketingBannerDto[], 0-N)</li></ul>
+<p> </p>
+<h3>Problémy s podklady a rozsahem</h3>
+<ul>
+<li>Figma není hotová, David potvrdil že se ještě překopává; chybí Figma pro administraci úplně</li><li>OPN (elektřina, plyn) je jiný tým/repo, MVNO je vlastní modul; nutno vyloučit ze scope nebo předat spec</li><li>Generování leadů je horror story, vyžaduje sladění s byznysem</li><li> 
+<ul>
+<li>15 FRQ, hrubý odhad ~150 MD + ~40 MD admin, reálně bude byznys admin škrtat</li></ul>
+</li></ul>
+<p> </p>
+<h3>Postup pro nacenění</h3>
+<ul>
+<li>Odmítnout přesné nacenění do zítřka, dodat jen otázky a pushback (nehotová Figma, chybí admin Figma)</li></ul>
+<p> </p>
+<h3>Next Steps</h3>
+<ul>
+<li>(Filip Kalina) Předat Šárce pushback: bez hotové Figmy nenacenit, nabídnout statickou variantu</li></ul>
+<p> </p>
+<h3>Decisions Made</h3>
+<ul>
+<li>Do zítřka se nedodá přesné nacenění, jen otázky a pushback</li><li>Marketing banner sdílí stejné DTO jako dashboard (MarketingBannerDto[], 0-N)</li></ul>
+<p> </p>
+<p> </p>`;
+
+describe("teamsHtmlToMarkdown", () => {
+    test("keeps headings, lists, nested indent, and unescaped brackets from a real Teams body", () => {
+        const md = teamsHtmlToMarkdown(FLOW_SUMMARY_HTML);
+
+        expect(md.startsWith("A tady ještě summary")).toBe(true);
+        expect(md).toContain("## Flow Summary");
+        expect(md).toContain("### Architektura marketplace stránek");
+        expect(md).toContain(
+            "- Bannery a landing pages produktů řídí online platforma (clever chest), layout kategorií přes číselníky s admin UI"
+        );
+        expect(md).toContain(
+            "- L1 = hierarchie (chybí field pro chip a online bonus), L2 = detail kategorie, L3 = landing page produktu"
+        );
+        expect(md).toContain("MarketingBannerDto[], 0-N");
+        expect(md.includes("MarketingBannerDto\\[]")).toBe(false);
+        expect(md).toContain("### Problémy s podklady a rozsahem");
+        expect(md).toContain("- Generování leadů je horror story, vyžaduje sladění s byznysem");
+        expect(md).toContain("    - 15 FRQ, hrubý odhad ~150 MD + ~40 MD admin, reálně bude byznys admin škrtat");
+        expect(md).toContain("### Postup pro nacenění");
+        expect(md).toContain("### Next Steps");
+        expect(md).toContain("### Decisions Made");
+        expect(md.includes(" Flow Summary ")).toBe(false);
+    });
+
+    test("drops skype Reply quotes and keeps the reply body", () => {
+        const html =
+            '<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="m-parent"><p>parent</p></blockquote><p>child reply</p>';
+        expect(teamsHtmlToMarkdown(html)).toBe("child reply");
+    });
+
+    test("drops a Reply quote whole, including a nested quote inside it", () => {
+        // A reply to a reply. The first </blockquote> closes the INNER quote,
+        // so a lazy match stopped there and left everything after it — the
+        // outer quote's own text — in the export.
+        const html =
+            '<blockquote itemscope itemtype="http://schema.skype.com/Reply" itemid="m-parent">' +
+            '<blockquote itemtype="http://schema.skype.com/Reply"><p>inner parent</p></blockquote>' +
+            "<p>outer parent</p></blockquote><p>child reply</p>";
+        const md = teamsHtmlToMarkdown(html);
+
+        expect(md).not.toContain("outer parent");
+        expect(md).not.toContain("inner parent");
+        expect(md).toBe("child reply");
+    });
+
+    test("keeps forwarded quotes as markdown blockquotes", () => {
+        const html =
+            '<blockquote itemtype="http://schema.skype.com/Forward"><p>Hoj, na develop je aktualne nasazena migrace.</p></blockquote>';
+        const md = teamsHtmlToMarkdown(html);
+        expect(md).toContain("Hoj, na develop je aktualne nasazena migrace.");
+        expect(md.startsWith(">")).toBe(true);
+    });
+
+    test("turns emoji images into their alt text and leaves mentions as names", () => {
+        const html =
+            '<p>hello <span itemtype="http://schema.skype.com/Mention" itemscope itemid="0">Všichni</span> <img itemscope itemtype="http://schema.skype.com/Emoji" alt="😄" /></p>';
+        expect(teamsHtmlToMarkdown(html)).toBe("hello Všichni 😄");
+    });
+
+    test("inlines a local AMS image and drops unresolved AMS urls", () => {
+        const objectId = "0-weu-d1-0123456789abcdef01234567";
+        const url = `https://eu-api.asm.skype.com/v1/objects/${objectId}/views/imgo`;
+        const localPath = `/tmp/${objectId}.png`;
+        const html = `<p>see</p><p><img src="${url}" itemtype="http://schema.skype.com/AMSImage" itemid="${objectId}" alt="image" /></p>`;
+        const inlined = teamsHtmlToMarkdown(html, [
+            {
+                name: `${objectId}.png`,
+                mimeHint: "png",
+                url,
+                itemId: objectId,
+                localPath,
+            },
+        ]);
+        expect(inlined).toContain(`![${objectId}.png](${localPath})`);
+        expect(inlined.includes("eu-api.asm.skype.com")).toBe(false);
+
+        const dropped = teamsHtmlToMarkdown(html);
+        expect(dropped).toBe("see");
+        expect(dropped.includes("eu-api.asm.skype.com")).toBe(false);
+    });
+
+    test("keeps markdown characters that were typed as plain Teams paragraphs", () => {
+        const html =
+            "<p># 01-01_01 - Úprava sekce Nabídky Web</p><p>## 1) Banner<br />- Textové sdělení<br />  - nested</p>";
+        const md = teamsHtmlToMarkdown(html);
+        expect(md).toContain("# 01-01_01 - Úprava sekce Nabídky Web");
+        expect(md).toContain("## 1) Banner");
+        expect(md).toContain("- Textové sdělení");
+        expect(md.includes("\\#")).toBe(false);
+        expect(md.includes("\\_")).toBe(false);
+        expect(md.includes("\\-")).toBe(false);
+    });
+
+    test("keeps emphasis, inline code, links, numbered lists and tables", () => {
+        const html = [
+            "<p><strong>Ahoj</strong> a <em>em</em> a <code>bun lint</code></p>",
+            '<p><a href="https://example.test/x" itemtype="http://schema.skype.com/HyperLink">click</a></p>',
+            "<ol><li>one</li><li>two</li></ol>",
+            "<table><tbody><tr><td>14683911</td><td>Vendula</td></tr></tbody></table>",
+            '<pre class="language-plaintext"><code>yarn codemod</code></pre>',
+        ].join("");
+        const md = teamsHtmlToMarkdown(html);
+        expect(md).toContain("**Ahoj**");
+        expect(md).toContain("`bun lint`");
+        expect(md).toContain("[click](https://example.test/x)");
+        expect(md).toContain("1. one");
+        expect(md).toContain("2. two");
+        expect(md).toContain("| 14683911 | Vendula |");
+        expect(md).toContain("```");
+        expect(md).toContain("yarn codemod");
+    });
+});

--- a/src/ms-teams/lib/html-to-markdown.ts
+++ b/src/ms-teams/lib/html-to-markdown.ts
@@ -1,0 +1,145 @@
+import { htmlToMarkdown } from "@genesiscz/utils/markdown/html-to-md";
+import { decodeTeamsString } from "./decode";
+import { parseAmsObjectId } from "./disk-cache";
+import { sanitizeHtml } from "./export/html";
+import type { Attachment } from "./types";
+
+/**
+ * Convert a Teams RichText/Html body to markdown, keeping headings, lists, links,
+ * emphasis, tables and code. Reply quotes are dropped (export already has replyTo).
+ * AMS images with a local file become inline markdown images; unresolved AMS tags are dropped.
+ */
+export function teamsHtmlToMarkdown(html: unknown, attachments: Attachment[] = []): string {
+    const raw = decodeTeamsString(html);
+
+    if (!raw) {
+        return "";
+    }
+
+    let prepared = stripReplyQuotes(raw);
+    prepared = prepared.replace(/&nbsp;/gi, " ").replace(/\u00a0/g, " ");
+    prepared = hoistOrphanNestedLists(prepared);
+    prepared = rewriteImages(prepared, attachments);
+    prepared = sanitizeHtml(prepared);
+
+    return tidyMarkdown(htmlToMarkdown(prepared));
+}
+
+const REPLY_ITEMTYPE = /itemtype=["']http:\/\/schema\.skype\.com\/Reply["']/i;
+
+/** Index just past the `</blockquote>` closing the tag that opened before `from`. */
+function endOfBlockquote(html: string, from: number): number {
+    const tag = /<blockquote\b[^>]*>|<\/blockquote\s*>/gi;
+    tag.lastIndex = from;
+    let depth = 1;
+
+    for (let m = tag.exec(html); m !== null; m = tag.exec(html)) {
+        depth += m[0].startsWith("</") ? -1 : 1;
+
+        if (depth === 0) {
+            return tag.lastIndex;
+        }
+    }
+
+    // Unbalanced markup: drop the rest rather than leave half a quote behind.
+    return html.length;
+}
+
+/**
+ * A Reply quote may contain another blockquote (a reply to a reply), so the
+ * first `</blockquote>` is not necessarily the one that closes it. Matching
+ * lazily left the outer quoted text in the export.
+ */
+function stripReplyQuotes(html: string): string {
+    const open = /<blockquote\b[^>]*>/gi;
+    let out = "";
+    let cursor = 0;
+
+    for (let m = open.exec(html); m !== null; m = open.exec(html)) {
+        if (!REPLY_ITEMTYPE.test(m[0])) {
+            continue;
+        }
+
+        const end = endOfBlockquote(html, open.lastIndex);
+        out += html.slice(cursor, m.index);
+        cursor = end;
+        open.lastIndex = end;
+    }
+
+    return out + html.slice(cursor);
+}
+
+/**
+ * Teams often stores an indent as an empty <li> wrapping a nested list.
+ * Fold that into the previous item so markdown keeps a real nested list.
+ */
+function hoistOrphanNestedLists(html: string): string {
+    return html.replace(/<\/li>\s*<li>\s*<(ul|ol)\b/gi, "<$1");
+}
+
+function rewriteImages(html: string, attachments: Attachment[]): string {
+    return html.replace(/<img\b[^>]*>/gi, (tag) => {
+        if (/schema\.skype\.com\/(Emoji|CustomEmoji)/i.test(tag)) {
+            const alt = htmlAttr(tag, "alt");
+
+            return alt ? ` ${alt} ` : " ";
+        }
+
+        const src = htmlAttr(tag, "src") ?? "";
+        const itemId = htmlAttr(tag, "itemid") ?? parseAmsObjectId(src);
+        const attachment = findImageAttachment(attachments, src, itemId);
+
+        if (attachment?.localPath) {
+            return `<img src="${escapeAttr(attachment.localPath)}" alt="${escapeAttr(attachment.name)}" />`;
+        }
+
+        if (/schema\.skype\.com\/AMSImage/i.test(tag) || /asm\.skype\.com/i.test(src)) {
+            return " ";
+        }
+
+        return tag;
+    });
+}
+
+function findImageAttachment(attachments: Attachment[], src: string, itemId: string | null): Attachment | undefined {
+    return attachments.find((attachment) => {
+        if (src && attachment.url === src) {
+            return true;
+        }
+
+        if (src && attachment.localPath === src) {
+            return true;
+        }
+
+        if (itemId && attachment.itemId === itemId) {
+            return true;
+        }
+
+        if (itemId && parseAmsObjectId(attachment.url) === itemId) {
+            return true;
+        }
+
+        return false;
+    });
+}
+
+function tidyMarkdown(markdown: string): string {
+    return markdown
+        .replace(/\\([#[\]_\\-])/g, "$1")
+        .replace(/\u00a0/g, " ")
+        .replace(/^(\s*)-(\s{2,})/gm, "$1- ")
+        .replace(/^(\s*)(\d+)\.(\s{2,})/gm, "$1$2. ")
+        .replace(/[ \t]+\n/g, "\n")
+        .replace(/\n{3,}/g, "\n\n")
+        .trim();
+}
+
+function htmlAttr(tag: string, name: string): string | null {
+    const match = tag.match(new RegExp(`\\b${name}=["']([^"']*)["']`, "i"));
+
+    return match?.[1] ?? null;
+}
+
+function escapeAttr(value: string): string {
+    return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}

--- a/src/utils/claude/token-verify.test.ts
+++ b/src/utils/claude/token-verify.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
     hasValidLongLivedToken,
     LONG_TOKEN_MIN_LENGTH,
+    longLivedTokenUsable,
     probeLongLivedToken,
     verifyLongLivedToken,
 } from "./token-verify";
@@ -27,6 +28,30 @@ describe("hasValidLongLivedToken", () => {
 
     test("a full-length token is valid", () => {
         expect(hasValidLongLivedToken({ longLivedToken: "x".repeat(LONG_TOKEN_MIN_LENGTH) })).toBe(true);
+    });
+});
+
+describe("longLivedTokenUsable", () => {
+    const token = "x".repeat(LONG_TOKEN_MIN_LENGTH);
+
+    test("a full-length token with no expiry is usable", () => {
+        expect(longLivedTokenUsable({ longLivedToken: token })).toBe(true);
+    });
+
+    test("a truncated token is not usable", () => {
+        expect(longLivedTokenUsable({ longLivedToken: "short" })).toBe(false);
+    });
+
+    test("a minted token past its expiry is not usable", () => {
+        expect(longLivedTokenUsable({ longLivedToken: token, longLivedTokenExpiresAt: Date.now() - 1_000 })).toBe(
+            false
+        );
+    });
+
+    test("a minted token still inside its expiry is usable", () => {
+        expect(longLivedTokenUsable({ longLivedToken: token, longLivedTokenExpiresAt: Date.now() + 60_000 })).toBe(
+            true
+        );
     });
 });
 

--- a/src/utils/claude/token-verify.ts
+++ b/src/utils/claude/token-verify.ts
@@ -24,6 +24,19 @@ export function hasValidLongLivedToken(tokens: { longLivedToken?: string }): boo
     return Boolean(tokens.longLivedToken && tokens.longLivedToken.length >= LONG_TOKEN_MIN_LENGTH);
 }
 
+/** Length-valid and not past a known mint expiry. Pasted tokens have no expiry, so they stay usable. */
+export function longLivedTokenUsable(tokens: { longLivedToken?: string; longLivedTokenExpiresAt?: number }): boolean {
+    if (!hasValidLongLivedToken(tokens)) {
+        return false;
+    }
+
+    if (tokens.longLivedTokenExpiresAt !== undefined && tokens.longLivedTokenExpiresAt <= Date.now()) {
+        return false;
+    }
+
+    return true;
+}
+
 const MESSAGES_URL = "https://api.anthropic.com/v1/messages";
 const PROFILE_URL = "https://api.anthropic.com/api/oauth/profile";
 /** A blackholed connection must not hang an interactive login forever. */
@@ -73,8 +86,13 @@ export async function probeLongLivedToken(token: string): Promise<TokenVerdict> 
     }
 }
 
-/** One-token call: proves the token authenticates. 429 means authenticated but rate-limited. */
-export async function verifyLongLivedToken(token: string): Promise<TokenVerdict> {
+/**
+ * POST /v1/messages with the oat-required claude-cli user-agent.
+ *
+ * Capture-time verify and warmup fallback share this: oat tokens reject 401
+ * without that UA, and ChatEngine does not send it.
+ */
+export async function sendLongLivedInferencePing(token: string): Promise<TokenVerdict> {
     try {
         const res = await fetch(MESSAGES_URL, {
             method: "POST",
@@ -117,4 +135,9 @@ export async function verifyLongLivedToken(token: string): Promise<TokenVerdict>
         logger.debug({ error }, "[token-verify] verification request failed");
         return "unreachable";
     }
+}
+
+/** One-token call: proves the token authenticates. 429 means authenticated but rate-limited. */
+export async function verifyLongLivedToken(token: string): Promise<TokenVerdict> {
+    return sendLongLivedInferencePing(token);
 }

--- a/src/utils/env/envVariables.ts
+++ b/src/utils/env/envVariables.ts
@@ -92,6 +92,14 @@ export const env = {
             const raw = getTrimmed("AI_PROXY_TRANSCRIPTS")?.toLowerCase();
             return raw !== "0" && raw !== "false" && raw !== "off";
         },
+        /**
+         * Which grok upstream serves Anthropic /v1/messages requests.
+         * "responses" (default) translates to the /responses wire, which names
+         * every parallel tool call; "shim" is the instant fallback to the
+         * native /v1/messages passthrough with the routing-tag repair.
+         */
+        getGrokMessagesRoute: (): "responses" | "shim" =>
+            getTrimmed("AI_PROXY_GROK_MESSAGES_ROUTE")?.toLowerCase() === "shim" ? "shim" : "responses",
     },
 
     github: {


### PR DESCRIPTION
Cherry-picks from the last two hours of work that are not on `master`.

Base: `origin/master` (`d2b551d9a`). Nine commits, oldest first.

## Included

- **ai-proxy web search** (also on #323)
  - Fold streamed tool inputs into transcripts and name the server-tool 422
  - Route transcript tool-input deltas by block index
  - Emulate Anthropic `web_search` for grok via Brave
  - Run WebSearch on xAI native `/responses`, Brave as fallback
  - PR #323 review: clamp `max_uses`, redact queries, abort on cancel, whole-list server-tool guard, domain-filter limits
- **handoff / plugins**
  - Preview proofs on `handoff_list` instead of dumping them
  - Name the real `agents-talk` skill id in the session hint
- **ms-teams**
  - Keep headings and lists in markdown export (`teamsHtmlToMarkdown`)

## Not included

- Local `feat/ms-teams` leftover SHAs: already on master via `origin/feat/ms-teams`
- `bkp/recommit/feat-ai-proxy-grok-*` rewrite history: patch-duplicates of master

#323 already carries the ai-proxy slice. This PR adds that slice plus the ms-teams markdown fix on a fresh branch off current master.


---

**Correction (2026-08-20), `max_uses` scope.** `max_uses` is clamped on parse (ceiling 20) and genuinely enforced only on the Brave emulation loop. It is NOT enforceable on the preferred native path: probed live against `cli-chat-proxy.grok.com`, `max_tool_calls: 1` was accepted with HTTP 200 and ignored — the reply still carried 9 `web_search_call` items against the uncapped control's 10. The code documents this at the build site and logs a warning when the upstream exceeds the caller's `max_uses`, rather than sending a cap field that does nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Anthropic web-search support through Grok, including native and fallback search, domain filters, streaming, cancellation, and clearer errors.
  - Added improved Grok request and response translation, including reasoning preservation and streaming support.
  - Improved Teams exports by converting rich HTML messages to Markdown.
  - Added improved handling and visibility for live in-process teammate sessions and sidechains.

- **Improvements**
  - Handoff lists now show concise proof previews with retrieval guidance.
  - Added safer path validation, clearer login wait feedback, and improved warmup credential fallback reporting.
  - Enhanced wrap-up target resolution and registry diagnostics.

- **Bug Fixes**
  - Improved streamed tool-call reconstruction and teammate session reattachment.
  - Prevented duplicate teammate sessions and preserved attachment accuracy in exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->