### PR TITLE
feat(chrome-devtools): port the CDP debugging skill as a first-class tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
         "supports-color": "^10.2.2",
         "tar-stream": "^3.2.0",
         "telegram": "^2.26.22",
+        "tough-cookie": "^6.0.2",
         "ts-lsp-client": "^1.1.0",
         "turndown": "^7.2.1",
         "tweetnacl": "^1.0.3",
@@ -3446,7 +3447,7 @@
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
-    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
@@ -3673,6 +3674,8 @@
     "@clack/prompts/@clack/core": ["@clack/core@1.0.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ=="],
 
     "@crawlee/core/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@crawlee/core/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "@electron/get/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -4075,6 +4078,8 @@
     "ipull/pretty-ms": ["pretty-ms@8.0.0", "", { "dependencies": { "parse-ms": "^3.0.0" } }, "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q=="],
 
     "is-ci/ci-info": ["ci-info@1.6.0", "", {}, "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="],
+
+    "jsdom/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "jsdom/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
         "supports-color": "^10.2.2",
         "tar-stream": "^3.2.0",
         "telegram": "^2.26.22",
+        "tough-cookie": "^6.0.2",
         "ts-lsp-client": "^1.1.0",
         "turndown": "^7.2.1",
         "tweetnacl": "^1.0.3",

--- a/plugins/genesis-tools/skills/chrome-devtools/SKILL.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: chrome-devtools
+description: Drive a REAL running browser (Brave/Chrome) over the Chrome DevTools Protocol via `tools chrome-devtools` to debug things that only break in the user's own browser — auth/SSO redirect loops, OAuth and OIDC failures, "works in incognito but not for me", cookie/session corruption, stuck SPAs, CORS errors, and captured .har files. Use this WHENEVER the user says "hook into my browser", "use chrome devtools", "attach to my brave", "why does this loop", "I get redirected forever", "login fails only for me", "unknown_error", "check my cookies/localStorage/session", "trace the redirects", "read this HAR", "download the HAR", or shares a URL that misbehaves while logged in. Also use it PROACTIVELY when a bug reproduces for the user but not on a clean profile — the differential (broken browser vs fresh profile) is the fastest root cause there is. Covers launching a CDP endpoint, retroactive HAR capture, live channel following, CDP scripting, and HAR analysis via tools har-analyzer.
+---
+
+# Chrome DevTools debugging harness
+
+Attach to the browser where the bug actually lives. Read the raw redirect chain, all
+cookies (including httpOnly ones page JS can never see), and storage. Then diff a broken
+browser against a working fresh profile. Everything runs through **`tools chrome-devtools`**;
+`--readme` prints the full docs, every verb has `--help`, and wrong invocations print the
+right one.
+
+## Non-negotiable first fact
+
+`--remote-debugging-port` is parsed at browser STARTUP. It cannot be enabled on a running
+browser. Any plan that assumes "just attach to their open Brave" is wrong until the browser
+is relaunched with the flag.
+
+```bash
+# A) reuse the real profile — restart quits, waits for exit, then relaunches with the flag
+tools chrome-devtools restart --browser brave --port 9222
+# if quit sticks: add --force (kill -KILL). Ask first. Tabs usually restore.
+
+# B) throwaway profile alongside their browser — nothing of theirs touched, but they must log in again
+tools chrome-devtools open --browser chrome --port 9223 --fresh <url>
+```
+
+Ask which before quitting anything. Losing their tab set without warning is the one thing
+they will be annoyed about. Do not `osascript quit` + `open -a`: `open -a` reuses the live
+process and ignores the flag. ⚠️ Chrome ≥136 refuses the flag on the DEFAULT profile dir;
+`restart` detects that and suggests the `--fresh` fallback.
+
+## Start here, every time
+
+```bash
+tools chrome-devtools attach     # scans 9222-9230 + lsof + DevToolsActivePort
+```
+
+If two or more Chromium browsers are open, `attach` exits 1 and lists each app with its
+exact restart command; pass `--port` to pick. `attach` also starts the **background
+recorder** for each listed endpoint (one per port, pidfile-deduped across concurrent agent
+sessions, dies when the browser's CDP endpoint dies) and prints a guidance block with the
+next commands. That recorder is what makes retroactive HAR possible.
+
+## One engine, two views
+
+- **`record`** — the capture engine. Background process, browser-wide (`--all-tabs`) or
+  scoped (`--match <substr>`), HAR-grade metadata into a rolling 4-hour buffer. Extra
+  capture channels: `--channels +ws,body,storage`. Stop: `record --port N --stop`.
+- **`follow`** — the live view. `--channels nav,doc,redirect,xhr,ws,console,error,cookie,body,storage`,
+  `--match substr|/regex/`, `--last 10m` to replay first. Prints Monitor-ready commands
+  before streaming, so you can arm a Monitor and THEN reproduce.
+- **`har`** — the retroactive view. `har --last 30m -o /tmp/cdp.har` dumps what already
+  happened; `har --now --reload` records a fresh load of one tab WITH bodies;
+  `--sanitize` redacts secrets; `--analyze` chains into `tools har-analyzer load`.
+
+The old `watch` verb is gone; running it explains this split.
+
+`/tmp/...` paths in the examples here are the POSIX default. On Windows the tool uses
+`%TEMP%` — trust the paths the tool itself prints (guidance, doctor, `--help`) over
+the literal examples.
+
+## 🛑 Do not pipe, do not tail raw
+
+| Never | Why | Instead |
+|---|---|---|
+| `record`/`follow`/`trace` piped to `head`, `tail`, or anything that closes stdout | long-running; the pid and paths print FIRST | run_in_background + `--out` + Monitor |
+| `tail -f` on `/tmp/GenesisTools/ChromeDevtools/<port>/seg-*.jsonl` | segments rotate every 30 min; your fd goes silently quiet and you conclude "no traffic" | `tools chrome-devtools follow` |
+| `pkill -f chrome-devtools` | kills MCP servers and the CLI you are typing | `status` then `cleanup --kill <pid>` |
+| `rm` capture dirs or the leftover buffer | that IS the retroactive HAR | `cleanup` (moves to trash), after dumping |
+| `cat`/`jq` a `.har` | token bonfire | `tools har-analyzer load x.har` |
+
+Health at any time: `tools chrome-devtools status` (CPU, memory, buffer sizes) ·
+`doctor` (read-only findings + fix commands) · `cleanup` (applies them, interactively in a
+terminal). The 2026-08-25 incident that forced these rules is `references/arm-cpu-leak.md`.
+The tool runs on macOS, Linux and Windows; on Windows the capture root is
+`%TEMP%\GenesisTools\ChromeDevtools` and `status` shows cpu-time without a live %CPU.
+
+## Then the verbs
+
+| Need | Command |
+|---|---|
+| All cookies incl. httpOnly, all domains | `cookies --domain <substr>` (`--json` to diff two browsers) |
+| Raw redirect chain with `Location` + `Set-Cookie` | `follow --channels redirect,cookie --match <substr>` (live) or `har --last 10m` (retroactive) |
+| Quick one-tab docs+redirect trace to a file | `trace --seconds 90 --match <substr> --out /tmp/t.log` |
+| HAR of what already happened | `har --last 30m -o /tmp/cdp.har` |
+| HAR of a fresh load + bodies | `har --now --reload -o /tmp/cdp.har` |
+| One-shot per-request assertion table (method/status/sizes/auth scheme) | `har --last 10m --match token --summary` |
+| Read page state | `eval '() => ({url: location.href, ls: {...localStorage}, ss: {...sessionStorage}})'` — quoting trouble or a hook blocking inline eval? write the JS to a file and use `eval --file <path>` |
+| Console messages incl. load-time ones | `console --match <substr> --reload` (attaches first — the MCP `list_console_messages` misses everything before ITS attach) |
+| Navigate / screenshot | `nav <url>` · `shot /tmp/x.png [--full]` |
+| Surgical cookie delete | `rm-cookie --name X --domain Y --path /cas` |
+| Pixel-coordinate grid over a screenshot | `grid /tmp/g.png [--region x,y,w,h] [--step 60]` |
+| The real MCP tools, against ANY port | `mcp list` · `mcp navigate_page '{"url":"…"}'` |
+| CDP scratch script | `scaffold <name> --recipe redirect-chain\|cookie-diff\|storage-snapshot\|body-fetch\|console-trap\|blank` |
+| The scripting API | `cheatsheet` (or `references/cdp-cheatsheet.md`) |
+
+Page verbs take `--match <url substr>` to pick a tab and ERROR when nothing matches; they
+never grab a random tab.
+
+## The method that actually finds these bugs
+
+For SSO/OIDC specifically, `references/auth-loop-playbook.md` has the federation chain
+shape, the which-bad-`Location`-means-which-symptom table, and the cookie-scope regression
+fingerprint.
+
+1. **Reproduce while a recorder runs.** `attach` starts one; the buffer holds the last 4
+   hours. An empty `har` means the recorder started after the action, not that nothing
+   happened.
+2. **Read the raw 302 chain, not the MCP request list.** `redirectResponse` carries the
+   `Location` and `Set-Cookie` that a flat list hides. The bug is usually one hop whose
+   `Location` is wrong (missing `?code=`/`?state=`, or pointing back at the app instead of
+   the IdP callback).
+3. **Diff broken vs working.** Launch a fresh-profile browser on another port
+   (`open --fresh --port 9223`), have the user do the same flow there. If it works, the
+   poison is in their browser state, and `cookies --json` on both ports is the whole answer.
+4. **Compare by (name, domain, path), never by name.** Duplicate cookie names on different
+   paths are the classic killer: RFC 6265 sends the longer path FIRST, servers that read
+   the first value bind to a stale session. A host-only `path=/cas` leftover next to a
+   current `domain=.x.cz path=/` cookie is exactly this.
+5. **Confirm by surgical deletion.** `rm-cookie` only the suspects, re-run the flow.
+   Working = proof, and it fixes the user's browser. Never "clear site data" — that
+   destroys the evidence and their logins.
+6. **Know what you cannot forge.** Injecting fake stale cookies usually does NOT reproduce
+   a session bug: servers tolerate unknown session ids, and signed artifacts (CAS `TGC`,
+   delegation JWTs) cannot be minted client-side. Reliable repro of those is server-side.
+   Say so rather than claiming a failed injection exonerates anything.
+
+## When the trace is not enough — network and wire forensics
+
+Read the file named, jumping to the section given. `references/net-forensics-index.md` is
+the full symptom index.
+
+| You see | Read |
+|---|---|
+| `(unknown)` Type · `(canceled)` · `(blocked:other)` · `(failed)` · XHR status 0 | `net-panel-symptoms.md` 1.2 |
+| Response body missing/empty even with Preserve log on | `net-panel-symptoms.md` 2.1 |
+| **Token/OAuth POST whose body vanished** — a navigation aborted it mid-flight | `net-panel-symptoms.md` 2.6 |
+| Opaque / CORB-stripped cross-origin response | `net-panel-symptoms.md` 2.5 |
+| Live panel and exported HAR disagree | `net-panel-symptoms.md` 1.5 |
+| Need more capture: settings, columns, experiments, starting a raw log | `net-capture-settings.md` 3.1-3.7 |
+| Brave Shields / fingerprinting may be altering requests | `net-capture-settings.md` 3.9 |
+| Need what panel AND HAR cannot see: socket bytes, DNS, TLS, preflight verdict, the numeric net error behind a cancel | `net-export-recipes.md` 4, 5.2-5.4 |
+| OAuth token endpoint, end to end | `net-export-recipes.md` 5.6 |
+| When did this start / how often did the user loop | `recipes.md` "Browsing history" — 🛑 `strftime('%s')` returns TEXT, so an epoch `BETWEEN` is silently always false (0 rows, no error) |
+
+Two facts that change conclusions, so carry them always: Chrome does not stream body bytes
+to DevTools until you view them and a navigation destroys the in-memory copy (a missing
+body is usually THIS, not the server); and a HAR is a DevTools-level artifact, so
+everything below HTTP exists only in a net-export log.
+
+## HAR files
+
+Never `cat`/`jq` a .har. Use `tools har-analyzer` (the `analyze-har` skill has the full
+command set):
+
+```bash
+tools har-analyzer load capture.har        # dashboard first, always
+tools har-analyzer errors                  # 4xx/5xx
+tools har-analyzer redirects               # chains (may under-report; cross-check Location headers)
+tools har-analyzer search "<pattern>" --scope url|body
+tools har-analyzer show e638 --raw | rg -o 'location: [^\n]*'   # THE money line for auth bugs
+```
+
+🛑 A HAR of a login flow contains the plaintext password in the POST body and live session
+tokens. Before it leaves the machine: `tools chrome-devtools har --sanitize`, or
+`tools har-analyzer export --sanitize --strip-bodies -o clean.har`. Warn the user
+explicitly; do not paste secrets into shell commands (they land in shell history and agent
+transcripts).
+
+## Extension debugging
+
+The YouTube extension has its own harness: `tools youtube extension devtools launch --port
+9333` plus ready-made page scripts in the vault (`references/prior-art.md` section 3).
+Plain extension loading: `tools chrome-devtools open --extension <dist-dir>`.
+
+## Writing it up
+
+Reports for a third party (an IdP team, another vendor) need: the numbered hop-by-hop chain
+with real URLs, the exact hop that misbehaves and what it SHOULD have returned, the
+cookie-diff table (working vs broken), the mechanism in two sentences, a concrete
+server-side fix, and the client-side workaround. Attach the sanitized HAR only.

--- a/plugins/genesis-tools/skills/chrome-devtools/references/arm-cpu-leak.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/arm-cpu-leak.md
@@ -1,0 +1,377 @@
+# Chrome DevTools arm: CPU leak, duplicate processes, what we found
+
+Date: 2026-08-25 to 2026-08-26
+Host: Martin's Mac (macOS 26.3.1, Bun 1.3.13)
+Skill: `~/.agents/skills/chrome-devtools/` (since ported to `tools chrome-devtools`)
+
+**2026-08-26 14:30 — this document is now history, kept as the "why".** The skill became
+`src/chrome-devtools/` in GenesisTools. The port keeps every fix from section 7 and goes
+further: `arm` is now `record`, the unbounded jsonl became rotating 30-minute segments with
+a 4-hour window, pidfiles carry process identity (command + start time) via
+`@genesiscz/utils/process/pidfile`, and `dataReceived` is aggregated through a regex fast
+path instead of being dropped entirely (HAR sizes stay correct at near-zero parse cost).
+Section 9's checklist was executed in that port; the contract table at the end still holds,
+with `arm` read as `record`.
+
+The arm is a background Bun process that attaches to a Chromium browser over the Chrome DevTools Protocol (CDP), turns on `Network.enable` on http(s) tabs, and appends metadata events to `/tmp/cdp-arm-<port>.jsonl` so `har` can dump "attach until now" later. It is not `chrome-devtools-mcp`. It is `bun chrome-devtools.ts arm --port N`.
+
+---
+
+## 1. What the user saw
+
+Activity Monitor showed two hot PIDs:
+
+| PID | Status when inspected | Command |
+|---|---|---|
+| **49166** | Already gone | Never recovered. Close in number to 49862, likely a sibling recorder or the parent `attach` that spawned the arm and exited. |
+| **49862** | Alive, 50-80% CPU for 4.5 hours | `bun /Users/Martin/.agents/skills/chrome-devtools/scripts/chrome-devtools.ts arm --port 9222` |
+
+A third recorder was the same class of leftover, not this skill:
+
+| PID | Command |
+|---|---|
+| **96932** | `bun scripts/per-target-record.ts --target 186BBA31073525576BED85533107F2C5 --label run5-tabA --port 9222` (GenesisBrain login experiment, same dead port, ~78% CPU, no TCP) |
+
+The user then said: let it arm, but it should not be five processes at high CPU when nothing is happening. Find the leak.
+
+---
+
+## 2. Process 49862, measured
+
+Taken 2026-08-25 ~20:22 local (CEST).
+
+```
+PID     PPID  USER    %CPU  RSS     ELAPSED   STAT  COMMAND
+49862   1     Martin  50-87 113312  04:29     R     bun chrome-devtools.ts arm --port 9222
+```
+
+- **PPID 1** (`launchd`). Orphan. Parent was the `attach` CLI, which `unref()`'d the child and exited.
+- Started **Tue Aug 25 15:52:35 2026**.
+- **STAT = R** (runnable), not S (sleeping).
+- CPU time **3m 15s** over 4h 32m. Live `%CPU` bounced 45-87 on five samples 0.4s apart.
+- RSS 113 MB, sample peak 211 MB.
+- cwd: `/Users/Martin/Tresors/Projects/CEZ/col-fe`
+- stdin/stdout/stderr: `/dev/null` (spawned with all three ignored).
+- No children.
+- `ps -M`: one hot thread (user 1:34, sys 0:23), rest idle.
+
+### Open files at inspect time (the smoking gun)
+
+`lsof -nP -p 49862` showed **no TCP, no Unix sockets**. Only:
+
+```
+cwd, bun binary, dyld, /dev/null x3
+KQUEUE  fd 3  count=3  state=0x10
+KQUEUE  fd 6  count=0  state=0x10
+KQUEUE  fd 7  count=0  state=0x12
+```
+
+Port **9222 was not listening**. Chrome was on **9223**. The arm had lost its browser and still ran hot.
+
+`sample 49862 2` spent **1573/1573 samples on the Bun JS main thread**. Not waiting on I/O. Not a syscall. JS was busy.
+
+### The capture file
+
+```
+/tmp/cdp-arm-9222.pid     6 bytes   "49862\n"   mtime 15:52
+/tmp/cdp-arm-9222.jsonl   635 MB    293,040 lines   mtime 20:20  (frozen)
+```
+
+First events: GitLab MR diffs (`gitlab.apps.corp/.../merge_requests/5908`).
+Later events: `localhost:3000` col-web chunks, GitLab Sentry envelopes, `muj.cez.cz/col`, Bing UET `bat.bing.com`.
+
+Last 200 KB method mix (252 events):
+
+| method | count |
+|---|---|
+| Network.dataReceived | 84 |
+| Network.loadingFinished | 30 |
+| Network.responseReceivedExtraInfo | 28 |
+| Network.responseReceived | 28 |
+| Network.webSocketFrameReceived | 15 |
+| Network.requestWillBeSent | 14 |
+| Network.requestWillBeSentExtraInfo | 13 |
+| Network.webSocketCreated | 10 |
+| Network.webSocketWillSendHandshakeRequest | 10 |
+| Network.webSocketFrameError | 10 |
+| Network.webSocketClosed | 10 |
+
+The skill called this "metadata only, will not keep response bodies". That was true about bodies. It was **not** cheap. `dataReceived` and websocket **frames** dominated.
+
+---
+
+## 3. What the arm was (architecture)
+
+### How it got started (the old contract)
+
+`bun chrome-devtools.ts attach` listed CDP endpoints on 9222-9230. For every listed port it called `startArmBackground(port)` unless `--no-arm`.
+
+Old spawn (the leaky one):
+
+```ts
+const child = Bun.spawn(["bun", script, "arm", "--port", String(port)], {
+  stdin: "ignore",
+  stdout: "ignore",
+  stderr: "ignore",
+});
+child.unref();
+```
+
+`unref()` means Bun will not keep the parent alive for the child. The parent `process.exit()`s after printing next commands. The child is adopted by `launchd` (PPID 1). Stdio to `/dev/null` means you never see it die.
+
+The child:
+
+1. Wrote `/tmp/cdp-arm-<port>.pid` **after** `connectBrowser` (HTTP `/json/version` then a WebSocket to `webSocketDebuggerUrl`).
+2. `Target.setDiscoverTargets` + `Target.setAutoAttach` + `Target.getTargets` + `attachToTarget` for every http(s) **page and iframe**.
+3. `Network.enable` on each of those sessions.
+4. On every `Network.*` event, `JSON.stringify` + **`appendFileSync`** (open, write, close, every line).
+5. Hung forever: `await new Promise(() => {})`.
+6. No websocket `close` / `error` handler. No TTL. No `/json/version` health check.
+
+`isArmAlive(port)` was `kill -0` on the pid file. The child wrote that file **after** CDP connect. Until then, the next `attach` saw "no arm" and spawned another.
+
+### What it is for
+
+`har --port N` has no `Network.getHAR`. The arm is the buffer: attach-until-now metadata, dump later. Useful. The bug was the lifetime and the event volume, not the idea.
+
+---
+
+## 4. Hypotheses we tested
+
+### H1. Bun WebSocket busy-loops after the peer dies
+
+This looked true: no TCP, STAT=R, kqueue count=3, 50-80% CPU.
+
+**Repro (Bun 1.3.13):** a real `Bun.serve` websocket (with `upgrade`), flood JSON at 1 ms, then either `server.stop(true)` or `kill -9` the server.
+
+Result: client got `close` / `readyState 3`, CPU fell to **0%**, STAT=S, one kqueue with count=0. Bun's WebSocket **parks** after a clean drop or RST.
+
+So 49862's spin was **not** "Bun WS always busy-loops when Chrome is gone". A dead socket that actually fires `close` is fine.
+
+### H2. `await new Promise(() => {})` is a spin loop
+
+False. That parks. STAT would be S if that were the only thing running. 49862 was R. Something else was running JS.
+
+### H3. Duplicate unref'd arms from a pid race (the "5 processes")
+
+**True.** Sequence:
+
+1. Agent session A runs `attach`. `startArmBackground` spawns child 1, `unref`s, parent exits. Child 1 is still in `connectBrowser`. Pid file is missing or stale.
+2. Agent session B (or A again) runs `attach`. `isArmAlive` is false. Spawns child 2. `unref`. Repeat.
+3. Each child eventually connects to the **same** browser WS, enables Network on **all** tabs, and parses the **same** event flood.
+4. Last child to write the pid file wins. The others are invisible to `arm --stop` and to `isArmAlive`. They stay on PPID 1 until reboot or a manual kill.
+5. Five `attach` calls across Claude/Grok/Cursor sessions = five parsers.
+
+That matches "5 processes like that with high CPU when nothing is happening." The user was not doing five captures. Agents were.
+
+### H4. "Idle" is not idle: background tabs keep chatting
+
+**True, and this is the CPU while the browser is still up.**
+
+`Network.enable` on every http(s) page **and iframe** means GitLab GraphQL, GitLab Sentry envelopes, `bat.bing.com`, `localhost:3000` HMR, muj.cez.cz analytics, CAS iframes, all of it.
+
+`Conn.onmessage` did `JSON.parse(String(ev.data))` on **every** CDP packet, then the arm listener returned early for methods it did not record. The parse already happened. `Network.dataReceived` and `Network.webSocketFrame*` are high-rate and large. Filtering after parse does not save CPU.
+
+The jsonl tail proved it: 84 `dataReceived` vs 14 `requestWillBeSent` in 252 events.
+
+### H5. `appendFileSync` per event on a 635 MB file
+
+**True as an amplifier.** Every event: open, write one line, close. 293k syscalls. As the file grew, that got worse. Not the whole story (CPU stayed high after mtime froze), but it is why a live arm pegged a core during capture.
+
+### H6. After the port moved, orphans kept running
+
+**True.** Brave/Chrome had been on 9222, later Chrome listened on 9223. jsonl froze at 20:20 (last Bing ping / websocket close). The process had no sockets and no close handler, so it did not exit. Combined with H3, you keep N dead-or-half-dead parsers.
+
+Whether JS was still parsing a backlog, or Bun still had a half-open WS that did not fire `close` in that specific Chrome-restart case, we did not get a second sample of 49862 after the first. The RST repro did fire `close`. Chrome's debugger websocket on process death may differ. The health check (`GET /json/version` three failures) covers that without needing to win the Bun-vs-Chrome close argument.
+
+---
+
+## 5. What was *not* the leak
+
+These were on the machine the same afternoon and look similar in Activity Monitor if you sort by CPU.
+
+### chrome-devtools-mcp (many, ~0% CPU)
+
+Pairs of `chrome-devtools-mcp` + `.../telemetry/watchdog/main.js --parent-pid=...`. One pair per agent session that loaded the MCP server. They were **idle**. Do not kill them thinking they are the arm. They are not `/tmp/cdp-arm-*.pid`.
+
+### Kibana `--scan` (five bun processes, 55-99% CPU)
+
+```
+col-tools kibana logs --env wso2-prod --query 'GET /commonauth' --scan ...
+col-tools kibana logs --env wso2-prod --query 'oauthErrorCode' --scan ...
+```
+
+PIDs like 10493 (69 min CPU in 86 min elapsed), 12031, 12167, 12232, 67303 (already running more than a day). These are **not** CDP arms. They are stuck Elasticsearch scans from another investigation. If the machine is still hot after arms are gone, look here.
+
+### cmux, WindowServer, Spotify Helper (Renderer)
+
+Also high that day. Unrelated.
+
+---
+
+## 6. First fix (wrong): disable auto-arm
+
+We flipped `attachSpawnsArm()` to `false`, required `--match` or `--all-tabs`, default TTL 600s, and made `runArm` wait on websocket close / timeout / SIGTERM.
+
+That stops the leak by not having an arm. The user then said: **let it arm**, find the leak. Auto-arm is the point of `har` attach-until-now.
+
+Keep the death pact. Put auto-arm back. Fix uniqueness and parse volume.
+
+---
+
+## 7. The actual fix (current code)
+
+Files:
+
+- `scripts/arm.ts` (policy + `runArm`)
+- `scripts/cdp.ts` (`Conn` optional `dropRaw`)
+- `scripts/chrome-devtools.ts` (`startArmBackground`, CLI)
+- `scripts/arm.test.ts`, `scripts/arm-cli.test.ts`
+- `SKILL.md`
+
+### 7.1 One process per port
+
+Parent writes the **child pid immediately** after `Bun.spawn`, before the child connects.
+
+```ts
+const child = Bun.spawn(["bun", script, "arm", "--port", String(port), "--all-tabs", "--seconds", "0"], {
+  stdin: "ignore", stdout: "ignore", stderr: "ignore",
+});
+const claimed = claimArmPort(port, child.pid);
+if (!claimed.claimed) {
+  child.kill();  // lost the race, do not keep a second parser
+  return;
+}
+child.unref();
+```
+
+`claimArmPort`: if the pid file names a **live** process, refuse. If missing or dead, take over.
+
+The child must **not** treat its own pid as a duplicate (`shouldExitAsDuplicate`). Otherwise: parent writes child.pid, child starts, `isArmAlive` is true, child exits 0 and you have no arm.
+
+### 7.2 Drop noise before JSON.parse
+
+`Conn` takes `dropRaw?: (raw: string) => boolean`. The arm passes `shouldDropCdpPacket`:
+
+```ts
+raw.includes('"method":"Network.dataReceived"')
+|| raw.includes('"method":"Network.webSocketFrame')
+```
+
+That hits `webSocketFrameReceived`, `Sent`, `Error`. Command responses (`{"id":1,"result":...}`) are kept. `watch --channels ws` does **not** pass `dropRaw`, so frame capture still works there.
+
+We still `Network.enable` on pages and iframes (SSO/CAS login lives in iframes). We just do not parse the high-rate packets.
+
+### 7.3 One log fd
+
+`openSync(jsonl, "w")` then `writeSync(fd, line)` for the life of the arm. `closeSync` in `finally`. No `appendFileSync` per event.
+
+### 7.4 Die when CDP dies
+
+Every 2s: `GET http://127.0.0.1:<port>/json/version` with a 1s timeout. Three consecutive failures abort the arm (`healthIsDead`). Also exit on websocket `close`/`error`, SIGTERM/SIGINT, `arm --stop`, and optional `--seconds`.
+
+Attach-spawned arms use `--seconds 0` (until CDP drops). Explicit `arm` without `--seconds` still defaults to 600 in `resolveArmSeconds` as a forgotten-process net. Pass `--seconds 0` to wait only on CDP death.
+
+Bare CLI `arm` still requires `--match <url>` or `--all-tabs`. Attach uses `--all-tabs`.
+
+### 7.5 What we did **not** change
+
+- `unref()` is still there. The arm must outlive `attach`. Uniqueness + health check is what stops orphans, not "never unref".
+- Auto-arm on `attach` is **on** (`attachSpawnsArm() === true`).
+- One arm **per listed endpoint**. Two browsers with CDP (broken vs working) is two arms. That is intended. The race was many arms on the **same** port.
+
+---
+
+## 8. How to see it on a machine
+
+```bash
+# live arms
+ps -axo pid,ppid,pcpu,etime,stat,command | awk '/chrome-devtools\.ts arm/'
+
+# pid + capture (may be leftover after death)
+ls -lh /tmp/cdp-arm-*.pid /tmp/cdp-arm-*.jsonl
+cat /tmp/cdp-arm-9222.pid
+kill -0 $(cat /tmp/cdp-arm-9222.pid) && echo alive || echo stale
+
+# no sockets + STAT=R + kqueue = the 49862 fingerprint
+lsof -nP -p <pid>
+ps -p <pid> -o pid,stat,pcpu,time,etime,command
+sample <pid> 2 -file /tmp/sample-arm.txt
+
+# who listens
+lsof -nP -iTCP:9222
+lsof -nP -iTCP:9223
+```
+
+Stop one port:
+
+```bash
+bun chrome-devtools.ts arm --port 9222 --stop
+# or kill $(cat /tmp/cdp-arm-9222.pid)
+```
+
+Do not `pkill -f chrome-devtools.ts`. That can hit MCP, watch, and the CLI you are typing.
+
+The jsonl is the capture. Do not `rm` it if you still want `har --from-arm`. `/tmp` clears on reboot.
+
+---
+
+## 9. Porting checklist
+
+When you copy this skill to another repo:
+
+1. Copy `scripts/arm.ts`, `scripts/cdp.ts`, `scripts/chrome-devtools.ts`, the `*.test.ts` files, and `SKILL.md`. This document is the "why".
+2. Keep **claim-then-unref**, not unref-then-maybe-write-pid.
+3. Keep **drop-before-parse**. Filtering in the listener is too late.
+4. Keep **health probe**. Do not trust Bun `WebSocket.close` alone against Chrome's debugger socket.
+5. Keep **shouldExitAsDuplicate**. Easy to regress: "pid file exists and is alive" looks like a duplicate of yourself.
+6. Do not `appendFileSync` in a CDP event handler.
+7. `Conn` `dropRaw` is arm-only. `watch --channels ws` must not use it.
+8. Tests: `bun test scripts/` (54 passed here, 2026-08-25). The leak tests are in `arm.test.ts`: `claimArmPort`, `shouldDropCdpPacket`, `healthIsDead` / `probeCdp`, `shouldExitAsDuplicate`, `waitUntilArmDone`. CLI: `arm-cli.test.ts` (bare `arm` exits 1, no pid file).
+9. `/tmp/cdp-arm-<port>.{pid,jsonl}` is the on-disk contract. `har` reads the jsonl. Changing the path is a SKILL.md + `armPaths()` change together.
+
+### Contract the ported skill must keep
+
+| Action | Required behavior |
+|---|---|
+| `attach` lists a port | At most one arm for that port. Pid claimed **before** CDP connect. |
+| Second `attach` same port | Log `arm already up`, kill the extra child if spawn raced. |
+| Background tabs chatting | CPU stays near idle: no parse of `dataReceived` / websocket frames. |
+| Browser quits or port moves | Arm exits within ~6s (3 x 2s probes), pid file unlinked, jsonl kept. |
+| `arm` with no `--match` and no `--all-tabs` | Exit 1, write nothing. |
+| `arm --stop` | SIGTERM the pid in the pid file. jsonl kept. |
+
+---
+
+## 10. Numbers to quote
+
+| Thing | Value |
+|---|---|
+| PID | 49862 |
+| Command | `bun chrome-devtools.ts arm --port 9222` |
+| Parent | 1 (launchd) |
+| Start | 2026-08-25 15:52:35 |
+| Inspect | 2026-08-25 ~20:22 |
+| Live CPU | 45-87% |
+| CPU time | 3m 15s / 4h 32m |
+| RSS / peak | 113 MB / 211 MB |
+| jsonl | 635 MB, 293,040 lines, froze 20:20 |
+| Sockets at inspect | none |
+| Browser then | Chrome on 9223, nothing on 9222 |
+| Bun | 1.3.13 |
+| WS-after-RST repro | close fires, 0% CPU |
+| Test suite after fix | 54 pass, 0 fail |
+
+---
+
+## 11. Short version for a commit message
+
+```
+attach spawned unref'd CDP arms before the child wrote its pid, so every
+later attach added another Network.enable parser. Each JSON.parsed every
+dataReceived and websocket frame from every tab (GitLab, Sentry, Bing),
+which looks idle and is not. Orphans survived the browser leaving 9222.
+
+Claim the child pid immediately, drop those packets before parse, write
+the jsonl through one fd, and exit after three /json/version failures.
+```

--- a/plugins/genesis-tools/skills/chrome-devtools/references/auth-loop-playbook.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/auth-loop-playbook.md
@@ -1,0 +1,67 @@
+# Auth / SSO failure playbook
+
+Worked case: CEZ COL, 2026-07-28. Same browser, same root cause, two symptoms:
+UAT looped forever, PROD ended on a generic error page. Full reports:
+`GenesisBrain/ČEZ/col-294936-col-295714-CantLogInOrLogOut/2026-07-28-Mepas*.md`.
+
+## Shape of an OIDC federation chain
+
+```
+app  ->  IdP /oauth2/authorize            (client_id, redirect_uri=app/auth-callback, state, PKCE)
+     ->  upstream SSO /oidc/authorize     (redirect_uri=IdP/commonauth, its own state)
+     ->  upstream /login                  (SSO cookie present => auto ticket, no form)
+     ->  upstream /oauth2.0/callbackAuthorize?ticket=ST-...
+     ->  IdP /commonauth?code=...&state=...        <-- the hop that must carry code+state
+     ->  app /auth-callback?code=...&state=...
+     ->  app POSTs /token, done
+```
+
+Read the chain top-down and find the FIRST hop whose `Location` is not what the next
+step needs. That hop is the bug; everything after is fallout.
+
+Two observed failure modes of the same broken hop:
+
+| `callbackAuthorize` 302 Location | Symptom |
+|---|---|
+| back to the app URL (a URL stored in an old server session) | app sees itself unauthenticated, retries authorize, infinite loop |
+| bare `IdP/commonauth`, no `code`, no `state` | IdP cannot correlate → `retry.do` → generic error page |
+
+## Distinguishing the layers
+
+- App/frontend blamed? Check whether ANY frontend code runs between the ticket and the bad
+  redirect. If the bad `Location` comes from a raw 302 between two backend endpoints, no
+  frontend branch can cause it. State that plainly with the evidence line.
+- IdP down? Probe it directly: `curl -so /dev/null -w '%{http_code}' https://idp/commonauth`.
+  A 302 means alive; the handoff is what is broken.
+- Only one user? Compare against a fresh profile immediately (see SKILL.md step 3).
+
+## Cookie-scope regression (the actual root cause here)
+
+A server changed its session cookie scope (`path=/cas` host-only → `path=/` `domain=.host`)
+without expiring the old ones. Browsers alive across the change send BOTH. Longer path
+first → container binds the stale session → the OAuth transaction is missing from it →
+the callback has nothing to append.
+
+Fingerprint in a cookie dump: same cookie NAME twice, different `path`, one host-only.
+Fresh profiles only ever get the new scope, which is why it never shows in testing.
+
+Server fix to recommend:
+
+```
+Set-Cookie: JSESSIONID=; Path=/cas; Max-Age=0        (host-only, no Domain attribute)
+Set-Cookie: <other legacy names>=; Path=/cas; Max-Age=0
+```
+
+plus: the callback should emit an OAuth `error=` redirect when its request context is
+missing, instead of silently bouncing to a stored URL.
+
+User workaround: delete the stale `path=/cas` cookies, or fully quit the browser
+(they are session cookies).
+
+## Repro honesty
+
+Injecting fabricated stale cookies into a healthy profile did NOT reproduce it: the
+container ignores unknown session ids, and CAS-signed artifacts (`TGC`, delegation JWT)
+cannot be forged client-side. Reliable repro is server-side (create a session under the
+old scope, redeploy the new scope, log in with both present). Report a failed injection
+as inconclusive, never as "the theory is wrong".

--- a/plugins/genesis-tools/skills/chrome-devtools/references/cdp-cheatsheet.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/cdp-cheatsheet.md
@@ -1,0 +1,80 @@
+# CDP scripting cheatsheet (`tools chrome-devtools`)
+
+Printable any time: `tools chrome-devtools cheatsheet`. Scratch scripts:
+`tools chrome-devtools scaffold <name> --recipe <r>` → lands in the `tools scripts` store,
+run with `tools scripts run <name> -- --port 9222`.
+
+## Verbs, one line each
+
+```
+attach                        scan endpoints, start the background recorder, print next steps
+record  --match X|--all-tabs  the capture engine (one per port; --stop; --channels +ws,body,storage)
+follow  --channels a,b        live view over the buffer (+ Monitor hints; rotation-aware)
+har     [--last 30m|--now]    DevTools-grade HAR from the buffer, or a live window with bodies
+status | doctor | cleanup     inventory (CPU/mem) | read-only diagnosis | guided fixes
+cookies --domain X [--json]   ALL cookies incl. httpOnly, every domain
+console --match X --reload    console messages incl. load-time ones (attaches first)
+eval '() => …'                run JS in the tab, JSON out
+nav <url> | shot [png]        navigate | screenshot (--full)
+grid [png] --step 60          screenshot with pixel-coordinate grid (for clicking into pages)
+trace --match X               quick one-tab docs+redirect chain to a file
+targets                       raw /json/list
+open --fresh | restart        launch/relaunch a browser WITH the debugging flag
+mcp <tool> '<json>'           call real chrome-devtools-mcp tools on any port
+```
+
+## Channel vocabulary
+
+Capture (`record --channels`, cost real CPU/calls): `net`(always) `console`(default)
+`ws`(frames) `body`(≤2 KB fetch) `storage`(snapshot per nav).
+Render (`follow --channels`): `nav doc redirect xhr ws console error cookie body storage`.
+Rendering is free, but `ws`/`body`/`storage` (and `console`/`error`) only show data the
+recorder captured — follow prints the exact `record` restart command when the capture
+channel is off. For a one-off live storage read, skip the buffer: use the `eval` verb or
+the `storage-snapshot` recipe.
+
+## Do-not-pipe table
+
+| Never do | Why | Instead |
+|---|---|---|
+| `record … \| head` / `follow … \| tail` | long-running; they print their pid and paths FIRST, then keep going | run with run_in_background, read `--out`, arm a Monitor |
+| `tail -f /tmp/GenesisTools/ChromeDevtools/<port>/seg-*.jsonl` | segments rotate every 30 min; the fd goes silently quiet | `tools chrome-devtools follow` |
+| `pkill -f chrome-devtools` | hits MCP servers and the CLI you are typing | `status`, then `cleanup --kill <pid>` |
+| `cat`/`jq` a `.har` | token bonfire | `tools har-analyzer load x.har` |
+| `rm` the capture dir | it is the retroactive HAR | `cleanup --dir <port>` (moves to trash) |
+
+## cdp lib API (`@gt/chrome-devtools/cdp` in scaffolded scripts)
+
+```ts
+import { attach, browser, targets } from "@gt/chrome-devtools/cdp";
+
+const page = await attach({ port: 9222, url: "app.example.com" }); // url substring MUST match
+page.navigate(url) · page.reload(ignoreCache?) · page.evaluate("() => …")
+page.screenshot(path, fullPage?) · page.resize(w, h) · page.onConsole((level, text) => …)
+page.recordNetwork(urlFilter?)   // LIVE array; keeps redirectResponse hops (status/from/location/setCookie)
+page.responseBody(requestId) · page.waitForText(["Ready"], 15000)
+
+const b = await browser(9222);   // browser-level: cookies across ALL domains incl. httpOnly
+b.cookies("idp.example.com") · b.setCookies([...]) · b.deleteCookie(name, domain, path)
+b.deleteCookiesMatching(c => c.path === "/legacy")   // returns what was deleted
+```
+
+`recordNetwork` event kinds: `request` (type/method/url/postData/requestId) · `redirect`
+(status/from/location/setCookie[]) · `response` (status/url/headers/requestId) · `failed` ·
+`nav` (main frame only).
+
+## Recipes (scaffold --recipe …)
+
+`redirect-chain` live 302 chain while reproducing · `cookie-diff` broken-vs-fresh browser by
+(name,domain,path) with duplicate-name detection · `storage-snapshot` ls/ss dump ·
+`body-fetch` bodies of matching responses · `console-trap` console+exceptions around an
+action · `blank` empty scratch with targets list.
+
+## Method reminders (from the SKILL — the bugs live here)
+
+- Attach BEFORE the action; CDP starts empty and bodies die on navigation.
+- Read the raw 302 chain (`redirect` events), not a flat request list.
+- Diff broken vs fresh profile; compare cookies by (name, domain, path), never by name.
+- Confirm by surgical deletion (`rm-cookie`), never "clear site data".
+- A duplicate cookie name on different paths means the longer path is sent FIRST
+  (RFC 6265), so the stale session wins.

--- a/plugins/genesis-tools/skills/chrome-devtools/references/net-capture-settings.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/net-capture-settings.md
@@ -1,0 +1,200 @@
+# Maximum capture: settings, columns, flags, net-export, Brave Shields
+
+Everything to turn on before reproducing a bug, plus how to start a `chrome://net-export/`
+capture and what Brave's Shields do to requests behind your back.
+
+Further: `net-panel-symptoms.md` (reading the result) ·
+`net-export-recipes.md` (analysing a net-export log).
+
+---
+
+## 3. Every setting, flag and source for maximum logging
+
+### 3.1 DevTools network panel settings (the panel gear icon)
+
+| Setting | Effect | Default |
+|---------|--------|---------|
+| **Preserve log** | Keeps request rows across page navigations. Headers/timing preserved; response body NOT preserved (see §2.1). | Off |
+| **Disable cache** | Forces all requests to bypass the HTTP cache (equivalent to Ctrl+Shift+R for every request). Only active while DevTools is open. | Off |
+| **Capture screenshots** | Records filmstrip screenshots of the viewport during load. | Off |
+| **Show overview** | Shows the timing waterfall overview above the requests table. | On |
+| **Group by frame** | Groups requests by the iframe/frame that initiated them. Useful for multi-frame pages. | Off |
+| **Big request rows** | Two-line rows: top = transferred size, bottom = uncompressed size; Priority column shows initial + final priority. | Off |
+
+### 3.2 Filter bar options
+
+| Filter | Where | What it does |
+|--------|-------|--------------|
+| **Hide data URLs** | More filters → Hide data URLs | Removes `data:` URIs from the table |
+| **Hide extension URLs** | More filters → Hide extension URLs | Removes `chrome-extension://` requests |
+| **Blocked response cookies** | More filters → Blocked response cookies | Shows only requests where a cookie was blocked from being set |
+| **Blocked requests** | More filters → Blocked Requests | Shows only requests that were blocked (red rows) |
+| **3rd-party requests** | More filters → 3rd-party requests | Shows only requests whose origin differs from the page origin |
+| **Filter box** | Inline text box | Supports `domain:`, `mime-type:`, `status-code:`, `larger-than:`, `is:running`, `has-response-header:`, `method:`, `scheme:`, `url:`, and many more |
+
+### 3.3 Columns to enable (right-click the header row)
+
+Right-click any column header to add/remove columns:
+
+| Column | What it shows | When useful |
+|--------|--------------|-------------|
+| **Connection ID** | Numeric ID of the TCP/QUIC connection. Requests sharing the same ID reuse the same socket. | Debugging connection pooling, HTTP/2 multiplexing |
+| **Protocol** | `http/1.1`, `h2`, `h3`, `ws`, `wss` | Confirming HTTP/2 or HTTP/3 upgrade |
+| **Priority** | Two values in big-row mode: initial (bottom) and final (top) Fetch priority | Diagnosing resource loading order |
+| **Initiator** | Script filename + line, or "Parser", or "(other)" | Tracing which code caused a request |
+| **Set-Cookies** | Count of `Set-Cookie` headers | Cookie debugging |
+| **Has overrides** | Whether request/response was modified by a DevTools override rule | Override debugging |
+| **Method** | GET / POST / OPTIONS … | Filtering by HTTP verb |
+| **Path** | URL path without host | Cleaner view for same-origin requests |
+| **Domain** | Hostname only | Identifying third-party requests |
+| **Remote address** | `IP:port` of the server that responded | Confirming CDN edge or direct origin |
+| **Remote address space** | Public / Private / Local | For Private Network Access (PNA/LNA) debugging |
+| **Time** | Total elapsed from request start to last byte | Performance regression hunting |
+| **Cache-Control** | Response `Cache-Control` header value | Cache policy audit |
+| **Content-Encoding** | `gzip` / `br` / `zstd` / empty | Verifying compression |
+| **Waterfall** | Visual timeline bar | Default on; shows queuing/stalling/TTFB/download phases |
+
+Custom response headers: right-click header → Response Headers → Manage Header Columns → Add custom header. Useful for adding `X-Request-ID`, `ETag`, `CF-Ray`, etc.
+
+### 3.4 DevTools Settings → Preferences → Network
+
+Navigate via the ⚙ gear icon in the top-right of DevTools (not the panel gear):
+
+| Setting | Path | Effect |
+|---------|------|--------|
+| **Allow to generate HAR with sensitive data** | Settings → Preferences → Network | Enables the "Export HAR (with sensitive data)" option that includes `Cookie`, `Set-Cookie`, `Authorization` headers |
+| **Custom HAR columns** | Right-click header → add custom | Per-session only |
+
+### 3.5 DevTools Settings → Experiments
+
+Open DevTools Settings → Experiments (you may need to enable `chrome://flags/#enable-devtools-experiments` first on Brave):
+
+| Experiment | Effect |
+|-----------|--------|
+| **Network panel: show request headers on new line** | Readability improvement for long headers |
+| **Protocol monitor** | Shows raw Chrome DevTools Protocol messages — useful for seeing what DevTools itself sends/receives |
+| **Enable advanced network conditions** | Additional throttling and condition simulation options |
+
+Brave tracks Chromium closely (the build verified for this doc reports Chromium 151) — most "graduated" experiments from earlier majors are now permanent features.
+
+### 3.6 `chrome://net-export/`: usage and content
+
+This is the strongest capture tool of the lot. It operates at the network-process level, below DevTools.
+
+**How to use:**
+
+1. Open a new tab → `chrome://net-export/`
+2. Select logging level:
+   - **Strip private information** (default): strips cookies, auth headers, but keeps event structure
+   - **Include cookies and credentials**: adds `Cookie`/`Set-Cookie`/`Authorization` to events
+   - **Include raw bytes**: adds the raw wire bytes (`SOCKET_BYTES_SENT/_RECEIVED`, encrypted for TLS) AND the decrypted plaintext (`SSL_SOCKET_BYTES_SENT/_RECEIVED`) per socket; QUIC/HTTP3 logs `QUIC_SESSION_*` packet events, with no decrypted-byte export equivalent
+3. Click **Start Logging To Disk**
+4. Reproduce the problem in a **different tab** (keep the net-export tab open)
+5. Click **Stop Logging**
+6. Load the resulting JSON at https://netlog-viewer.appspot.com — with cookies or raw bytes enabled the file holds live credentials; the viewer is a static page that parses in your browser (no upload), but treat the JSON itself like a credentials file and never share it unstripped
+
+**Command-line equivalent (for startup-time problems):**
+```
+--log-net-log=/tmp/net-export.json
+--net-log-capture-mode=IncludeSensitive    # or Everything
+--net-log-max-size-mb=200                  # limit file size (Chrome M117+)
+```
+
+**What the JSON contains:**
+
+The file is a JSON object with:
+- `constants`: maps integer event type IDs to human-readable names (e.g. `354 → "URL_REQUEST_START_JOB"`)
+- `events`: array of event objects, each with `time`, `type` (integer), `source` (`{id, type}`), `phase` (0=none, 1=begin, 2=end), and `params`
+
+The `source.type` identifies the kind of network object:
+- `URL_REQUEST` — top-level request
+- `HTTP_STREAM_JOB` — stream connection job (one per HTTP/QUIC connection attempt)
+- `SOCKET` — raw TCP/QUIC socket
+- `HOST_RESOLVER_IMPL_JOB` — DNS resolution
+- `CERT_VERIFIER_TASK` — certificate chain verification
+
+**Top 5 event types to grep for:**
+
+| Event type name | What it means |
+|----------------|---------------|
+| `URL_REQUEST_START_JOB` | A URL request began. Params contain `url`, `method`, `load_flags`. Start here when tracing a request. |
+| `HTTP_TRANSACTION_READ_RESPONSE_HEADERS` | Response headers were received. Params contain the raw status line and headers. |
+| `URL_REQUEST_JOB_FILTERED_BYTES_READ` | Decompressed/decoded response body bytes were read. Present only with `Include raw bytes`. |
+| `URL_REQUEST_STATUS_CHANGED` | The request status changed. When followed by no further events on the same source, the request ended. |
+| `CANCELLED` / `ERR_ABORTED` | The request was cancelled. Look at the params for `net_error` (negative integer mapping to an `ERR_*` code). |
+
+### 3.7 `chrome://net-internals/` tabs
+
+`chrome://net-internals/` is now mostly a set of static snapshots (the live event viewer was removed in 2018 and moved to the external netlog-viewer). What remains:
+
+| Tab | Content | When to use |
+|-----|---------|-------------|
+| **Events** | Removed (2018). Use chrome://net-export/ instead. | — |
+| **DNS** | Current state of the DNS resolver cache: cached lookups, TTLs, resolution mode (system/async). Has a "Clear host cache" button. | DNS staling issues, HSTS preloads, when a domain resolves to the wrong IP |
+| **Sockets** | Pool of active and idle TCP/TLS sockets. Shows which sockets are in-use vs idle, connection parameters, error state. | "Max 6 connections per origin" stall diagnosis |
+| **HTTP/2** | Active and recently closed HTTP/2 sessions. Shows stream IDs, HPACK table state, flow control window sizes. | H2 multiplexing issues, GOAWAY frames |
+| **HSTS** | HTTP Strict Transport Security store. Can query whether a domain has HSTS. Has "Delete domain security policies" button. | Clearing stale HSTS entries, diagnosing forced HTTPS |
+| **Proxy** | Active proxy configuration. | Corporate proxy / PAC script debugging |
+
+To use the DNS tab: type the hostname and click "Lookup". It shows whether the resolution used the async DNS resolver or the system resolver, and what records were returned.
+
+### 3.8 HAR export gotchas
+
+1. **"Save all as HAR (sanitised)" vs "(with sensitive data)"**: The sanitised variant strips `Cookie`, `Set-Cookie`, `Authorization`, and `Proxy-Authorization` headers. For OAuth debugging, always use the sensitive-data variant (requires enabling in Settings → Preferences → Network first).
+
+2. **Response body not in HAR**: Chrome only includes `response.content.text` for requests whose body was loaded into the DevTools front-end before export. If you exported immediately after page load without clicking each request, many bodies will be `""`. This is Chrome's design, not a HAR spec limitation.
+
+3. **HAR 1.2 spec `bodySize` = -1**: HAR spec says `bodySize` should be -1 when the info is not available. Chrome uses `-1` for cache-served responses and for the rare case where headers don't include `Content-Length` and chunked transfer encoding is used.
+
+4. **`timings.connect = -1`**: HAR spec instructs that `-1` means "does not apply" — i.e. the request reused an existing connection. Not a bug.
+
+5. **Encoding field**: HAR 1.2 spec added `response.content.encoding` to support base64-encoded binary bodies. Chrome uses this for binary responses (images, fonts). If you see `"encoding": "base64"` in `content`, decode the `text` field with `atob()`.
+
+6. **Large HAR files**: Chrome does not cap the HAR size itself, but response bodies contribute to the DevTools front-end's memory footprint. Very large responses (> ~64 MB) may be truncated.
+
+Source: HAR 1.2 spec — http://www.softwareishard.com/blog/har-12-spec/
+
+### 3.9 Brave specifics: Shields and fingerprinting protection
+
+Brave adds significant network-level interceptors on top of Chromium. Shields' ad/tracker blocking is native browser code (the Rust `adblock-rust` engine in the browser process), not a `webRequest` extension, so it is harder to disable selectively and never shows up in the extensions list.
+
+**What Brave Shields intercept at the network layer:**
+
+| Protection | How it intercepts | DevTools effect |
+|-----------|------------------|----------------|
+| **Ad / tracker blocking (Standard mode)** | EasyList + EasyPrivacy + uBlock Origin + Brave internal lists, matched by the native adblock-rust engine before the request leaves the network stack. | Request shows `(blocked:other)` in Status, never reaches the server. |
+| **Ad / tracker blocking (Aggressive mode)** | Same lists plus first-party trackers. More requests blocked. | Same as Standard. |
+| **CNAME uncloaking** | DNS resolution exposes the real CNAME target; if it matches a tracker domain, the request is blocked. | Blocked requests may show the original domain, not the CNAME. DevTools does not surface the CNAME. |
+| **Cross-site cookie blocking** | Third-party cookies stripped at the browser level before the request is sent. | Headers in DevTools show no Cookie header for third-party requests. |
+| **Ephemeral storage** | Replaces third-party storage with per-session isolated storage. | No direct DevTools effect, but `document.cookie` may differ from what the server sees. |
+| **Fingerprint randomization (Standard)** | Randomizes canvas, WebGL, AudioContext APIs. Does NOT block network requests. | No network panel effect. |
+| **Fingerprint blocking (Aggressive)** | Blocks known fingerprinting scripts by URL. Uses webRequest block. | `(blocked:other)` in Status. |
+| **Social media blocking** | Blocks Facebook, Twitter, LinkedIn widgets. | `(blocked:other)`. |
+| **Script blocking** (manual) | When enabled per-site, all JS loaded from any origin is blocked. | Multiple `(blocked:other)` entries for every `.js` request. |
+
+**To diagnose Brave-specific blocking:**
+1. Click the Brave Shields lion icon → see the blocked count.
+2. Disable Shields for the site (toggle off) — blocked requests should now succeed.
+3. Cross-reference: open the same URL in a Chrome incognito window. If it works in Chrome but not Brave with Shields up, Shields is the culprit.
+4. `brave://settings/shields` — global defaults. `brave://shields-internals` (brave://components) shows the filter list versions loaded.
+5. Brave DevTools → Console: look for `ERR_BLOCKED_BY_CLIENT` messages.
+
+**WebSocket and Brave:** Brave Shields can block WebSocket upgrade requests if the WS URL matches a tracker domain — the WS connection will fail with `(failed)` in DevTools. Disabling "Block fingerprinting" sometimes also unblocks WS connections because some WS handshakes include timing fingerprinting vectors.
+
+Source: https://brave.com/shields/ ; https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
+
+### 3.10 `chrome://flags`: network-relevant flags
+
+| Flag | Chrome flag name | What it does |
+|------|-----------------|--------------|
+| **Private Network Access warnings** | `#private-network-access-send-preflights` | Controls whether PNA preflights are sent for private IP requests. Enabling shows the preflight in DevTools. |
+| **CORS for content scripts** | `#cors-for-content-scripts` | Makes extension content scripts subject to CORS like normal web content. |
+| **Block insecure private network requests** | `#block-insecure-private-network-requests` | Mixed-content enforcement for local network requests. Causes more `(blocked)` statuses for http:// requests to private IPs from https:// pages. |
+| **Enable DevTools experiments** | `#enable-devtools-experiments` | Unlocks the Experiments tab in DevTools Settings. Required on some Brave versions. |
+| **Partitioned cookies** | `#partitioned-cookies` | CHIPS — changes how cross-site cookies are sent; affects which Cookie headers appear in DevTools. |
+| **Network service in process** | `#network-service-in-process` | Moves the network service back into the browser process (debugging aid). May change crash behavior but not DevTools visibility. |
+| **Zero-copy video capture** | Unrelated — skip | — |
+
+Access via `brave://flags` (Brave) or `chrome://flags` (Chrome). Search by keyword.
+
+---

--- a/plugins/genesis-tools/skills/chrome-devtools/references/net-export-recipes.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/net-export-recipes.md
@@ -1,0 +1,272 @@
+# Below HTTP: what HAR drops, and how to grep a net-export log
+
+A HAR is a DevTools-level artifact. Raw socket bytes, DNS decisions, TLS handshakes, CORS
+preflight verdicts, and the numeric net error behind `(canceled)` exist ONLY in a
+`chrome://net-export/` log. This file is what HAR omits (section 4), the practical
+extraction recipes (section 5, including the OAuth token-endpoint checklist in 5.6), the
+FAQ, and source links.
+
+Further: `net-capture-settings.md` to produce the log · `net-panel-symptoms.md` to read the panel.
+
+---
+
+## 4. What HAR does not capture and net-export does
+
+This is the single biggest reason to use net-export for hard debugging problems.
+
+| Data | HAR | Net-export (default) | Net-export (raw bytes) |
+|------|-----|----------------------|----------------------|
+| **DNS queries** (wire-level) | No | Partial: `HOST_RESOLVER_IMPL_JOB` events show resolution time and result | Yes: `UDP_SOCKET` events show raw DNS packets |
+| **DNS resolution mode** | No | Yes: shows whether system resolver or async DNS was used | Yes |
+| **Socket pool events** (which TCP conn carried which request) | No | Yes: `SOCKET_POOL_BOUND_TO_CONNECT_JOB`, `SOCKET_POOL_REUSED_AN_EXISTING_SOCKET` | Yes |
+| **TLS handshake details** | No | Yes: `SSL_CONNECT_JOB`, cipher suite, cert chain, OCSP stapling | Yes |
+| **TLS decrypted bytes** | No | No | Yes (decrypted plaintext in `SSL_SOCKET_BYTES_RECEIVED` / `_SENT`; `SOCKET_BYTES_*` is the encrypted wire layer; QUIC traffic logs `QUIC_SESSION_*` packet events instead) |
+| **CORS preflight decision** (pass/fail reason) | No | Yes: `HTTP_TRANSACTION_SEND_REQUEST_HEADERS` + response headers; error reason in params | Yes |
+| **Private Network Access (PNA/LNA) enforcement** | No | Yes: `PRIVATE_NETWORK_ACCESS_CHECK` event with result | Yes |
+| **Service worker fetch event hooks** | No | Partial: `SERVICE_WORKER_TRANSMISSION_FINISHED` | Partial |
+| **Renderer-side abort reason** | No | Yes: `URL_REQUEST_STATUS_CHANGED` with `net_error` code | Yes |
+| **Request body bytes** | `postData.text` (if body was logged) | No (never logs request body bytes in any mode) | No (request body is NOT captured by net-export) |
+| **Response body bytes** | `content.text` (if loaded into DevTools) | No | Yes: `URL_REQUEST_JOB_FILTERED_BYTES_READ` |
+| **Proxy resolution** | No | Yes: `PROXY_RESOLUTION_REQUEST` events | Yes |
+| **Certificate verification details** | No | Yes: `CERT_VERIFIER_TASK` with chain, errors, OCSP | Yes |
+| **Cookie inclusion/exclusion reason** | No | Yes: `COOKIE_INCLUSION_STATUS` per-cookie per-request | Yes |
+| **HTTP/2 GOAWAY frames** | No | Yes: `HTTP2_SESSION_GOAWAY` | Yes |
+| **QUIC connection events** | No | Yes: `QUIC_SESSION_*` events | Yes |
+| **Extension-injected delays** | No | Yes: `URL_REQUEST_DELEGATE_*`, `NETWORK_DELEGATE_*` show when extensions blocked/modified the request | Yes |
+
+Source: chromium.org/developers/design-documents/network-stack/netlog/ ; textslashplain.com analysis — https://textslashplain.com/2020/04/08/analyzing-network-traffic-logs-netlog-json
+
+---
+
+## 5. Practical recipes
+
+### 5.1 Open a net-export log and find your URL
+
+```bash
+# Step 1: capture
+# Open chrome://net-export/ → Start Logging → reproduce → Stop Logging
+# File saved to ~/Downloads/net-export-log.json by default
+
+# Step 2: open in viewer (browser-based, no install needed)
+# PRIVACY: the log carries every cookie header, and with raw bytes the decrypted
+# plaintext of the socket-level byte events (SSL_SOCKET_BYTES_*), which can hold
+# request and response content. The appspot viewer parses the file in YOUR browser
+# (it is a static page, no upload) — but for a log from someone else's machine,
+# prefer the offline copy and treat the JSON like a credentials file.
+# Navigate to https://netlog-viewer.appspot.com
+# Drag net-export-log.json onto the page
+# OR use the offline version: open viewer.html saved from netlog-viewer.appspot.com
+
+# Step 3: in the viewer Events tab, type into the filter box:
+type:URL_REQUEST
+# then further filter by URL:
+type:URL_REQUEST   (search box on right for your URL pattern)
+```
+
+### 5.2 Grep a net-export JSON for one URL's full lifecycle
+
+The net-export JSON uses integer IDs for event types. The `constants.logEventTypes` dictionary at the top maps names → IDs. The following recipes work after you resolve the IDs:
+
+```bash
+# Extract the constant mappings first
+cat net-export-log.json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+types = data['constants']['logEventTypes']
+# Build reverse map: id -> name
+rev = {v: k for k, v in types.items()}
+print(json.dumps(rev, indent=2))
+" > /tmp/event-types.json
+
+# Find all events for a given URL (two-pass: find source ID, then dump its events)
+TARGET_URL="https://auth.example.com/token"
+
+python3 - "$TARGET_URL" << 'EOF'
+import json, sys
+
+with open('net-export-log.json') as f:
+    data = json.load(f)
+
+# Find source IDs that contain our URL (substring match on the argv URL)
+target = sys.argv[1]
+source_ids = set()
+for ev in data['events']:
+    params = ev.get('params', {})
+    if target in str(params.get('url', '')):
+        source_ids.add(ev['source']['id'])
+
+# Dump all events for those sources
+for ev in data['events']:
+    if ev['source']['id'] in source_ids:
+        print(json.dumps(ev))
+EOF
+```
+
+### 5.3 Filter only `URL_REQUEST` events
+
+```bash
+python3 << 'EOF'
+import json
+
+with open('net-export-log.json') as f:
+    data = json.load(f)
+
+# URL_REQUEST source type ID
+src_types = data['constants']['logSourceType']
+url_request_src_type = src_types.get('URL_REQUEST', 1)  # typically 1
+
+for ev in data['events']:
+    if ev['source']['type'] == url_request_src_type:
+        print(json.dumps(ev))
+EOF
+```
+
+### 5.4 Find why a request was cancelled: the net error code
+
+```bash
+python3 << 'EOF'
+import json
+
+with open('net-export-log.json') as f:
+    data = json.load(f)
+
+# Build event type name map
+types = {v: k for k, v in data['constants']['logEventTypes'].items()}
+
+for ev in data['events']:
+    params = ev.get('params', {})
+    net_error = params.get('net_error')
+    if net_error is not None and net_error < 0:
+        event_name = types.get(ev['type'], str(ev['type']))
+        print(f"source_id={ev['source']['id']} event={event_name} net_error={net_error} params={params}")
+EOF
+# net_error codes: -3 = ERR_ABORTED, -7 = ERR_TIMED_OUT, -100 = ERR_CONNECTION_CLOSED,
+# -101 = ERR_CONNECTION_RESET, -102 = ERR_CONNECTION_REFUSED, -200 = ERR_CERT_COMMON_NAME_INVALID
+# Full list: https://source.chromium.org/chromium/chromium/src/+/main:net/base/net_error_list.h
+```
+
+### 5.5 Convert net-export to a readable timeline
+
+```bash
+python3 << 'EOF'
+import json
+from datetime import datetime
+
+with open('net-export-log.json') as f:
+    data = json.load(f)
+
+# The timeTickOffset converts ticks to wall-clock time
+tick_offset_ms = data['constants']['timeTickOffset']
+types = {v: k for k, v in data['constants']['logEventTypes'].items()}
+phases = {0: '', 1: '+BEGIN', 2: '-END'}
+
+# Find base tick (earliest event)
+events = data['events']
+base_tick = min(int(e['time']) for e in events if 'time' in e)
+
+for ev in sorted(events, key=lambda e: int(e.get('time', 0))):
+    t_ms = int(ev.get('time', 0)) - base_tick
+    phase = phases.get(ev.get('phase', 0), '')
+    name = types.get(ev['type'], str(ev['type']))
+    src = f"src:{ev['source']['id']}"
+    params = ev.get('params', {})
+    url = params.get('url', '')
+    print(f"t+{t_ms:8}ms {src:12} {name}{phase:8} {url[:80]}")
+EOF
+```
+
+### 5.6 OAuth token endpoint: the full checklist
+
+When `/token` shows `Content-Length: 1126` in HAR but empty body:
+
+```bash
+# 1. Capture with net-export, Include raw bytes, Include cookies
+# 2. Find the token request source ID:
+python3 -c "
+import json
+data = json.load(open('net-export-log.json'))
+for ev in data['events']:
+    if '/token' in str(ev.get('params', {}).get('url', '')):
+        print('Source ID:', ev['source']['id'])
+        break
+"
+
+# 3. Dump all events for that source ID (replace 42 with actual ID):
+python3 -c "
+import json
+data = json.load(open('net-export-log.json'))
+types = {v: k for k, v in data['constants']['logEventTypes'].items()}
+for ev in data['events']:
+    if ev['source']['id'] == 42:
+        print(types.get(ev['type']), ev.get('params', {}))
+"
+
+# Look for:
+# - URL_REQUEST_START_JOB params: method=POST, url=.../token
+# - HTTP_TRANSACTION_READ_RESPONSE_HEADERS: status 200, Content-Length header
+# - URL_REQUEST_JOB_FILTERED_BYTES_READ: body bytes (only with raw bytes capture)
+# - CANCELLED / ERR_ABORTED: why the renderer discarded the response
+```
+
+---
+
+## Quick-fire FAQ
+
+**Q: I see `Content-Length: 1126` in response headers but the body is `(empty)`. Was the response really empty?**
+
+No. The server sent 1126 bytes. Chrome's network process received them. The body is missing from DevTools because either: (a) navigation happened before you clicked the Response tab, causing the renderer's in-memory copy to be discarded (§2.1); or (b) CORB/ORB stripped the body as an opaque cross-origin response (§2.5). Check the Console for CORB warnings. Use net-export with raw bytes to confirm what arrived.
+
+**Q: What is the difference between `(canceled)` and `(failed)`?**
+
+`(canceled)` means the request was **aborted client-side** — the browser tore down the request before a complete response, usually due to navigation, DOM removal, `AbortController.abort()`, form submission, or a browser extension. `(failed)` means a **network error** occurred — DNS failure, TLS error, TCP RST, CORS rejection, or similar. Both result in no response body.
+
+**Q: `Preserve log` is on, but my POST body is gone after the redirect. What should I have done?**
+
+`Preserve log` preserves metadata, not bodies. The fix: set a `beforeunload` breakpoint (Sources → Event Listener Breakpoints → Load → beforeunload), or use net-export with raw bytes, or use a proxy (Fiddler/mitmproxy) that captures outside the browser memory model.
+
+**Q: Why do I see `(blocked:other)` for requests I recognise as legitimate?**
+
+In Brave: Shields is blocking them. Click the Shields lion icon to see the count. Disable Shields for the site to confirm. Common triggers: URLs containing `track`, `analytics`, `advert`, `pixel`, `beacon` in the path; or the request domain matching EasyPrivacy/uBlock lists. In Chrome: a browser extension (uBlock, Privacy Badger) is blocking. Test in an incognito window with extensions disabled.
+
+**Q: How do I find which TCP connection carried which HTTP/2 request?**
+
+Enable the Connection ID column (right-click header → Connection ID). Requests with the same ID share the same underlying socket. In net-export, look for `HTTP_STREAM_JOB_BOUND_TO_REQUEST` events that link a stream job to a socket via `source_dependency`.
+
+**Q: The HAR shows `timings.connect: -1`. Is the connection broken?**
+
+No. HAR 1.2 spec §timings states `-1` means "does not apply". `connect = -1` means the request **reused an existing connection** — no new TCP handshake was needed. This is normal and good (keep-alive / HTTP/2 multiplexing working correctly).
+
+**Q: Status column shows `CORS error`. How do I get the full reason?**
+
+Hover the `CORS error` text in the Status column — Chrome shows a tooltip with the specific failing header or reason. Also check the Console tab for the full `Access-Control-*` header diagnostic. In net-export, look for `HTTP_TRANSACTION_READ_RESPONSE_HEADERS` params for the preflight (OPTIONS) request — the response headers will show whether `Access-Control-Allow-Origin` was missing or wrong.
+
+**Q: I want to capture what Brave is blocking before it even sends the request. Can DevTools show that?**
+
+DevTools shows requests that Brave's Shields has blocked — they appear as `(blocked:other)`. But Brave may also rewrite URLs or headers silently before sending (CNAME uncloaking, cookie stripping) — those modifications are NOT visible in DevTools. For full pre-send visibility, use net-export at the `IncludeSensitive` level, which captures headers as Chrome sends them after all modifications.
+
+**Q: Is there a way to get both the request body AND the response body for an OAuth token exchange without a proxy?**
+
+Request body: visible in DevTools → Payload tab (or HAR `postData.text`) as long as DevTools was open. Response body: only guaranteed if you capture with net-export `Include raw bytes`, OR if you add a `beforeunload` breakpoint and inspect before navigation completes. There is no DevTools setting that makes Chrome reliably preserve response bodies across navigations — this is a known longstanding limitation (Chromium issue #141129, open since 2012).
+
+**Q: What does `net_error = -3` mean in a net-export event?**
+
+`-3` is `ERR_ABORTED`. This is the standard "user action or browser logic aborted this load" code. It does NOT mean a network error — the connection was fine up to that point. Common causes: navigation, AbortController, extension block, CSP enforcement. For the full error code list: https://source.chromium.org/chromium/chromium/src/+/main:net/base/net_error_list.h
+
+---
+
+## Reference links
+
+- Chrome DevTools Network Reference: https://developer.chrome.com/docs/devtools/network/reference
+- NetLog design document: https://www.chromium.org/developers/design-documents/network-stack/netlog/
+- How to capture a NetLog dump: https://www.chromium.org/for-testers/providing-network-details
+- Analyzing NetLog JSON (textslashplain): https://textslashplain.com/2020/04/08/analyzing-network-traffic-logs-netlog-json
+- NetLog Viewer (online): https://netlog-viewer.appspot.com
+- Crash course in net-internals: https://chromium.googlesource.com/experimental/chromium/src/+/refs/tags/83.0.4089.2/net/docs/crash-course-in-net-internals.md
+- HAR 1.2 spec: http://www.softwareishard.com/blog/har-12-spec/
+- CORB for developers: https://chromium.org/Home/chromium-security/corb-for-developers/
+- CORB explainer (Chromium source): https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md
+- CORP (MDN): https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cross-Origin_Resource_Policy
+- Brave Shields: https://brave.com/shields/
+- Brave fingerprinting protections: https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
+- Chrome error codes list: https://source.chromium.org/chromium/chromium/src/+/main:net/base/net_error_list.h
+- Chromium issue #141129 (response body missing after navigation): https://bugs.chromium.org/p/chromium/issues/detail?id=141129

--- a/plugins/genesis-tools/skills/chrome-devtools/references/net-forensics-index.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/net-forensics-index.md
@@ -1,0 +1,25 @@
+# Network and wire-level forensics: index
+
+Split by topic so only the needed part is read. Source: the 2026-05-26 vault braindump
+(`GenesisBrain/Braindump/2026-05-26-ChromeDevTools.md`); these copies are canonical for agents.
+
+| Symptom | File | Section |
+|---|---|---|
+| `(unknown)` Type, odd Size/Initiator | `net-panel-symptoms.md` | 1, 1.3, 1.4 |
+| `(canceled)` · `(blocked:other)` · `(failed)` · XHR status 0 | `net-panel-symptoms.md` | 1.2 |
+| Live panel and exported HAR disagree | `net-panel-symptoms.md` | 1.5 |
+| Response body missing/empty with Preserve log on | `net-panel-symptoms.md` | 2.1-2.3 |
+| **Token/OAuth POST body vanished** (navigation aborted it) | `net-panel-symptoms.md` | 2.6 |
+| Opaque / CORB-stripped cross-origin response | `net-panel-symptoms.md` | 2.5 |
+| Need more capture: panel settings, columns, experiments | `net-capture-settings.md` | 3.1-3.5 |
+| Start a raw capture (`chrome://net-export/`, `net-internals`) | `net-capture-settings.md` | 3.6-3.7 |
+| Brave Shields / fingerprinting altering requests | `net-capture-settings.md` | 3.9 |
+| What HAR does not capture at all | `net-export-recipes.md` | 4 |
+| Grep a net-export log for one URL's lifecycle | `net-export-recipes.md` | 5.2-5.3 |
+| Find the numeric net error behind a cancel | `net-export-recipes.md` | 5.4 |
+| OAuth token endpoint end-to-end checklist | `net-export-recipes.md` | 5.6 |
+
+Two facts to carry into every investigation:
+
+- Chrome withholds body bytes from DevTools until viewed; navigation destroys the copy.
+- Anything below HTTP is invisible to both the panel and HAR — only net-export has it.

--- a/plugins/genesis-tools/skills/chrome-devtools/references/net-panel-symptoms.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/net-panel-symptoms.md
@@ -1,0 +1,194 @@
+# Network panel: what the columns actually mean
+
+Covers `(unknown)` Type, every Status value (`(canceled)`, `(blocked:origin)`,
+`(blocked:other)`, `(failed)`, XHR status 0), Size/Initiator oddities, and why a response
+body is missing or empty. Read when the panel says something you cannot reconcile with
+what the server did.
+
+**The single most load-bearing fact:** Chrome does not stream response body bytes to
+DevTools until you actively view them, and a navigation destroys the in-memory copy. A
+missing body is usually THIS, not the server. See 2.1. For an OAuth/token POST killed by a
+navigation, go straight to 2.6.
+
+Further: `net-capture-settings.md` (get more out of the browser) ·
+`net-export-recipes.md` (see below HTTP) · `SKILL.md` trigger table.
+
+---
+
+## 1. Why `(unknown)` appears, exhaustively
+
+### 1.1 Type column
+
+The Type column shows the MIME type derived from the `Content-Type` response header, after sniffing is applied. It shows `(unknown)` in the following situations:
+
+| Cause | Mechanism | What You See |
+|-------|-----------|--------------|
+| **No `Content-Type` header** | Chrome has no declared type and sniffing fails or is disabled (`X-Content-Type-Options: nosniff` present) | `(unknown)` |
+| **Unrecognised MIME type** | e.g. `application/x-custom-type` with a non-standard subtype not in Chrome's MIME registry | `(unknown)` or the raw string |
+| **Service worker short-circuit** | SW intercepts with `respondWith()` and synthesises a `Response` object with no `Content-Type` set | `(unknown)`, Initiator shows `ServiceWorker` |
+| **Prefetch / preload cache hit** | Resource served from the prefetch cache before headers were inspected | `(unknown)` or `Other` |
+| **Opaque response (no-cors)** | Cross-origin fetch in `mode: 'no-cors'` — CORB/ORB strips the content-type | `(unknown)` in Type; size column may also be `0 B` |
+| **`data:` URL** | Chrome doesn't classify these into a named MIME bucket unless the prefix is a common type | `(unknown)` or `text/plain` |
+
+**Primary source:** Chrome DevTools network reference — https://developer.chrome.com/docs/devtools/network/reference
+
+### 1.2 Status column: values and causes
+
+The Status column is not just an HTTP status code. It carries a rich vocabulary:
+
+| Displayed value | Meaning |
+|----------------|---------|
+| `200`, `301`, `401` … | Normal HTTP status. |
+| `(canceled)` | Chrome aborted the request **before** a response arrived. See §1.2.1 for causes. |
+| `(failed)` + error message | Network-level error (DNS failure, TLS handshake failure, RST from server, etc). |
+| `(blocked:origin)` | CORB / ORB blocked the cross-origin response. Hover for a tooltip. |
+| `(blocked:other)` | Browser extension (uBlock, Brave Shields, Privacy Badger) or a CSP / mixed-content enforcement blocked it at the network layer, **before** it reached the server. The request was never sent. |
+| `(blocked:devtools)` | You manually blocked the URL via the Network request blocking panel (DevTools drawer). |
+| `(failed) net::ERR_BLOCKED_BY_CLIENT` | Same as `(blocked:other)` at the net layer — extension intercepted. |
+| `(failed) net::ERR_BLOCKED_BY_RESPONSE` | `Cross-Origin-Embedder-Policy` or `Cross-Origin-Opener-Policy` rejected the response after arrival. |
+| `CORS error` | Pre-flight failed or the actual response lacked the required `Access-Control-Allow-*` header. |
+| **Status 0** | The request was aborted **client-side** before any HTTP response was received. This is the XHR/fetch representation of a connection that was torn down. Common causes: `fetch().abort()` / `AbortController`, navigation happened while the request was in-flight, CSP block, mixed-content block, SW `event.respondWith()` throwing. In the Network panel this renders as `(canceled)` or `(failed)`, never as a literal `0` in the Status column — but XHR's `readyState === 4` with `status === 0` maps to this same condition. |
+
+#### 1.2.1 `(canceled)` causes in detail
+
+Source: chromium.org crash-course, SO thread https://stackoverflow.com/questions/12009423/
+
+- The DOM element that triggered the load was **removed** before the response arrived (e.g. an `<img>` node deleted, an `<iframe>` src changed or the iframe removed, a React component unmounted).
+- **Navigation** happened (user clicked a link, JS set `window.location`, form `<button>` submitted the parent form simultaneously with an XHR click handler — missing `event.preventDefault()`).
+- **`AbortController.abort()`** was called, or jQuery/axios/RxJS `switchMap` cancelled in-flight requests.
+- **JS timeout** (axios `timeout`, jQuery `$.ajax({timeout: …})`) expired.
+- A redirect crossed the **https→http** boundary inside an iframe (mixed content: a secure page must not load insecure content).
+- **X-Frame-Options: DENY** or **SAMEORIGIN** caused a framed load to be cancelled silently.
+- **TLS certificate mismatch** — Chrome silently auto-redirected to the canonical domain and cancelled the original.
+- A **malformed redirect URL** (`Location:` header was invalid or contained a relative path that Chrome couldn't resolve).
+- Font: Chrome cancels **ttf/woff** requests when it already has a **woff2** version of the same font.
+- Multiple redundant `onclick` + `href` triggers firing simultaneously (double-loading).
+- **Extension** (uBlock, Privacy Badger, Brave Shields, JavaScript Errors Notifier, Hola) injected a `webRequest.onBeforeRequest` block.
+- **Many requests to the same host** when earlier ones returned DNS failures.
+
+### 1.3 Size column
+
+The Size column has two values in big-row mode (Settings → Big request rows): top = transferred size (compressed, over wire), bottom = uncompressed resource size. In normal mode only the transferred/cache annotation is shown.
+
+| Displayed value | Meaning |
+|----------------|---------|
+| `(memory cache)` | Response was served from the **in-process memory cache** (MemoryCache in Blink). Zero bytes transferred over the wire. Typical for resources fetched multiple times on the same page. |
+| `(disk cache)` | Response was served from the **on-disk HTTP cache** (CacheStorage / HTTP Cache). Zero bytes transferred. |
+| `(prefetch cache)` | Resource was preloaded via `<link rel="prefetch">` or the Speculation Rules API and served from the prefetch cache. Zero bytes transferred at this point. |
+| `(service worker)` | Response was synthesised or retrieved by a service worker and handed to the page without hitting the network. The SW's `respondWith()` can return a cached Response or a fabricated one. |
+| `(from preloaded response)` / `(push)` | HTTP/2 server push or `<link rel="preload">` early hints — the response was already buffered. |
+| `0 B` (numeric) | Either the server sent no body (204 No Content, 304 Not Modified, intentional empty body), or the server DID send one and CORB/ORB stripped it before the renderer saw it — the note below tells the two apart. |
+
+**Note on CORB/ORB:** When Cross-Origin Read Blocking fires, Chrome replaces the response body with an **empty body** and injects a `0 B` transferred size. The original `Content-Length` header remains in the panel (the server did send bytes, Chrome just discarded them). This is why you can see `Content-Length: 1126` alongside `(empty)` body in the Response tab — the bytes arrived, Chrome stripped them as opaque.
+
+Source: https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md
+
+### 1.4 Initiator column: `(other)` and empty
+
+| Displayed value | Cause |
+|----------------|-------|
+| **Parser** | Injected from the HTML parser (`<script src>`, `<img src>`, `<link href>`). |
+| **Script** + stack trace | Initiated by JS. Hover to see the call stack. |
+| **Redirect** | HTTP 301/302/307/308 redirect. |
+| **(other)** | Triggered by browser internals that are not attributable to a specific script or HTML element. Common: browser startup, extension requests, service worker internal fetches, preconnect attempts, OCSP stapling, CRL fetches, speculative preconnects. |
+| **Empty** | Request happened before DevTools was open and the initiator metadata was not captured. |
+
+### 1.5 HAR export vs. live panel
+
+The HAR format (spec: http://www.softwareishard.com/blog/har-12-spec/) drops or degrades the following data compared to what is live in the panel:
+
+| Data | Live panel | HAR export |
+|------|-----------|------------|
+| Response body | Present if viewed before navigation | Present only if "Save all as HAR **with content**" was chosen AND body was loaded into DevTools memory |
+| Request body bytes | Full | `postData.text` or `postData.params` (spec supports it but Chrome's sanitised export may omit it) |
+| Cookie / Authorization headers | Shown | Stripped in the **sanitised** variant; included in "with sensitive data" |
+| Timing phases | Full (ms resolution) | Preserved but precision varies |
+| Initiator stack trace | Shown in column | Not in HAR 1.2 spec; Chrome adds it as a custom `_initiator` field |
+| Connection reuse info | Shown via Connection ID column | `connection` field (string, not always populated) |
+| `(memory cache)` / `(disk cache)` tag | Shown | `cache.beforeRequest` / `cache.afterRequest` objects, but often empty `{}` |
+| Websocket frames | Shown in Messages tab | Not in HAR 1.2; Chrome omits them |
+| Response body for CORB-blocked requests | `(blocked)` shown | `response.content.size: 0`, `text: ""` |
+
+---
+
+## 2. Why the response body is missing or empty (even with Preserve log on)
+
+### 2.1 Chrome's "low overhead" policy, the root cause
+
+Chrome DevTools uses a **lazy transfer** model: response bytes are **not** sent from the renderer/network process to the DevTools front-end until you **explicitly click on a request and view the Response tab**. This is documented in Chromium bug #141129 (2012, open as of 2024):
+
+> "This is an outcome of 'low overhead' policy — resource content isn't transferred to DevTools until user explicitly wants to view it."
+> — Chrome developer Eustas, https://bugs.chromium.org/p/chromium/issues/detail?id=141129
+
+Consequence: if a navigation happens (including a redirect, a `window.location` change, or the page reloading) before you clicked the Response tab, the in-memory copy is discarded. `Preserve log` keeps the **request/response metadata** (headers, timing, URL, status) across navigations but **not the response body bytes** — those are already gone.
+
+This is NOT fixed as of Chromium 151 (verified live on Brave, 2026-08). Workarounds:
+
+1. Set a **beforeunload breakpoint** in Sources → Event Listener Breakpoints → Load → beforeunload, then inspect the response before the breakpoint resumes.
+2. Use **Firefox**, which does preserve response bodies across navigations.
+3. Use a proxy tool (Charles, Fiddler, mitmproxy) that sits outside the browser's memory model.
+4. Use `chrome://net-export/` with `Include raw bytes` enabled — this captures bodies at the network process level, before the renderer sees them.
+
+Source: https://superuser.com/questions/1788537/
+
+### 2.2 Response body size cap
+
+Chrome DevTools has a per-response body size limit. In Chrome/Brave, responses larger than approximately **64 MB** are truncated. In the HAR export, the `response.content.text` field will be cut off mid-stream with no warning in the HAR itself. The `response.content.size` field still reflects the real (untruncated) size.
+
+Firefox has a configurable limit via `devtools.netmonitor.responseBodyLimit` (default 1 MB, set to 0 for unlimited). Chrome does not expose this setting in DevTools UI — the only workaround is `chrome://net-export/` with raw bytes.
+
+### 2.3 Streaming responses
+
+If the server sends a streaming response (chunked transfer-encoding with an open connection, SSE, or a large body that is still arriving), and you export the HAR or navigate away, the body captured in the HAR will be whatever arrived up to that moment. The `content.size` will be the partial size.
+
+### 2.4 Service worker intercept
+
+When a service worker intercepts a fetch and calls `event.respondWith(cachedResponse)`, the response body is delivered directly from the SW to the page's renderer. The network process never sees the bytes. DevTools shows the request with `(service worker)` in the Size column, and the Response tab often shows `(no response data)` or an empty body — because the SW synthesised the response from its own CacheStorage, which is a separate process.
+
+The only way to inspect the body in this case is:
+- Application → Cache Storage → inspect the cached entry.
+- In the SW DevTools (Sources → Service Workers), intercept via `respondWith()` logging.
+
+### 2.5 CORB / CORP / CORS opaque response body stripping
+
+When Cross-Origin Read Blocking (CORB) or its successor Opaque Response Blocking (ORB) fires, Chrome:
+1. Receives the full response bytes from the server.
+2. **Replaces the body with an empty body** before delivering to the renderer.
+3. Keeps the original HTTP headers (including `Content-Length`) intact in the panel.
+
+Result: DevTools shows `Content-Length: 1126` in headers but `(empty)` in the Response tab and `0 B` transferred in the Size column. The CORB decision is logged to the DevTools Console as:
+
+```
+Cross-Origin Read Blocking (CORB) blocked cross-origin response https://… with MIME type text/html.
+```
+
+CORB applies to cross-origin responses with HTML, JSON, or XML MIME types loaded by `<script>`, `<img>`, etc. in `no-cors` mode. It does NOT apply to same-origin requests or to requests with proper CORS headers.
+
+Source: https://chromium.org/Home/chromium-security/corb-for-developers/
+
+**CORP** (`Cross-Origin-Resource-Policy` response header) is a server-opt-in equivalent: when `Cross-Origin-Resource-Policy: same-origin` is set and a cross-origin request arrives, the browser strips the body after receiving it. The MDN description: "the browser prevents the result from being leaked by stripping the response body" — https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cross-Origin_Resource_Policy
+
+### 2.6 Navigation aborts an in-flight fetch: the OAuth token-endpoint pattern
+
+This is the canonical cause for Martin's CEZ OAuth issue:
+
+1. Page A makes a `POST /token` with `Content-Type: application/x-www-form-urlencoded`.
+2. Before the response body arrives (or before you click the entry in DevTools), the server issues a `302` redirect or JS sets `window.location` to complete the OAuth callback.
+3. Navigation destroys the renderer process's copy of the in-flight response.
+4. HAR shows: headers including `Content-Length: 1126`, status `200`, but `response.content.text: ""` and `response.content.size: 0` (or the correct size with empty text).
+
+The `Content-Length: 1126` is real — the server did send that many bytes. Chrome's network process received them. But the DevTools UI never got them transferred because the navigation happened first.
+
+**Fix:** Use `chrome://net-export/` with `Include raw bytes`. The net-export capture happens at the network process level and is not affected by renderer navigation. Decrypted plaintext lands in `SSL_SOCKET_BYTES_RECEIVED` events (`SOCKET_BYTES_RECEIVED` is the encrypted wire layer; QUIC/HTTP3 traffic logs `QUIC_SESSION_*` packet events instead, which the viewer does not reassemble into bodies).
+
+### 2.7 Content-Encoding mismatch
+
+If the server sends `Content-Encoding: gzip` but the body is not valid gzip, Chrome's decompressor will fail. The Response tab shows an error or empty content. The HAR body will be empty. The Size column shows the raw wire bytes (the garbage gzip). The `Content-Length` header shows what the server claimed.
+
+### 2.8 `Cache-Control: no-store` and bfcache
+
+When a page is stored in the Back/Forward Cache (bfcache) and the response had `Cache-Control: no-store`, the bfcache entry is still created (bfcache operates at the rendering layer, separate from the HTTP cache). However, if DevTools was not recording when the page was first loaded, bfcache restores will not re-emit network events to DevTools. You see the page appear but nothing in the Network panel — `Preserve log` does not help here because no new network events are generated.
+
+To force a real network request (bypassing bfcache): hold Shift while clicking the refresh button, or open DevTools → Application → Back/Forward Cache and use the "Test back/forward cache" tool.
+
+---

--- a/plugins/genesis-tools/skills/chrome-devtools/references/prior-art.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/prior-art.md
@@ -1,0 +1,63 @@
+# Prior art
+
+Three earlier bodies of work fed this tool. Know them before building anything new.
+
+## 1. The standalone skill (now this tool)
+
+`~/.agents/skills/chrome-devtools/` was the original: 14 bun scripts, no repo dependency.
+It is now a thin pointer to `tools chrome-devtools`; the scripts moved to
+`src/chrome-devtools/` in GenesisTools, hardened after the 2026-08-25 CPU-leak incident
+(`arm-cpu-leak.md` is the forensics). What changed in the port:
+
+- `arm` became `record` (hidden alias kept); `watch` split into `record` (engine) +
+  `follow` (live view).
+- The unbounded `/tmp/cdp-arm-<port>.jsonl` became rotating 30-minute segments with a 4-hour
+  window under `/tmp/GenesisTools/ChromeDevtools/<port>/`.
+- Pidfiles now carry process identity (command + start time), so pid recycling cannot fake
+  a live recorder and concurrent attaches cannot stack duplicates.
+- The HAR builder is a TS port of chrome-har v1.3.1 with sessionId-aware entry keying;
+  parity is pinned against upstream goldens in `src/chrome-devtools/lib/har/`.
+
+## 2. GenesisTools youtube extension harness
+
+`src/youtube/lib/devtools/` still owns extension debugging:
+
+```bash
+tools youtube extension dev                                  # watch + chrome.runtime.reload on change
+tools youtube extension devtools launch --port 9333          # browser WITH the extension loaded
+tools youtube extension devtools call <tool> '<json>'
+```
+
+Go there when the work is the YouTube extension itself. `tools chrome-devtools open
+--extension <dist>` covers plain extension loading; the youtube tool adds watch-reload.
+
+The generalized pieces live here now: `mcp` verb (programmatic chrome-devtools-mcp client
+against any port), `grid` verb (pixel-coordinate screenshots), `open --extension`.
+
+## 3. Vault: extension audit harness
+
+`GenesisBrain/GenesisTools/Youtube/ext-audit-harness/` keeps 13 page scripts from the
+2026-07-27 session that found 8 bugs: `audit.js` (CSSOM missing-Tailwind-class detector),
+`realclick.js` (full pointer sequence; a bare `.click()` does NOT switch Radix tabs),
+`loginfill.js` (sets values through the native `HTMLInputElement.prototype.value` setter so
+React's onChange fires), and others.
+
+Its hard-won gotchas: Chrome caches the extension loaded AT LAUNCH (rebuilding and
+reloading the page re-injects the OLD content script); React batches state, so read results
+in a SEPARATE call; never text-grep a built bundle for Tailwind classes (escaped arbitrary
+values give false negatives).
+
+## 4. Vault: network-panel reference
+
+Folded into this skill as `net-panel-symptoms.md`, `net-capture-settings.md`,
+`net-export-recipes.md`, indexed by `net-forensics-index.md`. Route via the trigger table
+in SKILL.md. Still vault-only:
+
+- `GenesisBrain/Dev/ChromeDevTools/AutoReloadDuringDev.md`, `BackgroundHotSwap.md`
+- `GenesisBrain/Claude/Bugs/PlayWright-MCP-ParallelAndChromeConflict.research.md`
+
+## 5. Upstream chrome-har
+
+Clone at `../_Playgrounds/chrome-har` (sitespeedio/chrome-har, MIT). The TS port's golden
+fixtures came from its `test/perflogs/`. Re-generate goldens against it if the port ever
+changes shape.

--- a/plugins/genesis-tools/skills/chrome-devtools/references/recipes.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/recipes.md
@@ -1,0 +1,186 @@
+# CDP recipes
+
+The cdp lib mirrors the chrome-devtools-mcp tool surface as importable functions. For a
+scratch script, don't hand-write the boilerplate. Scaffold it into the scripts store:
+
+```bash
+tools chrome-devtools scaffold myProbe --recipe redirect-chain
+tools scripts run myProbe -- --port 9222 --match idp.example.com
+```
+
+Scaffolded scripts import the lib as `@gt/chrome-devtools/cdp`. Inside this repo, import
+`src/chrome-devtools/lib/cdp.ts` directly. The full API is in `cdp-cheatsheet.md`.
+
+## Record a redirect chain while it happens
+
+```ts
+import { attach } from "@gt/chrome-devtools/cdp";
+
+const page = await attach({ port: 9222, url: "example.com" });
+const events = page.recordNetwork((u) => /example|idp/.test(u));
+await page.navigate("https://example.com/app");
+await Bun.sleep(15000);
+for (const e of events) {
+    if (e.kind === "redirect") console.log(e.status, e.from, "->", e.location);
+    if (e.kind === "nav") console.log("NAV", e.url);
+}
+```
+
+`recordNetwork` keeps `redirectResponse` hops (status, from, `Location`, `Set-Cookie`). A
+flat request list drops them, and that is where auth bugs live. Usually you don't need the
+script at all anymore: with a recorder running, `tools chrome-devtools har --last 10m` has
+the same hops retroactively.
+
+## Cookie diff: broken browser vs fresh profile
+
+The `cookie-diff` recipe is this, ready to run. The core:
+
+```ts
+const key = (c) => `${c.name}|${c.domain}|${c.path}`;
+const [a, b] = await Promise.all([browser(9222), browser(9223)]);
+const [A, B] = await Promise.all([a.cookies("idp.example.com"), b.cookies("idp.example.com")]);
+const mapB = new Map(B.map((c) => [key(c), c]));
+for (const c of A) {
+    if (!mapB.has(key(c))) console.log("BROKEN-ONLY", key(c), "httpOnly=" + c.httpOnly, "len=" + c.value.length);
+}
+```
+
+Duplicate name across paths means the longer path is sent first (RFC 6265) and a stale
+session wins. `tools chrome-devtools cookies` flags duplicates without any script.
+
+## Surgical cookie deletion
+
+```bash
+tools chrome-devtools rm-cookie --name JSESSIONID --domain idp.example.com --path /legacy
+```
+
+Delete ONE suspect at a time and re-run the flow between deletions. That isolates the
+culprit. Never wipe all site data: it destroys the evidence and the user's logins.
+
+## Storage snapshot
+
+```bash
+tools chrome-devtools eval '() => ({
+  url: location.href,
+  ls: Object.fromEntries(Object.entries(localStorage).map(([k, v]) => [k, String(v).slice(0, 120)])),
+  ss: Object.fromEntries(Object.entries(sessionStorage).map(([k, v]) => [k, String(v).slice(0, 120)])),
+})'
+```
+
+Growing families of per-attempt keys (dozens of `*_appauth_authorization_request`) mean a
+client retry loop with no circuit breaker. A real finding, but usually a symptom, not the
+cause.
+
+## Decode a JWT-shaped cookie without printing secrets
+
+```ts
+const payload = (tok: string) => {
+    const p = tok.split(".")[1];
+    return JSON.parse(Buffer.from(p + "=".repeat((4 - (p.length % 4)) % 4), "base64url").toString());
+};
+```
+
+A nested/encrypted JWE (5 segments) will not decode. Say so instead of guessing at its
+contents.
+
+## Fetch a response body
+
+Bodies die when the tab navigates, so grab them while the request is fresh:
+
+```bash
+tools chrome-devtools har --now --reload -o /tmp/cdp.har     # bodies of a fresh load
+tools chrome-devtools scaffold apiBodies --recipe body-fetch # bodies of matching XHRs, live
+```
+
+Or start the recorder with the body channel: `record --match app.example.com --channels +body`
+(2 KB cap per body).
+
+## Browsing history: when the loop happened, how many times
+
+The `History` SQLite DB proves *when* a user hit a bug and how often. Visit volume per day
+exposes retry loops that a single HAR cannot. It never contains cookies or headers, so it
+dates an incident, it does not explain one.
+
+```bash
+cp "$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/History" /tmp/hist.db
+# Chrome: ~/Library/Application Support/Google/Chrome/Default/History
+# ALWAYS copy. The live file is locked by the running browser.
+
+# Loop detection: visits per day to the auth host. A clean login touches /cas 2-3x;
+# hundreds means the flow was looping.
+sqlite3 /tmp/hist.db "
+SELECT date(v.visit_time/1000000 - 11644473600,'unixepoch','localtime') d, COUNT(*) n
+FROM visits v JOIN urls u ON u.id = v.url
+WHERE u.url LIKE '%idp.example.com/cas%'
+GROUP BY d ORDER BY d;"
+```
+
+🛑 **`strftime('%s', …)` returns TEXT, so `<integer epoch> BETWEEN strftime(...) AND
+strftime(...)` is ALWAYS FALSE.** SQLite compares storage classes before values: every
+INTEGER sorts below every TEXT. The query returns 0 rows and no error, which reads exactly
+like "the user never visited that site". That wrong conclusion has been drawn once already.
+Verified 2026-08-10: identical query, 0 rows without the cast, 774 with it.
+
+```bash
+# ❌ silently 0 rows, always
+WHERE v.visit_time/1000000 - 11644473600
+      BETWEEN strftime('%s','2026-07-28 00:00:00') AND strftime('%s','2026-07-28 23:59:59')
+
+# ✅ cast both bounds
+WHERE v.visit_time/1000000 - 11644473600
+      BETWEEN CAST(strftime('%s','2026-07-28 00:00:00') AS INTEGER)
+          AND CAST(strftime('%s','2026-07-28 23:59:59') AS INTEGER)
+
+# ✅ better: compare rendered datetimes, no epoch arithmetic, timezone explicit
+WHERE datetime(v.visit_time/1000000 - 11644473600,'unixepoch','localtime')
+      BETWEEN '2026-07-28 00:00:00' AND '2026-07-28 23:59:59'
+```
+
+Prefer the third form. Two more traps in the same family:
+
+- Epoch base. Chromium `visit_time` is microseconds since 1601-01-01 (WebKit epoch), not
+  Unix. Subtract `11644473600` after dividing by 1e6. `downloads.start_time` and
+  `cookies.expires_utc` use the same base.
+- Timezone. `'localtime'` renders local, `strftime('%s', …)` parses as UTC. Mixing them
+  shifts results by your offset. Pick one and state it in the output.
+
+Always sanity-check a zero. Before reporting "no visits in that window", re-run the same
+query grouped by day with no time filter. If rows exist there but not in the window, the
+filter is broken, not the data.
+
+## Gotchas
+
+- Attach BEFORE the action. Live recorders start empty and bodies reset per navigation.
+  The background recorder (`attach` starts it) is the cure for "I attached too late".
+- A 0-row SQL result is a claim, not a fact. Prove the filter works before concluding
+  absence.
+- `--user-data-dir` is what makes `open -na` start a SECOND instance. Without it macOS
+  focuses the running app and silently drops the flags.
+- Launching a browser under CDP that is already running with the same profile: flags
+  ignored, no endpoint. Check with `attach` right after `open`.
+- CDP on localhost lets any local process drive a logged-in browser. Tell the user, and
+  remind them to relaunch without the flag when done.
+
+## The standard live-bug loop
+
+```bash
+tools chrome-devtools attach                       # starts the recorder
+tools chrome-devtools follow --channels nav,redirect,error,cookie \
+  --match idp.example.com --out /tmp/auth.log      # run with run_in_background: true
+```
+
+`follow` prints Monitor-ready commands first. Arm one, THEN reproduce. Never `until … sleep`
+on the log; that blocks you and duplicates what Monitor already does.
+
+Channel picking, by symptom:
+
+| Symptom | `follow --channels` |
+|---|---|
+| redirect loop / OAuth dead end | `nav,doc,redirect,cookie` |
+| API failing only for this user | `xhr,error,cookie` |
+| SPA stuck, blank, spinner forever | `nav,console,error,xhr` |
+| realtime feature broken | `ws,error` (recorder needs `--channels +ws`) |
+| "what does the server actually return" | `body` (recorder needs `--channels +body`) |
+| storage growing per attempt (retry loop) | `nav,storage` (recorder needs `--channels +storage`) |
+
+`--match` takes `/regex/flags` too: `--match '/(idp|auth)\.example/'`.

--- a/src/chrome-devtools/README.md
+++ b/src/chrome-devtools/README.md
@@ -1,0 +1,136 @@
+# chrome-devtools
+
+![Status](https://img.shields.io/badge/Status-Active-success?style=flat-square)
+
+> **Drive a REAL running browser (Brave/Chrome) over the Chrome DevTools Protocol.**
+
+The debugging harness for bugs that only exist in the user's own browser: auth/SSO redirect
+loops, cookie/session poison, "works in incognito but not for me", stuck SPAs, CORS errors.
+Ported from the `~/.agents/skills/chrome-devtools` skill after the 2026-08-25 CPU-leak
+incident (full forensics in the plugin skill's `references/arm-cpu-leak.md`).
+
+---
+
+## Non-negotiable first fact
+
+`--remote-debugging-port` is parsed at browser **STARTUP**. It cannot be enabled on a
+running browser. Any plan that assumes "just attach to their open Brave" is wrong until the
+browser is relaunched with the flag. `attach` prints the exact commands when nothing
+listens. **Ask before quitting anyone's browser** — their open tabs are at stake.
+
+⚠️ Chrome ≥ 136 refuses to open the CDP port when launched with the DEFAULT profile
+directory (anti-automation). Chromium builds are unaffected; Brave's stance can differ per
+version. `restart` detects the failure and suggests the `open --fresh` fallback.
+
+## Quick start
+
+```bash
+tools chrome-devtools attach            # scan, list endpoints, start the recorder, print next steps
+tools chrome-devtools har --last 30m -o /tmp/cdp.har    # what happened in the last 30 minutes
+tools chrome-devtools follow --channels nav,redirect,error --match idp.example.com
+tools chrome-devtools status            # who records what, at what CPU cost
+```
+
+`/tmp/...` output paths in the examples are the POSIX default; on Windows the tool
+writes under `%TEMP%` instead, and every command it PRINTS (attach guidance, doctor
+fixes, `--help` examples) already carries the right path for the running platform.
+
+## The mental model: one engine, two views
+
+| Piece | What it is |
+|---|---|
+| `record` | The only capture engine. One detached process per port, attaches browser-wide (or `--match`-scoped), appends HAR-grade metadata to a rolling buffer. `attach` starts it automatically. |
+| `follow` | The live view. Renders chosen channels as human lines, prints Monitor-ready commands. Rotation-aware — the only sanctioned way to tail the buffer. |
+| `har` | The retroactive view. Builds a DevTools-grade HAR 1.2 from the buffer (`--last 30m`), or records a live window on one tab (`--now --reload`, with bodies). |
+
+The old skill's `watch` verb is gone; invoking it explains the split.
+
+### The buffer
+
+`/tmp/GenesisTools/ChromeDevtools/<port>/` — 30-minute jsonl segments, pruned past 4 h at
+rotation (one inline unlink, no timer process), ~500 MB/port safety cap. Segments are
+**internal**: never `tail -f` them (rotation silently breaks the fd). `/tmp` clears on
+reboot. On Windows the root is `%TEMP%\GenesisTools\ChromeDevtools` instead.
+
+### Platform support
+
+darwin, linux and win32, factored through `lib/platform.ts` (injectable primitives with
+per-platform parser tests). POSIX shares `ps`/`lsof`/`pgrep`; Windows uses PowerShell CIM,
+`netstat -ano` and `tasklist`/`taskkill`. Browser launch: `open -na` on macOS, the browser
+binary on PATH on Linux, known install paths on Windows. `restart` quits gracefully
+everywhere (osascript / `pkill -TERM` / `taskkill` without `/F`) so session restore keeps
+the tabs. Windows caveats: `status` shows cpu-time but no instantaneous %CPU, and the
+frame-grid verb still needs ImageMagick on PATH. macOS and Linux are exercised end to end;
+Windows support is parser-tested but not yet run against a live Windows browser.
+
+### Recorder lifecycle (the incident, encoded)
+
+- Pid-recycling-safe pidfiles (`@genesiscz/utils/process/pidfile`) claimed **before** the
+  child connects — concurrent `attach` from many agent sessions yields exactly one recorder
+  per port.
+- High-rate packets are never `JSON.parse`d: websocket frames are dropped pre-parse
+  (unless the `ws` channel is on) and `Network.dataReceived` goes through a regex fast path
+  that aggregates byte counts in memory and emits one synthetic summary event per request.
+- One open fd per segment, `writeSync` per event. Never `appendFileSync`.
+- Dies when CDP dies: `/json/version` probe every 2 s, 3 failures = exit. Also exits on
+  websocket close, SIGTERM, `record --stop`, `--seconds`, and a hard 24 h lifetime cap.
+
+### Capture channels (`record --channels`)
+
+`net` (always on — the HAR diet) · `console` (default) · `+ws` frames · `+body` (≤2 KB,
+active fetch) · `+storage` (snapshot per navigation). Render channels on `follow` are free:
+`nav doc redirect xhr ws console error cookie body storage`.
+
+## HAR pipeline
+
+`lib/har/` is a **TypeScript port of chrome-har v1.3.1** (sitespeedio/chrome-har, MIT) —
+the converter browsertime/puppeteer-har/playwright-har all wrap — with four documented
+deviations (see `lib/har/build.ts` header), the important one being sessionId-aware entry
+keying so multi-tab captures cannot corrupt each other. Parity is pinned by
+`lib/har/build.parity.test.ts` against goldens generated from the upstream package over its
+own real-Chrome perflogs (upstream clone: `../_Playgrounds/chrome-har`). There is no
+chrome-har npm dependency; `tough-cookie` remains for Set-Cookie parsing fidelity.
+
+Research that led here (no native CDP/MCP/Playwright export exists for an attached user
+browser): `.claude/work/research/2026-08-26-CdpNativeHarExport.md`.
+
+## Ops
+
+- `status` — recorders with live CPU/mem/cpu-time samples, buffer sizes, endpoints,
+  orphan recorder-shaped processes, legacy `/tmp/cdp-arm-*` leftovers. `--detailed`,
+  `--format json`.
+- `doctor` — read-only diagnosis; prints one fix command per finding. Never mutates.
+- `cleanup` — the mutating counterpart. TTY: guided multi-select. Non-TTY: explicit flags
+  (`--kill <pid>`, `--stale <port>`, `--legacy [port…]`, `--dir <port>`). Kill safety is
+  three-layered: the pid must still be recorder-shaped (pid recycling), must not BE a live
+  pidfile-owned recorder (use `record --stop`), and must not be a launcher ANCESTOR of one
+  (the launch chain carries the same argv — a field test caught doctor suggesting exactly
+  that kill before this guard existed). Kills are never batched: `--yes` applies only the
+  safe fixes. Files are MOVED to a /tmp trash dir, never destroyed in place.
+
+## Scripting
+
+- `scaffold <name> --recipe <r>` creates a CDP scratch script **in the `tools scripts`
+  store** (versioned, `tools scripts run <name>`). Recipes: `redirect-chain`,
+  `cookie-diff`, `storage-snapshot`, `body-fetch`, `console-trap`, `blank`. The store's
+  tsconfig maps `@gt/chrome-devtools/*` to this tool's `lib/`.
+- `cheatsheet` prints the CDP scripting cheatsheet (also in the plugin skill's references).
+- `mcp [tool] [json]` calls the real chrome-devtools-mcp tools against any port, no session
+  config edit.
+
+## Do not
+
+- Do not pipe `record`, `follow`, or `trace` to `head`/`tail` — they are long-running and
+  print pid + paths first.
+- Do not `tail -f` segment files — use `follow`.
+- Do not `pkill -f chrome-devtools` — that can hit MCP servers and the CLI you are typing.
+  `status` shows pids; `cleanup --kill` verifies before killing.
+- Do not `cat`/`jq` a `.har` — `tools har-analyzer load` it.
+- A HAR of a login flow contains the plaintext password and live session tokens. `--sanitize`
+  before it leaves the machine.
+
+## Benchmark
+
+The `attach` auto-record default was validated on the real browser before shipping; numbers
+live in a dated section of `.claude/plans/2026-08-26-ChromeDevtoolsTool.md`. Re-measure with
+interleaved runs (≥5 per arm) if the recorder ever looks hot in `status`.

--- a/src/chrome-devtools/cli-guidance.test.ts
+++ b/src/chrome-devtools/cli-guidance.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { captureDir } from "./lib/paths.ts";
+
+/** The junior-proof CLI contract: every wrong invocation teaches the right one. */
+
+function run(args: string[]): { code: number; text: string } {
+    const r = Bun.spawnSync({
+        cmd: ["bun", `${import.meta.dir}/index.ts`, ...args],
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+
+    return { code: r.exitCode ?? 1, text: `${r.stdout.toString()}${r.stderr.toString()}` };
+}
+
+describe("record CLI", () => {
+    test("exits 1 without a scope, names both scope flags, and writes no pidfile", () => {
+        const r = run(["record", "--port", "59999"]);
+        expect(r.code).toBe(1);
+        expect(r.text).toContain("record needs a scope");
+        expect(r.text).toContain("--match <url-substr>");
+        expect(r.text).toContain("--all-tabs");
+        expect(existsSync(join(captureDir(59999), "recorder.pid"))).toBe(false);
+    });
+
+    test("rejects an unknown capture channel and enumerates the vocabulary", () => {
+        const r = run(["record", "--port", "59999", "--all-tabs", "--channels", "bogus"]);
+        expect(r.code).toBe(1);
+        expect(r.text).toContain("unknown capture channel(s): bogus");
+        for (const channel of ["net", "console", "ws", "body", "storage"]) {
+            expect(r.text).toContain(channel);
+        }
+    });
+});
+
+describe("watch tombstone", () => {
+    test("explains the record/follow split and exits 1", () => {
+        const r = run(["watch", "--channels", "nav"]);
+        expect(r.code).toBe(1);
+        expect(r.text).toContain("record");
+        expect(r.text).toContain("follow");
+        expect(r.text).toContain("har");
+    });
+});
+
+describe("follow CLI", () => {
+    test("rejects an unknown render channel and enumerates the vocabulary", () => {
+        const r = run(["follow", "--port", "59999", "--channels", "nope"]);
+        expect(r.code).toBe(1);
+        expect(r.text).toContain("unknown render channel(s): nope");
+        expect(r.text).toContain("redirect");
+        expect(r.text).toContain("cookie");
+    });
+
+    test("with nothing to follow, points at record and attach", () => {
+        const r = run(["follow", "--port", "59998", "--channels", "nav"]);
+        expect(r.code).toBe(1);
+        expect(r.text).toContain("nothing to follow");
+        expect(r.text).toContain("record --port 59998 --all-tabs");
+    });
+});
+
+describe("har CLI", () => {
+    test("with no recorder and no buffer, teaches record / attach / --now", () => {
+        const r = run(["har", "--port", "59997"]);
+        expect(r.code).toBe(1);
+        expect(r.text).toContain("nothing to dump");
+        expect(r.text).toContain("record --port 59997 --all-tabs");
+        expect(r.text).toContain("--now --reload");
+    });
+
+    test("rejects a malformed --last with the accepted forms", async () => {
+        // --last is parsed only once a buffer exists, so plant a leftover
+        // segment (no recorder → --from-buffer reaches the parser). The name
+        // must match seg-<digits>.jsonl or segmentStats will not count it.
+        const dir = captureDir(59996);
+        const segment = join(dir, `seg-${Date.now()}.jsonl`);
+        mkdirSync(dir, { recursive: true });
+        await Bun.write(segment, "");
+        try {
+            const r = run(["har", "--port", "59996", "--from-buffer", "--last", "bananas"]);
+            expect(r.code).toBe(1);
+            expect(r.text).toContain("--last takes 90s / 30m / 2h");
+            expect(r.text).toContain("'bananas'");
+        } finally {
+            // Remove ONLY the planted segment — a real capture on this port
+            // (however unlikely) must survive the test.
+            rmSync(segment, { force: true });
+        }
+    });
+});
+
+describe("scaffold CLI", () => {
+    test("without a name lists every recipe and exits 1", () => {
+        const r = run(["scaffold"]);
+        expect(r.code).toBe(1);
+        for (const recipe of [
+            "redirect-chain",
+            "cookie-diff",
+            "storage-snapshot",
+            "body-fetch",
+            "console-trap",
+            "blank",
+        ]) {
+            expect(r.text).toContain(recipe);
+        }
+
+        expect(r.text).toContain("scaffold needs a script name");
+    });
+
+    test("unknown recipe lists the valid ones", () => {
+        const r = run(["scaffold", "myProbe", "--recipe", "nope"]);
+        expect(r.code).toBe(1);
+        expect(r.text).toContain("unknown recipe 'nope'");
+        expect(r.text).toContain("redirect-chain");
+    });
+});
+
+describe("help completeness", () => {
+    // Per-verb markers: a flag or guidance line that only that verb's help
+    // carries — a length check would pass on any truncated or generic help.
+    const HELP_MARKERS: Record<string, string[]> = {
+        record: ["--all-tabs", "Capture channels", "Examples:"],
+        follow: ["Render channels", "--last <duration>", "Examples:"],
+        har: ["--from-buffer", "Buffer dumps are metadata + headers", "Examples:"],
+        cleanup: ["--stale <port...>", "--yes"],
+        scaffold: ["--recipe <recipe>", "Recipes"],
+        mcp: ["take_snapshot", "Examples:"],
+        attach: ["read at browser STARTUP", "--port <n>"],
+    };
+
+    test("every verb's --help carries its own flags and guidance", () => {
+        for (const [verb, markers] of Object.entries(HELP_MARKERS)) {
+            const r = run([verb, "--help"]);
+            expect(r.code).toBe(0);
+            for (const marker of markers) {
+                expect(r.text).toContain(marker);
+            }
+        }
+    });
+});

--- a/src/chrome-devtools/commands/attach.ts
+++ b/src/chrome-devtools/commands/attach.ts
@@ -1,0 +1,93 @@
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import { CDP_PORTS, isPortSpecified, planAttach, renderAttachPlan } from "../lib/resolve-attach.ts";
+import {
+    guidanceBlock,
+    portOf,
+    scanInventory,
+    startRecorderBackground,
+    suggest,
+    TOOL_CMD,
+    withPort,
+} from "./shared.ts";
+
+/**
+ * Auto-record on attach. Benchmarked on the real browser before shipping
+ * (see README "Benchmark"); if that ever regresses, flip this to false and
+ * attach degrades to guidance-only, never silently.
+ */
+const ATTACH_AUTO_RECORD = true;
+
+export function registerAttach(program: Command): void {
+    withPort(program.command("attach"))
+        .description(
+            "scan the 9222-9230 range PLUS every listening Chromium debug port (lsof, DevToolsActivePort files), list every CDP endpoint, start the background recorder, and print what to do next. Errors when two Chromium browsers are open and no --port picks one."
+        )
+        .addHelpText(
+            "after",
+            `
+The debugging flag is read at browser STARTUP — it cannot be enabled on a
+running browser. When nothing listens, attach prints the exact restart/open
+commands. Ask the user before quitting their browser (open tabs are at stake).`
+        )
+        .action(async (opts: { port?: string }) => {
+            const inventory = await scanInventory();
+            const explicitPort = isPortSpecified() ? portOf(opts) : undefined;
+            const plan = planAttach(inventory, { explicitPort });
+
+            if (plan.status === "none" && plan.running.length === 0) {
+                out.log.error(`No CDP endpoint on ${CDP_PORTS.join(", ")}.
+
+A browser must be LAUNCHED with the flag — it cannot be enabled at runtime.
+  Reuse your real profile (keeps logins, costs open tabs):
+    ${suggest(["restart", "--browser", "brave", "--port", "9222"])}
+  Or a throwaway profile alongside it (nothing of yours touched):
+    ${suggest(["open", "--browser", "chrome", "--port", "9223", "--fresh", "https://example.com"])}`);
+                process.exit(1);
+            }
+
+            const { text, exitCode } = renderAttachPlan(plan, { cmd: TOOL_CMD, suggestCommand: suggest });
+            out.println(text);
+
+            if (plan.status === "list") {
+                for (const e of plan.endpoints) {
+                    let recording = false;
+                    if (ATTACH_AUTO_RECORD) {
+                        const r = startRecorderBackground(e.port);
+                        recording = true;
+                        if (r.started) {
+                            out.log.info(
+                                `recorder started on ${e.port} (pid ${r.pid}, one per port, dies when CDP drops)`
+                            );
+                        }
+                    }
+
+                    out.println("");
+                    out.println(guidanceBlock(e.port, recording));
+                }
+
+                if (plan.endpoints.length > 1) {
+                    out.println(`
+Two endpoints live. Compare broken vs working:
+    ${suggest(["cookies", "--port", String(plan.endpoints[0].port), "--json"])} > /tmp/a.json
+    ${suggest(["cookies", "--port", String(plan.endpoints[1].port), "--json"])} > /tmp/b.json
+    then diff by (name, domain, path). Duplicate name on different paths is a classic stale-session bug.`);
+                }
+
+                if (explicitPort !== undefined) {
+                    const others = inventory.endpoints.filter((e) => e.port !== explicitPort);
+                    if (others.length > 0) {
+                        out.println(
+                            `\nOther live endpoints not shown: ${others.map((e) => e.port).join(", ")} (bare '${TOOL_CMD} attach' lists them all).`
+                        );
+                    }
+                }
+
+                out.println(`
+Scratch scripts beyond these verbs: ${suggest(["scaffold", "<name>", "--recipe", "redirect-chain"])}
+Cheatsheet: ${suggest(["cheatsheet"])}`);
+            }
+
+            process.exit(exitCode);
+        });
+}

--- a/src/chrome-devtools/commands/browse.test.ts
+++ b/src/chrome-devtools/commands/browse.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { launchArgs } from "./browse.ts";
+
+describe("launchArgs (PR #326 review — the profile-isolation rule, pinned)", () => {
+    test("a plain launch carries the debug port and NO --user-data-dir (the real profile)", () => {
+        const args = launchArgs(9222, {});
+        expect(args).toContain("--remote-debugging-port=9222");
+        expect(args.some((a) => a.startsWith("--user-data-dir"))).toBe(false);
+        expect(args.some((a) => a.startsWith("--load-extension"))).toBe(false);
+    });
+
+    test("the real profile NEVER gets the private-network downgrade flag", () => {
+        expect(launchArgs(9222, {}).some((a) => a.startsWith("--disable-features"))).toBe(false);
+    });
+
+    test("--fresh isolates into a /tmp profile so the user's own profile stays untouched", () => {
+        const args = launchArgs(9223, { fresh: true });
+        expect(args).toContain("--user-data-dir=/tmp/cdp-profile-9223");
+        expect(args).toContain("--disable-features=LocalNetworkAccessChecks,PrivateNetworkAccessChecks");
+    });
+
+    test("--extension implies its own profile and restricts loaded extensions to the one given", () => {
+        const args = launchArgs(9333, { extension: "/dist/ext" });
+        expect(args).toContain("--user-data-dir=/tmp/cdp-profile-9333");
+        expect(args).toContain("--load-extension=/dist/ext");
+        expect(args).toContain("--disable-extensions-except=/dist/ext");
+    });
+});

--- a/src/chrome-devtools/commands/browse.ts
+++ b/src/chrome-devtools/commands/browse.ts
@@ -1,0 +1,166 @@
+/** open / restart / targets — getting a CDP endpoint to exist, on any platform. */
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import { targets } from "../lib/cdp.ts";
+import {
+    BROWSER_APPS,
+    BROWSERS,
+    browserById,
+    freshProfileDir,
+    launchBrowser,
+    listRunningBrowsers,
+    quitBrowser,
+    waitForCdp,
+} from "../lib/resolve-attach.ts";
+import { portOf, probe, refuseIfAmbiguous, suggest, withPort } from "./shared.ts";
+
+/** Chromium launch flags. Exported for tests: the --user-data-dir rule is what keeps `open` off the real profile. */
+export function launchArgs(port: number, opts: { fresh?: boolean; extension?: string }): string[] {
+    const args = [`--remote-debugging-port=${port}`, "--no-first-run", "--no-default-browser-check"];
+
+    if (opts.fresh || opts.extension) {
+        args.push(`--user-data-dir=${freshProfileDir(port)}`);
+        // Local/private-network access checks block CDP-driven fetches to dev
+        // servers, so throwaway profiles disable them. The user's REAL profile
+        // (plain open / restart) keeps every protection — a normal browsing
+        // session must never run security-downgraded.
+        args.push("--disable-features=LocalNetworkAccessChecks,PrivateNetworkAccessChecks");
+    }
+
+    if (opts.extension) {
+        args.push(`--load-extension=${opts.extension}`, `--disable-extensions-except=${opts.extension}`);
+    }
+
+    return args;
+}
+
+/**
+ * Strict: an unknown --browser value must ERROR, never fall back to Chrome —
+ * a typo like `--browser bave` would otherwise quit the WRONG browser in
+ * `restart` and cost the user their open tabs.
+ */
+function browserDefOf(raw: unknown): { id: string; name: string } {
+    // Object.hasOwn: a plain index check would accept --browser toString via the prototype.
+    if (raw !== undefined && (typeof raw !== "string" || !Object.hasOwn(BROWSER_APPS, raw))) {
+        out.log.error(`unknown --browser '${String(raw)}'. Valid: ${BROWSER_IDS}`);
+        process.exit(1);
+    }
+
+    const id = typeof raw === "string" ? raw : "chrome";
+
+    return { id, name: BROWSER_APPS[id] };
+}
+
+const BROWSER_IDS = BROWSERS.map((b) => b.id).join("|");
+
+interface OpenOpts {
+    port?: string;
+    browser?: string;
+    fresh?: boolean;
+    extension?: string;
+}
+
+export function registerBrowse(program: Command): void {
+    withPort(program.command("open"))
+        .description(
+            "launch a CDP-enabled browser (the flag is read at startup only; refuses if that app is already running)"
+        )
+        .argument("[url]", "url to open", "about:blank")
+        .option("--browser <name>", BROWSER_IDS, "chrome")
+        .option("--fresh", "throwaway profile — your own profile stays untouched (but you must log in again)")
+        .option("--extension <dist-dir>", "load an unpacked extension (implies its own profile)")
+        .action(async (url: string, opts: OpenOpts) => {
+            const { id, name } = browserDefOf(opts.browser);
+            const def = browserById(id);
+            const port = portOf(opts);
+
+            if (!def) {
+                out.log.error(`unknown browser '${id}'. Valid: ${BROWSER_IDS}`);
+                process.exit(1);
+            }
+
+            if (!opts.fresh && !opts.extension && listRunningBrowsers().includes(id)) {
+                out.log.error(`${name} is already running. The debug flag cannot be added to a live process.`);
+                out.log.info(`  ${suggest(["restart", "--browser", id, "--port", String(port)])}`);
+                process.exit(1);
+            }
+
+            const launch = launchBrowser({
+                browser: def,
+                args: launchArgs(port, { fresh: opts.fresh === true, extension: opts.extension }),
+                url,
+            });
+
+            if (!launch.ok) {
+                out.log.error(launch.message);
+                process.exit(1);
+            }
+
+            const up = await waitForCdp({ port, probe, timeoutMs: 20000 });
+            const result = up ? await probe(port) : null;
+            out.log.info(
+                result
+                    ? `up: ${result.browser} on ${port} (${result.pages.length} pages)`
+                    : `launched but no CDP on ${port} yet. Do not raw-curl /json/version — re-run: ${suggest(["attach"])}`
+            );
+            out.log.info(`  next: ${suggest(["attach", "--port", String(port)])}`);
+            process.exit(result ? 0 : 1);
+        });
+
+    withPort(program.command("restart"))
+        .description(
+            "quit the app, wait until it is gone, relaunch with --remote-debugging-port. Costs open tabs (session restore usually brings them back) — ask the user first."
+        )
+        .argument("[url]", "url to open after relaunch", "about:blank")
+        .option("--browser <name>", BROWSER_IDS, "chrome")
+        .option("--force", "if quit sticks, force-kill (ask the user first)")
+        .action(async (url: string, opts: OpenOpts & { force?: boolean }) => {
+            const { id, name } = browserDefOf(opts.browser);
+            const def = browserById(id);
+            const port = portOf(opts);
+
+            if (!def) {
+                out.log.error(`unknown browser '${id}'. Valid: ${BROWSER_IDS}`);
+                process.exit(1);
+            }
+
+            out.log.info(`quitting ${name} (tabs come back via session restore)...`);
+            const q = await quitBrowser({ app: name, browser: def, force: opts.force === true });
+
+            if (!q.exited) {
+                out.log.error(`${name} is still running. Re-run with --force to force-kill.`);
+                process.exit(1);
+            }
+
+            const launch = launchBrowser({ browser: def, args: launchArgs(port, {}), url });
+            if (!launch.ok) {
+                out.log.error(launch.message);
+                process.exit(1);
+            }
+
+            const up = await waitForCdp({ port, probe, timeoutMs: 20000 });
+            const result = up ? await probe(port) : null;
+
+            if (!result) {
+                out.log.error(
+                    `relaunched but no CDP on ${port}. Chrome ≥136 refuses the flag on the DEFAULT profile dir (anti-automation).`
+                );
+                out.log.info(
+                    `  fallback with a separate profile: ${suggest(["open", "--browser", id, "--port", String(port), "--fresh", url])}`
+                );
+                process.exit(1);
+            }
+
+            out.log.info(`up: ${result.browser} on ${port} (${result.pages.length} pages)`);
+            out.log.info(`  next: ${suggest(["attach", "--port", String(port)])}`);
+            process.exit(0);
+        });
+
+    withPort(program.command("targets"))
+        .description("raw /json/list of the endpoint (every tab, its targetId and URL)")
+        .action(async (opts: { port?: string }) => {
+            await refuseIfAmbiguous();
+            out.result(await targets(portOf(opts)));
+            process.exit(0);
+        });
+}

--- a/src/chrome-devtools/commands/cleanup.ts
+++ b/src/chrome-devtools/commands/cleanup.ts
@@ -1,0 +1,142 @@
+import * as p from "@clack/prompts";
+import { isInteractive } from "@genesiscz/utils/cli";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import {
+    actionsFromFindings,
+    clearStalePidfile,
+    killRecorderPid,
+    moveCaptureDir,
+    moveLegacyFiles,
+    partitionForYes,
+} from "../lib/cleanup.ts";
+import { diagnose } from "../lib/doctor.ts";
+import { suggest } from "./shared.ts";
+
+interface CleanupOpts {
+    kill?: string[];
+    stale?: string[];
+    legacy?: boolean | string[];
+    dir?: string[];
+    yes?: boolean;
+}
+
+export function registerCleanup(program: Command): void {
+    program
+        .command("cleanup")
+        .description(
+            "apply the fixes doctor found: kill orphans, clear stale pidfiles, move legacy files and dead buffers to a /tmp trash dir. Interactive in a terminal; explicit flags otherwise."
+        )
+        .option(
+            "--kill <pid...>",
+            "SIGTERM these recorder pids (refuses recycled pids, live recorders, and launcher ancestors of live recorders)"
+        )
+        .option("--stale <port...>", "clear dead/foreign recorder pidfiles for these ports")
+        .option("--legacy [port...]", "move legacy /tmp/cdp-arm-* files to trash (all, or only the given ports')")
+        .option("--dir <port...>", "move these ports' capture dirs to trash (the buffer is gone from har afterwards)")
+        .option("--yes", "apply all SAFE fixes without confirmation — never kills anything")
+        .addHelpText(
+            "after",
+            `
+Nothing is destroyed in place: files are MOVED to /tmp/GenesisTools/ChromeDevtools/trash-<date>/
+and survive until reboot. Run 'doctor' first to see what needs cleaning.`
+        )
+        .action(async (opts: CleanupOpts) => {
+            const explicit = Boolean(opts.kill?.length || opts.stale?.length || opts.legacy || opts.dir?.length);
+
+            if (explicit) {
+                const results = await Promise.all([
+                    ...(opts.kill ?? []).map((pid) => killRecorderPid(Number(pid))),
+                    ...(opts.stale ?? []).map((port) => clearStalePidfile(Number(port))),
+                    ...(opts.legacy
+                        ? [moveLegacyFiles(Array.isArray(opts.legacy) ? opts.legacy.map(Number) : undefined)]
+                        : []),
+                    ...(opts.dir ?? []).map((port) => moveCaptureDir(Number(port))),
+                ]);
+
+                let failed = 0;
+                for (const r of results) {
+                    if (r.ok) {
+                        out.log.success(r.message);
+                    } else {
+                        out.log.error(r.message);
+                        failed++;
+                    }
+                }
+
+                process.exit(failed ? 1 : 0);
+            }
+
+            const findings = await diagnose();
+            const actions = actionsFromFindings(findings);
+
+            if (actions.length === 0) {
+                out.log.success("nothing to clean.");
+                process.exit(0);
+            }
+
+            const { batchable: safeActions, excludedKills: killActions } = partitionForYes(actions);
+
+            if (!isInteractive() && !opts.yes) {
+                out.log.error("cleanup needs a terminal (or explicit flags). Findings and their commands:");
+                for (const f of findings) {
+                    out.log.info(`  ${f.title}${f.fix ? `\n    ${f.fix}` : ""}`);
+                }
+
+                if (safeActions.length > 0) {
+                    out.log.info(`  all SAFE fixes at once (never kills anything): ${suggest(["cleanup", "--yes"])}`);
+                }
+
+                if (killActions.length > 0) {
+                    out.log.warn(
+                        "  kills are never batched — run each 'cleanup --kill <pid>' deliberately after checking 'status'."
+                    );
+                }
+
+                process.exit(1);
+            }
+
+            let chosen = actions;
+            if (opts.yes) {
+                chosen = safeActions;
+                for (const kill of killActions) {
+                    out.log.warn(
+                        `skipped (kills are never batched): ${kill.label} — run its cleanup --kill explicitly`
+                    );
+                }
+
+                if (chosen.length === 0) {
+                    out.log.info("nothing safe to batch; only kill actions remain and those need explicit --kill.");
+                    process.exit(0);
+                }
+            }
+
+            if (!opts.yes) {
+                const picked = await p.multiselect({
+                    message: "What should be cleaned? (space toggles, enter confirms)",
+                    options: actions.map((a, i) => ({ value: i, label: a.label })),
+                    required: false,
+                });
+
+                if (p.isCancel(picked) || (Array.isArray(picked) && picked.length === 0)) {
+                    p.cancel("nothing cleaned");
+                    process.exit(0);
+                }
+
+                chosen = (picked as number[]).map((i) => actions[i]);
+            }
+
+            let failed = 0;
+            for (const action of chosen) {
+                const r = await action.apply();
+                if (r.ok) {
+                    out.log.success(r.message);
+                } else {
+                    out.log.error(r.message);
+                    failed++;
+                }
+            }
+
+            process.exit(failed ? 1 : 0);
+        });
+}

--- a/src/chrome-devtools/commands/doctor.ts
+++ b/src/chrome-devtools/commands/doctor.ts
@@ -1,0 +1,40 @@
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { diagnose } from "../lib/doctor.ts";
+import { suggest } from "./shared.ts";
+
+export function registerDoctor(program: Command): void {
+    program
+        .command("doctor")
+        .description(
+            "diagnose stale pidfiles, orphan recorders, legacy old-skill leftovers, hot processes, and broken debug flags. READ-ONLY: prints fixes, applies nothing."
+        )
+        .option("--json", "machine-readable findings")
+        .action(async (opts: { json?: boolean }) => {
+            const findings = await diagnose();
+
+            if (opts.json) {
+                out.result(findings);
+                process.exit(findings.some((f) => f.severity === "err") ? 1 : 0);
+            }
+
+            if (findings.length === 0) {
+                out.log.success("clean: no stale pidfiles, no orphans, no legacy leftovers, no hot recorders.");
+                process.exit(0);
+            }
+
+            for (const f of findings) {
+                const mark = f.severity === "err" ? pc.red("✗") : f.severity === "warn" ? pc.yellow("!") : pc.dim("·");
+                out.println(`${mark} ${f.title}`);
+                out.println(`    ${f.detail}`);
+                if (f.fix) {
+                    out.println(`    fix: ${f.fix}`);
+                }
+            }
+
+            out.println("");
+            out.println(`apply fixes interactively: ${suggest(["cleanup"])}`);
+            process.exit(findings.some((f) => f.severity === "err") ? 1 : 0);
+        });
+}

--- a/src/chrome-devtools/commands/follow.ts
+++ b/src/chrome-devtools/commands/follow.ts
@@ -1,0 +1,142 @@
+import { out } from "@genesiscz/utils/logger";
+import { inspectPidFile } from "@genesiscz/utils/process/pidfile";
+import type { Command } from "commander";
+import {
+    channelHelpLines,
+    monitorHints,
+    parseChannels,
+    RENDER_CHANNEL_HELP,
+    RENDER_CHANNELS,
+    type RenderChannel,
+} from "../lib/channels.ts";
+import { follow, missingCaptureChannels } from "../lib/follow.ts";
+import { parseDuration } from "../lib/har-io.ts";
+import { recorderPidPath } from "../lib/paths.ts";
+import { artifactPath } from "../lib/platform.ts";
+import { segmentStats } from "../lib/status.ts";
+import { ignoreSigpipe, portOf, positiveNumber, suggest, withPort } from "./shared.ts";
+
+const DEFAULT_RENDER: RenderChannel[] = ["nav", "doc", "redirect", "error"];
+
+const EXAMPLE_OUT_LOG = artifactPath("api.log");
+
+interface FollowOpts {
+    port?: string;
+    channels?: string;
+    match?: string;
+    last?: string;
+    seconds?: string;
+    out?: string;
+}
+
+export function registerFollow(program: Command): void {
+    withPort(program.command("follow"))
+        .description(
+            "live view over the recorder's buffer — the sanctioned tail (rotation-aware; raw segment files must never be tailed). Prints Monitor-ready commands first."
+        )
+        .option("--channels <list>", `render channels (default ${DEFAULT_RENDER.join(",")})`)
+        .option("--match <substr>", "URL filter — substring or /regex/flags")
+        .option("--last <duration>", "replay the last 90s / 30m / 2h of the buffer first, then go live")
+        .option("--seconds <n>", "stop after N seconds (default: run until killed)")
+        .option("--out <file>", "also mirror lines into this file (what the printed Monitor commands tail)")
+        .addHelpText(
+            "after",
+            `
+Render channels (all derived from the buffer — picking them costs nothing).
+'net' is accepted as shorthand for nav,doc,redirect,xhr,cookie (the network set):
+${channelHelpLines(RENDER_CHANNEL_HELP).join("\n")}
+
+Channels marked "needs the recorder's X channel" only show data when the
+recorder captures X — follow tells you the exact restart command when not.
+
+Examples:
+  ${suggest(["follow", "--channels", "nav,redirect,cookie", "--match", "idp.example.com"])}
+  ${suggest(["follow", "--channels", "error", "--last", "10m"])}
+  ${suggest(["follow", "--channels", "xhr,error", "--out", EXAMPLE_OUT_LOG, "--seconds", "120"])}
+
+Run long follows with run_in_background and --out, then arm a Monitor on the
+printed command. Never pipe follow to head/tail.`
+        )
+        .action(async (opts: FollowOpts) => {
+            const port = portOf(opts);
+            // `net` is the recorder's CAPTURE channel; people naturally type it
+            // here (status prints it), so accept it as the network render set.
+            const raw = (opts.channels ?? "").replace(/\bnet\b/g, "nav,doc,redirect,xhr,cookie");
+            const parsed = parseChannels(raw, RENDER_CHANNELS, DEFAULT_RENDER);
+
+            if (parsed.invalid.length) {
+                out.log.error(`unknown render channel(s): ${parsed.invalid.join(", ")}. Valid channels:`);
+                out.log.error(channelHelpLines(RENDER_CHANNEL_HELP).join("\n"));
+                process.exit(1);
+            }
+
+            const recorder = inspectPidFile(recorderPidPath(port));
+            const stats = segmentStats(port);
+
+            if (recorder.status !== "live" && stats.count === 0) {
+                out.log.error(`nothing to follow on ${port}: no recorder is running and no buffer exists.`);
+                out.log.info(
+                    `  start one: ${suggest(["record", "--port", String(port), "--all-tabs"])}   (or just: ${suggest(["attach"])})`
+                );
+                process.exit(1);
+            }
+
+            if (recorder.status !== "live") {
+                out.log.warn(
+                    `recorder on ${port} is not running — following the leftover buffer only (no new events will arrive).`
+                );
+            }
+
+            for (const missing of missingCaptureChannels(port, parsed.channels)) {
+                out.log.warn(
+                    `'${missing.channel}' needs the recorder's '${missing.needs}' capture channel, which is OFF. Restart it: ${suggest(["record", "--port", String(port), "--stop"])} && ${suggest(["record", "--port", String(port), "--all-tabs", "--channels", `+${missing.needs}`])}`
+                );
+            }
+
+            let sinceMs: number | undefined;
+            if (opts.last) {
+                const ms = parseDuration(opts.last);
+                if (ms === null) {
+                    out.log.error(`--last takes 90s / 30m / 2h (bare number = minutes), got '${opts.last}'`);
+                    process.exit(1);
+                }
+
+                sinceMs = Date.now() - ms;
+            }
+
+            ignoreSigpipe();
+
+            // The mirror goes through one buffered FileSink (flushed per line),
+            // not a per-line appendFileSync — a blocking write per rendered
+            // event is the texture the recorder incident forbade.
+            let mirror: ReturnType<ReturnType<typeof Bun.file>["writer"]> | undefined;
+            if (opts.out) {
+                await Bun.write(opts.out, "");
+                mirror = Bun.file(opts.out).writer();
+                out.log.info(
+                    `pid ${process.pid} mirroring -> ${opts.out}    stop: kill ${process.pid}  # never pkill -f`
+                );
+                out.log.info("watch it (Monitor tool takes any of these verbatim):");
+                for (const hint of monitorHints(opts.out, parsed.channels)) {
+                    out.log.info(`  ${hint}`);
+                }
+            }
+
+            await follow({
+                port,
+                channels: parsed.channels,
+                match: opts.match,
+                sinceMs,
+                seconds: opts.seconds ? positiveNumber(opts.seconds, 0, "--seconds") : undefined,
+                onLine: (line) => {
+                    out.println(line);
+                    if (mirror) {
+                        mirror.write(`${line}\n`);
+                        void mirror.flush();
+                    }
+                },
+            });
+            await mirror?.end();
+            process.exit(0);
+        });
+}

--- a/src/chrome-devtools/commands/har.ts
+++ b/src/chrome-devtools/commands/har.ts
@@ -1,0 +1,230 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { out } from "@genesiscz/utils/logger";
+import { inspectPidFile } from "@genesiscz/utils/process/pidfile";
+import type { Command } from "commander";
+import type { HarFile } from "../lib/har/types.ts";
+import { buildHarFromBuffer, captureLiveWindow, parseDuration, sanitizeHar } from "../lib/har-io.ts";
+import { captureDir, recorderPidPath } from "../lib/paths.ts";
+import { artifactPath } from "../lib/platform.ts";
+import { probeCdp } from "../lib/recorder.ts";
+import { segmentStats } from "../lib/status.ts";
+import { portOf, positiveNumber, refuseIfAmbiguous, suggest, withPage } from "./shared.ts";
+
+const DEFAULT_HAR_OUT = artifactPath("cdp.har");
+
+interface HarOpts {
+    port?: string;
+    match?: string;
+    out?: string;
+    last?: string;
+    now?: boolean;
+    reload?: boolean;
+    seconds?: string;
+    fromBuffer?: boolean;
+    sanitize?: boolean;
+    analyze?: boolean;
+    bodies?: boolean;
+    summary?: boolean;
+}
+
+function clock(ms: number | null): string {
+    return ms === null ? "?" : new Date(ms).toTimeString().slice(0, 8);
+}
+
+/** One line per entry: the OAuth-assertion table (method/status/sizes/auth shape) without har-analyzer round-trips. */
+function printHarSummary(har: HarFile): void {
+    for (const e of har.log.entries) {
+        const auth = e.request.headers.find((h) => h.name.toLowerCase() === "authorization")?.value ?? "";
+        const authShape = auth ? (auth.split(" ")[0] ?? "yes") : "-";
+        const reqSize = e.request.postData?.text?.length ?? e.request.bodySize ?? 0;
+        const respSize = e.response?.content.size ?? e.response?.bodySize ?? 0;
+        out.println(
+            `${e.startedDateTime.slice(11, 19)}  ${e.request.method.padEnd(6)} ${String(e.response?.status ?? "-").padEnd(4)} req=${String(reqSize).padEnd(7)} resp=${String(respSize).padEnd(8)} auth=${authShape.padEnd(7)} ${e.request.url.slice(0, 110)}`
+        );
+    }
+
+    out.println(
+        `\n${har.log.entries.length} entries. Columns: time method status req-bytes resp-bytes auth-scheme url`
+    );
+}
+
+async function writeHarFile(
+    har: HarFile,
+    opts: { sanitize?: boolean; analyze?: boolean; out: string; droppedFailed: number; note: string }
+): Promise<void> {
+    const outHar = opts.sanitize ? sanitizeHar(har) : har;
+    await Bun.write(opts.out, SafeJSON.stringify(outHar, { strict: true }, 2));
+    out.log.info(`${outHar.log.entries.length} entries, ${outHar.log.pages.length} page(s) -> ${opts.out}`);
+    out.log.info(opts.note);
+
+    if (opts.droppedFailed > 0) {
+        out.log.warn(
+            `${opts.droppedFailed} failed request(s) are NOT in the HAR (the format cannot represent network-level failures). See them: ${suggest(["follow", "--channels", "error"])}`
+        );
+    }
+
+    if (!opts.sanitize) {
+        out.log.warn(
+            "this HAR can contain cookies, tokens, and POST passwords. Before sharing: re-run with --sanitize, or tools har-analyzer export --sanitize --strip-bodies -o clean.har"
+        );
+    }
+
+    out.log.info(`Do not cat/jq the file. Next: tools har-analyzer load ${opts.out}`);
+
+    if (opts.analyze) {
+        const proc = Bun.spawn(["tools", "har-analyzer", "load", opts.out], {
+            stdio: ["ignore", "inherit", "inherit"],
+        });
+        await proc.exited;
+    }
+}
+
+export function registerHar(program: Command): void {
+    withPage(program.command("har"))
+        .description(
+            "write a DevTools-grade HAR 1.2: retroactively from the recorder's buffer (default), or from a live window on one tab (--now / --reload)"
+        )
+        .option("-o, --out <file>", "HAR path", DEFAULT_HAR_OUT)
+        .option("--last <duration>", "only events from the last 90s / 30m / 2h (buffer mode; bare number = minutes)")
+        .option("--now", "ignore the buffer; record a live window on one tab from this moment")
+        .option("--reload", "live window: reload the tab first so load-time requests (and bodies) are captured")
+        .option("--seconds <n>", "live-window length (default 8 with --reload, else 15)")
+        .option("--from-buffer", "dump a leftover buffer although its recorder already exited")
+        .option(
+            "--sanitize",
+            "redact Cookie, Set-Cookie, Authorization headers, cookie values, and password/token/code POST params"
+        )
+        .option("--no-bodies", "live window: skip Network.getResponseBody calls")
+        .option("--analyze", "run tools har-analyzer load on the result")
+        .option(
+            "--summary",
+            "also print one line per entry (time, method, status, req/resp bytes, auth scheme, url) — the one-shot assertion table"
+        )
+        .addHelpText(
+            "after",
+            `
+Examples:
+  ${suggest(["har", "-o", DEFAULT_HAR_OUT, "--last", "30m"])}            # what happened in the last 30 min
+  ${suggest(["har", "--now", "--reload", "-o", DEFAULT_HAR_OUT])}        # fresh load of the current tab, with bodies
+  ${suggest(["har", "--from-buffer", "--port", "9222", "-o", "x.har"])} # recorder died, dump what it left
+  ${suggest(["har", "-o", "clean.har", "--sanitize", "--analyze"])}
+
+Buffer dumps are metadata + headers: response bodies are physically gone once
+a tab navigates (Chrome discards them — Chromium #141129). For bodies use
+--now --reload, or start the recorder with --channels +body.`
+        )
+        .action(async (opts: HarOpts) => {
+            const port = portOf(opts);
+
+            if (opts.now || opts.reload) {
+                await refuseIfAmbiguous();
+
+                if (!(await probeCdp(port))) {
+                    out.log.error(`no CDP endpoint on port ${port} — nothing listens there.`);
+                    out.log.info(`  see what is live: ${suggest(["attach"])}`);
+                    process.exit(1);
+                }
+
+                const seconds = positiveNumber(opts.seconds, opts.reload ? 8 : 15, "--seconds");
+                let live: Awaited<ReturnType<typeof captureLiveWindow>>;
+                try {
+                    live = await captureLiveWindow({
+                        port,
+                        match: opts.match,
+                        reload: opts.reload,
+                        seconds,
+                        bodies: opts.bodies !== false,
+                        onAttached: (page) => {
+                            out.log.info(
+                                `recording a live window on ${page.target.url.slice(0, 90)} for ${seconds}s (CDP only sees traffic after attach)...`
+                            );
+                        },
+                    });
+                } catch (err) {
+                    out.log.error(err instanceof Error ? err.message : String(err));
+                    out.log.info(`See open tabs first: ${suggest(["targets", "--port", String(port)])}`);
+                    process.exit(1);
+                }
+
+                await writeHarFile(live.har, {
+                    sanitize: opts.sanitize,
+                    analyze: opts.analyze,
+                    out: opts.out ?? DEFAULT_HAR_OUT,
+                    droppedFailed: live.droppedFailed,
+                    note:
+                        live.har.log.entries.length === 0
+                            ? "0 entries: CDP starts empty at attach. Re-run with --reload, or longer --seconds while you reproduce."
+                            : `live window on ${live.pageUrl.slice(0, 90)} (bodies ${live.bodiesGot}, missing ${live.bodiesMiss})`,
+                });
+
+                if (opts.summary) {
+                    printHarSummary(opts.sanitize ? sanitizeHar(live.har) : live.har);
+                }
+
+                process.exit(0);
+            }
+
+            const recorder = inspectPidFile(recorderPidPath(port));
+            const stats = segmentStats(port);
+
+            if (recorder.status !== "live" && stats.count === 0) {
+                out.log.error(`nothing to dump on ${port}: no recorder and no buffer under ${captureDir(port)}.`);
+                out.log.info(
+                    `  start recording: ${suggest(["record", "--port", String(port), "--all-tabs"])}   (or just: ${suggest(["attach"])})`
+                );
+                out.log.info(
+                    `  or a live window right now: ${suggest(["har", "--port", String(port), "--now", "--reload"])}`
+                );
+                process.exit(1);
+            }
+
+            if (recorder.status !== "live" && !opts.fromBuffer) {
+                out.log.error(
+                    `the recorder on ${port} is not running; the buffer (${stats.count} segment(s), ${Math.round(stats.bytes / 1024)} KB) is a leftover.`
+                );
+                out.log.info(
+                    `  dump it anyway: ${suggest(["har", "--port", String(port), "--from-buffer", "-o", String(opts.out ?? DEFAULT_HAR_OUT)])}`
+                );
+                out.log.info(`  or record fresh: ${suggest(["record", "--port", String(port), "--all-tabs"])}`);
+                process.exit(1);
+            }
+
+            let sinceMs: number | undefined;
+            if (opts.last) {
+                const ms = parseDuration(opts.last);
+                if (ms === null) {
+                    out.log.error(`--last takes 90s / 30m / 2h (bare number = minutes), got '${opts.last}'`);
+                    process.exit(1);
+                }
+
+                sinceMs = Date.now() - ms;
+            }
+
+            const built = buildHarFromBuffer({ port, sinceMs, match: opts.match });
+
+            if (built.har.log.entries.length === 0) {
+                // An empty window must never read as "no traffic": say what the
+                // buffer actually holds so a too-narrow --last is self-evident.
+                out.log.warn(
+                    `0 entries${opts.last ? ` in the last ${opts.last}` : ""}${opts.match ? ` matching '${opts.match}'` : ""} — but the buffer holds ${built.coverage.totalEvents} event(s) covering ${clock(built.coverage.oldestT)}-${clock(built.coverage.newestT)}. An empty window is NOT proof of no traffic; widen --last or drop --match.`
+                );
+            }
+
+            await writeHarFile(built.har, {
+                sanitize: opts.sanitize,
+                analyze: opts.analyze,
+                out: opts.out ?? DEFAULT_HAR_OUT,
+                droppedFailed: built.droppedFailed,
+                note:
+                    built.har.log.entries.length === 0
+                        ? "0 entries written (see the coverage warning above)."
+                        : `from the ${recorder.status === "live" ? "live" : "leftover"} buffer (metadata + headers${built.stitchedBodies ? `, ${built.stitchedBodies} captured bodies` : ""}). Bodies of a fresh load: --now --reload.`,
+            });
+
+            if (opts.summary) {
+                printHarSummary(opts.sanitize ? sanitizeHar(built.har) : built.har);
+            }
+
+            process.exit(0);
+        });
+}

--- a/src/chrome-devtools/commands/inspect.ts
+++ b/src/chrome-devtools/commands/inspect.ts
@@ -1,0 +1,238 @@
+/** cookies / rm-cookie / console / eval / nav / shot / grid / trace — page and browser inspection. */
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import { browser } from "../lib/cdp.ts";
+import { artifactPath } from "../lib/platform.ts";
+import {
+    attachTab,
+    ignoreSigpipe,
+    portOf,
+    positiveNumber,
+    refuseIfAmbiguous,
+    suggest,
+    withPage,
+    withPort,
+} from "./shared.ts";
+
+export function registerInspect(program: Command): void {
+    withPort(program.command("cookies"))
+        .description("every cookie incl. httpOnly, across all domains — what page JS can never see")
+        .option("--domain <substr>", "only cookies whose domain contains this")
+        .option("--json", "machine-readable, for diffing two browsers")
+        .action(async (opts: { port?: string; domain?: string; json?: boolean }) => {
+            await refuseIfAmbiguous();
+            const b = await browser(portOf(opts));
+            const cs = await b.cookies(opts.domain);
+
+            if (opts.json) {
+                out.result(
+                    cs.map((c) => ({
+                        name: c.name,
+                        domain: c.domain,
+                        path: c.path,
+                        httpOnly: c.httpOnly,
+                        secure: c.secure,
+                        sameSite: c.sameSite,
+                        session: c.expires === -1,
+                        len: c.value.length,
+                    }))
+                );
+            } else {
+                const seen = new Map<string, number>();
+                for (const c of cs) {
+                    seen.set(c.name, (seen.get(c.name) ?? 0) + 1);
+                }
+
+                for (const c of cs.sort((a, z) => a.name.localeCompare(z.name))) {
+                    const dup = (seen.get(c.name) ?? 0) > 1 ? "  <-- DUPLICATE NAME" : "";
+                    out.println(
+                        `${c.name.padEnd(38)} ${c.domain.padEnd(22)} path=${(c.path ?? "/").padEnd(10)} httpOnly=${c.httpOnly ? "y" : "n"} session=${c.expires === -1 ? "y" : "n"} len=${c.value.length}${dup}`
+                    );
+                }
+
+                out.println(
+                    `\n${cs.length} cookies. Duplicate name on different paths => longer path is sent FIRST (RFC 6265); servers taking the first value bind to the stale session.`
+                );
+            }
+
+            b.close();
+            process.exit(0);
+        });
+
+    withPort(program.command("rm-cookie"))
+        .description(
+            "delete ONE cookie by name+domain+path — the surgical confirmation step. Never 'clear site data' (it destroys the evidence and the user's logins)."
+        )
+        .requiredOption("--name <name>", "cookie name")
+        .requiredOption("--domain <domain>", "cookie domain, exactly as listed by 'cookies'")
+        .option("--path <path>", "cookie path", "/")
+        .action(async (opts: { port?: string; name: string; domain: string; path: string }) => {
+            await refuseIfAmbiguous();
+            const b = await browser(portOf(opts));
+            await b.deleteCookie(opts.name, opts.domain, opts.path);
+            out.log.info(`deleted ${opts.name} ${opts.domain} ${opts.path}`);
+            b.close();
+            process.exit(0);
+        });
+
+    withPage(program.command("console"))
+        .description(
+            "dump console messages of a tab. Attaches FIRST, so --reload replays load-time messages (the MCP list_console_messages can never see those)."
+        )
+        .option("--reload", "reload the page once attached")
+        .option("--wait <n>", "seconds to listen (default 5, or 8 with --reload)")
+        .action(async (opts: { port?: string; match?: string; reload?: boolean; wait?: string }) => {
+            const page = await attachTab(opts);
+            const lines: string[] = [];
+            page.onConsole((level, text) => lines.push(`[${level}] ${text}`));
+            out.log.info(`attached to: ${page.target.url}`);
+
+            if (opts.reload) {
+                await page.reload();
+            }
+
+            await Bun.sleep(positiveNumber(opts.wait, opts.reload ? 8 : 5, "--wait") * 1000);
+            out.println(
+                lines.length
+                    ? lines.join("\n")
+                    : "<nothing logged in that window — use --reload to replay load-time messages>"
+            );
+            process.exit(0);
+        });
+
+    withPage(program.command("eval"))
+        .description("run JS in the page and print the result as JSON")
+        .argument(
+            "[fnOrExpr]",
+            "arrow function or expression, e.g. '() => ({url: location.href, ls: {...localStorage}})'"
+        )
+        .option(
+            "--file <path>",
+            "read the function/expression from a file — dodges shell quoting (and hooks that block inline eval strings)"
+        )
+        .action(async (fnOrExpr: string | undefined, opts: { port?: string; match?: string; file?: string }) => {
+            let source = fnOrExpr;
+            if (opts.file) {
+                const f = Bun.file(opts.file);
+                if (!(await f.exists())) {
+                    out.log.error(`--file ${opts.file} does not exist.`);
+                    process.exit(1);
+                }
+
+                source = await f.text();
+            }
+
+            if (!source?.trim()) {
+                out.log.error("eval needs an expression argument or --file <path>.");
+                out.log.info(`  e.g. ${suggest(["eval", "() => location.href"])}`);
+                out.log.info(`  or:  ${suggest(["eval", "--file", artifactPath("probe.js")])}`);
+                process.exit(1);
+            }
+
+            const page = await attachTab(opts);
+            out.result(await page.evaluate(source));
+            process.exit(0);
+        });
+
+    withPage(program.command("nav"))
+        .description("navigate the tab")
+        .argument("<url>", "destination URL")
+        .action(async (url: string, opts: { port?: string; match?: string }) => {
+            const page = await attachTab(opts);
+            await page.navigate(url);
+            await Bun.sleep(2500);
+            out.log.info(`now at: ${page.target.url}`);
+            process.exit(0);
+        });
+
+    withPage(program.command("shot"))
+        .description("screenshot the tab")
+        .argument("[path]", "output PNG", artifactPath("shot.png"))
+        .option("--full", "capture beyond the viewport")
+        .action(async (path: string, opts: { port?: string; match?: string; full?: boolean }) => {
+            const page = await attachTab(opts);
+            out.println(await page.screenshot(path, opts.full === true));
+            process.exit(0);
+        });
+
+    withPort(program.command("grid"))
+        .description(
+            "screenshot with a pixel-coordinate grid burned in — read the label, click the pixel (for pages where AX-tree tools see nothing). Needs ImageMagick."
+        )
+        .argument("[path]", "output PNG", artifactPath("grid.png"))
+        .option("--region <x,y,w,h>", "crop before gridding")
+        .option("--step <n>", "grid spacing in px", "60")
+        .option("--full", "capture beyond the viewport")
+        .action(async (path: string, opts: { port?: string; region?: string; step: string; full?: boolean }) => {
+            await refuseIfAmbiguous();
+            const { captureFrameGrid } = await import("../lib/frame-grid.ts");
+            out.println(
+                await captureFrameGrid({
+                    outPath: path,
+                    port: portOf(opts),
+                    region: opts.region,
+                    gridStep: positiveNumber(opts.step, 60, "--step"),
+                    fullPage: opts.full === true,
+                })
+            );
+            process.exit(0);
+        });
+
+    withPage(program.command("trace"))
+        .description(
+            "quick one-liner: record the document + redirect chain (Location and Set-Cookie per hop) of ONE tab to a file. For multi-tab or channels, use record + follow."
+        )
+        .option("--seconds <n>", "how long to record", "90")
+        .option("--out <file>", "log path", artifactPath("cdp-trace.log"))
+        .action(async (opts: { port?: string; match?: string; seconds: string; out: string }) => {
+            ignoreSigpipe();
+            const secs = positiveNumber(opts.seconds, 90, "--seconds");
+            const match = opts.match;
+            const page = await attachTab(opts);
+            out.log.info(`tracing ${page.target.url.slice(0, 90)} for ${secs}s (match=${match ?? "*"}) -> ${opts.out}`);
+            const events = page.recordNetwork(match ? (u) => u.includes(match) : undefined);
+            const lines: string[] = [];
+            const t0 = Date.now();
+
+            const timer = setInterval(() => {
+                while (events.length) {
+                    const e = events.shift();
+                    if (!e) {
+                        break;
+                    }
+
+                    const ts = ((Date.now() - t0) / 1000).toFixed(2).padStart(7);
+                    let line = "";
+
+                    if (e.kind === "redirect") {
+                        const cookies =
+                            Array.isArray(e.setCookie) && e.setCookie.length
+                                ? `\n         set-cookie: ${e.setCookie.join(" | ")}`
+                                : "";
+                        line = `${ts} REDIR ${e.status} ${e.from}\n         -> ${e.location}${cookies}`;
+                    } else if (e.kind === "request" && e.type === "Document") {
+                        line = `${ts} DOC   ${e.method} ${e.url}`;
+                    } else if (e.kind === "nav") {
+                        line = `${ts} NAV   ${e.url}`;
+                    } else if (e.kind === "failed") {
+                        line = `${ts} FAIL  ${e.error} (${e.requestId})`;
+                    } else {
+                        continue;
+                    }
+
+                    lines.push(line);
+                    out.println(line);
+                }
+            }, 250);
+
+            setTimeout(async () => {
+                clearInterval(timer);
+                await Bun.write(opts.out, lines.join("\n"));
+                out.log.info(`DONE ${lines.length} lines -> ${opts.out}`);
+                out.log.info(
+                    `retroactive alternative next time: ${suggest(["attach"])} then ${suggest(["har", "--last", "10m"])}`
+                );
+                process.exit(0);
+            }, secs * 1000);
+        });
+}

--- a/src/chrome-devtools/commands/record.ts
+++ b/src/chrome-devtools/commands/record.ts
@@ -1,0 +1,148 @@
+import { existsSync } from "node:fs";
+import { out } from "@genesiscz/utils/logger";
+import { inspectPidFile, readSignalablePid } from "@genesiscz/utils/process/pidfile";
+import type { Command } from "commander";
+import {
+    CAPTURE_CHANNEL_HELP,
+    CAPTURE_CHANNELS,
+    channelHelpLines,
+    DEFAULT_CAPTURE_CHANNELS,
+    parseChannels,
+} from "../lib/channels.ts";
+import { captureDir, recorderPidPath } from "../lib/paths.ts";
+import { terminatePid } from "../lib/platform.ts";
+import { recordScopeError, resolveRecordSeconds, runRecorder } from "../lib/recorder.ts";
+import { ignoreSigpipe, portOf, suggest, withPort } from "./shared.ts";
+
+interface RecordOpts {
+    port?: string;
+    match?: string;
+    allTabs?: boolean;
+    seconds?: string;
+    channels?: string;
+    stop?: boolean;
+}
+
+function registerRecordLike(program: Command, name: string, hidden: boolean): void {
+    const cmd = withPort(program.command(name, { hidden }))
+        .description(
+            "the capture engine: one background recorder per port, HAR-grade metadata into a rolling 4h buffer. `har` dumps it retroactively, `follow` views it live."
+        )
+        .option("--match <substr>", "record only tabs whose URL contains this (the cheap scope)")
+        .option("--all-tabs", "record every http(s) tab")
+        .option(
+            "--seconds <n>",
+            "stop after N seconds (default 600 for a manual record; 0 = until the browser's CDP endpoint dies, max 24h)"
+        )
+        .option(
+            "--channels <list>",
+            `capture channels (default ${DEFAULT_CAPTURE_CHANNELS.join(",")}; prefix + adds to the default, e.g. +ws,body)`
+        )
+        .option("--stop", "stop the recorder for this port (the buffer stays dumpable)")
+        .addHelpText(
+            "after",
+            `
+Capture channels:
+${channelHelpLines(CAPTURE_CHANNEL_HELP).join("\n")}
+
+Examples:
+  ${suggest([name, "--match", "idp.example.com"])}
+  ${suggest([name, "--all-tabs", "--seconds", "0"])}
+  ${suggest([name, "--match", "app.example.com", "--channels", "+ws,body"])}
+  ${suggest([name, "--port", "9222", "--stop"])}
+
+Do not pipe this command to head/tail — it prints its pid and keeps running.
+The buffer segments under ${captureDir(9222).replace("9222", "<port>")} are INTERNAL; never tail them raw (rotation
+breaks the fd silently). Use 'follow' for live viewing and 'har' for dumps.`
+        );
+
+    cmd.action(async (opts: RecordOpts) => {
+        const port = portOf(opts);
+
+        if (opts.stop) {
+            const pidPath = recorderPidPath(port);
+            if (!existsSync(pidPath)) {
+                out.log.info(`no recorder running on ${port}`);
+                process.exit(0);
+            }
+
+            const pid = readSignalablePid(pidPath);
+            if (pid === null) {
+                out.log.info(`no live recorder on ${port} (stale pidfile — 'cleanup --stale ${port}' clears it)`);
+                process.exit(0);
+            }
+
+            const r = terminatePid(pid);
+            out.log.info(
+                r.exitCode === 0
+                    ? `stopped recorder ${pid} on ${port} (buffer kept for har)`
+                    : `stop ${pid} failed: ${r.stderr}`
+            );
+            process.exit(r.exitCode === 0 ? 0 : 1);
+        }
+
+        const scopeErr = recordScopeError({ match: opts.match, allTabs: opts.allTabs });
+        if (scopeErr) {
+            out.log.error(scopeErr);
+            out.log.info(`  e.g. ${suggest([name, "--port", String(port), "--match", "idp.example.com"])}`);
+            process.exit(1);
+        }
+
+        const parsed = parseChannels(opts.channels ?? "", CAPTURE_CHANNELS, DEFAULT_CAPTURE_CHANNELS);
+        if (parsed.invalid.length) {
+            out.log.error(`unknown capture channel(s): ${parsed.invalid.join(", ")}. Valid channels:`);
+            out.log.error(channelHelpLines(CAPTURE_CHANNEL_HELP).join("\n"));
+            process.exit(1);
+        }
+
+        const state = inspectPidFile(recorderPidPath(port));
+        if (state.status === "live" && state.pid !== process.pid) {
+            out.log.info(`recorder already up on ${port} (pid ${state.pid}) -> ${captureDir(port)}`);
+            out.log.info(
+                `  stop it first to change scope/channels: ${suggest([name, "--port", String(port), "--stop"])}`
+            );
+            process.exit(0);
+        }
+
+        ignoreSigpipe();
+        try {
+            await runRecorder({
+                port,
+                match: opts.match,
+                allTabs: opts.allTabs,
+                seconds: resolveRecordSeconds(opts.seconds),
+                channels: parsed.channels,
+            });
+        } catch (err) {
+            out.log.error(err instanceof Error ? err.message : String(err));
+            out.log.info(`  see live ports: ${suggest(["attach"])}`);
+            process.exit(1);
+        }
+
+        process.exit(0);
+    });
+}
+
+export function registerRecord(program: Command): void {
+    registerRecordLike(program, "record", false);
+    // Hidden alias: the old skill called this verb `arm`.
+    registerRecordLike(program, "arm", true);
+}
+
+export function registerWatchTombstone(program: Command): void {
+    program
+        .command("watch", { hidden: true })
+        .allowUnknownOption(true)
+        .allowExcessArguments(true)
+        .description("removed — the engine/view split replaced it")
+        .action(() => {
+            out.log.error(`'watch' was split into an engine and a view:
+  record   the capture engine (background, browser-wide, rolling buffer)
+  follow   the live view (channels, Monitor hints) over that buffer
+  har      the retroactive dump
+
+  ${suggest(["record", "--match", "idp.example.com"])}
+  ${suggest(["follow", "--channels", "nav,redirect,error", "--match", "idp.example.com"])}`);
+            process.exit(1);
+        });
+}

--- a/src/chrome-devtools/commands/scripting.ts
+++ b/src/chrome-devtools/commands/scripting.ts
@@ -1,0 +1,124 @@
+/** scaffold / cheatsheet / mcp — the scripting doors. */
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import { findRecipe, recipeHelpLines, scaffoldRecipeScript } from "../lib/scaffold.ts";
+import { portOf, refuseIfAmbiguous, suggest, withPort } from "./shared.ts";
+
+const CHEATSHEET_PATH = join(
+    import.meta.dir,
+    "..",
+    "..",
+    "..",
+    "plugins",
+    "genesis-tools",
+    "skills",
+    "chrome-devtools",
+    "references",
+    "cdp-cheatsheet.md"
+);
+
+export function registerScripting(program: Command): void {
+    program
+        .command("scaffold")
+        .description(
+            "create a CDP scratch script in the `tools scripts` store (versioned, listable, runnable there) from a probed recipe"
+        )
+        .argument("[name]", "script name (letters, digits, dash, underscore)")
+        .option("--recipe <recipe>", "which recipe to start from (see --list)")
+        .option("--list", "list the recipes and exit")
+        .addHelpText(
+            "after",
+            `
+Recipes (each verified against a live CDP browser before shipping):
+${recipeHelpLines().join("\n")}
+
+Examples:
+  ${suggest(["scaffold", "colRedirects", "--recipe", "redirect-chain"])}
+  tools scripts run colRedirects -- --port 9222 --match idp.example.com
+  tools scripts show colRedirects`
+        )
+        .action(async (name: string | undefined, opts: { recipe?: string; list?: boolean }) => {
+            if (opts.list || !name) {
+                if (!name && !opts.list) {
+                    out.log.error("scaffold needs a script name.");
+                    out.log.info(`  e.g. ${suggest(["scaffold", "myProbe", "--recipe", "redirect-chain"])}`);
+                }
+
+                out.println("Recipes:");
+                out.println(recipeHelpLines().join("\n"));
+                process.exit(opts.list ? 0 : 1);
+            }
+
+            const recipeName = opts.recipe ?? "blank";
+            const recipe = findRecipe(recipeName);
+            if (!recipe) {
+                out.log.error(`unknown recipe '${recipeName}'. Available:`);
+                out.log.error(recipeHelpLines().join("\n"));
+                process.exit(1);
+            }
+
+            const result = await scaffoldRecipeScript({ name, recipe });
+            out.log.success(`created ${result.file}`);
+            out.log.info(`  run:  ${result.runHint}`);
+            out.log.info(`  edit: it is yours — tools scripts show ${name}`);
+            process.exit(0);
+        });
+
+    program
+        .command("cheatsheet")
+        .description("print the CDP scripting cheatsheet (lib API, recipes, channels, do-not-pipe rules)")
+        .action(async () => {
+            const file = Bun.file(CHEATSHEET_PATH);
+            if (!(await file.exists())) {
+                out.log.error(`cheatsheet missing at ${CHEATSHEET_PATH} — the plugin skill directory moved?`);
+                process.exit(1);
+            }
+
+            out.println(await file.text());
+            process.exit(0);
+        });
+
+    withPort(program.command("mcp"))
+        .description("call the real chrome-devtools-mcp tools against this port (no session config edit, no restart)")
+        .argument("[tool]", "tool name, or 'list'", "list")
+        .argument("[json]", "arguments as JSON", "{}")
+        .addHelpText(
+            "after",
+            `
+Examples:
+  ${suggest(["mcp", "list"])}
+  ${suggest(["mcp", "navigate_page", '{"url":"https://example.com"}'])}
+  ${suggest(["mcp", "take_snapshot"])}`
+        )
+        .action(async (tool: string, json: string, opts: { port?: string }) => {
+            await refuseIfAmbiguous();
+            const { callTool, listTools } = await import("../lib/mcp.ts");
+            const port = portOf(opts);
+
+            if (!tool || tool === "list") {
+                out.println((await listTools({ port })).join("\n"));
+                process.exit(0);
+            }
+
+            let args: unknown;
+            try {
+                args = SafeJSON.parse(json, { strict: true });
+            } catch {
+                out.log.error(`arguments are not valid JSON: ${json}`);
+                out.log.info(`  e.g. ${suggest(["mcp", tool, '{"url":"https://example.com"}'])}`);
+                process.exit(1);
+            }
+
+            if (typeof args !== "object" || args === null || Array.isArray(args)) {
+                out.log.error(`arguments must be a JSON object, got: ${json}`);
+                out.log.info(`  e.g. ${suggest(["mcp", tool, '{"url":"https://example.com"}'])}`);
+                process.exit(1);
+            }
+
+            const result = await callTool(tool, args as Record<string, unknown>, { port });
+            out.println(SafeJSON.stringify(result, { strict: true }, 1).slice(0, 4000));
+            process.exit(0);
+        });
+}

--- a/src/chrome-devtools/commands/shared.ts
+++ b/src/chrome-devtools/commands/shared.ts
@@ -1,0 +1,232 @@
+/** Shared plumbing for the thin command layer: inventory scan, ambiguity refusal, guidance, recorder spawn. */
+import { fileURLToPath } from "node:url";
+import { suggestCommand } from "@genesiscz/utils/cli";
+import { logger, out } from "@genesiscz/utils/logger";
+import { inspectPidFile, writePidFile } from "@genesiscz/utils/process/pidfile";
+import type { Command } from "commander";
+import { attach, type Page, targets } from "../lib/cdp.ts";
+import { DEFAULT_CAPTURE_CHANNELS } from "../lib/channels.ts";
+import { captureDir, ensureCaptureDir, recorderPidPath } from "../lib/paths.ts";
+import { artifactPath } from "../lib/platform.ts";
+import { readRecorderMeta } from "../lib/recorder.ts";
+import {
+    browsersWithEmptyDebugFlag,
+    CDP_PORTS,
+    discoverListeningCdpPorts,
+    type Inventory,
+    isPortSpecified,
+    listRunningBrowsers,
+    mergeProbePorts,
+    ownerOfPort,
+    planAttach,
+    readDevToolsActivePortsFromDisk,
+    renderAttachPlan,
+} from "../lib/resolve-attach.ts";
+
+const { log } = logger.scoped("chrome-devtools:cli");
+
+export const TOOL_CMD = "tools chrome-devtools";
+
+export function portOf(opts: { port?: string }): number {
+    const raw = opts.port ?? "9222";
+    const port = Number(raw);
+
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        out.log.error(`--port must be a TCP port number (1-65535), got '${raw}'.`);
+        out.log.info(`  see live ports: ${suggest(["attach"])}`);
+        process.exit(1);
+    }
+
+    return port;
+}
+
+/** Parse a numeric CLI value that must be a finite positive number; exits with guidance otherwise. */
+export function positiveNumber(raw: string | number | undefined, fallback: number, flag: string): number {
+    if (raw === undefined || raw === "") {
+        return fallback;
+    }
+
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) {
+        out.log.error(`${flag} must be a positive number, got '${raw}'.`);
+        process.exit(1);
+    }
+
+    return n;
+}
+
+export function withPort(cmd: Command): Command {
+    return cmd.option("--port <n>", "CDP port (attach lists what exists when you are unsure)", "9222");
+}
+
+export function withPage(cmd: Command): Command {
+    return withPort(cmd).option(
+        "--match <substr>",
+        "pick the tab whose URL contains this substring, or /regex/ (errors when nothing matches — never grabs a random tab)"
+    );
+}
+
+export function suggest(command: string[]): string {
+    // replaceCommand, not add: `add` appends to the CURRENT argv, which doubles
+    // the verb when the suggestion names a different one (attach attach --port …).
+    return suggestCommand(TOOL_CMD, { replaceCommand: command });
+}
+
+export { ignoreSigpipe } from "../lib/platform.ts";
+
+export async function probe(
+    port: number
+): Promise<{ port: number; browser: string; pages: { title?: string; url: string }[] } | null> {
+    try {
+        const r = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(1200) });
+        const v = (await r.json()) as { Browser?: string };
+        // The list fetch needs its own timeout: /json/version answering while
+        // /json/list stalls would otherwise hang every inventory-based command.
+        const list = (await targets(port, { signal: AbortSignal.timeout(1200) })).filter((t) => t.type === "page");
+
+        return { port, browser: v.Browser ?? "unknown", pages: list };
+    } catch {
+        return null;
+    }
+}
+
+export async function scanInventory(): Promise<Inventory> {
+    const running = listRunningBrowsers();
+    const ports = mergeProbePorts(CDP_PORTS, discoverListeningCdpPorts(), readDevToolsActivePortsFromDisk());
+    const found = (await Promise.all(ports.map(probe))).filter((x): x is NonNullable<typeof x> => x != null);
+
+    return {
+        running,
+        emptyDebugFlag: browsersWithEmptyDebugFlag(),
+        endpoints: found.map((f) => ({
+            port: f.port,
+            browser: f.browser,
+            owner: ownerOfPort(f.port),
+            pages: f.pages.map((p) => ({ title: p.title ?? "", url: p.url })),
+        })),
+    };
+}
+
+/** Refuse to guess between two open Chromium browsers unless --port picks one. */
+export async function refuseIfAmbiguous(): Promise<void> {
+    if (isPortSpecified()) {
+        return;
+    }
+
+    const plan = planAttach(await scanInventory());
+    if (plan.status !== "ambiguous") {
+        return;
+    }
+
+    const { text } = renderAttachPlan(plan, { cmd: TOOL_CMD, suggestCommand: suggest });
+    out.log.error(text);
+    process.exit(1);
+}
+
+/** attach() with the no-random-tab contract; exits with guidance when the match misses. */
+export async function attachTab(opts: { port?: string; match?: string }): Promise<Page> {
+    await refuseIfAmbiguous();
+    try {
+        return await attach({ port: portOf(opts), url: opts.match });
+    } catch (err) {
+        out.log.error(err instanceof Error ? err.message : String(err));
+        out.log.info(`See open tabs first: ${suggest(["targets", "--port", String(portOf(opts))])}`);
+        process.exit(1);
+    }
+}
+
+/**
+ * The unconditional attach guidance block — what is running, how to record,
+ * follow, dump, and inspect. Printed on EVERY attach, per Martin's contract.
+ */
+export function guidanceBlock(port: number, recording: boolean): string {
+    const lines: string[] = [];
+
+    if (recording) {
+        // The REAL channel list from the recorder's meta, not the default —
+        // and an explicit bodies-off warning: a field session burned an hour
+        // fingerprinting OAuth grants by Content-Length because nothing said
+        // the retroactive HARs would have no request bodies.
+        const channels = readRecorderMeta(port)?.channels ?? [...DEFAULT_CAPTURE_CHANNELS];
+        lines.push(`  recording: all http(s) tabs on ${port} -> ${captureDir(port)} (channels ${channels.join(",")})`);
+
+        if (!channels.includes("body")) {
+            lines.push(
+                `    NOTE: bodies are OFF — retroactive 'har' dumps carry headers but no request/response bodies.`
+            );
+            lines.push(
+                `    bodies on:   ${suggest(["record", "--port", String(port), "--stop"])} && ${suggest(["record", "--port", String(port), "--all-tabs", "--channels", "+body"])}`
+            );
+        }
+
+        lines.push(`    stop:        ${suggest(["record", "--port", String(port), "--stop"])}`);
+        lines.push(
+            `    scope down:  ${suggest(["record", "--port", String(port), "--match", "<url-substr>"])}   # stop first`
+        );
+    } else {
+        lines.push(`  NOT recording on ${port}. Start one (retroactive 'har' only works while a recorder runs):`);
+        lines.push(`    one site:    ${suggest(["record", "--port", String(port), "--match", "<url-substr>"])}`);
+        lines.push(`    everything:  ${suggest(["record", "--port", String(port), "--all-tabs"])}`);
+    }
+
+    lines.push(`  live view:     ${suggest(["follow", "--port", String(port), "--channels", "nav,redirect,error"])}`);
+    lines.push(
+        `  HAR (buffer):  ${suggest(["har", "--port", String(port), "-o", artifactPath(`cdp-${port}.har`), "--last", "30m"])}`
+    );
+    lines.push(
+        `  HAR (live):    ${suggest(["har", "--port", String(port), "--now", "--reload", "-o", artifactPath(`cdp-${port}.har`)])}`
+    );
+    lines.push(`  cookies:       ${suggest(["cookies", "--port", String(port), "--domain", "<substr>"])}`);
+    lines.push(`  console:       ${suggest(["console", "--port", String(port), "--match", "<substr>", "--reload"])}`);
+    lines.push(`  health:        ${suggest(["status"])}`);
+
+    return lines.join("\n");
+}
+
+/**
+ * Start the background recorder for a port: spawn, then claim via pidfile.
+ * Claim-races resolve by killing the child that lost (the child ALSO
+ * self-checks at boot — see runRecorder — so a raced duplicate exits either way).
+ */
+export function startRecorderBackground(port: number): { started: boolean; pid: number } {
+    ensureCaptureDir(port);
+    const pidPath = recorderPidPath(port);
+    const state = inspectPidFile(pidPath);
+
+    if (state.status === "live") {
+        out.log.info(`recorder already up on ${port} (pid ${state.pid}) -> ${captureDir(port)}`);
+
+        return { started: false, pid: state.pid };
+    }
+
+    const script = fileURLToPath(new URL("../index.ts", import.meta.url));
+    const child = Bun.spawn(
+        [
+            "bun",
+            script,
+            "record",
+            "--port",
+            String(port),
+            "--all-tabs",
+            "--seconds",
+            "0",
+            "--channels",
+            DEFAULT_CAPTURE_CHANNELS.join(","),
+        ],
+        { stdin: "ignore", stdout: "ignore", stderr: "ignore" }
+    );
+
+    const after = inspectPidFile(pidPath);
+    if (after.status === "live" && after.pid !== child.pid) {
+        child.kill();
+        out.log.info(`recorder already up on ${port} (pid ${after.pid}); killed the raced duplicate`);
+
+        return { started: false, pid: after.pid };
+    }
+
+    writePidFile(pidPath, { pid: child.pid });
+    child.unref();
+    log.debug({ port, pid: child.pid }, "recorder spawned");
+
+    return { started: true, pid: child.pid };
+}

--- a/src/chrome-devtools/commands/status.ts
+++ b/src/chrome-devtools/commands/status.ts
@@ -1,0 +1,135 @@
+import { out } from "@genesiscz/utils/logger";
+import { createBoxTable, formatDotStatus, renderCliHeader, renderCliSection } from "@genesiscz/utils/table";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { captureDir } from "../lib/paths.ts";
+import { artifactPath } from "../lib/platform.ts";
+import { collectStatus } from "../lib/status.ts";
+import { suggest } from "./shared.ts";
+
+function mb(bytes: number): string {
+    return bytes >= 1024 * 1024 ? `${(bytes / 1024 / 1024).toFixed(1)} MB` : `${Math.round(bytes / 1024)} KB`;
+}
+
+export function registerStatus(program: Command): void {
+    program
+        .command("status")
+        .description(
+            "every recorder and recorder-shaped process: pid, CPU, memory, cpu-time, buffer size, endpoint health. Read-only."
+        )
+        .option("--detailed", "add per-port meta, pidfile records and segment lists")
+        .option("--format <fmt>", "output format: table (default) or json")
+        .option("--json", "shorthand for --format json")
+        .action(async (opts: { detailed?: boolean; format?: string; json?: boolean }) => {
+            const report = await collectStatus();
+
+            if (opts.json || opts.format === "json") {
+                out.result(report);
+                process.exit(0);
+            }
+
+            if (opts.format && opts.format !== "table") {
+                out.log.error(`unknown --format '${opts.format}'. Valid: table, json.`);
+                process.exit(1);
+            }
+
+            renderCliHeader("chrome-devtools status", "recorders · buffers · endpoints");
+
+            if (report.ports.length === 0) {
+                out.println("no capture dirs yet — nothing has ever recorded on this machine.");
+                out.println(`  start: ${suggest(["attach"])}`);
+            } else {
+                const table = createBoxTable([
+                    "PORT",
+                    "RECORDER",
+                    "CPU",
+                    "MEM",
+                    "CPU TIME",
+                    "UP",
+                    "SCOPE",
+                    "CHANNELS",
+                    "BUFFER",
+                    "ENDPOINT",
+                ]);
+
+                for (const p of report.ports) {
+                    const rec =
+                        p.pidState.status === "live"
+                            ? formatDotStatus("ok", `pid ${p.pidState.pid}`)
+                            : p.pidState.status === "none"
+                              ? formatDotStatus("dim", "none")
+                              : formatDotStatus("err", p.pidState.status);
+                    const scope = p.meta?.scope.allTabs ? "all-tabs" : (p.meta?.scope.match ?? "—");
+                    table.push([
+                        pc.white(String(p.port)),
+                        rec,
+                        p.sample?.cpuPercent != null ? `${p.sample.cpuPercent}%` : "—",
+                        p.sample ? mb(p.sample.rssKb * 1024) : "—",
+                        p.sample?.cpuTime ?? "—",
+                        p.sample?.elapsed ?? "—",
+                        scope,
+                        p.meta?.channels.join(",") ?? "—",
+                        p.segments.count ? `${mb(p.segments.bytes)} / ${p.segments.count} seg` : "empty",
+                        p.endpoint
+                            ? `${p.endpoint.browser.slice(0, 22)} (${p.endpoint.pages}p)`
+                            : formatDotStatus("err", "no CDP"),
+                    ]);
+                }
+
+                out.println(table.toString());
+            }
+
+            if (report.orphans.length > 0) {
+                renderCliSection("Orphan recorder-shaped processes (no pidfile owns them)");
+                const table = createBoxTable(["PID", "CPU", "UP", "COMMAND"]);
+                for (const o of report.orphans) {
+                    table.push([
+                        pc.red(String(o.pid)),
+                        o.sample?.cpuPercent != null ? `${o.sample.cpuPercent}%` : "—",
+                        o.sample?.elapsed ?? "—",
+                        o.command.slice(0, 90),
+                    ]);
+                }
+
+                out.println(table.toString());
+                out.println(`  kill safely: ${suggest(["cleanup", "--kill", "<pid>"])}`);
+            }
+
+            if (report.legacyFiles.length > 0) {
+                renderCliSection("Legacy old-skill files");
+                for (const f of report.legacyFiles) {
+                    out.println(`  ${f}`);
+                }
+
+                out.println(`  remove: ${suggest(["cleanup", "--legacy"])}`);
+            }
+
+            if (opts.detailed) {
+                for (const p of report.ports) {
+                    renderCliSection(`port ${p.port} — detail`);
+                    out.println(`  dir:      ${captureDir(p.port)}`);
+                    out.println(
+                        `  pidfile:  ${p.pidState.status}${"record" in p.pidState ? ` (${p.pidState.record.command ?? "?"})` : ""}`
+                    );
+                    out.println(
+                        `  meta:     ${p.meta ? `started ${new Date(p.meta.startedAt).toISOString()} argv=${p.meta.argv.join(" ")}` : "—"}`
+                    );
+                    out.println(
+                        `  segments: ${p.segments.count} (oldest ${p.segments.oldestMs ? new Date(p.segments.oldestMs).toISOString() : "—"}, newest ${p.segments.newestMs ? new Date(p.segments.newestMs).toISOString() : "—"})`
+                    );
+                }
+            }
+
+            renderCliSection("Legend");
+            out.println(
+                "  RECORDER: ● pid = alive and pidfile-owned · none = no recorder · dead/foreign = stale pidfile (doctor explains)"
+            );
+            out.println("  ENDPOINT: browser build + (Np) = N open page tabs · no CDP = nothing listens on that port");
+            out.println("  BUFFER: total size / number of segment files (30-min rotation, 4h window)");
+            out.println("  UP / CPU TIME: ps elapsed and cpu time, [[dd-]hh:]mm:ss");
+            renderCliSection("Next");
+            out.println(`  ${suggest(["doctor"])}                 diagnose problems (read-only)`);
+            out.println(`  ${suggest(["har", "--last", "30m", "-o", artifactPath("cdp.har")])}   dump recent traffic`);
+            process.exit(0);
+        });
+}

--- a/src/chrome-devtools/index.ts
+++ b/src/chrome-devtools/index.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+/**
+ * tools chrome-devtools — drive a REAL running browser (Brave/Chrome) over the
+ * Chrome DevTools Protocol. The debugging harness for bugs that only exist in
+ * the user's own browser: auth loops, cookie poison, stuck SPAs, CORS.
+ *
+ *   attach       discover endpoints, start the background recorder, print next steps
+ *   record       the capture engine (one per port, rolling 4h buffer)
+ *   follow       live view over the buffer (channels + Monitor hints)
+ *   har          DevTools-grade HAR — retroactive from the buffer, or a live window
+ *   status       recorders, CPU/memory, buffers, endpoints
+ *   doctor       read-only diagnosis · cleanup — the mutating counterpart
+ *   cookies, console, eval, nav, shot, grid, trace, targets, rm-cookie
+ *   open, restart — launch/relaunch a browser WITH the debugging flag
+ *   scaffold, cheatsheet, mcp — scripting doors
+ */
+import { runTool } from "@genesiscz/utils/cli";
+import { Command } from "commander";
+import { registerAttach } from "./commands/attach.ts";
+import { registerBrowse } from "./commands/browse.ts";
+import { registerCleanup } from "./commands/cleanup.ts";
+import { registerDoctor } from "./commands/doctor.ts";
+import { registerFollow } from "./commands/follow.ts";
+import { registerHar } from "./commands/har.ts";
+import { registerInspect } from "./commands/inspect.ts";
+import { registerRecord, registerWatchTombstone } from "./commands/record.ts";
+import { registerScripting } from "./commands/scripting.ts";
+import { registerStatus } from "./commands/status.ts";
+
+const program = new Command();
+program
+    .name("tools chrome-devtools")
+    .description("drive a real running browser over CDP — attach, record, follow, HAR, cookies, doctor")
+    .showHelpAfterError()
+    .addHelpText(
+        "after",
+        `
+Non-negotiable first fact: --remote-debugging-port is parsed at browser
+STARTUP. It cannot be enabled on a running browser. 'attach' tells you
+exactly what to restart when nothing listens — ask the user before quitting
+their browser.
+
+Start here, every time:
+  tools chrome-devtools attach
+
+Do NOT pipe 'record', 'follow' or 'trace' to head/tail — they are long-running
+and print their pid + output paths first. The capture segments under
+/tmp/GenesisTools/ChromeDevtools/<port>/ are internal: never tail them raw
+(rotation breaks the fd) — 'follow' is the live view, 'har' the dump.`
+    );
+
+registerAttach(program);
+registerRecord(program);
+registerWatchTombstone(program);
+registerFollow(program);
+registerHar(program);
+registerStatus(program);
+registerDoctor(program);
+registerCleanup(program);
+registerBrowse(program);
+registerInspect(program);
+registerScripting(program);
+
+await runTool(program, { tool: "chrome-devtools" });

--- a/src/chrome-devtools/lib/cdp.test.ts
+++ b/src/chrome-devtools/lib/cdp.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { pickPageTarget } from "./cdp.ts";
+
+describe("pickPageTarget", () => {
+    test("throws when no tab URL matches instead of returning the first tab", () => {
+        const pages = [
+            { type: "page", url: "http://localhost:3000/" },
+            { type: "page", url: "https://idp.example.com/login" },
+        ];
+
+        expect(() => pickPageTarget(pages, { url: "app.example.com" })).toThrow('no tab matching "app.example.com"');
+    });
+
+    test("returns the matching tab when the URL substring hits", () => {
+        const pages = [
+            { type: "page", url: "http://localhost:3000/" },
+            { type: "page", url: "https://app.example.com/portal" },
+        ];
+
+        expect(pickPageTarget(pages, { url: "app.example.com" }).url).toBe("https://app.example.com/portal");
+    });
+
+    test("errors with the port when there is no page at all", () => {
+        expect(() => pickPageTarget([], { port: 9222 })).toThrow("no page target on port 9222");
+    });
+});

--- a/src/chrome-devtools/lib/cdp.ts
+++ b/src/chrome-devtools/lib/cdp.ts
@@ -1,0 +1,401 @@
+/**
+ * Scriptable CDP client. Same capabilities as chrome-devtools-mcp tools, but
+ * callable from any bun script (no MCP session, no config reload).
+ * Ported from ~/.agents/skills/chrome-devtools/scripts/cdp.ts.
+ */
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+const log = logger.child({ component: "chrome-devtools:cdp" });
+
+export type Target = { id: string; type: string; title: string; url: string; webSocketDebuggerUrl: string };
+
+export type CdpEventListener = (method: string, params: Record<string, unknown>, sessionId?: string) => void;
+
+interface CdpIncoming {
+    id?: number;
+    result?: unknown;
+    error?: unknown;
+    method?: string;
+    params?: Record<string, unknown>;
+    sessionId?: string;
+}
+
+export interface ConnOpts {
+    /**
+     * Called with every raw packet BEFORE JSON.parse; return true to skip the
+     * parse entirely. This is the recorder's CPU lever: high-rate packets
+     * (dataReceived, websocket frames) never become objects.
+     */
+    dropRaw?: (raw: string) => boolean;
+}
+
+export class Conn {
+    private ws: WebSocket;
+    private id = 0;
+    private pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+    private listeners: CdpEventListener[] = [];
+    private ready: Promise<void>;
+    readonly closed: Promise<void>;
+
+    /** Settle every in-flight send() — a request against a dead socket must reject, never hang. */
+    private rejectPending(reason: string): void {
+        for (const [, p] of this.pending) {
+            p.reject(new Error(reason));
+        }
+
+        this.pending.clear();
+    }
+
+    constructor(wsUrl: string, opts?: ConnOpts) {
+        this.ws = new WebSocket(wsUrl);
+        this.ready = new Promise((resolve, reject) => {
+            this.ws.onopen = () => resolve();
+            this.ws.onerror = (e) => reject(e);
+        });
+        this.closed = new Promise((resolve) => {
+            const finish = () => {
+                this.rejectPending("CDP connection closed");
+                resolve();
+            };
+            this.ws.addEventListener("close", finish);
+            this.ws.addEventListener("error", finish);
+        });
+        this.ws.onmessage = (ev) => {
+            const raw = String(ev.data);
+            if (opts?.dropRaw?.(raw)) {
+                return;
+            }
+
+            const msg = SafeJSON.parse(raw, { strict: true }) as CdpIncoming;
+            if (msg.id !== undefined) {
+                const p = this.pending.get(msg.id);
+                if (p) {
+                    this.pending.delete(msg.id);
+                    if (msg.error) {
+                        p.reject(new Error(SafeJSON.stringify(msg.error, { strict: true })));
+                    } else {
+                        p.resolve(msg.result);
+                    }
+                }
+
+                return;
+            }
+
+            for (const l of this.listeners) {
+                l(msg.method ?? "", msg.params ?? {}, msg.sessionId);
+            }
+        };
+    }
+
+    async send(method: string, params: Record<string, unknown> = {}, sessionId?: string): Promise<unknown> {
+        await this.ready;
+
+        if (this.ws.readyState !== WebSocket.OPEN) {
+            throw new Error("CDP connection closed");
+        }
+
+        const id = ++this.id;
+
+        return new Promise((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            const payload: Record<string, unknown> = { id, method, params };
+            if (sessionId) {
+                payload.sessionId = sessionId;
+            }
+
+            this.ws.send(SafeJSON.stringify(payload, { strict: true }));
+        });
+    }
+
+    on(fn: CdpEventListener): void {
+        this.listeners.push(fn);
+    }
+
+    close(): void {
+        this.rejectPending("CDP connection closed by client");
+        this.ws.close();
+    }
+}
+
+export interface RecordedNetworkEvent {
+    kind: "request" | "redirect" | "response" | "failed" | "nav";
+    [key: string]: unknown;
+}
+
+/** Page-level session: navigation, DOM, per-page network/console. */
+export class Page {
+    constructor(
+        private conn: Conn,
+        public target: Target
+    ) {}
+
+    send = (method: string, params?: Record<string, unknown>) => this.conn.send(method, params);
+    on = (fn: CdpEventListener) => this.conn.on(fn);
+    close = () => this.conn.close();
+
+    async enable(domains: string[] = ["Network", "Page", "Runtime", "Log"]): Promise<void> {
+        for (const d of domains) {
+            await this.conn.send(`${d}.enable`).catch((err: unknown) => {
+                log.debug({ err, domain: d }, "domain enable failed");
+            });
+        }
+    }
+
+    navigate(url: string) {
+        return this.conn.send("Page.navigate", { url });
+    }
+
+    reload(ignoreCache = false) {
+        return this.conn.send("Page.reload", { ignoreCache });
+    }
+
+    /** Pass a function source string (`"() => …"`) or a bare expression. */
+    async evaluate(fnOrExpr: string): Promise<unknown> {
+        const expression = /^\s*(\(|async|function)/.test(fnOrExpr) ? `(${fnOrExpr})()` : fnOrExpr;
+        const r = (await this.conn.send("Runtime.evaluate", {
+            expression,
+            awaitPromise: true,
+            returnByValue: true,
+        })) as {
+            result?: { value?: unknown };
+            exceptionDetails?: { text: string; exception?: { description?: string } };
+        };
+
+        if (r.exceptionDetails) {
+            throw new Error(`${r.exceptionDetails.text} ${r.exceptionDetails.exception?.description ?? ""}`);
+        }
+
+        return r.result?.value;
+    }
+
+    async screenshot(path: string, fullPage = false): Promise<string> {
+        const r = (await this.conn.send("Page.captureScreenshot", {
+            format: "png",
+            captureBeyondViewport: fullPage,
+        })) as { data: string };
+        await Bun.write(path, Buffer.from(r.data, "base64"));
+
+        return path;
+    }
+
+    resize(width: number, height: number) {
+        return this.conn.send("Emulation.setDeviceMetricsOverride", {
+            width,
+            height,
+            deviceScaleFactor: 0,
+            mobile: false,
+        });
+    }
+
+    /** Live console feed; attach BEFORE the action you want to observe. */
+    onConsole(fn: (level: string, text: string) => void): void {
+        this.conn.on((m, p) => {
+            if (m === "Runtime.consoleAPICalled") {
+                const args = (p.args ?? []) as { value?: unknown; description?: string; type?: string }[];
+                fn(String(p.type), args.map((a) => a.value ?? a.description ?? a.type).join(" "));
+            }
+
+            if (m === "Log.entryAdded") {
+                const entry = p.entry as { level: string; text: string };
+                fn(entry.level, entry.text);
+            }
+        });
+    }
+
+    /**
+     * Network recorder. Returns a LIVE array of events. Captures
+     * redirectResponse hops — the data a flat request list hides.
+     */
+    recordNetwork(filter?: (url: string) => boolean): RecordedNetworkEvent[] {
+        const events: RecordedNetworkEvent[] = [];
+        const keep = (u: string) => (filter ? filter(u) : true);
+        this.conn.on((m, p) => {
+            if (m === "Network.requestWillBeSent") {
+                const req = p.request as { url: string; method: string; postData?: string };
+                if (!keep(req.url)) {
+                    return;
+                }
+
+                const redirect = p.redirectResponse as
+                    | { status: number; url: string; headers?: Record<string, string> }
+                    | undefined;
+                if (redirect) {
+                    const h = redirect.headers ?? {};
+                    events.push({
+                        kind: "redirect",
+                        status: redirect.status,
+                        from: redirect.url,
+                        location: h.location ?? h.Location ?? null,
+                        setCookie: Object.entries(h)
+                            .filter(([k]) => k.toLowerCase() === "set-cookie")
+                            .map(([, v]) => v),
+                        ts: p.timestamp,
+                    });
+                }
+
+                events.push({
+                    kind: "request",
+                    type: p.type,
+                    method: req.method,
+                    url: req.url,
+                    postData: req.postData ?? null,
+                    requestId: p.requestId,
+                    ts: p.timestamp,
+                });
+            }
+
+            if (m === "Network.responseReceived") {
+                const res = p.response as { status: number; url: string; headers: Record<string, string> };
+                if (keep(res.url)) {
+                    events.push({
+                        kind: "response",
+                        status: res.status,
+                        url: res.url,
+                        headers: res.headers,
+                        requestId: p.requestId,
+                        ts: p.timestamp,
+                    });
+                }
+            }
+
+            if (m === "Network.loadingFailed") {
+                events.push({ kind: "failed", requestId: p.requestId, error: p.errorText, ts: p.timestamp });
+            }
+
+            if (m === "Page.frameNavigated") {
+                const frame = p.frame as { parentId?: string; url: string };
+                if (!frame.parentId) {
+                    events.push({ kind: "nav", url: frame.url, ts: Date.now() / 1000 });
+                }
+            }
+        });
+
+        return events;
+    }
+
+    async responseBody(requestId: string): Promise<{ body?: string; base64Encoded?: boolean }> {
+        return (await this.conn.send("Network.getResponseBody", { requestId })) as {
+            body?: string;
+            base64Encoded?: boolean;
+        };
+    }
+
+    async waitForText(texts: string[], timeoutMs = 15000): Promise<boolean> {
+        const deadline = Date.now() + timeoutMs;
+
+        while (Date.now() < deadline) {
+            const found = await this.evaluate(
+                `() => ${SafeJSON.stringify(texts, { strict: true })}.some(t => document.body?.innerText?.includes(t))`
+            ).catch(() => false);
+
+            if (found) {
+                return true;
+            }
+
+            await Bun.sleep(300);
+        }
+
+        return false;
+    }
+}
+
+export interface CdpCookie {
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite?: string;
+}
+
+/** Browser-level session: cookies across ALL domains incl. httpOnly, target list. */
+export class Browser {
+    constructor(
+        private conn: Conn,
+        public port: number
+    ) {}
+
+    send = (method: string, params?: Record<string, unknown>) => this.conn.send(method, params);
+    close = () => this.conn.close();
+
+    /** ALL cookies incl. httpOnly and other domains — impossible from page JS. */
+    async cookies(domainFilter?: string): Promise<CdpCookie[]> {
+        const r = (await this.conn.send("Storage.getCookies", {})) as { cookies: CdpCookie[] };
+        const all = r.cookies;
+
+        return domainFilter ? all.filter((c) => c.domain.includes(domainFilter)) : all;
+    }
+
+    setCookies(cookies: CdpCookie[]) {
+        return this.conn.send("Storage.setCookies", { cookies: cookies as unknown as Record<string, unknown>[] });
+    }
+
+    deleteCookie(name: string, domain: string, path = "/") {
+        return this.conn.send("Network.deleteCookies", { name, domain, path });
+    }
+
+    /** Delete every cookie matching the predicate; returns what was deleted. */
+    async deleteCookiesMatching(pred: (c: CdpCookie) => boolean): Promise<string[]> {
+        const victims = (await this.cookies()).filter(pred);
+
+        for (const c of victims) {
+            await this.deleteCookie(c.name, c.domain, c.path);
+        }
+
+        return victims.map((c) => `${c.name} ${c.domain} ${c.path}`);
+    }
+}
+
+export async function targets(port = 9222, opts: { signal?: AbortSignal } = {}): Promise<Target[]> {
+    const r = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: opts.signal });
+
+    return (await r.json()) as Target[];
+}
+
+/** Pick a page target. A given `url` must hit; never fall back to the first tab. */
+export function pickPageTarget<T extends { type?: string; url: string }>(
+    list: T[],
+    opts: { url?: string; index?: number; port?: number } = {}
+): T {
+    const pages = list.filter((t) => t.type === "page" || t.type === undefined);
+    const wanted = opts.url;
+
+    if (wanted) {
+        const t = pages.find((x) => x.url.includes(wanted));
+        if (!t) {
+            throw new Error(`no tab matching "${wanted}"`);
+        }
+
+        return t;
+    }
+
+    const t = pages[opts.index ?? 0];
+    if (!t) {
+        throw new Error(`no page target on port ${opts.port ?? "?"}`);
+    }
+
+    return t;
+}
+
+/** Attach to a page (url substring must match when given; otherwise first page). */
+export async function attach(opts: { port?: number; url?: string; index?: number } = {}): Promise<Page> {
+    const port = opts.port ?? 9222;
+    const list = (await targets(port)).filter((t) => t.type === "page");
+    const t = pickPageTarget(list, { url: opts.url, index: opts.index, port });
+    const page = new Page(new Conn(t.webSocketDebuggerUrl), t);
+    await page.enable();
+
+    return page;
+}
+
+/** Browser-level connection (cookies across all domains). */
+export async function browser(port = 9222): Promise<Browser> {
+    const v = (await (await fetch(`http://127.0.0.1:${port}/json/version`)).json()) as {
+        webSocketDebuggerUrl: string;
+    };
+
+    return new Browser(new Conn(v.webSocketDebuggerUrl), port);
+}

--- a/src/chrome-devtools/lib/channels.test.ts
+++ b/src/chrome-devtools/lib/channels.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+    CAPTURE_CHANNELS,
+    DEFAULT_CAPTURE_CHANNELS,
+    parseChannels,
+    RENDER_CHANNELS,
+    type RenderChannel,
+    renderEventLines,
+} from "./channels.ts";
+
+const all = (channels: RenderChannel[]) => new Set(channels);
+const yes = () => true;
+
+describe("parseChannels", () => {
+    test("empty input keeps the defaults", () => {
+        expect(parseChannels("", CAPTURE_CHANNELS, DEFAULT_CAPTURE_CHANNELS).channels).toEqual(
+            DEFAULT_CAPTURE_CHANNELS
+        );
+    });
+
+    test("+list is additive over the defaults; a plain list replaces them", () => {
+        const additive = parseChannels("+ws,body", CAPTURE_CHANNELS, DEFAULT_CAPTURE_CHANNELS);
+        expect(additive.channels).toEqual([...DEFAULT_CAPTURE_CHANNELS, "ws", "body"]);
+        const replace = parseChannels("net", CAPTURE_CHANNELS, DEFAULT_CAPTURE_CHANNELS);
+        expect(replace.channels).toEqual(["net"]);
+    });
+
+    test("invalid names are reported, never silently dropped", () => {
+        const parsed = parseChannels("nav,bogus", RENDER_CHANNELS, ["nav"]);
+        expect(parsed.invalid).toEqual(["bogus"]);
+        expect(parsed.channels).toEqual(["nav"]);
+    });
+});
+
+describe("renderEventLines", () => {
+    test("redirect events carry status, target and set-cookie", () => {
+        const lines = renderEventLines(
+            {
+                method: "Network.requestWillBeSent",
+                params: {
+                    requestId: "r1",
+                    request: { url: "https://idp.example.com/next", method: "GET" },
+                    redirectResponse: {
+                        status: 302,
+                        url: "https://idp.example.com/login",
+                        headers: { Location: "https://idp.example.com/next", "set-cookie": "seen=1" },
+                    },
+                },
+                t: 0,
+            },
+            all(["redirect"]),
+            yes
+        );
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain("REDIRECT");
+        expect(lines[0]).toContain("302");
+        expect(lines[0]).toContain("-> https://idp.example.com/next");
+        expect(lines[0]).toContain("set-cookie: seen=1");
+    });
+
+    test("console errors route to the error channel, plain logs to console", () => {
+        const err = renderEventLines(
+            { method: "Runtime.consoleAPICalled", params: { type: "error", args: [{ value: "boom" }] }, t: 0 },
+            all(["error"]),
+            yes
+        );
+        expect(err[0]).toContain("CERROR");
+
+        const plain = renderEventLines(
+            { method: "Runtime.consoleAPICalled", params: { type: "log", args: [{ value: "hello" }] }, t: 0 },
+            all(["error"]),
+            yes
+        );
+        expect(plain).toEqual([]);
+    });
+
+    test("match filter applies to URLs", () => {
+        const lines = renderEventLines(
+            {
+                method: "Network.requestWillBeSent",
+                params: {
+                    requestId: "r1",
+                    type: "Document",
+                    request: { url: "https://other.example.com/", method: "GET" },
+                },
+                t: 0,
+            },
+            all(["doc"]),
+            (u) => u.includes("app.example.com")
+        );
+        expect(lines).toEqual([]);
+    });
+
+    test("Genesis marker events always render", () => {
+        const lines = renderEventLines(
+            { method: "Genesis.marker", params: { kind: "capDropped", detail: "x" }, t: 0 },
+            all(["nav"]),
+            yes
+        );
+        expect(lines[0]).toContain("MARKER");
+        expect(lines[0]).toContain("capDropped");
+    });
+});

--- a/src/chrome-devtools/lib/channels.ts
+++ b/src/chrome-devtools/lib/channels.ts
@@ -1,0 +1,357 @@
+/**
+ * Channel vocabulary, in two layers:
+ *
+ * - CAPTURE channels tell the recorder what to put into the buffer. `net` is
+ *   the chrome-har diet (HAR-grade metadata) and is always on; the rest cost
+ *   CPU or perform active CDP calls, so they are explicit.
+ * - RENDER channels tell `follow` which lines to show. They are free — all
+ *   derived from what the buffer already holds.
+ */
+
+export const CAPTURE_CHANNELS = ["net", "console", "ws", "body", "storage"] as const;
+export type CaptureChannel = (typeof CAPTURE_CHANNELS)[number];
+
+export const DEFAULT_CAPTURE_CHANNELS: CaptureChannel[] = ["net", "console"];
+
+export const CAPTURE_CHANNEL_HELP: Record<CaptureChannel, string> = {
+    net: "HAR-grade network + page metadata (always on; requests, redirects, headers, timings)",
+    console: "console messages, thrown exceptions, browser log entries",
+    ws: "websocket FRAMES (high-rate; scope with --match, adds CPU)",
+    body: "response bodies up to 2 KB, fetched at loadingFinished (active CDP calls)",
+    storage: "local/sessionStorage snapshot on every navigation (active JS evaluation)",
+};
+
+export const RENDER_CHANNELS = [
+    "nav",
+    "doc",
+    "redirect",
+    "xhr",
+    "ws",
+    "console",
+    "error",
+    "cookie",
+    "body",
+    "storage",
+] as const;
+export type RenderChannel = (typeof RENDER_CHANNELS)[number];
+
+export const RENDER_CHANNEL_HELP: Record<RenderChannel, string> = {
+    nav: "main-frame navigations",
+    doc: "document requests",
+    redirect: "3xx hops with Location and Set-Cookie",
+    xhr: "XHR/fetch requests and their response status",
+    ws: "websocket lifecycle, plus frames when the recorder captures the ws channel",
+    console: "console messages",
+    error: "console errors, exceptions, failed requests",
+    cookie: "every Set-Cookie seen",
+    body: "captured response bodies (needs the recorder's body channel)",
+    storage: "storage snapshots (needs the recorder's storage channel)",
+};
+
+/** Which recorder CAPTURE channel a render channel depends on beyond `net`. */
+export const RENDER_NEEDS_CAPTURE: Partial<Record<RenderChannel, CaptureChannel>> = {
+    console: "console",
+    error: "console",
+    ws: "ws",
+    body: "body",
+    storage: "storage",
+};
+
+export function parseChannels<T extends string>(
+    raw: string,
+    valid: readonly T[],
+    defaults: T[]
+): { channels: T[]; invalid: string[] } {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return { channels: defaults, invalid: [] };
+    }
+
+    const additive = trimmed.startsWith("+");
+    const names = (additive ? trimmed.slice(1) : trimmed)
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean);
+    const invalid = names.filter((n) => !(valid as readonly string[]).includes(n));
+    const picked = names.filter((n): n is T => (valid as readonly string[]).includes(n));
+    const channels = additive ? [...new Set([...defaults, ...picked])] : [...new Set(picked)];
+
+    return { channels: channels.length ? channels : defaults, invalid };
+}
+
+export function channelHelpLines(help: Record<string, string>): string[] {
+    return Object.entries(help).map(([name, text]) => `  ${name.padEnd(8)} ${text}`);
+}
+
+/** One recorded buffer line. `Genesis.*` methods are recorder-synthesized (invisible to the HAR builder). */
+export interface RecordedEvent {
+    method: string;
+    params: Record<string, unknown>;
+    sessionId?: string;
+    /** Wall-clock epoch ms at record time. */
+    t: number;
+}
+
+function fmtTime(epochMs: number): string {
+    const d = new Date(epochMs);
+    const pad = (n: number, w = 2) => String(n).padStart(w, "0");
+
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
+}
+
+function setCookieOf(headers: Record<string, string> | undefined): string {
+    if (!headers) {
+        return "";
+    }
+
+    return Object.entries(headers)
+        .filter(([k]) => k.toLowerCase() === "set-cookie")
+        .map(([, v]) => v)
+        .join(" | ");
+}
+
+/**
+ * Render one recorded event as zero or more human lines for the chosen render
+ * channels. Ported from the old skill's `watch` formatting.
+ */
+export function renderEventLines(
+    ev: RecordedEvent,
+    on: ReadonlySet<RenderChannel>,
+    matches: (url: string) => boolean
+): string[] {
+    const lines: string[] = [];
+    const t = fmtTime(ev.t);
+    const emit = (kind: string, rest: string) => {
+        lines.push(`${t} ${kind.toUpperCase().padEnd(8)} ${rest}`);
+    };
+
+    const p = ev.params;
+
+    switch (ev.method) {
+        case "Page.frameNavigated": {
+            const frame = p.frame as { parentId?: string; url: string } | undefined;
+            if (frame && !frame.parentId && on.has("nav") && matches(frame.url)) {
+                emit("nav", frame.url);
+            }
+
+            break;
+        }
+
+        case "Network.requestWillBeSent": {
+            const req = p.request as { url: string; method: string; postData?: string } | undefined;
+            const redirect = p.redirectResponse as
+                | { status: number; url: string; headers?: Record<string, string> }
+                | undefined;
+
+            if (redirect && on.has("redirect") && matches(redirect.url)) {
+                const h = redirect.headers ?? {};
+                const sc = setCookieOf(h);
+                emit(
+                    "redirect",
+                    `${redirect.status} ${redirect.url} -> ${h.location ?? h.Location ?? "(no Location)"}${sc ? `  set-cookie: ${sc}` : ""}`
+                );
+            }
+
+            if (!req || !matches(req.url)) {
+                break;
+            }
+
+            if (p.type === "Document" && on.has("doc")) {
+                emit("doc", `${req.method} ${req.url}`);
+            }
+
+            if ((p.type === "XHR" || p.type === "Fetch") && on.has("xhr")) {
+                emit("xhr", `${req.method} ${req.url}${req.postData ? ` post=${req.postData.slice(0, 300)}` : ""}`);
+            }
+
+            break;
+        }
+
+        case "Network.responseReceived": {
+            const res = p.response as { status: number; url: string; headers?: Record<string, string> } | undefined;
+            if (!res || !matches(res.url)) {
+                break;
+            }
+
+            if ((p.type === "XHR" || p.type === "Fetch") && on.has("xhr")) {
+                emit("resp", `${res.status} ${res.url}`);
+            }
+
+            if (on.has("cookie")) {
+                const sc = setCookieOf(res.headers);
+                if (sc) {
+                    emit("cookie", `${res.url} set-cookie: ${sc}`);
+                }
+            }
+
+            break;
+        }
+
+        case "Network.responseReceivedExtraInfo": {
+            if (on.has("cookie")) {
+                const sc = setCookieOf(p.headers as Record<string, string> | undefined);
+                if (sc) {
+                    emit("cookie", `(raw) set-cookie: ${sc}`);
+                }
+            }
+
+            break;
+        }
+
+        case "Network.loadingFailed": {
+            if (on.has("error") || on.has("xhr")) {
+                emit("fail", `${p.errorText} type=${p.type} (${p.requestId})`);
+            }
+
+            break;
+        }
+
+        case "Network.webSocketCreated": {
+            if (on.has("ws")) {
+                emit("ws", `created ${p.url}`);
+            }
+
+            break;
+        }
+
+        case "Network.webSocketClosed": {
+            if (on.has("ws")) {
+                emit("ws", `closed (${p.requestId})`);
+            }
+
+            break;
+        }
+
+        case "Network.webSocketFrameSent":
+        case "Network.webSocketFrameReceived": {
+            if (on.has("ws")) {
+                const dir = ev.method.endsWith("Sent") ? "->" : "<-";
+                const payload = (p.response as { payloadData?: string } | undefined)?.payloadData ?? "";
+                emit("ws", `${dir} ${String(payload).slice(0, 500)}`);
+            }
+
+            break;
+        }
+
+        case "Runtime.consoleAPICalled": {
+            const args = (p.args ?? []) as { value?: unknown; description?: string; type?: string }[];
+            const text = args.map((a) => a.value ?? a.description ?? a.type).join(" ");
+            const isErr = p.type === "error" || p.type === "assert";
+
+            if ((isErr && on.has("error")) || (!isErr && on.has("console"))) {
+                emit(isErr ? "cerror" : "console", `[${p.type}] ${text.slice(0, 800)}`);
+            }
+
+            break;
+        }
+
+        case "Runtime.exceptionThrown": {
+            if (on.has("error")) {
+                const details = p.exceptionDetails as
+                    | { text?: string; exception?: { description?: string } }
+                    | undefined;
+                emit("throw", String(details?.exception?.description ?? details?.text ?? "").slice(0, 800));
+            }
+
+            break;
+        }
+
+        case "Log.entryAdded": {
+            const entry = p.entry as { level: string; text: string } | undefined;
+            if (!entry) {
+                break;
+            }
+
+            if ((entry.level === "error" && on.has("error")) || (entry.level !== "error" && on.has("console"))) {
+                emit(
+                    entry.level === "error" ? "cerror" : "console",
+                    `[${entry.level}] ${String(entry.text).slice(0, 800)}`
+                );
+            }
+
+            break;
+        }
+
+        case "Genesis.responseBody": {
+            if (on.has("body") && matches(String(p.url ?? ""))) {
+                emit("body", `${p.url} ${String(p.body ?? "").slice(0, 2000)}`);
+            }
+
+            break;
+        }
+
+        case "Genesis.storageSnapshot": {
+            if (on.has("storage")) {
+                emit("storage", `${p.url} ls=${p.ls} ss=${p.ss} lsKeys=${SafeStringify(p.lsKeys)}`);
+            }
+
+            break;
+        }
+
+        case "Genesis.marker": {
+            emit("marker", `${p.kind}${p.detail ? ` ${p.detail}` : ""}`);
+            break;
+        }
+
+        default:
+            break;
+    }
+
+    return lines;
+}
+
+function SafeStringify(v: unknown): string {
+    if (Array.isArray(v)) {
+        return v.map(String).join(",");
+    }
+
+    return String(v ?? "");
+}
+
+/** Monitor / follow-up commands tailored to the chosen render channels (ported from watch.ts). */
+export function monitorHints(out: string, channels: RenderChannel[]): string[] {
+    const hints: string[] = [];
+    const has = (c: RenderChannel) => channels.includes(c);
+    const pats: string[] = [];
+
+    if (has("redirect")) {
+        pats.push("REDIRECT");
+    }
+
+    if (has("error")) {
+        pats.push("CERROR", "THROW", "FAIL");
+    }
+
+    if (has("nav")) {
+        pats.push("NAV");
+    }
+
+    if (has("cookie")) {
+        pats.push("COOKIE");
+    }
+
+    hints.push(`tail -f ${out}    # everything, live`);
+
+    if (pats.length) {
+        hints.push(
+            `tail -f ${out} | grep --line-buffered -E '${pats.join("|")}'    # Monitor tool: wakes per matching event`
+        );
+    }
+
+    if (has("redirect")) {
+        hints.push(
+            `tail -f ${out} | grep --line-buffered -E 'REDIRECT.*(no Location|commonauth|error|retry)'    # bad OAuth hop only`
+        );
+        hints.push(`rg -n 'REDIRECT' ${out}    # after the fact: the whole hop chain`);
+    }
+
+    if (has("error")) {
+        hints.push(`tail -f ${out} | grep --line-buffered -E 'CERROR|THROW|FAIL'    # failures only`);
+    }
+
+    if (has("xhr")) {
+        hints.push(`rg -n 'RESP     (4|5)' ${out}    # after the fact: failed API calls`);
+    }
+
+    return hints;
+}

--- a/src/chrome-devtools/lib/cleanup.ts
+++ b/src/chrome-devtools/lib/cleanup.ts
@@ -1,0 +1,243 @@
+/**
+ * `cleanup` — the mutating counterpart of doctor. Every destructive action is
+ * verified at apply time: kills re-check the pid still runs a recorder-shaped
+ * command (pid recycling), pidfiles are cleared through the pidfile module,
+ * and captures are MOVED to a trash dir under /tmp, never destroyed in place.
+ */
+import { existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
+import { basename, join } from "node:path";
+import { logger } from "@genesiscz/utils/logger";
+import { attemptStaleTakeover, inspectPidFile, readLivePid } from "@genesiscz/utils/process/pidfile";
+import { captureDir, knownCapturePorts, listLegacyArmFiles, recorderPidPath } from "./paths.ts";
+import { defaultExec, type ExecFn, terminatePid, tmpRoot } from "./platform.ts";
+import { ancestorPids, findRecorderProcesses } from "./status.ts";
+
+const { log } = logger.scoped("chrome-devtools:cleanup");
+
+export interface CleanupResult {
+    ok: boolean;
+    message: string;
+}
+
+function trashDir(): string {
+    const dir = join(tmpRoot(), "GenesisTools", "ChromeDevtools", `trash-${new Date().toISOString().slice(0, 10)}`);
+    mkdirSync(dir, { recursive: true });
+
+    return dir;
+}
+
+/** Live pidfile-owned recorder pids, keyed by port. Injectable for tests. */
+export function liveRecorderPids(): Map<number, number> {
+    const owned = new Map<number, number>();
+    for (const port of knownCapturePorts()) {
+        const pid = readLivePid(recorderPidPath(port));
+        if (pid !== null) {
+            owned.set(port, pid);
+        }
+    }
+
+    return owned;
+}
+
+/**
+ * SIGTERM a recorder-shaped pid. Refuses when the pid no longer looks like a
+ * recorder (recycled), IS a live pidfile-owned recorder (stop it with
+ * `record --stop` instead), or is an ANCESTOR of one (the launch chain carries
+ * the same argv — killing it tears down a healthy recorder).
+ */
+export function killRecorderPid(
+    pid: number,
+    exec: ExecFn = defaultExec,
+    owned: () => Map<number, number> = liveRecorderPids
+): CleanupResult {
+    const current = findRecorderProcesses(exec).find((p) => p.pid === pid);
+    if (!current) {
+        return {
+            ok: false,
+            message: `pid ${pid} is not a recorder-shaped process (gone, or the pid was recycled). Refusing to kill it.`,
+        };
+    }
+
+    const live = owned();
+    for (const [port, livePid] of live) {
+        if (livePid === pid) {
+            return {
+                ok: false,
+                message: `pid ${pid} IS the live recorder for port ${port}. Stop it properly: record --port ${port} --stop`,
+            };
+        }
+    }
+
+    if (ancestorPids(live.values(), exec).has(pid)) {
+        return {
+            ok: false,
+            message: `pid ${pid} is a launcher ancestor of a LIVE recorder. Killing it would tear the recorder down; refusing.`,
+        };
+    }
+
+    const r = terminatePid(pid, exec);
+    if (r.exitCode !== 0) {
+        return { ok: false, message: `kill ${pid} failed: ${r.stderr.trim()}` };
+    }
+
+    log.info({ pid, command: current.command }, "recorder killed");
+
+    return { ok: true, message: `stopped pid ${pid} (${current.command.slice(0, 80)})` };
+}
+
+/**
+ * Clear a dead/foreign pidfile for a port. Refuses a LIVE or UNVERIFIED one
+ * (`unverified` = the pid is alive but the OS would not name it — the normal
+ * Windows answer; an alive recorder's claim must never be deleted). The
+ * delete itself is the shared rename-verify takeover with `claim: false`, so
+ * a recorder claiming the path mid-clear keeps its file — a compare followed
+ * by a separate unlink would race. `hooks.afterInspect` exists ONLY so tests
+ * can interleave a rival claim deterministically.
+ */
+export async function clearStalePidfile(port: number, hooks?: { afterInspect?: () => void }): Promise<CleanupResult> {
+    const path = recorderPidPath(port);
+    if (!existsSync(path)) {
+        return { ok: true, message: `port ${port}: no pidfile` };
+    }
+
+    let staleContent: string;
+    try {
+        staleContent = readFileSync(path, "utf8");
+    } catch (err) {
+        // ENOENT here is a benign vanish; anything else (permissions, I/O)
+        // must be visible or the cleanup failure is undiagnosable.
+        log.debug({ err, path }, "pidfile read failed during stale clear");
+
+        return { ok: true, message: `port ${port}: pidfile vanished while inspecting (nothing to clear)` };
+    }
+
+    const state = inspectPidFile(path);
+    if (state.status === "live" || state.status === "unverified") {
+        return {
+            ok: false,
+            message: `port ${port}: that pidfile belongs to a LIVE recorder (pid ${state.pid}). Stop it properly: record --port ${port} --stop`,
+        };
+    }
+
+    hooks?.afterInspect?.();
+
+    const cleared = await attemptStaleTakeover(path, staleContent, { claim: false });
+
+    return cleared
+        ? { ok: true, message: `port ${port}: stale pidfile cleared` }
+        : {
+              ok: false,
+              message: `port ${port}: pidfile changed while clearing — a recorder just claimed it, leaving it alone`,
+          };
+}
+
+/** Move legacy /tmp/cdp-arm-* files to the trash dir (recoverable until reboot). Optional per-port scope. */
+export function moveLegacyFiles(ports?: number[]): CleanupResult {
+    const all = listLegacyArmFiles();
+    const files = ports?.length ? all.filter((f) => ports.some((p) => f.includes(`cdp-arm-${p}.`))) : all;
+    if (files.length === 0) {
+        return {
+            ok: true,
+            message: `no legacy /tmp/cdp-arm-* files${ports?.length ? ` for port(s) ${ports.join(", ")}` : ""}`,
+        };
+    }
+
+    const dir = trashDir();
+    const moved: string[] = [];
+    for (const file of files) {
+        try {
+            // Timestamp prefix: a same-day recreation of the same filename must
+            // not overwrite the earlier trashed copy (recoverable contract).
+            renameSync(file, join(dir, `${Date.now()}-${basename(file)}`));
+            moved.push(file);
+        } catch (err) {
+            log.warn({ err, file }, "legacy file move failed");
+        }
+    }
+
+    return {
+        ok: moved.length === files.length,
+        message: `moved ${moved.length}/${files.length} legacy file(s) to ${dir} (moved, not destroyed; /tmp clears on reboot)`,
+    };
+}
+
+export interface PlannedAction {
+    label: string;
+    /** Kills never ride `--yes` or a batch shortcut; they need an explicit --kill or an interactive pick. */
+    kind: "kill" | "safe";
+    apply: () => CleanupResult | Promise<CleanupResult>;
+}
+
+/** Findings → concrete cleanup actions. Pure mapping; the safety property is the `kind` tag. */
+export function actionsFromFindings(findings: { id: string }[]): PlannedAction[] {
+    const actions: PlannedAction[] = [];
+
+    for (const f of findings) {
+        const orphan = f.id.match(/^orphan-(\d+)$/);
+        if (orphan) {
+            const pid = Number(orphan[1]);
+            actions.push({ label: `kill orphan recorder pid ${pid}`, kind: "kill", apply: () => killRecorderPid(pid) });
+        }
+
+        const stale = f.id.match(/^(stale-pidfile|recycled-pid)-(\d+)$/);
+        if (stale) {
+            const port = Number(stale[2]);
+            actions.push({
+                label: `clear stale pidfile for port ${port}`,
+                kind: "safe",
+                apply: () => clearStalePidfile(port),
+            });
+        }
+
+        if (f.id === "legacy-arm-files") {
+            actions.push({
+                label: "move legacy /tmp/cdp-arm-* files to trash",
+                kind: "safe",
+                apply: () => moveLegacyFiles(),
+            });
+        }
+
+        const leftover = f.id.match(/^leftover-buffer-(\d+)$/);
+        if (leftover) {
+            const port = Number(leftover[1]);
+            actions.push({
+                label: `move leftover capture buffer of port ${port} to trash (dump it FIRST if you still need a HAR)`,
+                kind: "safe",
+                apply: () => moveCaptureDir(port),
+            });
+        }
+    }
+
+    return actions;
+}
+
+/** What `--yes` may run: the safe subset, never kills. The excluded kills are returned for the warning lines. */
+export function partitionForYes(actions: PlannedAction[]): {
+    batchable: PlannedAction[];
+    excludedKills: PlannedAction[];
+} {
+    return {
+        batchable: actions.filter((a) => a.kind === "safe"),
+        excludedKills: actions.filter((a) => a.kind === "kill"),
+    };
+}
+
+/** Move a port's capture dir to trash (recoverable until reboot). */
+export function moveCaptureDir(port: number): CleanupResult {
+    const dir = captureDir(port);
+    if (!existsSync(dir)) {
+        return { ok: true, message: `port ${port}: no capture dir` };
+    }
+
+    const dest = join(trashDir(), `port-${port}-${Date.now()}`);
+    try {
+        renameSync(dir, dest);
+    } catch (err) {
+        return { ok: false, message: `port ${port}: move failed: ${err instanceof Error ? err.message : String(err)}` };
+    }
+
+    return {
+        ok: true,
+        message: `port ${port}: capture moved to ${dest} (moved, not destroyed; /tmp clears on reboot)`,
+    };
+}

--- a/src/chrome-devtools/lib/doctor.ts
+++ b/src/chrome-devtools/lib/doctor.ts
@@ -1,0 +1,112 @@
+/**
+ * `doctor` — READ-ONLY diagnosis. It reports and prints fix commands; the
+ * mutating counterpart is lib/cleanup.ts. (Repo rule: a diagnostic must never
+ * mutate — see CLAUDE.md "Side Effects".)
+ */
+
+import { artifactPath } from "./platform.ts";
+import { browsersWithEmptyDebugFlag } from "./resolve-attach.ts";
+import { CAPTURE_CAP_BYTES } from "./segments.ts";
+import { collectStatus, type StatusReport } from "./status.ts";
+
+export interface Finding {
+    severity: "err" | "warn" | "info";
+    id: string;
+    title: string;
+    detail: string;
+    fix?: string;
+}
+
+export function findingsFromStatus(report: StatusReport, emptyDebugFlag: string[]): Finding[] {
+    const findings: Finding[] = [];
+
+    for (const p of report.ports) {
+        if (p.pidState.status === "dead") {
+            findings.push({
+                severity: "warn",
+                id: `stale-pidfile-${p.port}`,
+                title: `port ${p.port}: stale recorder pidfile`,
+                detail: `pid ${p.pidState.pid} is gone; the pidfile survived a crash or a reboot.`,
+                fix: `tools chrome-devtools cleanup --stale ${p.port}`,
+            });
+        }
+
+        if (p.pidState.status === "foreign") {
+            findings.push({
+                severity: "err",
+                id: `recycled-pid-${p.port}`,
+                title: `port ${p.port}: pidfile points at a DIFFERENT program`,
+                detail: `pid ${p.pidState.pid} now runs "${p.pidState.command}". Never kill it; clear the pidfile.`,
+                fix: `tools chrome-devtools cleanup --stale ${p.port}`,
+            });
+        }
+
+        if (p.pidState.status === "live" && p.sample?.cpuPercent != null && p.sample.cpuPercent > 25) {
+            findings.push({
+                severity: "warn",
+                id: `hot-recorder-${p.port}`,
+                title: `port ${p.port}: recorder is hot (${p.sample.cpuPercent}% CPU)`,
+                detail: `Scope it down with --match, or stop it. Channels: ${p.meta?.channels.join(",") ?? "?"}.`,
+                fix: `tools chrome-devtools record --port ${p.port} --stop`,
+            });
+        }
+
+        if (p.pidState.status !== "live" && p.segments.count > 0) {
+            findings.push({
+                severity: "info",
+                id: `leftover-buffer-${p.port}`,
+                title: `port ${p.port}: leftover capture buffer (${p.segments.count} segment(s))`,
+                detail: "No recorder is running; the buffer is still dumpable.",
+                fix: `tools chrome-devtools har --port ${p.port} --from-buffer -o ${artifactPath(`cdp-${p.port}.har`)}   # or: cleanup --dir ${p.port}`,
+            });
+        }
+
+        if (p.segments.bytes > CAPTURE_CAP_BYTES) {
+            findings.push({
+                severity: "warn",
+                id: `over-cap-${p.port}`,
+                title: `port ${p.port}: capture buffer over the ${Math.round(CAPTURE_CAP_BYTES / 1e6)} MB cap`,
+                detail: `${Math.round(p.segments.bytes / 1e6)} MB on disk; the recorder prunes at its next rotation.`,
+            });
+        }
+    }
+
+    for (const orphan of report.orphans) {
+        const old = orphan.command.includes("skills/chrome-devtools/scripts");
+        findings.push({
+            severity: "err",
+            id: `orphan-${orphan.pid}`,
+            title: `orphan ${old ? "OLD-skill arm" : "recorder-shaped"} process (pid ${orphan.pid})`,
+            detail: `${orphan.sample?.cpuPercent != null ? `${orphan.sample.cpuPercent}% CPU, up ${orphan.sample.elapsed}. ` : ""}No pidfile owns it: ${orphan.command.slice(0, 120)}`,
+            fix: `tools chrome-devtools cleanup --kill ${orphan.pid}`,
+        });
+    }
+
+    if (report.legacyFiles.length > 0) {
+        findings.push({
+            severity: "info",
+            id: "legacy-arm-files",
+            title: `${report.legacyFiles.length} legacy /tmp/cdp-arm-* file(s) from the old skill`,
+            detail: report.legacyFiles.join(", "),
+            fix: "tools chrome-devtools cleanup --legacy",
+        });
+    }
+
+    for (const id of emptyDebugFlag) {
+        findings.push({
+            severity: "warn",
+            id: `empty-debug-flag-${id}`,
+            title: `${id}: running with an EMPTY --remote-debugging-port= flag`,
+            detail: "The flag has no value, so nothing listens. Restart the browser with a real port.",
+            fix: `tools chrome-devtools restart --browser ${id} --port 9222`,
+        });
+    }
+
+    return findings;
+}
+
+export async function diagnose(): Promise<Finding[]> {
+    const report = await collectStatus();
+
+    return findingsFromStatus(report, browsersWithEmptyDebugFlag());
+}

--- a/src/chrome-devtools/lib/follow.test.ts
+++ b/src/chrome-devtools/lib/follow.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "bun:test";
+// follow() is driven against an isolated temp dir via its dir override, so the
+// test can never touch a real port's capture.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RecordedEvent } from "./channels.ts";
+import { follow, makeMatcher } from "./follow.ts";
+import { SegmentWriter } from "./segments.ts";
+
+const cleanups: (() => void)[] = [];
+
+afterEach(() => {
+    for (const fn of cleanups.splice(0)) {
+        fn();
+    }
+});
+
+describe("makeMatcher", () => {
+    test("substring and /regex/ forms", () => {
+        expect(makeMatcher("idp.example")("https://idp.example.com/x")).toBe(true);
+        expect(makeMatcher("idp.example")("https://app.example.com/x")).toBe(false);
+        expect(makeMatcher("/(idp|auth)\\.example/")("https://auth.example.com/")).toBe(true);
+        expect(makeMatcher(undefined)("anything")).toBe(true);
+    });
+
+    test("a /pattern/g matcher stays stateless across repeated calls", () => {
+        const matches = makeMatcher("/example/g");
+        expect(matches("https://app.example.com/")).toBe(true);
+        expect(matches("https://app.example.com/")).toBe(true);
+        expect(matches("https://app.example.com/")).toBe(true);
+    });
+});
+
+describe("follow across rotation", () => {
+    test("renders replayed events, live appends, and hops to a rotated segment without losing lines", async () => {
+        // A high fake port keeps this out of any real capture dir's way.
+        const port = 59_876;
+        const dir = mkdtempSync(join(tmpdir(), "cdp-follow-"));
+        cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+
+        const nav = (url: string, t: number): RecordedEvent => ({
+            method: "Page.frameNavigated",
+            params: { frame: { url } },
+            sessionId: "S1",
+            t,
+        });
+
+        let now = 1_000_000;
+        const writer = new SegmentWriter(dir, { rotateMs: 500, maxAgeMs: 1e9, now: () => now });
+        writer.write(nav("https://one.example.com/", now));
+
+        const lines: string[] = [];
+        const ac = new AbortController();
+        const done = follow({
+            port,
+            dir,
+            channels: ["nav"],
+            sinceMs: 0,
+            onLine: (line) => lines.push(line),
+            signal: ac.signal,
+            pollMs: 20,
+            seconds: 5,
+        });
+
+        // live append into the SAME segment
+        await Bun.sleep(80);
+        writer.write(nav("https://two.example.com/", now));
+
+        // force a rotation, then write into the NEW segment
+        now += 600;
+        writer.write(nav("https://three.example.com/", now));
+        await Bun.sleep(150);
+        writer.close();
+        ac.abort();
+        await done;
+
+        const urls = lines.map((l) => l.split(" ").at(-1));
+        expect(urls).toEqual(["https://one.example.com/", "https://two.example.com/", "https://three.example.com/"]);
+    });
+});

--- a/src/chrome-devtools/lib/follow.ts
+++ b/src/chrome-devtools/lib/follow.ts
@@ -1,0 +1,177 @@
+/**
+ * `follow` — the live view over the recorder's segment buffer.
+ *
+ * Rotation-aware by construction: it does not hold one fd like `tail -f`
+ * (which silently goes quiet when the recorder rotates segments). Each poll
+ * tick it finishes draining the current segment, then hops to a newer one
+ * from offset 0. This is the ONLY sanctioned live reader of the buffer.
+ */
+import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
+import { parseJsonlChunk } from "@genesiscz/utils/jsonl";
+import { logger } from "@genesiscz/utils/logger";
+import { RENDER_NEEDS_CAPTURE, type RecordedEvent, type RenderChannel, renderEventLines } from "./channels.ts";
+import { captureDir } from "./paths.ts";
+import { readRecorderMeta } from "./recorder.ts";
+import { listSegments } from "./segments.ts";
+
+const { log } = logger.scoped("chrome-devtools:follow");
+
+/** URL matcher: substring, or /regex/flags. Ported from the old watch verb. */
+export function makeMatcher(m?: string): (url: string) => boolean {
+    if (!m) {
+        return () => true;
+    }
+
+    if (m.startsWith("/") && m.lastIndexOf("/") > 0) {
+        const i = m.lastIndexOf("/");
+        // g/y make test() stateful via lastIndex — a repeated matcher would
+        // silently skip every other hit. They add nothing to a boolean test.
+        const flags = m.slice(i + 1).replace(/[gy]/g, "");
+        const re = new RegExp(m.slice(1, i), flags);
+
+        return (u: string) => re.test(u);
+    }
+
+    return (u: string) => u.includes(m);
+}
+
+/** Render channels the recorder is not capturing, with the restart command that would add them. */
+export function missingCaptureChannels(
+    port: number,
+    renderChannels: RenderChannel[]
+): { channel: RenderChannel; needs: string }[] {
+    const meta = readRecorderMeta(port);
+    if (!meta) {
+        return [];
+    }
+
+    const captured = new Set(meta.channels);
+    const missing: { channel: RenderChannel; needs: string }[] = [];
+
+    for (const channel of renderChannels) {
+        const needs = RENDER_NEEDS_CAPTURE[channel];
+        if (needs && !captured.has(needs)) {
+            missing.push({ channel, needs });
+        }
+    }
+
+    return missing;
+}
+
+export interface FollowOpts {
+    port: number;
+    channels: RenderChannel[];
+    match?: string;
+    /** Replay buffered events from this epoch-ms before going live. */
+    sinceMs?: number;
+    /** Stop after N seconds; omit = until killed. */
+    seconds?: number;
+    onLine: (line: string) => void;
+    signal?: AbortSignal;
+    pollMs?: number;
+    /** Capture dir override (tests). Defaults to the port's real dir. */
+    dir?: string;
+}
+
+export async function follow(opts: FollowOpts): Promise<void> {
+    const dir = opts.dir ?? captureDir(opts.port);
+    const on = new Set(opts.channels);
+    const matches = makeMatcher(opts.match);
+    const render = (ev: RecordedEvent) => {
+        for (const line of renderEventLines(ev, on, matches)) {
+            opts.onLine(line);
+        }
+    };
+
+    let currentPath: string | null = null;
+    let offset = 0;
+    let remainder: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+
+    // Replay history when asked, and position the live cursor at the end of
+    // the newest segment either way (follow never re-prints what it replayed).
+    const segments = listSegments(dir);
+    if (opts.sinceMs !== undefined) {
+        for (const seg of segments) {
+            drainFile(seg.path, 0, (ev) => {
+                if (ev.t >= (opts.sinceMs ?? 0)) {
+                    render(ev);
+                }
+            });
+        }
+    }
+
+    const newest = segments.at(-1);
+    if (newest) {
+        currentPath = newest.path;
+        offset = safeSize(newest.path);
+    }
+
+    const deadline = opts.seconds ? Date.now() + opts.seconds * 1000 : Infinity;
+
+    while (Date.now() < deadline && !opts.signal?.aborted) {
+        const segs = listSegments(dir);
+        const latest = segs.at(-1);
+
+        if (currentPath && existsSync(currentPath)) {
+            const drained = drainFile(currentPath, offset, render, remainder);
+            offset = drained.offset;
+            remainder = drained.remainder;
+        }
+
+        if (latest && latest.path !== currentPath) {
+            // Rotation: the old segment is fully drained above; hop to the new
+            // one from byte 0 so nothing written during the hop is lost.
+            currentPath = latest.path;
+            offset = 0;
+            remainder = Buffer.alloc(0);
+            const drained = drainFile(currentPath, offset, render, remainder);
+            offset = drained.offset;
+            remainder = drained.remainder;
+        }
+
+        await Bun.sleep(opts.pollMs ?? 300);
+    }
+}
+
+function safeSize(path: string): number {
+    try {
+        return statSync(path).size;
+    } catch {
+        return 0;
+    }
+}
+
+function drainFile(
+    path: string,
+    fromOffset: number,
+    onEvent: (ev: RecordedEvent) => void,
+    remainder: Buffer<ArrayBufferLike> = Buffer.alloc(0)
+): { offset: number; remainder: Buffer<ArrayBufferLike> } {
+    const size = safeSize(path);
+    if (size <= fromOffset) {
+        return { offset: fromOffset, remainder };
+    }
+
+    let fd: number;
+    try {
+        fd = openSync(path, "r");
+    } catch (err) {
+        log.debug({ err, path }, "follow open failed (raced a prune?)");
+
+        return { offset: fromOffset, remainder };
+    }
+
+    try {
+        const len = size - fromOffset;
+        const buf = Buffer.alloc(len);
+        const read = readSync(fd, buf, 0, len, fromOffset);
+        const parsed = parseJsonlChunk<RecordedEvent>(buf.subarray(0, read), remainder);
+        for (const value of parsed.values) {
+            onEvent(value);
+        }
+
+        return { offset: fromOffset + read, remainder: parsed.remainder };
+    } finally {
+        closeSync(fd);
+    }
+}

--- a/src/chrome-devtools/lib/frame-grid.ts
+++ b/src/chrome-devtools/lib/frame-grid.ts
@@ -1,0 +1,112 @@
+/**
+ * frame-grid.ts — screenshot with a pixel-coordinate grid burned in.
+ *
+ * AX-tree tools (peekaboo) see nothing inside a web page, so pixel coordinates are
+ * the only way to aim a click. Read the output PNG, find the pixel, click it.
+ *
+ * Ported from GenesisTools src/youtube/lib/devtools/frame-grid.ts; takes the shot via
+ * raw CDP instead of an MCP client, so it has no MCP dependency.
+ * Requires ImageMagick (`magick`).
+ */
+import { attach } from "./cdp.ts";
+
+export interface FrameGridOpts {
+    /** Crop region in the SCREENSHOT's own pixel space: "x,y,w,h". Omit for full viewport. */
+    region?: string;
+    /** Grid spacing px. Default 60 — smaller crowds the labels into illegibility. */
+    gridStep?: number;
+    outPath: string;
+    port?: number;
+    fullPage?: boolean;
+}
+
+export async function captureFrameGrid(opts: FrameGridOpts): Promise<string> {
+    const step = opts.gridStep ?? 60;
+
+    if (!Number.isFinite(step) || step <= 0) {
+        throw new Error(`--step must be a positive number of pixels, got '${opts.gridStep}'`);
+    }
+
+    const rawPath = `${opts.outPath}.raw.png`;
+    const page = await attach({ port: opts.port ?? 9222 });
+    try {
+        await page.screenshot(rawPath, opts.fullPage ?? false);
+    } finally {
+        page.close();
+    }
+
+    return gridify(rawPath, opts.outPath, step, opts.region);
+}
+
+/** Overlay a labeled grid on an existing PNG. */
+export function gridify(source: string, outPath: string, step = 60, region?: string): string {
+    if (!Number.isFinite(step) || step <= 0) {
+        throw new Error(`grid step must be a positive number of pixels, got '${step}'`);
+    }
+
+    let src = source;
+
+    if (region) {
+        const [x, y, w, h] = region.split(",").map(Number);
+
+        if ([x, y, w, h].some((n) => Number.isNaN(n))) {
+            throw new Error(`region must be "x,y,w,h", got: ${region}`);
+        }
+
+        const cropped = `${outPath}.crop.png`;
+        const crop = Bun.spawnSync(["magick", src, "-crop", `${w}x${h}+${x}+${y}`, "+repage", cropped]);
+
+        if (crop.exitCode !== 0) {
+            throw new Error(`magick crop failed: ${crop.stderr.toString()}`);
+        }
+
+        src = cropped;
+    }
+
+    const identify = Bun.spawnSync(["magick", "identify", "-format", "%w %h", src]);
+
+    if (identify.exitCode !== 0) {
+        throw new Error(`magick identify failed: ${identify.stderr.toString()}`);
+    }
+
+    const [width, height] = identify.stdout.toString().trim().split(" ").map(Number);
+    const xOffset = region ? Number(region.split(",")[0]) : 0;
+    const yOffset = region ? Number(region.split(",")[1]) : 0;
+    const vLines = Array.from({ length: Math.floor(width / step) + 1 }, (_, i) => i * step);
+    const hLines = Array.from({ length: Math.floor(height / step) + 1 }, (_, i) => i * step);
+    const labelW = 34;
+    const labelH = 15;
+
+    // Order matters: gridlines first (under labels), then a solid chip behind each
+    // label, then the text — bare pointsize-10 labels were unreadable over busy content.
+    const drawArgs = [
+        "-fill",
+        "none",
+        "-stroke",
+        "red",
+        "-strokewidth",
+        "1",
+        ...vLines.flatMap((x) => ["-draw", `line ${x},0 ${x},${height}`]),
+        ...hLines.flatMap((y) => ["-draw", `line 0,${y} ${width},${y}`]),
+        "-fill",
+        "black",
+        "-stroke",
+        "none",
+        ...vLines.flatMap((x) => ["-draw", `rectangle ${x},0 ${x + labelW},${labelH}`]),
+        ...hLines.flatMap((y) => ["-draw", `rectangle 0,${y} ${labelW},${y + labelH}`]),
+        "-fill",
+        "yellow",
+        "-pointsize",
+        "13",
+        ...vLines.flatMap((x) => ["-draw", `text ${x + 2},${labelH - 3} '${x + xOffset}'`]),
+        ...hLines.flatMap((y) => ["-draw", `text 2,${y + labelH - 3} '${y + yOffset}'`]),
+    ];
+
+    const overlay = Bun.spawnSync(["magick", src, ...drawArgs, outPath]);
+
+    if (overlay.exitCode !== 0) {
+        throw new Error(`magick grid overlay failed: ${overlay.stderr.toString()}`);
+    }
+
+    return outPath;
+}

--- a/src/chrome-devtools/lib/har-io.test.ts
+++ b/src/chrome-devtools/lib/har-io.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RecordedEvent } from "./channels.ts";
+import { harFromMessages } from "./har/build.ts";
+import type { CdpMessage } from "./har/types.ts";
+import { buildHarFromBuffer, countDroppedFailures, parseDuration, sanitizeHar, stitchBodies } from "./har-io.ts";
+import { segmentName } from "./segments.ts";
+
+describe("parseDuration", () => {
+    test("supports 90s / 30m / 2h and bare minutes; rejects garbage", () => {
+        expect(parseDuration("90s")).toBe(90_000);
+        expect(parseDuration("30m")).toBe(1_800_000);
+        expect(parseDuration("2h")).toBe(7_200_000);
+        expect(parseDuration("15")).toBe(900_000);
+        expect(parseDuration("1.5h")).toBe(5_400_000);
+        expect(parseDuration("soon")).toBeNull();
+        expect(parseDuration("-5m")).toBeNull();
+    });
+});
+
+describe("countDroppedFailures", () => {
+    test("counts only failures HAR cannot represent (aborts stay)", () => {
+        expect(
+            countDroppedFailures([
+                { method: "Network.loadingFailed", params: { errorText: "net::ERR_NAME_NOT_RESOLVED" } },
+                { method: "Network.loadingFailed", params: { errorText: "net::ERR_ABORTED" } },
+                { method: "Network.loadingFinished", params: {} },
+            ])
+        ).toBe(1);
+    });
+});
+
+describe("stitchBodies", () => {
+    test("attaches a Genesis.responseBody capture onto its session's responseReceived", () => {
+        const events: RecordedEvent[] = [
+            {
+                method: "Network.responseReceived",
+                params: { requestId: "r1", response: { url: "https://app.example.com/api" } },
+                sessionId: "S1",
+                t: 1,
+            },
+            {
+                method: "Network.responseReceived",
+                params: { requestId: "r1", response: { url: "https://idp.example.com/api" } },
+                sessionId: "S2",
+                t: 2,
+            },
+            {
+                method: "Genesis.responseBody",
+                params: { requestId: "r1", url: "https://app.example.com/api", body: '{"ok":true}' },
+                sessionId: "S1",
+                t: 3,
+            },
+        ];
+
+        expect(stitchBodies(events)).toBe(1);
+        expect((events[0].params.response as { body?: string }).body).toBe('{"ok":true}');
+        expect((events[1].params.response as { body?: string }).body).toBeUndefined();
+    });
+});
+
+describe("sanitizeHar", () => {
+    test("redacts sensitive headers, cookie values and credential POST params; leaves the rest", () => {
+        const messages: CdpMessage[] = [
+            { method: "Page.frameStartedLoading", params: { frameId: "F1" } },
+            {
+                method: "Network.requestWillBeSent",
+                params: {
+                    requestId: "r1",
+                    frameId: "F1",
+                    timestamp: 1,
+                    wallTime: 1700000000,
+                    type: "Document",
+                    initiator: { type: "other" },
+                    request: {
+                        method: "POST",
+                        url: "https://idp.example.com/login?code=oauth-secret&state=keepme",
+                        headers: { Cookie: "sid=hunter2", Accept: "text/html", "Content-Type": "text/plain" },
+                        postData: "user=alice&password=hunter2&stay=1",
+                    },
+                },
+            },
+            {
+                method: "Network.responseReceived",
+                params: {
+                    requestId: "r1",
+                    frameId: "F1",
+                    timestamp: 1.2,
+                    response: {
+                        url: "https://idp.example.com/login",
+                        protocol: "http/1.1",
+                        status: 200,
+                        statusText: "OK",
+                        mimeType: "text/html",
+                        headers: { "Set-Cookie": "auth=tok; HttpOnly", "content-type": "text/html" },
+                        encodedDataLength: 100,
+                        connectionId: 1,
+                    },
+                },
+            },
+            { method: "Network.loadingFinished", params: { requestId: "r1", timestamp: 1.4, encodedDataLength: 100 } },
+        ];
+
+        const raw = harFromMessages(messages);
+        const clean = sanitizeHar(raw);
+        const entry = clean.log.entries[0];
+        expect(entry.request.headers.find((h) => h.name === "Cookie")?.value).toBe("[REDACTED]");
+        expect(entry.request.headers.find((h) => h.name === "Accept")?.value).toBe("text/html");
+        expect(entry.response?.headers.find((h) => h.name === "Set-Cookie")?.value).toBe("[REDACTED]");
+        expect(entry.request.postData?.text).toContain("password=[REDACTED]");
+        expect(entry.request.postData?.text).toContain("user=alice");
+        // OAuth ?code= must not survive --sanitize in the URL or queryString
+        expect(entry.request.url).toContain("code=[REDACTED]");
+        expect(entry.request.url).toContain("state=keepme");
+        expect(entry.request.queryString?.find((q) => q.name === "code")?.value).toBe("[REDACTED]");
+        expect(entry.request.queryString?.find((q) => q.name === "state")?.value).toBe("keepme");
+        // the original is untouched
+        expect(raw.log.entries[0].request.headers.find((h) => h.name === "Cookie")?.value).toBe("sid=hunter2");
+        expect(raw.log.entries[0].request.url).toContain("code=oauth-secret");
+    });
+});
+
+describe("buildHarFromBuffer", () => {
+    const dirs: string[] = [];
+
+    afterEach(() => {
+        for (const dir of dirs.splice(0)) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("reads segments, honors sinceMs and match, and reports dropped failures", () => {
+        const root = mkdtempSync(join(tmpdir(), "cdp-har-io-"));
+        dirs.push(root);
+        const port = 59991;
+        const dir = join(root, String(port));
+        mkdirSync(dir, { recursive: true });
+
+        const mk = (t: number, method: string, params: Record<string, unknown>): string =>
+            // biome-ignore lint/style/noRestrictedGlobals: strict JSON fixture line
+            JSON.stringify({ method, params, sessionId: "S1", t });
+
+        writeFileSync(
+            join(dir, segmentName(1_000)),
+            [
+                mk(1_000, "Page.frameStartedLoading", { frameId: "F1" }),
+                mk(1_001, "Network.requestWillBeSent", {
+                    requestId: "r1",
+                    frameId: "F1",
+                    timestamp: 1,
+                    wallTime: 1700000000,
+                    type: "Document",
+                    initiator: { type: "other" },
+                    request: { method: "GET", url: "https://app.example.com/", headers: {} },
+                }),
+                mk(1_002, "Network.responseReceived", {
+                    requestId: "r1",
+                    frameId: "F1",
+                    timestamp: 1.2,
+                    response: {
+                        url: "https://app.example.com/",
+                        protocol: "h2",
+                        status: 200,
+                        statusText: "",
+                        mimeType: "text/html",
+                        headers: {},
+                        encodedDataLength: 50,
+                        connectionId: 1,
+                    },
+                }),
+                mk(1_003, "Network.loadingFinished", { requestId: "r1", timestamp: 1.4, encodedDataLength: 50 }),
+                mk(1_004, "Network.loadingFailed", { requestId: "rX", timestamp: 2, errorText: "net::ERR_FAILED" }),
+            ].join("\n")
+        );
+
+        const all = buildHarFromBuffer({ port, dir });
+        expect(all.har.log.entries).toHaveLength(1);
+        expect(all.har.log.entries[0].request.url).toBe("https://app.example.com/");
+        expect(all.har.log.pages).toHaveLength(1);
+        expect(all.droppedFailed).toBe(1);
+        expect(all.eventCount).toBe(5);
+
+        const since = buildHarFromBuffer({ port, dir, sinceMs: 5_000 });
+        expect(since.har.log.entries).toHaveLength(0);
+        // coverage always describes the WHOLE buffer, so an empty window is diagnosable
+        expect(since.coverage).toEqual({ totalEvents: 5, oldestT: 1_000, newestT: 1_004 });
+
+        const miss = buildHarFromBuffer({ port, dir, match: "nomatch.example.com" });
+        expect(miss.har.log.entries).toHaveLength(0);
+    });
+
+    test("a --last window that starts AFTER the navigation still emits entries (pre-window page anchors)", () => {
+        // Field failure: har --last 40s returned 0 entries for a window full
+        // of traffic, because the Page.* anchor predated the window and the
+        // builder drops page-less entries.
+        const root = mkdtempSync(join(tmpdir(), "cdp-har-io-"));
+        dirs.push(root);
+        const port = 59992;
+        const dir = join(root, String(port));
+        mkdirSync(dir, { recursive: true });
+
+        const mk = (t: number, method: string, params: Record<string, unknown>): string =>
+            // biome-ignore lint/style/noRestrictedGlobals: strict JSON fixture line
+            JSON.stringify({ method, params, sessionId: "S1", t });
+
+        writeFileSync(
+            join(dir, segmentName(1_000)),
+            [
+                mk(1_000, "Page.frameStartedLoading", { frameId: "F1" }),
+                mk(9_001, "Network.requestWillBeSent", {
+                    requestId: "r1",
+                    frameId: "F1",
+                    timestamp: 1,
+                    wallTime: 1700000000,
+                    type: "XHR",
+                    initiator: { type: "other" },
+                    request: { method: "POST", url: "https://idp.example.com/token", headers: {} },
+                }),
+                mk(9_002, "Network.responseReceived", {
+                    requestId: "r1",
+                    frameId: "F1",
+                    timestamp: 1.2,
+                    response: {
+                        url: "https://idp.example.com/token",
+                        protocol: "h2",
+                        status: 200,
+                        statusText: "",
+                        mimeType: "application/json",
+                        headers: {},
+                        encodedDataLength: 50,
+                        connectionId: 1,
+                    },
+                }),
+                mk(9_003, "Network.loadingFinished", { requestId: "r1", timestamp: 1.4, encodedDataLength: 50 }),
+            ].join("\n")
+        );
+
+        const windowed = buildHarFromBuffer({ port, dir, sinceMs: 5_000 });
+        expect(windowed.har.log.entries).toHaveLength(1);
+        expect(windowed.har.log.entries[0].request.url).toBe("https://idp.example.com/token");
+    });
+});

--- a/src/chrome-devtools/lib/har-io.ts
+++ b/src/chrome-devtools/lib/har-io.ts
@@ -1,0 +1,302 @@
+/**
+ * HAR assembly on top of the capture buffer (retroactive) or a live window.
+ * The conversion itself is the chrome-har port in ./har/build.ts.
+ */
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { attach, type Page } from "./cdp.ts";
+import type { RecordedEvent } from "./channels.ts";
+import { harFromMessages } from "./har/build.ts";
+import type { CdpMessage, HarFile } from "./har/types.ts";
+import { captureDir } from "./paths.ts";
+import { readEvents } from "./segments.ts";
+
+const { log } = logger.scoped("chrome-devtools:har-io");
+
+const SENSITIVE_HEADER = /^(cookie|set-cookie|authorization|proxy-authorization|x-api-key|x-auth-token|x-csrf-token)$/i;
+
+/** "90s" | "30m" | "2h" → ms. Bare numbers are minutes. */
+export function parseDuration(raw: string): number | null {
+    const m = raw.trim().match(/^(\d+(?:\.\d+)?)\s*(s|m|h)?$/i);
+    if (!m) {
+        return null;
+    }
+
+    const n = Number(m[1]);
+    const unit = (m[2] ?? "m").toLowerCase();
+    const factor = unit === "s" ? 1000 : unit === "m" ? 60_000 : 3_600_000;
+
+    return Math.round(n * factor);
+}
+
+/** Count Network.loadingFailed events that HAR cannot represent (everything but ERR_ABORTED). */
+export function countDroppedFailures(events: { method: string; params: Record<string, unknown> }[]): number {
+    return events.filter((e) => e.method === "Network.loadingFailed" && e.params.errorText !== "net::ERR_ABORTED")
+        .length;
+}
+
+/**
+ * Stitch recorder-captured bodies (Genesis.responseBody events, body channel)
+ * onto their responseReceived params so the HAR builder can inline them.
+ */
+export function stitchBodies(events: RecordedEvent[]): number {
+    const bodies = new Map<string, string>();
+
+    for (const ev of events) {
+        if (ev.method === "Genesis.responseBody") {
+            bodies.set(`${ev.sessionId ?? ""} ${ev.params.requestId}`, String(ev.params.body ?? ""));
+        }
+    }
+
+    if (bodies.size === 0) {
+        return 0;
+    }
+
+    let stitched = 0;
+    for (const ev of events) {
+        if (ev.method !== "Network.responseReceived") {
+            continue;
+        }
+
+        const body = bodies.get(`${ev.sessionId ?? ""} ${ev.params.requestId}`);
+        if (body !== undefined) {
+            (ev.params.response as { body?: string }).body = body;
+            stitched++;
+        }
+    }
+
+    return stitched;
+}
+
+export interface BufferHarResult {
+    har: HarFile;
+    eventCount: number;
+    droppedFailed: number;
+    stitchedBodies: number;
+    /** Event-time coverage of the WHOLE buffer, so an empty window is diagnosable. */
+    coverage: { totalEvents: number; oldestT: number | null; newestT: number | null };
+}
+
+/**
+ * Page lifecycle events that anchor entries to a page in the HAR builder.
+ * A `--last` window that starts AFTER the navigation contains only network
+ * events; without an anchor every entry stays page-less and the builder drops
+ * them all — `har --last 40s` returned 0 entries for a window full of traffic
+ * (field-verified). So windowed builds prepend the pre-window anchors; pages
+ * that end up with no entries are pruned by the builder, never invented.
+ */
+const PAGE_ANCHOR_METHODS = new Set([
+    "Page.frameStartedLoading",
+    "Page.frameRequestedNavigation",
+    "Page.navigatedWithinDocument",
+    "Page.frameNavigated",
+    "Page.frameAttached",
+]);
+
+export function buildHarFromBuffer(opts: {
+    port: number;
+    sinceMs?: number;
+    match?: string;
+    /** Capture dir override (tests). Defaults to the port's real dir. */
+    dir?: string;
+}): BufferHarResult {
+    const all = readEvents(opts.dir ?? captureDir(opts.port));
+    const coverage = {
+        totalEvents: all.length,
+        oldestT: all.length ? all[0].t : null,
+        newestT: all.length ? all[all.length - 1].t : null,
+    };
+
+    let events = all;
+    if (opts.sinceMs !== undefined) {
+        const since = opts.sinceMs;
+        const anchors = all.filter((e) => e.t < since && PAGE_ANCHOR_METHODS.has(e.method));
+        events = [...anchors, ...all.filter((e) => e.t >= since)];
+    }
+
+    const stitchedBodies = stitchBodies(events);
+    const har = harFromMessages(events as CdpMessage[], { includeTextFromResponseBody: stitchedBodies > 0 });
+
+    if (opts.match) {
+        const m = opts.match;
+        har.log.entries = har.log.entries.filter(
+            (e) => e.request.url.includes(m) || (e.response?.redirectURL ?? "").includes(m)
+        );
+    }
+
+    return {
+        har,
+        eventCount: events.length,
+        droppedFailed: countDroppedFailures(events),
+        stitchedBodies,
+        coverage,
+    };
+}
+
+export interface LiveWindowResult {
+    har: HarFile;
+    bodiesGot: number;
+    bodiesMiss: number;
+    droppedFailed: number;
+    pageUrl: string;
+}
+
+/** `har --now [--reload]`: one tab, a recording window, optional body fetch. */
+export async function captureLiveWindow(opts: {
+    port: number;
+    match?: string;
+    reload?: boolean;
+    seconds: number;
+    bodies: boolean;
+    onAttached?: (page: Page) => void;
+}): Promise<LiveWindowResult> {
+    const page = await attach({ port: opts.port, url: opts.match });
+    opts.onAttached?.(page);
+    const messages: CdpMessage[] = [];
+    page.on((method, params) => {
+        if (method.startsWith("Network.") || method.startsWith("Page.")) {
+            messages.push({ method, params });
+        }
+    });
+
+    await page
+        .send("Network.enable", {
+            maxTotalBufferSize: 100_000_000,
+            maxResourceBufferSize: 50_000_000,
+            maxPostDataSize: 10_000_000,
+        })
+        .catch((err: unknown) => {
+            log.warn({ err }, "Network.enable failed");
+        });
+
+    if (opts.reload) {
+        await page.reload();
+    }
+
+    await Bun.sleep(opts.seconds * 1000);
+
+    let bodiesGot = 0;
+    let bodiesMiss = 0;
+
+    if (opts.bodies) {
+        const ids = [
+            ...new Set(
+                messages.filter((m) => m.method === "Network.responseReceived").map((m) => String(m.params.requestId))
+            ),
+        ];
+
+        for (const id of ids) {
+            try {
+                const r = await page.responseBody(id);
+                if (r?.body != null) {
+                    const resp = messages.find(
+                        (m) => m.method === "Network.responseReceived" && String(m.params.requestId) === id
+                    );
+                    if (resp) {
+                        (resp.params.response as { body?: string }).body = r.body;
+                        bodiesGot++;
+                    }
+                } else {
+                    bodiesMiss++;
+                }
+            } catch (err) {
+                bodiesMiss++;
+                log.debug({ err, id }, "body miss");
+            }
+        }
+    }
+
+    const har = harFromMessages(messages, { includeTextFromResponseBody: opts.bodies });
+    const pageUrl = page.target.url;
+    page.close();
+
+    return { har, bodiesGot, bodiesMiss, droppedFailed: countDroppedFailures(messages), pageUrl };
+}
+
+/** Redact Cookie / Set-Cookie / Authorization headers, cookie values, and credential-shaped POST params. */
+const SENSITIVE_PARAM =
+    /^(password|passwd|pwd|secret|authorization|code|access_token|refresh_token|id_token|token|client_secret)$/i;
+
+function redactJsonDeep(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(redactJsonDeep);
+    }
+
+    if (value && typeof value === "object") {
+        const out: Record<string, unknown> = {};
+        for (const [key, v] of Object.entries(value)) {
+            out[key] = SENSITIVE_PARAM.test(key) ? "[REDACTED]" : redactJsonDeep(v);
+        }
+
+        return out;
+    }
+
+    return value;
+}
+
+/** Redact sensitive query params (and any fragment) inside a URL string. OAuth ?code= lives here. */
+function redactUrl(url: string): string {
+    return url
+        .replace(/([?&])([^=&#]+)=([^&#]*)/g, (all, sep: string, name: string, _v) =>
+            SENSITIVE_PARAM.test(name) ? `${sep}${name}=[REDACTED]` : all
+        )
+        .replace(/#.+$/, "#[REDACTED]");
+}
+
+export function sanitizeHar(har: HarFile): HarFile {
+    const clone = structuredClone(har);
+
+    for (const entry of clone.log.entries) {
+        entry.request.url = redactUrl(entry.request.url);
+        for (const q of entry.request.queryString ?? []) {
+            if (SENSITIVE_PARAM.test(q.name)) {
+                q.value = "[REDACTED]";
+            }
+        }
+
+        if (entry.response?.redirectURL) {
+            entry.response.redirectURL = redactUrl(entry.response.redirectURL);
+        }
+
+        for (const h of [...entry.request.headers, ...(entry.response?.headers ?? [])]) {
+            if (SENSITIVE_HEADER.test(h.name)) {
+                h.value = "[REDACTED]";
+            }
+        }
+
+        for (const c of [...entry.request.cookies, ...(entry.response?.cookies ?? [])]) {
+            c.value = "[REDACTED]";
+        }
+
+        const postData = entry.request.postData;
+        if (postData?.text) {
+            // JSON bodies get a structural deep-redaction ({"access_token": …});
+            // everything else falls back to the URL-encoded pattern pass.
+            let handled = false;
+            if (/^\s*[{[]/.test(postData.text)) {
+                try {
+                    const parsed = SafeJSON.parse(postData.text, { strict: true });
+                    postData.text = SafeJSON.stringify(redactJsonDeep(parsed), { strict: true });
+                    handled = true;
+                } catch (err) {
+                    log.debug({ err }, "postData looked like JSON but did not parse; regex redaction applies");
+                }
+            }
+
+            if (!handled) {
+                postData.text = postData.text.replace(
+                    /(password|passwd|pwd|secret|token|code)=([^&]*)/gi,
+                    "$1=[REDACTED]"
+                );
+            }
+        }
+
+        for (const param of postData?.params ?? []) {
+            if (SENSITIVE_PARAM.test(param.name)) {
+                param.value = "[REDACTED]";
+            }
+        }
+    }
+
+    return clone;
+}

--- a/src/chrome-devtools/lib/har/__fixtures__/golden/iframe-not-attached.har.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/golden/iframe-not-attached.har.json
@@ -1,0 +1,1515 @@
+{
+ "pages": [
+  {
+   "id": "page_1",
+   "startedDateTime": "2020-05-25T04:13:30.017Z",
+   "title": "https://qduej.csb.app/",
+   "pageTimings": {
+    "onContentLoad": 623.547,
+    "onLoad": 1119.79
+   }
+  }
+ ],
+ "entries": [
+  {
+   "cache": {},
+   "startedDateTime": "2020-05-25T04:13:30.018Z",
+   "_requestId": "4355017A2060DF8B961B1AD927083EAA",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://qduej.csb.app/",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "qduej.csb.app"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/"
+     },
+     {
+      "name": "upgrade-insecure-requests",
+      "value": "1"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "none"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "navigate"
+     },
+     {
+      "name": "sec-fetch-user",
+      "value": "?1"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "document"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 365.487,
+   "_initiator_detail": "{\"type\":\"other\"}",
+   "_initiator_type": "other",
+   "_resourceType": "document",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/html",
+     "size": 708
+    },
+    "headersSize": -1,
+    "bodySize": 787,
+    "cookies": [
+     {
+      "name": "__cfduid",
+      "value": "dd980c511f388fad37f60c6500bc554891590380010",
+      "path": "/",
+      "domain": "csb.app",
+      "expires": "2020-06-24T04:13:30.000Z",
+      "httpOnly": true,
+      "secure": false
+     }
+    ],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Mon, 25 May 2020 04:13:30 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "text/html"
+     },
+     {
+      "name": "set-cookie",
+      "value": "__cfduid=dd980c511f388fad37f60c6500bc554891590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "cache-control",
+      "value": "private, max-age=0, no-cache, no-store"
+     },
+     {
+      "name": "x-request-id",
+      "value": "FhIqMXMSH4WPHgAaEuvh"
+     },
+     {
+      "name": "via",
+      "value": "1.1 google"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "DYNAMIC"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "cf-ray",
+      "value": "598c6c974ebefe68-SYD"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "02eba2328e0000fe683799c200000001"
+     }
+    ],
+    "_transferSize": 787,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "27",
+   "serverIPAddress": "104.18.26.114",
+   "timings": {
+    "blocked": 0.261,
+    "dns": 18.584,
+    "connect": 27.683,
+    "send": 0.083,
+    "wait": 318.266,
+    "receive": 0.61,
+    "ssl": 18.826,
+    "_queued": 0.99
+   },
+   "_requestTime": 162823.189828,
+   "_chunks": [
+    {
+     "ts": 386.088,
+     "bytes": 708
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-05-25T04:13:30.405Z",
+   "_requestId": "83685.2",
+   "_initialPriority": "High",
+   "_priority": "High",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://codesandbox.io/public/sse-hooks/sse-hooks.js",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "Referer",
+      "value": "https://qduej.csb.app/"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "codesandbox.io"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/public/sse-hooks/sse-hooks.js"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "*/*"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "no-cors"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "script"
+     },
+     {
+      "name": "referer",
+      "value": "https://qduej.csb.app/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 72.618,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://qduej.csb.app/\",\"lineNumber\":3}",
+   "_initiator_type": "parser",
+   "_resourceType": "script",
+   "_initiator": "https://qduej.csb.app/",
+   "_initiator_line": 4,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "application/javascript",
+     "size": 19255,
+     "compression": 13054
+    },
+    "headersSize": -1,
+    "bodySize": 6201,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Mon, 25 May 2020 04:13:30 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "application/javascript"
+     },
+     {
+      "name": "set-cookie",
+      "value": "__cfduid=d925d936af841b02970a0c09c228bc9bd1590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure"
+     },
+     {
+      "name": "last-modified",
+      "value": "Sat, 18 Jan 2020 18:18:59 GMT"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "etag",
+      "value": "W/\"5e234c13-4b37\""
+     },
+     {
+      "name": "expires",
+      "value": "Thu, 31 Dec 2037 23:55:55 GMT"
+     },
+     {
+      "name": "cache-control",
+      "value": "max-age=315360000"
+     },
+     {
+      "name": "access-control-allow-origin",
+      "value": "*"
+     },
+     {
+      "name": "access-control-allow-methods",
+      "value": "GET"
+     },
+     {
+      "name": "via",
+      "value": "1.1 google"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "HIT"
+     },
+     {
+      "name": "age",
+      "value": "10905540"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "cf-ray",
+      "value": "598c6c99bb30fd22-SYD"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "02eba234100000fd2299b83200000001"
+     }
+    ],
+    "_transferSize": 6201,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "47",
+   "serverIPAddress": "104.18.23.207",
+   "timings": {
+    "blocked": 0.171,
+    "dns": 16.481,
+    "connect": 27.279,
+    "send": 0.133,
+    "wait": 27.581,
+    "receive": 0.973,
+    "ssl": 16.612,
+    "_queued": 0.478
+   },
+   "_requestTime": 162823.577299,
+   "_chunks": [
+    {
+     "ts": 462.22,
+     "bytes": 19255
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-05-25T04:13:30.406Z",
+   "_requestId": "83685.3",
+   "_initialPriority": "High",
+   "_priority": "High",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "Origin",
+      "value": "https://qduej.csb.app"
+     },
+     {
+      "name": "Referer",
+      "value": "https://qduej.csb.app/"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "codesandbox.io"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/static/js/watermark-button.b90db4dc7.js"
+     },
+     {
+      "name": "origin",
+      "value": "https://qduej.csb.app"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "*/*"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "cors"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "script"
+     },
+     {
+      "name": "referer",
+      "value": "https://qduej.csb.app/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 73.267,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://qduej.csb.app/\",\"lineNumber\":17}",
+   "_initiator_type": "parser",
+   "_resourceType": "script",
+   "_initiator": "https://qduej.csb.app/",
+   "_initiator_line": 18,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "application/javascript",
+     "size": 2792,
+     "compression": 1060
+    },
+    "headersSize": -1,
+    "bodySize": 1732,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Mon, 25 May 2020 04:13:30 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "application/javascript"
+     },
+     {
+      "name": "set-cookie",
+      "value": "__cfduid=d239ee441e68fed7d9fdd3af885f2ad131590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure"
+     },
+     {
+      "name": "last-modified",
+      "value": "Fri, 22 May 2020 11:44:40 GMT"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "etag",
+      "value": "W/\"5ec7bb28-ae8\""
+     },
+     {
+      "name": "expires",
+      "value": "Thu, 31 Dec 2037 23:55:55 GMT"
+     },
+     {
+      "name": "cache-control",
+      "value": "max-age=315360000"
+     },
+     {
+      "name": "access-control-allow-origin",
+      "value": "*"
+     },
+     {
+      "name": "access-control-allow-methods",
+      "value": "GET"
+     },
+     {
+      "name": "via",
+      "value": "1.1 google"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "HIT"
+     },
+     {
+      "name": "age",
+      "value": "16470"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "cf-ray",
+      "value": "598c6c99bd1d65df-SYD"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "02eba23413000065dff3bf6200000001"
+     }
+    ],
+    "_transferSize": 1732,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "48",
+   "serverIPAddress": "104.18.23.207",
+   "timings": {
+    "blocked": 0.147,
+    "dns": 15.985,
+    "connect": 29.54,
+    "send": 0.069,
+    "wait": 27.198,
+    "receive": 0.328,
+    "ssl": 18.847,
+    "_queued": 0.632
+   },
+   "_requestTime": 162823.577895,
+   "_chunks": [
+    {
+     "ts": 621.08,
+     "bytes": 2792
+    },
+    {
+     "ts": 622.305,
+     "bytes": 0
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-05-25T04:13:30.488Z",
+   "_requestId": "8EA8D7896DF4A1423936BC7CF70715CA",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "deploy-preview-26--michaeldijkstra-netlify-test.netlify.app"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/"
+     },
+     {
+      "name": "upgrade-insecure-requests",
+      "value": "1"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "navigate"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "iframe"
+     },
+     {
+      "name": "referer",
+      "value": "https://qduej.csb.app/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 166.61599999999999,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://qduej.csb.app/\",\"lineNumber\":15}",
+   "_initiator_type": "parser",
+   "_resourceType": "document",
+   "_initiator": "https://qduej.csb.app/",
+   "_initiator_line": 16,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/html",
+     "size": 215
+    },
+    "headersSize": -1,
+    "bodySize": 442,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "cache-control",
+      "value": "public, max-age=0, must-revalidate"
+     },
+     {
+      "name": "content-length",
+      "value": "215"
+     },
+     {
+      "name": "content-type",
+      "value": "text/html; charset=UTF-8"
+     },
+     {
+      "name": "date",
+      "value": "Mon, 25 May 2020 03:30:54 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "\"a09a28bcb712a003aa33d497f1b42b1e-ssl\""
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=31536000"
+     },
+     {
+      "name": "x-robots-tag",
+      "value": "noindex"
+     },
+     {
+      "name": "age",
+      "value": "2556"
+     },
+     {
+      "name": "server",
+      "value": "Netlify"
+     },
+     {
+      "name": "x-nf-request-id",
+      "value": "73febc57-cf41-4661-ae21-14b0e37eff44-32126039"
+     }
+    ],
+    "_transferSize": 442,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "60",
+   "serverIPAddress": "54.206.19.82",
+   "timings": {
+    "blocked": 0.156,
+    "dns": 130.363,
+    "connect": 26.862,
+    "send": 0.158,
+    "wait": 8.85,
+    "receive": 0.227,
+    "ssl": 16.179,
+    "_queued": 0.481
+   },
+   "_requestTime": 162823.660227,
+   "_chunks": [
+    {
+     "ts": 657.929,
+     "bytes": 215
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-05-25T04:13:30.679Z",
+   "_requestId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://zfh61.csb.app/",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "zfh61.csb.app"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/"
+     },
+     {
+      "name": "upgrade-insecure-requests",
+      "value": "1"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "navigate"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "iframe"
+     },
+     {
+      "name": "referer",
+      "value": "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 339.543,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/\",\"lineNumber\":6}",
+   "_initiator_type": "parser",
+   "_resourceType": "document",
+   "_initiator": "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/",
+   "_initiator_line": 7,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/html",
+     "size": 365
+    },
+    "headersSize": -1,
+    "bodySize": 400,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Mon, 25 May 2020 04:13:31 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "text/html"
+     },
+     {
+      "name": "set-cookie",
+      "value": "__cfduid=ddd0c0efa83d24ecb104a2572b598d8541590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "cache-control",
+      "value": "private, max-age=0, no-cache, no-store"
+     },
+     {
+      "name": "x-request-id",
+      "value": "FhIqMZjZzZSIBAEWLnki"
+     },
+     {
+      "name": "via",
+      "value": "1.1 google"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "DYNAMIC"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "cf-ray",
+      "value": "598c6c9b4c5dfe68-SYD"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "02eba2350b0000fe68379c4200000001"
+     }
+    ],
+    "_transferSize": 400,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "27",
+   "serverIPAddress": "104.18.26.114",
+   "timings": {
+    "blocked": 19.874,
+    "dns": -1,
+    "connect": -1,
+    "send": 0.219,
+    "wait": 318.84,
+    "receive": 0.61,
+    "ssl": -1,
+    "_queued": 0.43
+   },
+   "_requestTime": 162823.851658,
+   "_chunks": [
+    {
+     "ts": 1009.979,
+     "bytes": 365
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-05-25T04:13:31.033Z",
+   "_requestId": "83685.7",
+   "_initialPriority": "Low",
+   "_priority": "High",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://www.w3schools.com/html/img_girl.jpg",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "Referer",
+      "value": "https://zfh61.csb.app/"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "www.w3schools.com"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/html/img_girl.jpg"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "image/webp,image/apng,image/*,*/*;q=0.8"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "no-cors"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "image"
+     },
+     {
+      "name": "referer",
+      "value": "https://zfh61.csb.app/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 78.497,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://zfh61.csb.app/\",\"lineNumber\":3}",
+   "_initiator_type": "parser",
+   "_resourceType": "image",
+   "_initiator": "https://zfh61.csb.app/",
+   "_initiator_line": 4,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "image/jpeg",
+     "size": 36836
+    },
+    "headersSize": -1,
+    "bodySize": 37058,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "accept-ranges",
+      "value": "bytes"
+     },
+     {
+      "name": "age",
+      "value": "5010"
+     },
+     {
+      "name": "cache-control",
+      "value": "public,max-age=14400,public"
+     },
+     {
+      "name": "content-type",
+      "value": "image/jpeg"
+     },
+     {
+      "name": "date",
+      "value": "Mon, 25 May 2020 04:13:31 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "\"ead5b13d31d31:0\""
+     },
+     {
+      "name": "last-modified",
+      "value": "Tue, 19 Sep 2017 11:51:57 GMT"
+     },
+     {
+      "name": "server",
+      "value": "ECS (sya/E0E0)"
+     },
+     {
+      "name": "x-cache",
+      "value": "HIT"
+     },
+     {
+      "name": "x-frame-options",
+      "value": "SAMEORIGIN"
+     },
+     {
+      "name": "x-powered-by",
+      "value": "ASP.NET"
+     },
+     {
+      "name": "content-length",
+      "value": "36836"
+     }
+    ],
+    "_transferSize": 37058,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "85",
+   "serverIPAddress": "192.229.179.87",
+   "timings": {
+    "blocked": 0.196,
+    "dns": 18.614,
+    "connect": 39.452,
+    "send": 0.165,
+    "wait": 12.99,
+    "receive": 7.08,
+    "ssl": 29.902,
+    "_queued": 0.402
+   },
+   "_requestTime": 162824.204958,
+   "_chunks": [
+    {
+     "ts": 1096.557,
+     "bytes": 36836
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-05-25T04:13:31.046Z",
+   "_requestId": "83685.11",
+   "_initialPriority": "Low",
+   "_priority": "Low",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://www.w3schools.com/tags/movie.mp4",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "Referer",
+      "value": "https://zfh61.csb.app/"
+     },
+     {
+      "name": "Accept-Encoding",
+      "value": "identity;q=1, *;q=0"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "Range",
+      "value": "bytes=0-"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "www.w3schools.com"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/tags/movie.mp4"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "identity;q=1, *;q=0"
+     },
+     {
+      "name": "accept",
+      "value": "*/*"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "no-cors"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "video"
+     },
+     {
+      "name": "referer",
+      "value": "https://zfh61.csb.app/"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     },
+     {
+      "name": "range",
+      "value": "bytes=0-"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 373.532,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://zfh61.csb.app/\",\"lineNumber\":7}",
+   "_initiator_type": "parser",
+   "_resourceType": "media",
+   "_initiator": "https://zfh61.csb.app/",
+   "_initiator_line": 8,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 206,
+    "statusText": "",
+    "content": {
+     "mimeType": "video/mp4",
+     "size": 131072
+    },
+    "headersSize": -1,
+    "bodySize": -1,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "206"
+     },
+     {
+      "name": "accept-ranges",
+      "value": "bytes"
+     },
+     {
+      "name": "age",
+      "value": "7733"
+     },
+     {
+      "name": "cache-control",
+      "value": "public,max-age=14400,public"
+     },
+     {
+      "name": "content-type",
+      "value": "video/mp4"
+     },
+     {
+      "name": "date",
+      "value": "Mon, 25 May 2020 04:13:31 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "\"8179b1407fbcf1:0\""
+     },
+     {
+      "name": "last-modified",
+      "value": "Tue, 07 Jan 2014 08:05:39 GMT"
+     },
+     {
+      "name": "server",
+      "value": "ECS (sya/E08E)"
+     },
+     {
+      "name": "x-cache",
+      "value": "HIT"
+     },
+     {
+      "name": "x-frame-options",
+      "value": "SAMEORIGIN"
+     },
+     {
+      "name": "x-powered-by",
+      "value": "ASP.NET"
+     },
+     {
+      "name": "Content-Range",
+      "value": "bytes 0-318464/318465"
+     },
+     {
+      "name": "Content-Length",
+      "value": "318465"
+     }
+    ],
+    "_transferSize": 112,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "85",
+   "serverIPAddress": "192.229.179.87",
+   "timings": {
+    "blocked": 45.461,
+    "dns": -1,
+    "connect": -1,
+    "send": 0.102,
+    "wait": 20.361,
+    "receive": 307.608,
+    "ssl": -1,
+    "_queued": 0.423
+   },
+   "_requestTime": 162824.218001,
+   "_chunks": [
+    {
+     "ts": 1106.669,
+     "bytes": 16384
+    },
+    {
+     "ts": 1106.723,
+     "bytes": 16384
+    },
+    {
+     "ts": 1114.05,
+     "bytes": 16384
+    },
+    {
+     "ts": 1117.81,
+     "bytes": 16384
+    },
+    {
+     "ts": 1390.453,
+     "bytes": 65536
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-05-25T04:13:31.139Z",
+   "_requestId": "83685.20",
+   "_initialPriority": "High",
+   "_priority": "High",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://qduej.csb.app/favicon.ico",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [
+     {
+      "name": "__cfduid",
+      "value": "dd980c511f388fad37f60c6500bc554891590380010",
+      "httpOnly": false,
+      "secure": false
+     }
+    ],
+    "headers": [
+     {
+      "name": ":path",
+      "value": "/favicon.ico"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "no-cors"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "image/webp,image/apng,image/*,*/*;q=0.8"
+     },
+     {
+      "name": "referer",
+      "value": "https://qduej.csb.app/"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "image"
+     },
+     {
+      "name": ":authority",
+      "value": "qduej.csb.app"
+     },
+     {
+      "name": "cookie",
+      "value": "__cfduid=dd980c511f388fad37f60c6500bc554891590380010"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "same-origin"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 487.67800000000005,
+   "_initiator_detail": "{\"type\":\"other\"}",
+   "_initiator_type": "other",
+   "_resourceType": "other",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "image/x-icon",
+     "size": 15086,
+     "compression": 12913
+    },
+    "headersSize": -1,
+    "bodySize": 2173,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Mon, 25 May 2020 04:13:31 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "image/x-icon"
+     },
+     {
+      "name": "last-modified",
+      "value": "Fri, 22 May 2020 11:44:42 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "W/\"5ec7bb2a-3aee\""
+     },
+     {
+      "name": "via",
+      "value": "1.1 google"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "REVALIDATED"
+     },
+     {
+      "name": "expires",
+      "value": "Mon, 25 May 2020 08:13:31 GMT"
+     },
+     {
+      "name": "cache-control",
+      "value": "public, max-age=14400"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "cf-ray",
+      "value": "598c6c9e08a6fe68-SYD"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "02eba236c30000fe68379db200000001"
+     }
+    ],
+    "_transferSize": 2173,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "27",
+   "serverIPAddress": "104.18.26.114",
+   "timings": {
+    "blocked": 0.47,
+    "dns": -1,
+    "connect": -1,
+    "send": 0.347,
+    "wait": 485.898,
+    "receive": 0.963,
+    "ssl": -1,
+    "_queued": 0.375
+   },
+   "_requestTime": 162824.31131,
+   "_chunks": [
+    {
+     "ts": 1611.714,
+     "bytes": 15086
+    },
+    {
+     "ts": 1612.381,
+     "bytes": 0
+    }
+   ]
+  }
+ ]
+}

--- a/src/chrome-devtools/lib/har/__fixtures__/golden/linkClickChrome.har.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/golden/linkClickChrome.har.json
@@ -1,0 +1,182 @@
+{
+ "pages": [
+  {
+   "id": "page_1",
+   "startedDateTime": "2018-11-23T11:48:51.302Z",
+   "title": "https://www.sitespeed.io/documentation/",
+   "pageTimings": {
+    "onLoad": 53.814,
+    "onContentLoad": 54.09
+   }
+  }
+ ],
+ "entries": [
+  {
+   "cache": {},
+   "startedDateTime": "2018-11-23T11:48:51.302Z",
+   "_requestId": "498739478C13F27AE4EFDA7A005918D6",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://www.sitespeed.io/documentation/",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":authority",
+      "value": "www.sitespeed.io"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":path",
+      "value": "/documentation/"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": "accept",
+      "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     },
+     {
+      "name": "upgrade-insecure-requests",
+      "value": "1"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 35.491,
+   "_initiator_detail": "{\"type\":\"other\"}",
+   "_initiator_type": "other",
+   "_resourceType": "document",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/html",
+     "size": 30175,
+     "compression": 21781
+    },
+    "headersSize": -1,
+    "bodySize": 8394,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "age",
+      "value": "12099"
+     },
+     {
+      "name": "cache-control",
+      "value": "public, max-age=0, must-revalidate"
+     },
+     {
+      "name": "content-encoding",
+      "value": "gzip"
+     },
+     {
+      "name": "content-length",
+      "value": "8261"
+     },
+     {
+      "name": "content-security-policy",
+      "value": "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'"
+     },
+     {
+      "name": "content-type",
+      "value": "text/html; charset=UTF-8"
+     },
+     {
+      "name": "date",
+      "value": "Fri, 23 Nov 2018 08:27:12 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "\"5845d0af318484658eb606d3cdf8dec0-ssl-df\""
+     },
+     {
+      "name": "referrer-policy",
+      "value": "no-referrer"
+     },
+     {
+      "name": "server",
+      "value": "Netlify"
+     },
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=31536000"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "x-content-type-options",
+      "value": "nosniff"
+     },
+     {
+      "name": "x-frame-options",
+      "value": "SAMEORIGIN"
+     },
+     {
+      "name": "x-nf-request-id",
+      "value": "cf03b3c7-2996-41f4-bf4a-a12fd10aefa1-11213500"
+     },
+     {
+      "name": "x-xss-protection",
+      "value": "1; mode=block"
+     }
+    ],
+    "_transferSize": 8394,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "46",
+   "serverIPAddress": "142.93.108.123",
+   "timings": {
+    "blocked": 0.494,
+    "dns": -1,
+    "connect": -1,
+    "send": 0.06,
+    "wait": 33.361,
+    "receive": 1.576,
+    "ssl": -1,
+    "_queued": 0.305
+   },
+   "_requestTime": 186182.089366,
+   "_chunks": [
+    {
+     "ts": 36.588,
+     "bytes": 30175
+    }
+   ]
+  }
+ ]
+}

--- a/src/chrome-devtools/lib/har/__fixtures__/golden/navigatedWithinDocument.har.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/golden/navigatedWithinDocument.har.json
@@ -1,0 +1,199 @@
+{
+ "pages": [
+  {
+   "id": "page_1",
+   "startedDateTime": "2018-10-11T22:59:02.385Z",
+   "title": "https://dvajs.github.io/dva-hackernews/#/show",
+   "pageTimings": {}
+  }
+ ],
+ "entries": [
+  {
+   "cache": {},
+   "startedDateTime": "2018-10-11T22:59:02.385Z",
+   "_requestId": "1000000526.38",
+   "_initialPriority": "Low",
+   "_priority": "Low",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://dvajs.github.io/dva-hackernews/static/src__pages__show__index.40f2c771.async.js",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":authority",
+      "value": "dvajs.github.io"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":path",
+      "value": "/dva-hackernews/static/src__pages__show__index.40f2c771.async.js"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": "accept",
+      "value": "*/*"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-US,en;q=0.9"
+     },
+     {
+      "name": "referer",
+      "value": "https://dvajs.github.io/dva-hackernews/"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 119.18499999999999,
+   "_initiator_detail": "{\"stack\":{\"callFrames\":[{\"columnNumber\":1542,\"functionName\":\"e.e\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":447799,\"functionName\":\"\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":450536,\"functionName\":\"value\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":450345,\"functionName\":\"n\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":152501,\"functionName\":\"constructClassInstance\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":162834,\"functionName\":\"beginWork\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":174999,\"functionName\":\"o\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":175320,\"functionName\":\"a\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":175558,\"functionName\":\"u\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":179101,\"functionName\":\"E\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":178838,\"functionName\":\"w\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":177966,\"functionName\":\"d\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":177356,\"functionName\":\"p\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":151937,\"functionName\":\"enqueueSetState\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":131240,\"functionName\":\"o.setState\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":83092,\"functionName\":\"\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":50542,\"functionName\":\"n\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":50766,\"functionName\":\"\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":50737,\"functionName\":\"notifyListeners\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":54547,\"functionName\":\"O\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":54839,\"functionName\":\"\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":50435,\"functionName\":\"n\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":54795,\"functionName\":\"T\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"},{\"columnNumber\":54753,\"functionName\":\"S\",\"lineNumber\":0,\"scriptId\":\"21\",\"url\":\"https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js\"}]},\"type\":\"script\"}",
+   "_initiator_type": "script",
+   "_resourceType": "script",
+   "_initiator": "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js",
+   "_initiator_line": 1,
+   "_initiator_column": 1543,
+   "_initiator_function_name": "e.e",
+   "_initiator_script_id": "21",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "application/javascript",
+     "size": 156
+    },
+    "headersSize": -1,
+    "bodySize": 355,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "accept-ranges",
+      "value": "bytes"
+     },
+     {
+      "name": "access-control-allow-origin",
+      "value": "*"
+     },
+     {
+      "name": "age",
+      "value": "0"
+     },
+     {
+      "name": "cache-control",
+      "value": "max-age=600"
+     },
+     {
+      "name": "content-length",
+      "value": "156"
+     },
+     {
+      "name": "content-type",
+      "value": "application/javascript; charset=utf-8"
+     },
+     {
+      "name": "date",
+      "value": "Thu, 11 Oct 2018 22:59:02 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "\"5a91196f-9c\""
+     },
+     {
+      "name": "expires",
+      "value": "Thu, 11 Oct 2018 22:04:05 GMT"
+     },
+     {
+      "name": "last-modified",
+      "value": "Sat, 24 Feb 2018 07:51:11 GMT"
+     },
+     {
+      "name": "server",
+      "value": "GitHub.com"
+     },
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=31557600"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "via",
+      "value": "1.1 varnish"
+     },
+     {
+      "name": "x-cache",
+      "value": "HIT"
+     },
+     {
+      "name": "x-cache-hits",
+      "value": "1"
+     },
+     {
+      "name": "x-fastly-request-id",
+      "value": "309f2fa6efeeb8dcc5a7b8fc86f40bc4bf4e790c"
+     },
+     {
+      "name": "x-github-request-id",
+      "value": "A074:029E:CD930:107B9F:5BBFC67D"
+     },
+     {
+      "name": "x-served-by",
+      "value": "cache-bma1649-BMA"
+     },
+     {
+      "name": "x-timer",
+      "value": "S1539298742.367525,VS0,VE114"
+     }
+    ],
+    "_transferSize": 355,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "40",
+   "serverIPAddress": "185.199.109.153",
+   "timings": {
+    "blocked": 0.606,
+    "dns": -1,
+    "connect": -1,
+    "send": 0.486,
+    "wait": 117.27,
+    "receive": 0.823,
+    "ssl": -1,
+    "_queued": 0.578
+   },
+   "_requestTime": 310790.369062,
+   "_chunks": [
+    {
+     "ts": 120.29,
+     "bytes": 156
+    }
+   ]
+  }
+ ]
+}

--- a/src/chrome-devtools/lib/har/__fixtures__/golden/response-blocked-cookies.har.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/golden/response-blocked-cookies.har.json
@@ -1,0 +1,899 @@
+{
+ "pages": [
+  {
+   "id": "page_1",
+   "startedDateTime": "2020-07-29T04:52:29.332Z",
+   "title": "https://1j7om.csb.app/",
+   "pageTimings": {
+    "onContentLoad": 391.291,
+    "onLoad": 1785.613
+   }
+  }
+ ],
+ "entries": [
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T04:52:29.333Z",
+   "_requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://1j7om.csb.app/",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "1j7om.csb.app"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/"
+     },
+     {
+      "name": "upgrade-insecure-requests",
+      "value": "1"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "none"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "navigate"
+     },
+     {
+      "name": "sec-fetch-user",
+      "value": "?1"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "document"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 371.669,
+   "_initiator_detail": "{\"type\":\"other\"}",
+   "_initiator_type": "other",
+   "_resourceType": "document",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/html",
+     "size": 229
+    },
+    "headersSize": -1,
+    "bodySize": 657,
+    "cookies": [
+     {
+      "name": "__cfduid",
+      "value": "da0f64c008e4700b2ef1278a954bbfaab1595998349",
+      "path": "/",
+      "domain": "csb.app",
+      "expires": "2020-08-28T04:52:29.000Z",
+      "httpOnly": true,
+      "secure": false
+     },
+     {
+      "name": "signedIn",
+      "value": "",
+      "path": "/",
+      "expires": "1970-01-01T00:00:00.000Z",
+      "httpOnly": true,
+      "secure": false
+     }
+    ],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Wed, 29 Jul 2020 04:52:29 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "text/html"
+     },
+     {
+      "name": "set-cookie",
+      "value": "__cfduid=da0f64c008e4700b2ef1278a954bbfaab1595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax\nsignedIn=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; max-age=0; HttpOnly"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "cache-control",
+      "value": "private, max-age=0, no-cache, no-store"
+     },
+     {
+      "name": "x-request-id",
+      "value": "FiYgCwONI2AAty-jgboB"
+     },
+     {
+      "name": "via",
+      "value": "1.1 google"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "DYNAMIC"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "043a83409e000016c9312cf200000001"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "cf-ray",
+      "value": "5ba43b1438bf16c9-SYD"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     }
+    ],
+    "_transferSize": 657,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "27",
+   "serverIPAddress": "104.18.26.114",
+   "timings": {
+    "blocked": 0.201,
+    "dns": 18.628,
+    "connect": 40.34,
+    "send": 0.156,
+    "wait": 311.86,
+    "receive": 0.484,
+    "ssl": 26.829,
+    "_queued": 0.66
+   },
+   "_requestTime": 105304.900931,
+   "_chunks": [
+    {
+     "ts": 388.224,
+     "bytes": 229
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T04:52:29.724Z",
+   "_requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://ow5u1.sse.codesandbox.io/",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "ow5u1.sse.codesandbox.io"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/"
+     },
+     {
+      "name": "upgrade-insecure-requests",
+      "value": "1"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "navigate"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "iframe"
+     },
+     {
+      "name": "referer",
+      "value": "https://1j7om.csb.app/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 419.096,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://1j7om.csb.app/\",\"lineNumber\":3}",
+   "_initiator_type": "parser",
+   "_resourceType": "document",
+   "_initiator": "https://1j7om.csb.app/",
+   "_initiator_line": 4,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/html",
+     "size": 363
+    },
+    "headersSize": -1,
+    "bodySize": 792,
+    "cookies": [
+     {
+      "name": "super-secret-cookie",
+      "value": "s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok",
+      "path": "/",
+      "expires": "2020-07-29T04:53:30.000Z",
+      "httpOnly": true,
+      "secure": false
+     }
+    ],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Wed, 29 Jul 2020 04:52:30 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "text/html; charset=utf-8"
+     },
+     {
+      "name": "set-cookie",
+      "value": "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure\nsuper-secret-cookie=s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok; Path=/; Expires=Wed, 29 Jul 2020 04:53:30 GMT; HttpOnly"
+     },
+     {
+      "name": "cf-ray",
+      "value": "5ba43b169e1eda52-SYD"
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=15724800; includeSubDomains"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "DYNAMIC"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "043a83421c0000da528939e200000001"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "x-powered-by",
+      "value": "Express"
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+     }
+    ],
+    "_transferSize": 792,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "42",
+   "serverIPAddress": "104.18.23.207",
+   "timings": {
+    "blocked": 0.236,
+    "dns": 15.413,
+    "connect": 36.184,
+    "send": 0.092,
+    "wait": 366.496,
+    "receive": 0.675,
+    "ssl": 24.921,
+    "_queued": 1.034
+   },
+   "_requestTime": 105305.292368,
+   "_chunks": [
+    {
+     "ts": 817.581,
+     "bytes": 363
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T04:52:30.151Z",
+   "_requestId": "45305.3",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://ow5u1.sse.codesandbox.io/style.css",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "Referer",
+      "value": "https://ow5u1.sse.codesandbox.io/"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 368.06,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://ow5u1.sse.codesandbox.io/\",\"lineNumber\":5}",
+   "_initiator_type": "parser",
+   "_resourceType": "stylesheet",
+   "_initiator": "https://ow5u1.sse.codesandbox.io/",
+   "_initiator_line": 6,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/css",
+     "size": 1842,
+     "compression": 960
+    },
+    "headersSize": -1,
+    "bodySize": 882,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Wed, 29 Jul 2020 04:52:30 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "text/css; charset=UTF-8"
+     },
+     {
+      "name": "set-cookie",
+      "value": "__cfduid=d1a3eeb06208778c719235145dfee08521595998350; expires=Fri, 28-Aug-20 04:52:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure"
+     },
+     {
+      "name": "cf-ray",
+      "value": "5ba43b18e992da52-SYD"
+     },
+     {
+      "name": "cache-control",
+      "value": "public, max-age=0"
+     },
+     {
+      "name": "etag",
+      "value": "W/\"732-17398e8d619\""
+     },
+     {
+      "name": "last-modified",
+      "value": "Wed, 29 Jul 2020 04:51:02 GMT"
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=15724800; includeSubDomains"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "DYNAMIC"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "043a8343940000da52893ab200000001"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "x-powered-by",
+      "value": "Express"
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+     }
+    ],
+    "_transferSize": 882,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "42",
+   "serverIPAddress": "104.18.23.207",
+   "timings": {
+    "blocked": 0.232,
+    "dns": -1,
+    "connect": -1,
+    "send": 0.914,
+    "wait": 366.519,
+    "receive": 0.395,
+    "ssl": -1,
+    "_queued": 0.558
+   },
+   "_requestTime": 105305.719385,
+   "_chunks": [
+    {
+     "ts": 1188.316,
+     "bytes": 1842
+    },
+    {
+     "ts": 1188.64,
+     "bytes": 0
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T04:52:30.152Z",
+   "_requestId": "45305.4",
+   "_initialPriority": "High",
+   "_priority": "High",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://sse-0.codesandbox.io/client-hook-3.js",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "Referer",
+      "value": "https://ow5u1.sse.codesandbox.io/"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "sse-0.codesandbox.io"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/client-hook-3.js"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "*/*"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "same-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "no-cors"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "script"
+     },
+     {
+      "name": "referer",
+      "value": "https://ow5u1.sse.codesandbox.io/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 955.4610000000001,
+   "_initiator_detail": "{\"type\":\"parser\",\"url\":\"https://ow5u1.sse.codesandbox.io/\",\"lineNumber\":6}",
+   "_initiator_type": "parser",
+   "_resourceType": "script",
+   "_initiator": "https://ow5u1.sse.codesandbox.io/",
+   "_initiator_line": 7,
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "application/javascript",
+     "size": 19255,
+     "compression": 12972
+    },
+    "headersSize": -1,
+    "bodySize": 6283,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "server",
+      "value": "nginx/1.17.10"
+     },
+     {
+      "name": "date",
+      "value": "Wed, 29 Jul 2020 04:52:31 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "application/javascript; charset=utf-8"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "cache-control",
+      "value": "max-age=0"
+     },
+     {
+      "name": "last-modified",
+      "value": "Mon, 20 Jul 2020 15:47:27 GMT"
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=15724800; includeSubDomains"
+     },
+     {
+      "name": "content-encoding",
+      "value": "gzip"
+     }
+    ],
+    "_transferSize": 6283,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "57",
+   "serverIPAddress": "5.9.114.19",
+   "timings": {
+    "blocked": 0.339,
+    "dns": 16.097,
+    "connect": 619.311,
+    "send": 0.083,
+    "wait": 314.819,
+    "receive": 4.812,
+    "ssl": 319.182,
+    "_queued": 0.705
+   },
+   "_requestTime": 105305.719941,
+   "_chunks": [
+    {
+     "ts": 1774.795,
+     "bytes": 16384
+    },
+    {
+     "ts": 1775.232,
+     "bytes": 2871
+    },
+    {
+     "ts": 1775.557,
+     "bytes": 0
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T04:52:31.121Z",
+   "_requestId": "45305.7",
+   "_initialPriority": "High",
+   "_priority": "High",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://1j7om.csb.app/favicon.ico",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [
+     {
+      "name": "__cfduid",
+      "value": "da0f64c008e4700b2ef1278a954bbfaab1595998349",
+      "path": "/",
+      "domain": ".csb.app",
+      "expires": "1970-01-19T12:03:10.349Z",
+      "httpOnly": true,
+      "secure": false
+     }
+    ],
+    "headers": [
+     {
+      "name": "Referer",
+      "value": "https://1j7om.csb.app/"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "1j7om.csb.app"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/favicon.ico"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "image/webp,image/apng,image/*,*/*;q=0.8"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "same-origin"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "no-cors"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "image"
+     },
+     {
+      "name": "referer",
+      "value": "https://1j7om.csb.app/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     },
+     {
+      "name": "cookie",
+      "value": "__cfduid=da0f64c008e4700b2ef1278a954bbfaab1595998349"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 359.53499999999997,
+   "_initiator_detail": "{\"type\":\"other\"}",
+   "_initiator_type": "other",
+   "_resourceType": "other",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "image/x-icon",
+     "size": 15086,
+     "compression": 12886
+    },
+    "headersSize": -1,
+    "bodySize": 2200,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Wed, 29 Jul 2020 04:52:31 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "image/x-icon"
+     },
+     {
+      "name": "last-modified",
+      "value": "Mon, 27 Jul 2020 12:13:58 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "W/\"5f1ec506-3aee\""
+     },
+     {
+      "name": "via",
+      "value": "1.1 google"
+     },
+     {
+      "name": "alt-svc",
+      "value": "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+     },
+     {
+      "name": "cf-cache-status",
+      "value": "REVALIDATED"
+     },
+     {
+      "name": "expires",
+      "value": "Wed, 29 Jul 2020 08:52:31 GMT"
+     },
+     {
+      "name": "cache-control",
+      "value": "public, max-age=14400"
+     },
+     {
+      "name": "cf-request-id",
+      "value": "043a83475c000016c931346200000001"
+     },
+     {
+      "name": "expect-ct",
+      "value": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "server",
+      "value": "cloudflare"
+     },
+     {
+      "name": "cf-ray",
+      "value": "5ba43b1efb9d16c9-SYD"
+     },
+     {
+      "name": "content-encoding",
+      "value": "br"
+     }
+    ],
+    "_transferSize": 2200,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "27",
+   "serverIPAddress": "104.18.26.114",
+   "timings": {
+    "blocked": 0.211,
+    "dns": -1,
+    "connect": -1,
+    "send": 0.126,
+    "wait": 358.721,
+    "receive": 0.477,
+    "ssl": -1,
+    "_queued": 0.317
+   },
+   "_requestTime": 105306.688854,
+   "_chunks": [
+    {
+     "ts": 2148.946,
+     "bytes": 15086
+    },
+    {
+     "ts": 2149.366,
+     "bytes": 0
+    }
+   ]
+  }
+ ]
+}

--- a/src/chrome-devtools/lib/har/__fixtures__/golden/samesite-sandbox.glitch.me.har.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/golden/samesite-sandbox.glitch.me.har.json
@@ -1,0 +1,817 @@
+{
+ "pages": [
+  {
+   "id": "page_1",
+   "startedDateTime": "2020-07-29T03:49:00.608Z",
+   "title": "https://samesite-sandbox.glitch.me/",
+   "pageTimings": {
+    "onContentLoad": 1036.245,
+    "onLoad": 1921.607
+   }
+  }
+ ],
+ "entries": [
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T03:49:00.609Z",
+   "_requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://samesite-sandbox.glitch.me/",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "samesite-sandbox.glitch.me"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/"
+     },
+     {
+      "name": "upgrade-insecure-requests",
+      "value": "1"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "none"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "navigate"
+     },
+     {
+      "name": "sec-fetch-user",
+      "value": "?1"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "document"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 886.834,
+   "_initiator_detail": "{\"type\":\"other\"}",
+   "_initiator_type": "other",
+   "_resourceType": "document",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/html",
+     "size": 10494
+    },
+    "headersSize": -1,
+    "bodySize": 10985,
+    "cookies": [
+     {
+      "name": "ck03",
+      "value": "vl03",
+      "httpOnly": false,
+      "secure": false
+     },
+     {
+      "name": "ck00",
+      "value": "vl00",
+      "path": "/",
+      "httpOnly": false,
+      "secure": false
+     },
+     {
+      "name": "ck01",
+      "value": "vl01",
+      "path": "/",
+      "httpOnly": false,
+      "secure": true
+     },
+     {
+      "name": "ck02",
+      "value": "vl02",
+      "path": "/",
+      "httpOnly": false,
+      "secure": false
+     },
+     {
+      "name": "ck04",
+      "value": "vl04",
+      "path": "/",
+      "httpOnly": false,
+      "secure": false
+     },
+     {
+      "name": "ck05",
+      "value": "vl05",
+      "path": "/",
+      "httpOnly": false,
+      "secure": false
+     }
+    ],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Wed, 29 Jul 2020 03:49:01 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "text/html; charset=UTF-8"
+     },
+     {
+      "name": "content-length",
+      "value": "10494"
+     },
+     {
+      "name": "x-powered-by",
+      "value": "Express"
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=63072000; inlcudeSubdomains; preload"
+     },
+     {
+      "name": "referrer-policy",
+      "value": "strict-origin-when-cross-origin"
+     },
+     {
+      "name": "set-cookie",
+      "value": "ck03=vl03; SameSite=InvalidValue\nck00=vl00; Path=/\nck01=vl01; Path=/; Secure; SameSite=None\nck02=vl02; Path=/; SameSite=None\nck04=vl04; Path=/; SameSite=Lax\nck05=vl05; Path=/; SameSite=Strict"
+     },
+     {
+      "name": "accept-ranges",
+      "value": "bytes"
+     },
+     {
+      "name": "cache-control",
+      "value": "public, max-age=0"
+     },
+     {
+      "name": "last-modified",
+      "value": "Thu, 26 Mar 2020 12:31:57 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "W/\"28fe-17116d3e248\""
+     }
+    ],
+    "_transferSize": 10985,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "27",
+   "serverIPAddress": "54.164.246.13",
+   "timings": {
+    "blocked": 0.219,
+    "dns": 16.139,
+    "connect": 437.532,
+    "send": 0.087,
+    "wait": 432.289,
+    "receive": 0.568,
+    "ssl": 224.861,
+    "_queued": 0.652
+   },
+   "_requestTime": 101502.530878,
+   "_chunks": [
+    {
+     "ts": 901.065,
+     "bytes": 10494
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T03:49:01.646Z",
+   "_requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+   "_initialPriority": "VeryHigh",
+   "_priority": "VeryHigh",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "googlechromelabs.github.io"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/samesite-examples/crosssite-embed.html"
+     },
+     {
+      "name": "upgrade-insecure-requests",
+      "value": "1"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "navigate"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "iframe"
+     },
+     {
+      "name": "referer",
+      "value": "https://samesite-sandbox.glitch.me/"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 874.4,
+   "_initiator_detail": "{\"type\":\"script\",\"stack\":{\"callFrames\":[{\"functionName\":\"\",\"scriptId\":\"13\",\"url\":\"https://samesite-sandbox.glitch.me/\",\"lineNumber\":372,\"columnNumber\":18}]}}",
+   "_initiator_type": "script",
+   "_resourceType": "document",
+   "_initiator": "https://samesite-sandbox.glitch.me/",
+   "_initiator_line": 373,
+   "_initiator_column": 19,
+   "_initiator_function_name": "",
+   "_initiator_script_id": "13",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "text/html",
+     "size": 697
+    },
+    "headersSize": -1,
+    "bodySize": 796,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "content-type",
+      "value": "text/html; charset=utf-8"
+     },
+     {
+      "name": "server",
+      "value": "GitHub.com"
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=31556952"
+     },
+     {
+      "name": "last-modified",
+      "value": "Thu, 02 Apr 2020 11:29:48 GMT"
+     },
+     {
+      "name": "etag",
+      "value": "W/\"5e85ccac-2b9\""
+     },
+     {
+      "name": "access-control-allow-origin",
+      "value": "*"
+     },
+     {
+      "name": "expires",
+      "value": "Wed, 29 Jul 2020 03:48:56 GMT"
+     },
+     {
+      "name": "cache-control",
+      "value": "max-age=600"
+     },
+     {
+      "name": "content-encoding",
+      "value": "gzip"
+     },
+     {
+      "name": "x-proxy-cache",
+      "value": "MISS"
+     },
+     {
+      "name": "x-github-request-id",
+      "value": "16B8:5823:26B58:32FB9:5F20EF50"
+     },
+     {
+      "name": "accept-ranges",
+      "value": "bytes"
+     },
+     {
+      "name": "date",
+      "value": "Wed, 29 Jul 2020 03:49:02 GMT"
+     },
+     {
+      "name": "via",
+      "value": "1.1 varnish"
+     },
+     {
+      "name": "age",
+      "value": "0"
+     },
+     {
+      "name": "x-served-by",
+      "value": "cache-syd10121-SYD"
+     },
+     {
+      "name": "x-cache",
+      "value": "HIT"
+     },
+     {
+      "name": "x-cache-hits",
+      "value": "1"
+     },
+     {
+      "name": "x-timer",
+      "value": "S1595994542.820717,VS0,VE804"
+     },
+     {
+      "name": "vary",
+      "value": "Accept-Encoding"
+     },
+     {
+      "name": "x-fastly-request-id",
+      "value": "2a80e9628aaf66d0eac077a1eb53e623008b2cae"
+     },
+     {
+      "name": "content-length",
+      "value": "409"
+     }
+    ],
+    "_transferSize": 796,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "42",
+   "serverIPAddress": "185.199.108.153",
+   "timings": {
+    "blocked": 0.576,
+    "dns": 25.522,
+    "connect": 32.225,
+    "send": 0.096,
+    "wait": 815.707,
+    "receive": 0.274,
+    "ssl": 20.667,
+    "_queued": 1.573
+   },
+   "_requestTime": 101503.568005,
+   "_chunks": [
+    {
+     "ts": 1919.008,
+     "bytes": 697
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T03:49:02.529Z",
+   "_requestId": "13720.3",
+   "_initialPriority": "High",
+   "_priority": "High",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://samesite-sandbox.glitch.me/cookies.json",
+    "queryString": [],
+    "headersSize": -1,
+    "bodySize": 0,
+    "cookies": [
+     {
+      "name": "ck03",
+      "value": "vl03",
+      "path": "/",
+      "domain": "samesite-sandbox.glitch.me",
+      "expires": "1969-12-31T23:59:59.999Z",
+      "httpOnly": false,
+      "secure": false
+     },
+     {
+      "name": "ck00",
+      "value": "vl00",
+      "path": "/",
+      "domain": "samesite-sandbox.glitch.me",
+      "expires": "1969-12-31T23:59:59.999Z",
+      "httpOnly": false,
+      "secure": false
+     },
+     {
+      "name": "ck01",
+      "value": "vl01",
+      "path": "/",
+      "domain": "samesite-sandbox.glitch.me",
+      "expires": "1969-12-31T23:59:59.999Z",
+      "httpOnly": false,
+      "secure": true
+     },
+     {
+      "name": "ck02",
+      "value": "vl02",
+      "path": "/",
+      "domain": "samesite-sandbox.glitch.me",
+      "expires": "1969-12-31T23:59:59.999Z",
+      "httpOnly": false,
+      "secure": false
+     }
+    ],
+    "headers": [
+     {
+      "name": "Referer",
+      "value": "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": ":method",
+      "value": "GET"
+     },
+     {
+      "name": ":authority",
+      "value": "samesite-sandbox.glitch.me"
+     },
+     {
+      "name": ":scheme",
+      "value": "https"
+     },
+     {
+      "name": ":path",
+      "value": "/cookies.json"
+     },
+     {
+      "name": "user-agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "accept",
+      "value": "*/*"
+     },
+     {
+      "name": "origin",
+      "value": "https://googlechromelabs.github.io"
+     },
+     {
+      "name": "sec-fetch-site",
+      "value": "cross-site"
+     },
+     {
+      "name": "sec-fetch-mode",
+      "value": "cors"
+     },
+     {
+      "name": "sec-fetch-dest",
+      "value": "empty"
+     },
+     {
+      "name": "referer",
+      "value": "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html"
+     },
+     {
+      "name": "accept-encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "accept-language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     },
+     {
+      "name": "cookie",
+      "value": "ck03=vl03; ck00=vl00; ck01=vl01; ck02=vl02"
+     }
+    ],
+    "httpVersion": "h2"
+   },
+   "time": 229.1,
+   "_initiator_detail": "{\"type\":\"script\",\"stack\":{\"callFrames\":[{\"functionName\":\"fetchCookies\",\"scriptId\":\"17\",\"url\":\"https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html\",\"lineNumber\":16,\"columnNumber\":8},{\"functionName\":\"\",\"scriptId\":\"17\",\"url\":\"https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html\",\"lineNumber\":19,\"columnNumber\":2}]}}",
+   "_initiator_type": "script",
+   "_resourceType": "xhr",
+   "_initiator": "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+   "_initiator_line": 17,
+   "_initiator_column": 9,
+   "_initiator_function_name": "fetchCookies",
+   "_initiator_script_id": "17",
+   "response": {
+    "httpVersion": "h2",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "",
+    "content": {
+     "mimeType": "application/json",
+     "size": 57
+    },
+    "headersSize": -1,
+    "bodySize": 315,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "status",
+      "value": "200"
+     },
+     {
+      "name": "date",
+      "value": "Wed, 29 Jul 2020 03:49:02 GMT"
+     },
+     {
+      "name": "content-type",
+      "value": "application/json; charset=utf-8"
+     },
+     {
+      "name": "content-length",
+      "value": "57"
+     },
+     {
+      "name": "x-powered-by",
+      "value": "Express"
+     },
+     {
+      "name": "strict-transport-security",
+      "value": "max-age=63072000; inlcudeSubdomains; preload"
+     },
+     {
+      "name": "access-control-allow-origin",
+      "value": "https://googlechromelabs.github.io"
+     },
+     {
+      "name": "access-control-allow-credentials",
+      "value": "true"
+     },
+     {
+      "name": "etag",
+      "value": "W/\"39-P/NBn2GNcAA8yGJ1I79HEa1fh8I\""
+     }
+    ],
+    "_transferSize": 315,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "27",
+   "serverIPAddress": "54.164.246.13",
+   "timings": {
+    "blocked": 0.247,
+    "dns": -1,
+    "connect": -1,
+    "send": 0.128,
+    "wait": 227.72,
+    "receive": 1.005,
+    "ssl": -1,
+    "_queued": 0.433
+   },
+   "_requestTime": 101504.450842,
+   "_chunks": [
+    {
+     "ts": 2151.254,
+     "bytes": 57
+    }
+   ]
+  },
+  {
+   "cache": {},
+   "startedDateTime": "2020-07-29T03:49:02.531Z",
+   "_requestId": "13720.4",
+   "_initialPriority": "High",
+   "_priority": "High",
+   "pageref": "page_1",
+   "request": {
+    "method": "GET",
+    "url": "https://cdn.glitch.com/e304e580-9956-4cb6-9f62-9e89ad6cd85f%2Fcookie.png?v=1572981153632",
+    "queryString": [
+     {
+      "name": "v",
+      "value": "1572981153632"
+     }
+    ],
+    "headersSize": 719,
+    "bodySize": 0,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "Referer",
+      "value": "https://samesite-sandbox.glitch.me/"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "Host",
+      "value": "cdn.glitch.com"
+     },
+     {
+      "name": "Connection",
+      "value": "keep-alive"
+     },
+     {
+      "name": "User-Agent",
+      "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+     },
+     {
+      "name": "Accept",
+      "value": "image/webp,image/apng,image/*,*/*;q=0.8"
+     },
+     {
+      "name": "Sec-Fetch-Site",
+      "value": "cross-site"
+     },
+     {
+      "name": "Sec-Fetch-Mode",
+      "value": "no-cors"
+     },
+     {
+      "name": "Sec-Fetch-Dest",
+      "value": "image"
+     },
+     {
+      "name": "Referer",
+      "value": "https://samesite-sandbox.glitch.me/"
+     },
+     {
+      "name": "Accept-Encoding",
+      "value": "gzip, deflate, br"
+     },
+     {
+      "name": "Accept-Language",
+      "value": "en-GB,en-US;q=0.9,en;q=0.8"
+     }
+    ],
+    "httpVersion": "http/1.1"
+   },
+   "time": 459.499,
+   "_initiator_detail": "{\"type\":\"other\"}",
+   "_initiator_type": "other",
+   "_resourceType": "other",
+   "response": {
+    "httpVersion": "http/1.1",
+    "redirectURL": "",
+    "status": 200,
+    "statusText": "OK",
+    "content": {
+     "mimeType": "image/png",
+     "size": 10010
+    },
+    "headersSize": 587,
+    "bodySize": 10010,
+    "cookies": [],
+    "headers": [
+     {
+      "name": "Content-Type",
+      "value": "image/png"
+     },
+     {
+      "name": "Content-Length",
+      "value": "10010"
+     },
+     {
+      "name": "Connection",
+      "value": "keep-alive"
+     },
+     {
+      "name": "Date",
+      "value": "Mon, 22 Jun 2020 10:05:03 GMT"
+     },
+     {
+      "name": "Access-Control-Allow-Origin",
+      "value": "*"
+     },
+     {
+      "name": "Access-Control-Allow-Methods",
+      "value": "GET, HEAD, POST"
+     },
+     {
+      "name": "Access-Control-Max-Age",
+      "value": "86400"
+     },
+     {
+      "name": "Cache-Control",
+      "value": "max-age=31536000"
+     },
+     {
+      "name": "Last-Modified",
+      "value": "Tue, 05 Nov 2019 19:12:33 GMT"
+     },
+     {
+      "name": "ETag",
+      "value": "\"4fc7568972cffeaa3b02ff05668179d4\""
+     },
+     {
+      "name": "Server",
+      "value": "AmazonS3"
+     },
+     {
+      "name": "X-Cache",
+      "value": "Hit from cloudfront"
+     },
+     {
+      "name": "Via",
+      "value": "1.1 0cd88f29d8c6e29a267867c45efda9a9.cloudfront.net (CloudFront)"
+     },
+     {
+      "name": "X-Amz-Cf-Pop",
+      "value": "SIN52-C2"
+     },
+     {
+      "name": "X-Amz-Cf-Id",
+      "value": "POKa3J20B_ZaSB17GG2WukHAyh4lRGmfUCfk-PtMyGfmGK6f7VbSYg=="
+     },
+     {
+      "name": "Age",
+      "value": "3174242"
+     }
+    ],
+    "_transferSize": 10597,
+    "fromDiskCache": false,
+    "fromEarlyHints": false,
+    "fromServiceWorker": false,
+    "fromPrefetchCache": false
+   },
+   "connection": "57",
+   "serverIPAddress": "13.225.5.120",
+   "timings": {
+    "blocked": 0.141,
+    "dns": 19.67,
+    "connect": 328.469,
+    "send": 0.194,
+    "wait": 110.103,
+    "receive": 0.922,
+    "ssl": 225.277,
+    "_queued": 0.264
+   },
+   "_requestTime": 101504.453423,
+   "_chunks": [
+    {
+     "ts": 2382.954,
+     "bytes": 10010
+    },
+    {
+     "ts": 2383.994,
+     "bytes": 0
+    }
+   ]
+  }
+ ]
+}

--- a/src/chrome-devtools/lib/har/__fixtures__/iframe-not-attached.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/iframe-not-attached.json
@@ -1,0 +1,3413 @@
+[
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "46AD3CF2705CD8368F42EFBB99186D47",
+      "name": "commit",
+      "timestamp": 162823.133475
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "46AD3CF2705CD8368F42EFBB99186D47",
+      "name": "DOMContentLoaded",
+      "timestamp": 162823.133547
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "46AD3CF2705CD8368F42EFBB99186D47",
+      "name": "load",
+      "timestamp": 162823.13368
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "46AD3CF2705CD8368F42EFBB99186D47",
+      "name": "networkAlmostIdle",
+      "timestamp": 162823.134021
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "46AD3CF2705CD8368F42EFBB99186D47",
+      "name": "networkIdle",
+      "timestamp": 162823.134021
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "4355017A2060DF8B961B1AD927083EAA",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "documentURL": "https://qduej.csb.app/",
+      "request": {
+        "url": "https://qduej.csb.app/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162823.188838,
+      "wallTime": 1590380010.017048,
+      "initiator": { "type": "other" },
+      "type": "Document",
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "4355017A2060DF8B961B1AD927083EAA",
+      "blockedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "qduej.csb.app",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "none",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-user": "?1",
+        "sec-fetch-dest": "document",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "4355017A2060DF8B961B1AD927083EAA",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Mon, 25 May 2020 04:13:30 GMT",
+        "content-type": "text/html",
+        "set-cookie":
+          "__cfduid=dd980c511f388fad37f60c6500bc554891590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax",
+        "vary": "Accept-Encoding",
+        "cache-control": "private, max-age=0, no-cache, no-store",
+        "x-request-id": "FhIqMXMSH4WPHgAaEuvh",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+        "cf-cache-status": "DYNAMIC",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "server": "cloudflare",
+        "cf-ray": "598c6c974ebefe68-SYD",
+        "content-encoding": "br",
+        "cf-request-id": "02eba2328e0000fe683799c200000001"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "4355017A2060DF8B961B1AD927083EAA",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "timestamp": 162823.556284,
+      "type": "Document",
+      "response": {
+        "url": "https://qduej.csb.app/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "date": "Mon, 25 May 2020 04:13:30 GMT",
+          "content-type": "text/html",
+          "set-cookie":
+            "__cfduid=dd980c511f388fad37f60c6500bc554891590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax",
+          "vary": "Accept-Encoding",
+          "cache-control": "private, max-age=0, no-cache, no-store",
+          "x-request-id": "FhIqMXMSH4WPHgAaEuvh",
+          "via": "1.1 google",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "server": "cloudflare",
+          "cf-ray": "598c6c974ebefe68-SYD",
+          "content-encoding": "br",
+          "cf-request-id": "02eba2328e0000fe683799c200000001"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "qduej.csb.app",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "none",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-user": "?1",
+          "sec-fetch-dest": "document",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 27,
+        "remoteIPAddress": "104.18.26.114",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 477,
+        "timing": {
+          "requestTime": 162823.189828,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.261,
+          "dnsEnd": 18.845,
+          "connectStart": 18.845,
+          "connectEnd": 46.528,
+          "sslStart": 27.698,
+          "sslEnd": 46.524,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 46.619,
+          "sendEnd": 46.702,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 364.968
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": ["sni.cloudflaressl.com", "csb.app", "*.csb.app"],
+          "issuer": "CloudFlare Inc ECC CA-2",
+          "validFrom": 1563235200,
+          "validTo": 1594814400,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1563281916019,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100B59FBDDD94AEDE9A9C83539B805EFAB1416D8D977C9B85003AAF1E345E27955502205FCF9B3B5A65395AC1260BEB799FD7543B3F81D6D3D74D4F76A31AC1AEB64767"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Cloudflare 'Nimbus2020' Log",
+              "logId":
+                "5EA773F9DF56C0E7B536487DD049E0327A919A0C84A112128418759681714558",
+              "timestamp": 1563281915852,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3046022100D4D1B9D8087037081BCE37765AF9420A879AD564A00AF82F74781343F1030826022100E4014490A0A106AF3E65D2675BC3585EE37278795DE2A5C91514197469AF758C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429"
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "31436884AD20CBC87477AF1D2B5A5429" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "name": "init",
+      "timestamp": 162823.56389
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "31436884AD20CBC87477AF1D2B5A5429",
+        "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+        "url": "https://qduej.csb.app/",
+        "securityOrigin": "https://qduej.csb.app",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "4355017A2060DF8B961B1AD927083EAA",
+      "timestamp": 162823.574926,
+      "dataLength": 708,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "4355017A2060DF8B961B1AD927083EAA",
+      "timestamp": 162823.555406,
+      "encodedDataLength": 787,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.2",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "documentURL": "https://qduej.csb.app/",
+      "request": {
+        "url": "https://codesandbox.io/public/sse-hooks/sse-hooks.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://qduej.csb.app/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162823.576821,
+      "wallTime": 1590380010.404975,
+      "initiator": {
+        "type": "parser",
+        "url": "https://qduej.csb.app/",
+        "lineNumber": 3
+      },
+      "type": "Script",
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.3",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "documentURL": "https://qduej.csb.app/",
+      "request": {
+        "url": "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+        "method": "GET",
+        "headers": {
+          "Origin": "https://qduej.csb.app",
+          "Referer": "https://qduej.csb.app/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162823.577263,
+      "wallTime": 1590380010.405417,
+      "initiator": {
+        "type": "parser",
+        "url": "https://qduej.csb.app/",
+        "lineNumber": 17
+      },
+      "type": "Script",
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "83685.2",
+      "blockedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "codesandbox.io",
+        ":scheme": "https",
+        ":path": "/public/sse-hooks/sse-hooks.js",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "script",
+        "referer": "https://qduej.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "83685.3",
+      "blockedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "codesandbox.io",
+        ":scheme": "https",
+        ":path": "/static/js/watermark-button.b90db4dc7.js",
+        "origin": "https://qduej.csb.app",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "script",
+        "referer": "https://qduej.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "83685.2",
+      "blockedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookieLine":
+            "__cfduid=d925d936af841b02970a0c09c228bc9bd1590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
+          "cookie": {
+            "name": "__cfduid",
+            "value": "d925d936af841b02970a0c09c228bc9bd1590380010",
+            "domain": ".codesandbox.io",
+            "path": "/",
+            "expires": 1592972010.477253,
+            "size": 51,
+            "httpOnly": true,
+            "secure": true,
+            "session": false,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        "status": "200",
+        "date": "Mon, 25 May 2020 04:13:30 GMT",
+        "content-type": "application/javascript",
+        "set-cookie":
+          "__cfduid=d925d936af841b02970a0c09c228bc9bd1590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
+        "last-modified": "Sat, 18 Jan 2020 18:18:59 GMT",
+        "vary": "Accept-Encoding",
+        "etag": "W/\"5e234c13-4b37\"",
+        "expires": "Thu, 31 Dec 2037 23:55:55 GMT",
+        "cache-control": "max-age=315360000",
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+        "cf-cache-status": "HIT",
+        "age": "10905540",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "server": "cloudflare",
+        "cf-ray": "598c6c99bb30fd22-SYD",
+        "content-encoding": "br",
+        "cf-request-id": "02eba234100000fd2299b83200000001"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "83685.3",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Mon, 25 May 2020 04:13:30 GMT",
+        "content-type": "application/javascript",
+        "set-cookie":
+          "__cfduid=d239ee441e68fed7d9fdd3af885f2ad131590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
+        "last-modified": "Fri, 22 May 2020 11:44:40 GMT",
+        "vary": "Accept-Encoding",
+        "etag": "W/\"5ec7bb28-ae8\"",
+        "expires": "Thu, 31 Dec 2037 23:55:55 GMT",
+        "cache-control": "max-age=315360000",
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+        "cf-cache-status": "HIT",
+        "age": "16470",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "server": "cloudflare",
+        "cf-ray": "598c6c99bd1d65df-SYD",
+        "content-encoding": "br",
+        "cf-request-id": "02eba23413000065dff3bf6200000001"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.2",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "timestamp": 162823.650942,
+      "type": "Script",
+      "response": {
+        "url": "https://codesandbox.io/public/sse-hooks/sse-hooks.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Mon, 25 May 2020 04:13:30 GMT",
+          "via": "1.1 google",
+          "cf-cache-status": "HIT",
+          "age": "10905540",
+          "status": "200",
+          "content-encoding": "br",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+          "cf-request-id": "02eba234100000fd2299b83200000001",
+          "last-modified": "Sat, 18 Jan 2020 18:18:59 GMT",
+          "server": "cloudflare",
+          "etag": "W/\"5e234c13-4b37\"",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "vary": "Accept-Encoding",
+          "access-control-allow-methods": "GET",
+          "content-type": "application/javascript",
+          "access-control-allow-origin": "*",
+          "cache-control": "max-age=315360000",
+          "cf-ray": "598c6c99bb30fd22-SYD",
+          "expires": "Thu, 31 Dec 2037 23:55:55 GMT"
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": false,
+        "connectionId": 47,
+        "remoteIPAddress": "104.18.23.207",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 550,
+        "timing": {
+          "requestTime": 162823.577299,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.171,
+          "dnsEnd": 16.652,
+          "connectStart": 16.652,
+          "connectEnd": 43.931,
+          "sslStart": 27.315,
+          "sslEnd": 43.927,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 44.065,
+          "sendEnd": 44.198,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 71.779
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": [
+            "sni.cloudflaressl.com",
+            "*.codesandbox.io",
+            "codesandbox.io"
+          ],
+          "issuer": "CloudFlare Inc ECC CA-2",
+          "validFrom": 1582934400,
+          "validTo": 1602244800,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Pilot' log",
+              "logId":
+                "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+              "timestamp": 1582986738958,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450221008A22A483895A4F019A9948B4F89F7C8F242CDBC21117286866BB37A1A5CA5F58022025AFD95228907FE3652509513FDA464C15C6B12562BA0844D9A5E9531FA1AF28"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2020 Log",
+              "logId":
+                "F095A459F200D18240102D2F93888EAD4BFE1D47E399E1D034A6B0A8AA8EB273",
+              "timestamp": 1582986739009,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100AB3C58A5E4D1BE0EDEC5D1BE554DD93A2EFD98857FA5B344EC77173E36564F37022064DB548B7E0EA8B9E2EE55D88E34181CC0EB316B7CF4985F46B458D21531F93C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.2",
+      "timestamp": 162823.651058,
+      "dataLength": 19255,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.2",
+      "timestamp": 162823.650051,
+      "encodedDataLength": 6201,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.frameAttached",
+    "params": {
+      "frameId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "parentFrameId": "31436884AD20CBC87477AF1D2B5A5429"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "loaderId": "6C29B8E7CF0257C15579673F99E686EC",
+      "name": "init",
+      "timestamp": 162823.656646
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "loaderId": "6C29B8E7CF0257C15579673F99E686EC",
+      "name": "DOMContentLoaded",
+      "timestamp": 162823.657001
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "B6C52BA4191283DB2B514A0AA6507C5A" }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "8EA8D7896DF4A1423936BC7CF70715CA",
+      "loaderId": "8EA8D7896DF4A1423936BC7CF70715CA",
+      "documentURL":
+        "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/",
+      "request": {
+        "url":
+          "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+          "Referer": "https://qduej.csb.app/"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162823.659746,
+      "wallTime": 1590380010.487925,
+      "initiator": {
+        "type": "parser",
+        "url": "https://qduej.csb.app/",
+        "lineNumber": 15
+      },
+      "type": "Document",
+      "frameId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.3",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "timestamp": 162823.809847,
+      "type": "Script",
+      "response": {
+        "url": "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Mon, 25 May 2020 04:13:30 GMT",
+          "via": "1.1 google",
+          "cf-cache-status": "HIT",
+          "age": "16470",
+          "status": "200",
+          "content-encoding": "br",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+          "cf-request-id": "02eba23413000065dff3bf6200000001",
+          "last-modified": "Fri, 22 May 2020 11:44:40 GMT",
+          "server": "cloudflare",
+          "etag": "W/\"5ec7bb28-ae8\"",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "vary": "Accept-Encoding",
+          "access-control-allow-methods": "GET",
+          "content-type": "application/javascript",
+          "access-control-allow-origin": "*",
+          "cache-control": "max-age=315360000",
+          "cf-ray": "598c6c99bd1d65df-SYD",
+          "expires": "Thu, 31 Dec 2037 23:55:55 GMT"
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": false,
+        "connectionId": 48,
+        "remoteIPAddress": "104.18.23.207",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 547,
+        "timing": {
+          "requestTime": 162823.577895,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.147,
+          "dnsEnd": 16.132,
+          "connectStart": 16.132,
+          "connectEnd": 45.672,
+          "sslStart": 26.822,
+          "sslEnd": 45.669,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 45.743,
+          "sendEnd": 45.812,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 73.01
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": [
+            "sni.cloudflaressl.com",
+            "*.codesandbox.io",
+            "codesandbox.io"
+          ],
+          "issuer": "CloudFlare Inc ECC CA-2",
+          "validFrom": 1582934400,
+          "validTo": 1602244800,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Pilot' log",
+              "logId":
+                "A4B90990B418581487BB13A2CC67700A3C359804F91BDFB8E377CD0EC80DDC10",
+              "timestamp": 1582986738958,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450221008A22A483895A4F019A9948B4F89F7C8F242CDBC21117286866BB37A1A5CA5F58022025AFD95228907FE3652509513FDA464C15C6B12562BA0844D9A5E9531FA1AF28"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2020 Log",
+              "logId":
+                "F095A459F200D18240102D2F93888EAD4BFE1D47E399E1D034A6B0A8AA8EB273",
+              "timestamp": 1582986739009,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100AB3C58A5E4D1BE0EDEC5D1BE554DD93A2EFD98857FA5B344EC77173E36564F37022064DB548B7E0EA8B9E2EE55D88E34181CC0EB316B7CF4985F46B458D21531F93C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.3",
+      "timestamp": 162823.809918,
+      "dataLength": 2792,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.3",
+      "timestamp": 162823.811143,
+      "dataLength": 0,
+      "encodedDataLength": 1185
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.3",
+      "timestamp": 162823.651233,
+      "encodedDataLength": 1732,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": { "timestamp": 162823.812385 }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "name": "DOMContentLoaded",
+      "timestamp": 162823.812385
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "8EA8D7896DF4A1423936BC7CF70715CA",
+      "blockedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority":
+          "deploy-preview-26--michaeldijkstra-netlify-test.netlify.app",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-dest": "iframe",
+        "referer": "https://qduej.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "8EA8D7896DF4A1423936BC7CF70715CA",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "cache-control": "public, max-age=0, must-revalidate",
+        "content-length": "215",
+        "content-type": "text/html; charset=UTF-8",
+        "date": "Mon, 25 May 2020 03:30:54 GMT",
+        "etag": "\"a09a28bcb712a003aa33d497f1b42b1e-ssl\"",
+        "strict-transport-security": "max-age=31536000",
+        "x-robots-tag": "noindex",
+        "age": "2556",
+        "server": "Netlify",
+        "x-nf-request-id": "73febc57-cf41-4661-ae21-14b0e37eff44-32126039"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "8EA8D7896DF4A1423936BC7CF70715CA",
+      "loaderId": "8EA8D7896DF4A1423936BC7CF70715CA",
+      "timestamp": 162823.827662,
+      "type": "Document",
+      "response": {
+        "url":
+          "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "cache-control": "public, max-age=0, must-revalidate",
+          "content-length": "215",
+          "content-type": "text/html; charset=UTF-8",
+          "date": "Mon, 25 May 2020 03:30:54 GMT",
+          "etag": "\"a09a28bcb712a003aa33d497f1b42b1e-ssl\"",
+          "strict-transport-security": "max-age=31536000",
+          "x-robots-tag": "noindex",
+          "age": "2556",
+          "server": "Netlify",
+          "x-nf-request-id": "73febc57-cf41-4661-ae21-14b0e37eff44-32126039"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority":
+            "deploy-preview-26--michaeldijkstra-netlify-test.netlify.app",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "cross-site",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-dest": "iframe",
+          "referer": "https://qduej.csb.app/",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 60,
+        "remoteIPAddress": "54.206.19.82",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 209,
+        "timing": {
+          "requestTime": 162823.660227,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.156,
+          "dnsEnd": 130.519,
+          "connectStart": 130.519,
+          "connectEnd": 157.381,
+          "sslStart": 141.196,
+          "sslEnd": 157.375,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 157.636,
+          "sendEnd": 157.794,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 166.644
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "*.netlify.app",
+          "sanList": ["*.netlify.app", "netlify.app"],
+          "issuer": "AlphaSSL CA - SHA256 - G2",
+          "validFrom": 1583320626,
+          "validTo": 1614943026,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Sectigo 'Sabre' CT log",
+              "logId":
+                "5581D4C2169036014AEA0B9B573C53F0C0E43878702508172FA3AA1D0713D30C",
+              "timestamp": 1583320629102,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402206E2F3848696DA638C72FD8B7B57431158297AB6DAF12B97DDD5C6DD85FDF3FAC02200A2D3F8138D03C529739DA36C87FF1F170CA2BBD750C5424F450FC1B40E19DD8"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1583320629070,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3046022100861BD20F98B25DAC25AF6EEB18ED297E9AC313D147699A3F87CB99A643B8EA64022100A8C684D21FAC015966FF06CAD47F3D8CC7C1402C7C12315CA505448F06D38058"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "B6C52BA4191283DB2B514A0AA6507C5A"
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "B6C52BA4191283DB2B514A0AA6507C5A" }
+  },
+  {
+    "method": "Page.frameDetached",
+    "params": { "frameId": "B6C52BA4191283DB2B514A0AA6507C5A" }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "8EA8D7896DF4A1423936BC7CF70715CA",
+      "timestamp": 162823.846767,
+      "dataLength": 215,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "sessionId": "1F88229A0F0DA12B6ADECDE9D3134F15"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "8EA8D7896DF4A1423936BC7CF70715CA",
+      "timestamp": 162823.827098,
+      "encodedDataLength": 442,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "sessionId": "1F88229A0F0DA12B6ADECDE9D3134F15"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url": "https://zfh61.csb.app/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+          "Referer":
+            "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162823.851228,
+      "wallTime": 1590380010.679388,
+      "initiator": {
+        "type": "parser",
+        "url":
+          "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/",
+        "lineNumber": 6
+      },
+      "type": "Document",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "sessionId": "1F88229A0F0DA12B6ADECDE9D3134F15"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "name": "firstPaint",
+      "timestamp": 162823.838913
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 162823.838913
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "blockedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookie": {
+            "name": "__cfduid",
+            "value": "dd980c511f388fad37f60c6500bc554891590380010",
+            "domain": ".csb.app",
+            "path": "/",
+            "expires": 1592972010.382995,
+            "size": 51,
+            "httpOnly": true,
+            "secure": false,
+            "session": false,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "zfh61.csb.app",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-dest": "iframe",
+        "referer":
+          "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    },
+    "source": {
+      "targetId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "sessionId": "1F88229A0F0DA12B6ADECDE9D3134F15"
+    }
+  },
+  {
+    "method": "Page.frameAttached",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "parentFrameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "n",
+            "scriptId": "15",
+            "url":
+              "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+            "lineNumber": 0,
+            "columnNumber": 2652
+          },
+          {
+            "functionName": "",
+            "scriptId": "15",
+            "url":
+              "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+            "lineNumber": 0,
+            "columnNumber": 2696
+          }
+        ],
+        "parent": {
+          "description": "setTimeout",
+          "callFrames": [
+            {
+              "functionName": "./src/watermark-button.js",
+              "scriptId": "15",
+              "url":
+                "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+              "lineNumber": 0,
+              "columnNumber": 2673
+            },
+            {
+              "functionName": "t",
+              "scriptId": "15",
+              "url":
+                "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+              "lineNumber": 0,
+              "columnNumber": 109
+            },
+            {
+              "functionName": "",
+              "scriptId": "15",
+              "url":
+                "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+              "lineNumber": 0,
+              "columnNumber": 926
+            },
+            {
+              "functionName": "",
+              "scriptId": "15",
+              "url":
+                "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+              "lineNumber": 0,
+              "columnNumber": 961
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "FA8B30CFBDF06B7DAED88D7EC1677155",
+      "name": "init",
+      "timestamp": 162824.069659
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "FA8B30CFBDF06B7DAED88D7EC1677155",
+      "name": "DOMContentLoaded",
+      "timestamp": 162824.070159
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "D74DD5178300A1AAB95823EC30A10ECD" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "init",
+      "timestamp": 162824.070685
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "D74DD5178300A1AAB95823EC30A10ECD",
+        "parentId": "31436884AD20CBC87477AF1D2B5A5429",
+        "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+        "name": "sb__open-sandbox9",
+        "url": "about:blank",
+        "securityOrigin": "://",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "load",
+      "timestamp": 162824.074269
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "D74DD5178300A1AAB95823EC30A10ECD" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "DOMContentLoaded",
+      "timestamp": 162824.074435
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "firstPaint",
+      "timestamp": 162824.098475
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "firstContentfulPaint",
+      "timestamp": 162824.098475
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 162824.098475
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "blockedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookieLine":
+            "__cfduid=ddd0c0efa83d24ecb104a2572b598d8541590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax",
+          "cookie": {
+            "name": "__cfduid",
+            "value": "ddd0c0efa83d24ecb104a2572b598d8541590380010",
+            "domain": ".csb.app",
+            "path": "/",
+            "expires": 1592972010.018739,
+            "size": 51,
+            "httpOnly": true,
+            "secure": false,
+            "session": false,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        "status": "200",
+        "date": "Mon, 25 May 2020 04:13:31 GMT",
+        "content-type": "text/html",
+        "set-cookie":
+          "__cfduid=ddd0c0efa83d24ecb104a2572b598d8541590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax",
+        "vary": "Accept-Encoding",
+        "cache-control": "private, max-age=0, no-cache, no-store",
+        "x-request-id": "FhIqMZjZzZSIBAEWLnki",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+        "cf-cache-status": "DYNAMIC",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "server": "cloudflare",
+        "cf-ray": "598c6c9b4c5dfe68-SYD",
+        "content-encoding": "br",
+        "cf-request-id": "02eba2350b0000fe68379c4200000001"
+      }
+    },
+    "source": {
+      "targetId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "sessionId": "1F88229A0F0DA12B6ADECDE9D3134F15"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.192059,
+      "type": "Document",
+      "response": {
+        "url": "https://zfh61.csb.app/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "date": "Mon, 25 May 2020 04:13:31 GMT",
+          "content-type": "text/html",
+          "set-cookie":
+            "__cfduid=ddd0c0efa83d24ecb104a2572b598d8541590380010; expires=Wed, 24-Jun-20 04:13:30 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax",
+          "vary": "Accept-Encoding",
+          "cache-control": "private, max-age=0, no-cache, no-store",
+          "x-request-id": "FhIqMZjZzZSIBAEWLnki",
+          "via": "1.1 google",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "server": "cloudflare",
+          "cf-ray": "598c6c9b4c5dfe68-SYD",
+          "content-encoding": "br",
+          "cf-request-id": "02eba2350b0000fe68379c4200000001"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "zfh61.csb.app",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "cross-site",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-dest": "iframe",
+          "referer":
+            "https://deploy-preview-26--michaeldijkstra-netlify-test.netlify.app/",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": true,
+        "connectionId": 27,
+        "remoteIPAddress": "104.18.26.114",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 210,
+        "timing": {
+          "requestTime": 162823.851658,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 19.874,
+          "sendEnd": 20.093,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 338.933
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": ["sni.cloudflaressl.com", "csb.app", "*.csb.app"],
+          "issuer": "CloudFlare Inc ECC CA-2",
+          "validFrom": 1563235200,
+          "validTo": 1594814400,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1563281916019,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100B59FBDDD94AEDE9A9C83539B805EFAB1416D8D977C9B85003AAF1E345E27955502205FCF9B3B5A65395AC1260BEB799FD7543B3F81D6D3D74D4F76A31AC1AEB64767"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Cloudflare 'Nimbus2020' Log",
+              "logId":
+                "5EA773F9DF56C0E7B536487DD049E0327A919A0C84A112128418759681714558",
+              "timestamp": 1563281915852,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3046022100D4D1B9D8087037081BCE37765AF9420A879AD564A00AF82F74781343F1030826022100E4014490A0A106AF3E65D2675BC3585EE37278795DE2A5C91514197469AF758C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "B6C52BA4191283DB2B514A0AA6507C5A",
+      "sessionId": "1F88229A0F0DA12B6ADECDE9D3134F15"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.198817,
+      "dataLength": 365,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.191201,
+      "encodedDataLength": 400,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "83685.8",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Mon, 25 May 2020 04:13:30 GMT",
+        "content-type": "application/javascript",
+        "last-modified": "Fri, 22 May 2020 11:44:40 GMT",
+        "vary": "Accept-Encoding",
+        "etag": "W/\"5ec7bb28-ae8\"",
+        "expires": "Thu, 31 Dec 2037 23:55:55 GMT",
+        "cache-control": "max-age=315360000",
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+        "cf-cache-status": "HIT",
+        "age": "16470",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "server": "cloudflare",
+        "cf-ray": "598c6c99bd1d65df-SYD",
+        "content-encoding": "br",
+        "cf-request-id": "02eba23413000065dff3bf6200000001"
+      }
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.7",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url": "https://www.w3schools.com/html/img_girl.jpg",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://zfh61.csb.app/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.204556,
+      "wallTime": 1590380011.032687,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 3
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.8",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url": "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+        "method": "GET",
+        "headers": {
+          "Origin": "https://zfh61.csb.app",
+          "Referer": "https://zfh61.csb.app/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Medium",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.204809,
+      "wallTime": 1590380011.032939,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 7
+      },
+      "type": "Script",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.11",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url": "https://www.w3schools.com/tags/movie.mp4",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://zfh61.csb.app/",
+          "Accept-Encoding": "identity;q=1, *;q=0",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+          "Range": "bytes=0-"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.217578,
+      "wallTime": 1590380011.045708,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 7
+      },
+      "type": "Media",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.8",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.218087,
+      "type": "Script",
+      "response": {
+        "url": "https://codesandbox.io/static/js/watermark-button.b90db4dc7.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Mon, 25 May 2020 04:13:30 GMT",
+          "via": "1.1 google",
+          "cf-cache-status": "HIT",
+          "age": "16470",
+          "status": "200",
+          "content-encoding": "br",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+          "cf-request-id": "02eba23413000065dff3bf6200000001",
+          "last-modified": "Fri, 22 May 2020 11:44:40 GMT",
+          "server": "cloudflare",
+          "etag": "W/\"5ec7bb28-ae8\"",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "vary": "Accept-Encoding",
+          "access-control-allow-methods": "GET",
+          "content-type": "application/javascript",
+          "access-control-allow-origin": "*",
+          "cache-control": "max-age=315360000",
+          "cf-ray": "598c6c99bd1d65df-SYD",
+          "expires": "Thu, 31 Dec 2037 23:55:55 GMT"
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "104.18.23.207",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 162824.205485,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.03,
+          "sendEnd": 0.03,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 0.327
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": [
+            "sni.cloudflaressl.com",
+            "*.codesandbox.io",
+            "codesandbox.io"
+          ],
+          "issuer": "CloudFlare Inc ECC CA-2",
+          "validFrom": 1582934400,
+          "validTo": 1602244800,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown"
+        }
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.8",
+      "timestamp": 162824.21861,
+      "dataLength": 2792,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.8",
+      "timestamp": 162824.206633,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.12",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url":
+          "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxOTYgMTk2IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxOTYgMTk2OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik05OCw0OXY0Yy0yNC45LDAtNDUsMjAuMS00NSw0NQoJYzAsMTgsMTAuNiwzMy42LDI1LjksNDAuOGwtMS43LDMuNmMwLjEsMCwwLjIsMC4xLDAuMywwLjFjLTAuMSwwLTAuMi0wLjEtMC4zLTAuMWwwLDBDNjAuNSwxMzQuNSw0OSwxMTcuNiw0OSw5OAoJQzQ5LDcwLjksNzAuOSw0OSw5OCw0OXoiLz4KPC9zdmc+Cg==",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.2289,
+      "wallTime": 1590380011.057032,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 0
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "83685.12" },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.12",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.228937,
+      "type": "Image",
+      "response": {
+        "url":
+          "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxOTYgMTk2IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxOTYgMTk2OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik05OCw0OXY0Yy0yNC45LDAtNDUsMjAuMS00NSw0NQoJYzAsMTgsMTAuNiwzMy42LDI1LjksNDAuOGwtMS43LDMuNmMwLjEsMCwwLjIsMC4xLDAuMywwLjFjLTAuMSwwLTAuMi0wLjEtMC4zLTAuMWwwLDBDNjAuNSwxMzQuNSw0OSwxMTcuNiw0OSw5OAoJQzQ5LDcwLjksNzAuOSw0OSw5OCw0OXoiLz4KPC9zdmc+Cg==",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/svg+xml" },
+        "mimeType": "image/svg+xml",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.12",
+      "timestamp": 162824.228942,
+      "dataLength": 547,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.12",
+      "timestamp": 162824.228947,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.13",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url":
+          "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxOTYgMTk2IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxOTYgMTk2OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0xNDcsOThjMCwxOS42LTExLjUsMzYuNS0yOC4yLDQ0LjRsMCwwYy0wLjEsMC0wLjIsMC4xLTAuMywwLjEKCWMwLjEsMCwwLjItMC4xLDAuMy0wLjFsLTEuNy0zLjZDMTMyLjQsMTMxLjYsMTQzLDExNiwxNDMsOThjMC0yNC45LTIwLjEtNDUtNDUtNDV2LTRDMTI1LjEsNDksMTQ3LDcwLjksMTQ3LDk4eiIvPgo8L3N2Zz4K",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.231706,
+      "wallTime": 1590380011.059836,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 0
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "83685.13" },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.13",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.23173,
+      "type": "Image",
+      "response": {
+        "url":
+          "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxOTYgMTk2IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAxOTYgMTk2OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0xNDcsOThjMCwxOS42LTExLjUsMzYuNS0yOC4yLDQ0LjRsMCwwYy0wLjEsMC0wLjIsMC4xLTAuMywwLjEKCWMwLjEsMCwwLjItMC4xLDAuMy0wLjFsLTEuNy0zLjZDMTMyLjQsMTMxLjYsMTQzLDExNiwxNDMsOThjMC0yNC45LTIwLjEtNDUtNDUtNDV2LTRDMTI1LjEsNDksMTQ3LDcwLjksMTQ3LDk4eiIvPgo8L3N2Zz4K",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/svg+xml" },
+        "mimeType": "image/svg+xml",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.13",
+      "timestamp": 162824.231735,
+      "dataLength": 552,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.13",
+      "timestamp": 162824.23174,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.14",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url":
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAAAXNSR0IArs4c6QAABqVJREFUeNrt3ctrFVccwHH/TsX3C3xgXCgoGBBfiOBjoSi6ECKKEjduVFwoLtyotcZUS9KEJiYYmzYmbUyT+Gj7E1vcdM65ucbM47P4LO8E5s43d86ZMzPL5ufnH0FTLbMTEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAASAAOwEBAACAAGAAEAAIAAQQIX19fX1nj17dqyjo2NmzZo175cvX/4X/y/2Ueyr2Gex7wRQUW/fvn185syZ1ytWrPjowF6Y2HexD2NfCqBiB39nZ+eUg/jriH1Z1whqGUD813Lgfl2xTwVQkXN+pz2LczpUxzFB7QKIwZsDdnHEvhVAycUMhoN1ccS+FUDJmepc3ClSAZRc6kt08cf+EwD2nwCw/wSAAHyBCMAXiAB8gQjAFygAAfgCBSAAX6AABOALFIAAfIECEAACEAACEAACEAACEAACEAACEAACEAACEMDSWrly5YcNGza827Jly+zOnTtn9u7d+/vx48fHL1++/PLu3bs/9ff3987NzTnYBdDMK8Fh/fr17w4ePPimu7t7qAkPgBWAAApt3bp19uLFi6ODg4PPBCCAxgXwpT179vxx69atwdnZWQEIoHkBfPmrcOPGjZ/r/GhwAQggafPmzXM3b94cFIAAGhnAv2I2qQkDZgEIoPAR4RcuXHhV59MiAVRcHJzj4+NPhoeHe168ePHDvXv3+q9cufLyxIkT47t27Zr+50ts+90Bu3fvno7tC0AAlTMxMfEkoog3nsT5/UIjWLdu3bu4sCYAAVRWTHU+ePCg79ixY7+uWrXqw0JC6OrqGhGAACpvbGzs+/Pnz79ayPsFTp8+/bouyysE0HAxfohXAbX6nrGjR4/+VofBsQD4JAbQcVW41Qiq/ksgAP4TB3MsmIsVpq2cDglAALXS29v7PJZGNGFgLIAa3Q8QV29Pnjw5fvXq1eGenp7n7Sxwi+nTffv2Zb99vqpTpAKo8SBu7dq17w8fPjwRB+dCBqzT09OPjxw5MpF7nWBoaKhHAAIo5VKI+JW4dOnSyNTU1HetjgtOnTr1S87fiCvPVZsZEkDD1gLF1eBY9tzK6VFEkPtLENcWBCCA0i+G27Fjx8z9+/f7WzkdyhkTxPWEKq0iFUDDV4PGas/cufwYGOfMDsVgXAACqMxy6AMHDryZnJzMGhvEFGnOdYKq3FQjAAF80tHRMZM7ixMXy3LGGlUYEAug4uI/98DAwLOHDx/+ePv27cFz586Nbdu2bXYhEWzcuHE+J4I4ZcpZNhGDbQEIYEnEQLSrq2s0DupWfwlyTodi7VBqAV2MF8r+tAkB1FwczPEMoNWrV79vZUyQMzCOVaSpbcUjVwQggFKs/z906NBEK7NDOUupU/cTxKmSAARQmtWe8WuQe59wznWCuPCV2k6Zn0AngAa6c+fOQM4tkXGxLHUOH78sqW1FdAIQQOkiyPkVyJnJiXuMU4NhAQigdD6fDiXn81ML6OJG+9R2yro8QgAVF4PQ7du3/7l///7J69evD42MjDxtZUyQMzCOVaSpp01s2rSpcLq1u7t7WAACWPQvMObm46FYo6OjT3Nnh1JTpLGUOnVVN547VLSNeD+BAATwzb7A+GXIvUsr51Qota14+Fbqhpky3kAvgHqvBfp47dq15KlHXCxLXTGOO8tSK0VT06vxuiYBCOBbL4b7mPNLEMsmUrdXpqZEPz+LtK37hhfzYb+til9RAdRgNWh8kakxQczSpLYTN9oXbSPGHkWfjxf3VSmAWBclgJosh46DM7Wt1CrSeNpE0efjqdRFn4+3V1YpgFjrJICaBBCzQ6kp0lhKXbSNeORKOwPhnDvFynLwV+3WTgFkiOsERduK+wnaOYBjiXTR5+M9xlUJIKZ163jxs9EBxMWyom3FTTVFn4+HbxV9Pl6i0c7nyxJAZ2fnVF3fitPoAOKKcdG24s6y1AWx1PLodj6/1AHEaU/856/zK6EaHUBqWi+uBxR9Pm6GL/p8HDjtfH4pAoh9ErM9MeBtwksBLYaj0QSAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAEYCcgABAACAAEAAIAAUCt/Q0TT+YRvd35vwAAAABJRU5ErkJggg==",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.232423,
+      "wallTime": 1590380011.060553,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 0
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "83685.14" },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.14",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.232451,
+      "type": "Image",
+      "response": {
+        "url":
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAAAXNSR0IArs4c6QAABqVJREFUeNrt3ctrFVccwHH/TsX3C3xgXCgoGBBfiOBjoSi6ECKKEjduVFwoLtyotcZUS9KEJiYYmzYmbUyT+Gj7E1vcdM65ucbM47P4LO8E5s43d86ZMzPL5ufnH0FTLbMTEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAAQAAgABgABAACAAEAAIAASAAOwEBAACAAGAAEAAIAAQQIX19fX1nj17dqyjo2NmzZo175cvX/4X/y/2Ueyr2Gex7wRQUW/fvn185syZ1ytWrPjowF6Y2HexD2NfCqBiB39nZ+eUg/jriH1Z1whqGUD813Lgfl2xTwVQkXN+pz2LczpUxzFB7QKIwZsDdnHEvhVAycUMhoN1ccS+FUDJmepc3ClSAZRc6kt08cf+EwD2nwCw/wSAAHyBCMAXiAB8gQjAFygAAfgCBSAAX6AABOALFIAAfIECEAACEAACEAACEAACEAACEAACEAACEAACEMDSWrly5YcNGza827Jly+zOnTtn9u7d+/vx48fHL1++/PLu3bs/9ff3987NzTnYBdDMK8Fh/fr17w4ePPimu7t7qAkPgBWAAApt3bp19uLFi6ODg4PPBCCAxgXwpT179vxx69atwdnZWQEIoHkBfPmrcOPGjZ/r/GhwAQggafPmzXM3b94cFIAAGhnAv2I2qQkDZgEIoPAR4RcuXHhV59MiAVRcHJzj4+NPhoeHe168ePHDvXv3+q9cufLyxIkT47t27Zr+50ts+90Bu3fvno7tC0AAlTMxMfEkoog3nsT5/UIjWLdu3bu4sCYAAVRWTHU+ePCg79ixY7+uWrXqw0JC6OrqGhGAACpvbGzs+/Pnz79ayPsFTp8+/bouyysE0HAxfohXAbX6nrGjR4/+VofBsQD4JAbQcVW41Qiq/ksgAP4TB3MsmIsVpq2cDglAALXS29v7PJZGNGFgLIAa3Q8QV29Pnjw5fvXq1eGenp7n7Sxwi+nTffv2Zb99vqpTpAKo8SBu7dq17w8fPjwRB+dCBqzT09OPjxw5MpF7nWBoaKhHAAIo5VKI+JW4dOnSyNTU1HetjgtOnTr1S87fiCvPVZsZEkDD1gLF1eBY9tzK6VFEkPtLENcWBCCA0i+G27Fjx8z9+/f7WzkdyhkTxPWEKq0iFUDDV4PGas/cufwYGOfMDsVgXAACqMxy6AMHDryZnJzMGhvEFGnOdYKq3FQjAAF80tHRMZM7ixMXy3LGGlUYEAug4uI/98DAwLOHDx/+ePv27cFz586Nbdu2bXYhEWzcuHE+J4I4ZcpZNhGDbQEIYEnEQLSrq2s0DupWfwlyTodi7VBqAV2MF8r+tAkB1FwczPEMoNWrV79vZUyQMzCOVaSpbcUjVwQggFKs/z906NBEK7NDOUupU/cTxKmSAARQmtWe8WuQe59wznWCuPCV2k6Zn0AngAa6c+fOQM4tkXGxLHUOH78sqW1FdAIQQOkiyPkVyJnJiXuMU4NhAQigdD6fDiXn81ML6OJG+9R2yro8QgAVF4PQ7du3/7l///7J69evD42MjDxtZUyQMzCOVaSpp01s2rSpcLq1u7t7WAACWPQvMObm46FYo6OjT3Nnh1JTpLGUOnVVN547VLSNeD+BAATwzb7A+GXIvUsr51Qota14+Fbqhpky3kAvgHqvBfp47dq15KlHXCxLXTGOO8tSK0VT06vxuiYBCOBbL4b7mPNLEMsmUrdXpqZEPz+LtK37hhfzYb+til9RAdRgNWh8kakxQczSpLYTN9oXbSPGHkWfjxf3VSmAWBclgJosh46DM7Wt1CrSeNpE0efjqdRFn4+3V1YpgFjrJICaBBCzQ6kp0lhKXbSNeORKOwPhnDvFynLwV+3WTgFkiOsERduK+wnaOYBjiXTR5+M9xlUJIKZ163jxs9EBxMWyom3FTTVFn4+HbxV9Pl6i0c7nyxJAZ2fnVF3fitPoAOKKcdG24s6y1AWx1PLodj6/1AHEaU/856/zK6EaHUBqWi+uBxR9Pm6GL/p8HDjtfH4pAoh9ErM9MeBtwksBLYaj0QSAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAQAAgABAACAAGAAEAAIAAEYCcgABAACAAEAAIAAUCt/Q0TT+YRvd35vwAAAABJRU5ErkJggg==",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/png" },
+        "mimeType": "image/png",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.14",
+      "timestamp": 162824.232459,
+      "dataLength": 1771,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.14",
+      "timestamp": 162824.232463,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.15",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url":
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAJwCAYAAABI9AvEAAACkklEQVRIS1XHdxQIZBiFcTtCkmRHqSh7U1mpJMlK9t7Jpm2WUFnZK7PsbGWWUfYohOy9NZFVznNP5/vOff/4vfdJkOD/S8iPJCJFYicJKZIGkrEi95AiuZOCFPc6KUmRyklNivsCaViR+0mR1nmAFOmcB0mR3nmIFBmcjKTIFMjMimQhRVYnGykedrKTIofzCCkeDeRkRR4jxePOE6TI5eQmxZPOU6TIE8jLiuQjRX6nACkKOoVIUdgpQoqigWKsSHFSlHBKkqKU8zQpnnGeJUXpQBlWpCwpyjnlSfGcU4EUzzsvkOJFpyIpXgpUYkVeJkVl5xVSVHFeJUVVpxopqgdqsCI1SfGaU4sUrzu1SVHHqUuKeoH6rEgDUjR0GpGisdOEFE2dZqRoHmjBirQkRSunNSnaOG1J8YbTjhRvOu1J0SHQkRXpRIrOThdSdHW6kaK78xYp3g68w4q8S4r3nPdJ8YHTgxQ9nV6k6B3ow4r0JcWHzkek6Od8TIr+zgBSDAx8wop8SorPnEGkGOwMIcVQZxgpPg8MZ0VGkGKkM4oUo50xpBjrjCPFeGcCKSYGvmBFJpFisjOFFFOdaaSY7nxJiq8CM1iRmaSY5cwmxRxnLinmOV+TYn5gASuykBSLnMWkWOIsJcUy5xtSfBtYzoqsIMVKZxUpVjtrSPGd8z0p1jrrSLE+sIEV+YEUPzobSbHJ2UyKLc5WUmwLbGdFdpBip7OLFD85P5Nit7OHFHsDv7Ai+0ix3zlAil+dg6Q45BwmxZHAUVbkGCmOOydIcdI5RYrTzhlSnA2cY0XOk+KCc5EUl5zLpLji/EaK350/SPFn4C9W5G9SXHWukeK68w8pbjg3SXErcJsVuUOKf53/7gIPXjbYDO78kgAAAABJRU5ErkJggg==",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.232606,
+      "wallTime": 1590380011.060736,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 0
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "83685.15" },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.15",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.232625,
+      "type": "Image",
+      "response": {
+        "url":
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAJwCAYAAABI9AvEAAACkklEQVRIS1XHdxQIZBiFcTtCkmRHqSh7U1mpJMlK9t7Jpm2WUFnZK7PsbGWWUfYohOy9NZFVznNP5/vOff/4vfdJkOD/S8iPJCJFYicJKZIGkrEi95AiuZOCFPc6KUmRyklNivsCaViR+0mR1nmAFOmcB0mR3nmIFBmcjKTIFMjMimQhRVYnGykedrKTIofzCCkeDeRkRR4jxePOE6TI5eQmxZPOU6TIE8jLiuQjRX6nACkKOoVIUdgpQoqigWKsSHFSlHBKkqKU8zQpnnGeJUXpQBlWpCwpyjnlSfGcU4EUzzsvkOJFpyIpXgpUYkVeJkVl5xVSVHFeJUVVpxopqgdqsCI1SfGaU4sUrzu1SVHHqUuKeoH6rEgDUjR0GpGisdOEFE2dZqRoHmjBirQkRSunNSnaOG1J8YbTjhRvOu1J0SHQkRXpRIrOThdSdHW6kaK78xYp3g68w4q8S4r3nPdJ8YHTgxQ9nV6k6B3ow4r0JcWHzkek6Od8TIr+zgBSDAx8wop8SorPnEGkGOwMIcVQZxgpPg8MZ0VGkGKkM4oUo50xpBjrjCPFeGcCKSYGvmBFJpFisjOFFFOdaaSY7nxJiq8CM1iRmaSY5cwmxRxnLinmOV+TYn5gASuykBSLnMWkWOIsJcUy5xtSfBtYzoqsIMVKZxUpVjtrSPGd8z0p1jrrSLE+sIEV+YEUPzobSbHJ2UyKLc5WUmwLbGdFdpBip7OLFD85P5Nit7OHFHsDv7Ai+0ix3zlAil+dg6Q45BwmxZHAUVbkGCmOOydIcdI5RYrTzhlSnA2cY0XOk+KCc5EUl5zLpLji/EaK350/SPFn4C9W5G9SXHWukeK68w8pbjg3SXErcJsVuUOKf53/7gIPXjbYDO78kgAAAABJRU5ErkJggg==",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/png" },
+        "mimeType": "image/png",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.15",
+      "timestamp": 162824.232631,
+      "dataLength": 715,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.15",
+      "timestamp": 162824.232635,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.16",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url":
+          "data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjZmZmZmZmIiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik04IDV2MTRsMTEtN3oiLz4KICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4KPC9zdmc+Cg==",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.234145,
+      "wallTime": 1590380011.062275,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 0
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "83685.16" },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.16",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.234196,
+      "type": "Image",
+      "response": {
+        "url":
+          "data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjZmZmZmZmIiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik04IDV2MTRsMTEtN3oiLz4KICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4KPC9zdmc+Cg==",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/svg+xml" },
+        "mimeType": "image/svg+xml",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.16",
+      "timestamp": 162824.234205,
+      "dataLength": 178,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.16",
+      "timestamp": 162824.234209,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.17",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url":
+          "data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjZmZmZmZmIiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4KICAgIDxwYXRoIGQ9Ik03IDE0SDV2NWg1di0ySDd2LTN6bS0yLTRoMlY3aDNWNUg1djV6bTEyIDdoLTN2Mmg1di01aC0ydjN6TTE0IDV2MmgzdjNoMlY1aC01eiIvPgo8L3N2Zz4K",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.23625,
+      "wallTime": 1590380011.06438,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 0
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "83685.17" },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.17",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.236272,
+      "type": "Image",
+      "response": {
+        "url":
+          "data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjZmZmZmZmIiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4KICAgIDxwYXRoIGQ9Ik03IDE0SDV2NWg1di0ySDd2LTN6bS0yLTRoMlY3aDNWNUg1djV6bTEyIDdoLTN2Mmg1di01aC0ydjN6TTE0IDV2MmgzdjNoMlY1aC01eiIvPgo8L3N2Zz4K",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/svg+xml" },
+        "mimeType": "image/svg+xml",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.17",
+      "timestamp": 162824.23628,
+      "dataLength": 243,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.17",
+      "timestamp": 162824.236285,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.18",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url":
+          "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgMjQgMjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDI1NSAyNTU7IiB4bWw6c3BhY2U9InByZXNlcnZlIiBmaWxsPSIjZmZmZmZmIj4KPGc+Cgk8Y2lyY2xlIGN4PSIxMiIgY3k9IjYiIHI9IjIiLz4KCTxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjIiLz4KCTxjaXJjbGUgY3g9IjEyIiBjeT0iMTgiIHI9IjIiLz4KPC9nPgo8L3N2Zz4K",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.237303,
+      "wallTime": 1590380011.065433,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 0
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "83685.18" },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.18",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.237324,
+      "type": "Image",
+      "response": {
+        "url":
+          "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgMjQgMjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDI1NSAyNTU7IiB4bWw6c3BhY2U9InByZXNlcnZlIiBmaWxsPSIjZmZmZmZmIj4KPGc+Cgk8Y2lyY2xlIGN4PSIxMiIgY3k9IjYiIHI9IjIiLz4KCTxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjIiLz4KCTxjaXJjbGUgY3g9IjEyIiBjeT0iMTgiIHI9IjIiLz4KPC9nPgo8L3N2Zz4K",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/svg+xml" },
+        "mimeType": "image/svg+xml",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.18",
+      "timestamp": 162824.237329,
+      "dataLength": 381,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.18",
+      "timestamp": 162824.237333,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.resourceChangedPriority",
+    "params": {
+      "requestId": "83685.7",
+      "newPriority": "High",
+      "timestamp": 162824.243341
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.19",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url":
+          "data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjZmZmZmZmIiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik0zIDl2Nmg0bDUgNVY0TDcgOUgzem0xMy41IDNjMC0xLjc3LTEuMDItMy4yOS0yLjUtNC4wM3Y4LjA1YzEuNDgtLjczIDIuNS0yLjI1IDIuNS00LjAyek0xNCAzLjIzdjIuMDZjMi44OS44NiA1IDMuNTQgNSA2Ljcxcy0yLjExIDUuODUtNSA2LjcxdjIuMDZjNC4wMS0uOTEgNy00LjQ5IDctOC43N3MtMi45OS03Ljg2LTctOC43N3oiLz4KICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4KPC9zdmc+Cg==",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.247451,
+      "wallTime": 1590380011.07558,
+      "initiator": {
+        "type": "parser",
+        "url": "https://zfh61.csb.app/",
+        "lineNumber": 0
+      },
+      "type": "Image",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "83685.19" },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.19",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.247479,
+      "type": "Image",
+      "response": {
+        "url":
+          "data:image/svg+xml;base64,PHN2ZyBmaWxsPSIjZmZmZmZmIiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGQ9Ik0zIDl2Nmg0bDUgNVY0TDcgOUgzem0xMy41IDNjMC0xLjc3LTEuMDItMy4yOS0yLjUtNC4wM3Y4LjA1YzEuNDgtLjczIDIuNS0yLjI1IDIuNS00LjAyek0xNCAzLjIzdjIuMDZjMi44OS44NiA1IDMuNTQgNSA2Ljcxcy0yLjExIDUuODUtNSA2LjcxdjIuMDZjNC4wMS0uOTEgNy00LjQ5IDctOC43N3MtMi45OS03Ljg2LTctOC43N3oiLz4KICAgIDxwYXRoIGQ9Ik0wIDBoMjR2MjRIMHoiIGZpbGw9Im5vbmUiLz4KPC9zdmc+Cg==",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/svg+xml" },
+        "mimeType": "image/svg+xml",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.19",
+      "timestamp": 162824.247484,
+      "dataLength": 352,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.19",
+      "timestamp": 162824.247488,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "83685.7",
+      "blockedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.w3schools.com",
+        ":scheme": "https",
+        ":path": "/html/img_girl.jpg",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "image",
+        "referer": "https://zfh61.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "83685.11",
+      "blockedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.w3schools.com",
+        ":scheme": "https",
+        ":path": "/tags/movie.mp4",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "accept-encoding": "identity;q=1, *;q=0",
+        "accept": "*/*",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "video",
+        "referer": "https://zfh61.csb.app/",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "range": "bytes=0-"
+      }
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "83685.7",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "accept-ranges": "bytes",
+        "age": "5010",
+        "cache-control": "public,max-age=14400,public",
+        "content-type": "image/jpeg",
+        "date": "Mon, 25 May 2020 04:13:31 GMT",
+        "etag": "\"ead5b13d31d31:0\"",
+        "last-modified": "Tue, 19 Sep 2017 11:51:57 GMT",
+        "server": "ECS (sya/E0E0)",
+        "x-cache": "HIT",
+        "x-frame-options": "SAMEORIGIN",
+        "x-powered-by": "ASP.NET",
+        "content-length": "36836"
+      }
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "83685.11",
+      "blockedCookies": [],
+      "headers": {
+        "status": "206",
+        "accept-ranges": "bytes",
+        "age": "7733",
+        "cache-control": "public,max-age=14400,public",
+        "content-type": "video/mp4",
+        "date": "Mon, 25 May 2020 04:13:31 GMT",
+        "etag": "\"8179b1407fbcf1:0\"",
+        "last-modified": "Tue, 07 Jan 2014 08:05:39 GMT",
+        "server": "ECS (sya/E08E)",
+        "x-cache": "HIT",
+        "x-frame-options": "SAMEORIGIN",
+        "x-powered-by": "ASP.NET",
+        "Content-Range": "bytes 0-318464/318465",
+        "Content-Length": "318465"
+      }
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.7",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.284671,
+      "type": "Image",
+      "response": {
+        "url": "https://www.w3schools.com/html/img_girl.jpg",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Mon, 25 May 2020 04:13:31 GMT",
+          "etag": "\"ead5b13d31d31:0\"",
+          "last-modified": "Tue, 19 Sep 2017 11:51:57 GMT",
+          "server": "ECS (sya/E0E0)",
+          "age": "5010",
+          "x-powered-by": "ASP.NET",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "HIT",
+          "content-type": "image/jpeg",
+          "status": "200",
+          "cache-control": "public,max-age=14400,public",
+          "accept-ranges": "bytes",
+          "content-length": "36836"
+        },
+        "mimeType": "image/jpeg",
+        "connectionReused": false,
+        "connectionId": 85,
+        "remoteIPAddress": "192.229.179.87",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 195,
+        "timing": {
+          "requestTime": 162824.204958,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.196,
+          "dnsEnd": 18.81,
+          "connectStart": 18.81,
+          "connectEnd": 58.262,
+          "sslStart": 28.352,
+          "sslEnd": 58.254,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 58.439,
+          "sendEnd": 58.604,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 71.594
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "*.w3schools.com",
+          "sanList": ["*.w3schools.com", "w3schools.com"],
+          "issuer": "DigiCert SHA2 Secure Server CA",
+          "validFrom": 1588636800,
+          "validTo": 1652184000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2022' log",
+              "logId":
+                "2979BEF09E393921F056739F63A577E5BE577D9C600AF8F94D5D265C255DC784",
+              "timestamp": 1588694768842,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3044022076B6D7A307CE32E0B6F6EB99015CCCCF17DEB806A9ECD1C46BAEBF32A1E7F5C202204A67E2D284E3562DF16C259EDA75D5E63A09FEA3D4297B119E3BFD0BC242D8A5"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2022 Log",
+              "logId":
+                "2245450759552456963FA12FF1F76D86E0232663ADC04B7F5DC6835C6EE20F02",
+              "timestamp": 1588694768888,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220797A5B731E872EAAEF14ED8D761E47540BA21AAAC978BCC26F0178A87310BDC0022100A27BE6BAF4B2EA2F5CFE551F5046140504F62176EDD168F48269CCB882B2580E"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Nessie2022 Log",
+              "logId":
+                "51A3B0F5FD01799C566DB837788F0CA47ACC1B27CBF79E88429A0DFED48B05E5",
+              "timestamp": 1588694768963,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3046022100DBDD6E8D24F68F08A2F3E06BC835EA3D06AA212EE99BFA515FFED3592C09F128022100A5B03946C3F3637AAD3E0ED978E64A96446FD6E04A36BEA48C37909A9ED88CED"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.11",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.285075,
+      "type": "Media",
+      "response": {
+        "url": "https://www.w3schools.com/tags/movie.mp4",
+        "status": 206,
+        "statusText": "",
+        "headers": {
+          "date": "Mon, 25 May 2020 04:13:31 GMT",
+          "etag": "\"8179b1407fbcf1:0\"",
+          "last-modified": "Tue, 07 Jan 2014 08:05:39 GMT",
+          "server": "ECS (sya/E08E)",
+          "age": "7733",
+          "status": "206",
+          "x-powered-by": "ASP.NET",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "HIT",
+          "content-type": "video/mp4",
+          "Content-Range": "bytes 0-318464/318465",
+          "cache-control": "public,max-age=14400,public",
+          "accept-ranges": "bytes",
+          "Content-Length": "318465"
+        },
+        "mimeType": "video/mp4",
+        "connectionReused": true,
+        "connectionId": 85,
+        "remoteIPAddress": "192.229.179.87",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 112,
+        "timing": {
+          "requestTime": 162824.218001,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 45.461,
+          "sendEnd": 45.563,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 65.924
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "*.w3schools.com",
+          "sanList": ["*.w3schools.com", "w3schools.com"],
+          "issuer": "DigiCert SHA2 Secure Server CA",
+          "validFrom": 1588636800,
+          "validTo": 1652184000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2022' log",
+              "logId":
+                "2979BEF09E393921F056739F63A577E5BE577D9C600AF8F94D5D265C255DC784",
+              "timestamp": 1588694768842,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3044022076B6D7A307CE32E0B6F6EB99015CCCCF17DEB806A9ECD1C46BAEBF32A1E7F5C202204A67E2D284E3562DF16C259EDA75D5E63A09FEA3D4297B119E3BFD0BC242D8A5"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2022 Log",
+              "logId":
+                "2245450759552456963FA12FF1F76D86E0232663ADC04B7F5DC6835C6EE20F02",
+              "timestamp": 1588694768888,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220797A5B731E872EAAEF14ED8D761E47540BA21AAAC978BCC26F0178A87310BDC0022100A27BE6BAF4B2EA2F5CFE551F5046140504F62176EDD168F48269CCB882B2580E"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Nessie2022 Log",
+              "logId":
+                "51A3B0F5FD01799C566DB837788F0CA47ACC1B27CBF79E88429A0DFED48B05E5",
+              "timestamp": 1588694768963,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3046022100DBDD6E8D24F68F08A2F3E06BC835EA3D06AA212EE99BFA515FFED3592C09F128022100A5B03946C3F3637AAD3E0ED978E64A96446FD6E04A36BEA48C37909A9ED88CED"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.7",
+      "timestamp": 162824.285395,
+      "dataLength": 36836,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.7",
+      "timestamp": 162824.283632,
+      "encodedDataLength": 37058,
+      "shouldReportCorbBlocking": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.11",
+      "timestamp": 162824.295507,
+      "dataLength": 16384,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.11",
+      "timestamp": 162824.295561,
+      "dataLength": 16384,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.11",
+      "timestamp": 162824.302888,
+      "dataLength": 16384,
+      "encodedDataLength": 32795
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.11",
+      "timestamp": 162824.306648,
+      "dataLength": 16384,
+      "encodedDataLength": 16393
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  { "method": "Page.loadEventFired", "params": { "timestamp": 162824.308628 } },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "name": "load",
+      "timestamp": 162824.308628
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "31436884AD20CBC87477AF1D2B5A5429" }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.20",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "documentURL": "https://qduej.csb.app/",
+      "request": {
+        "url": "https://qduej.csb.app/favicon.ico",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://qduej.csb.app/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.310935,
+      "wallTime": 1590380011.139062,
+      "initiator": { "type": "other" },
+      "type": "Other",
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "83685.20",
+      "blockedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "qduej.csb.app",
+        ":scheme": "https",
+        ":path": "/favicon.ico",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+        "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "image",
+        "referer": "https://qduej.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "__cfduid=dd980c511f388fad37f60c6500bc554891590380010"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "name": "networkAlmostIdle",
+      "timestamp": 162823.812468
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.11",
+      "timestamp": 162824.579291,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFailed",
+    "params": {
+      "requestId": "83685.11",
+      "timestamp": 162824.591533,
+      "type": "Media",
+      "errorText": "net::ERR_ABORTED",
+      "canceled": true
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "83685.21",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "documentURL": "https://zfh61.csb.app/",
+      "request": {
+        "url": "https://www.w3schools.com/tags/movie.mp4",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://zfh61.csb.app/",
+          "Accept-Encoding": "identity;q=1, *;q=0",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+          "Range": "bytes=131072-"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 162824.5998,
+      "wallTime": 1590380011.427916,
+      "initiator": { "type": "other" },
+      "type": "Media",
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "hasUserGesture": false
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "83685.21",
+      "blockedCookies": [],
+      "headers": {
+        "status": "206",
+        "accept-ranges": "bytes",
+        "age": "7733",
+        "cache-control": "public,max-age=14400,public",
+        "content-type": "video/mp4",
+        "date": "Mon, 25 May 2020 04:13:31 GMT",
+        "etag": "\"8179b1407fbcf1:0\"",
+        "last-modified": "Tue, 07 Jan 2014 08:05:39 GMT",
+        "server": "ECS (sya/E08E)",
+        "x-cache": "HIT",
+        "x-frame-options": "SAMEORIGIN",
+        "x-powered-by": "ASP.NET",
+        "Content-Range": "bytes 131072-318464/318465",
+        "Content-Length": "187393"
+      }
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.21",
+      "loaderId": "A96E1426CD51C4AC5E90C43EE09F3C23",
+      "timestamp": 162824.603239,
+      "type": "Media",
+      "response": {
+        "url": "https://www.w3schools.com/tags/movie.mp4",
+        "status": 206,
+        "statusText": "",
+        "headers": {
+          "date": "Mon, 25 May 2020 04:13:31 GMT",
+          "etag": "\"8179b1407fbcf1:0\"",
+          "last-modified": "Tue, 07 Jan 2014 08:05:39 GMT",
+          "server": "ECS (sya/E08E)",
+          "age": "7733",
+          "status": "206",
+          "x-powered-by": "ASP.NET",
+          "x-frame-options": "SAMEORIGIN",
+          "x-cache": "HIT",
+          "content-type": "video/mp4",
+          "Content-Range": "bytes 131072-318464/318465",
+          "cache-control": "public,max-age=14400,public",
+          "accept-ranges": "bytes",
+          "Content-Length": "187393"
+        },
+        "mimeType": "video/mp4",
+        "connectionReused": false,
+        "connectionId": 0,
+        "remoteIPAddress": "192.229.179.87",
+        "remotePort": 443,
+        "fromDiskCache": true,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "timing": {
+          "requestTime": 162824.600289,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.072,
+          "sendEnd": 0.072,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 0.818
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_256_GCM",
+          "certificateId": 0,
+          "subjectName": "*.w3schools.com",
+          "sanList": ["*.w3schools.com", "w3schools.com"],
+          "issuer": "DigiCert SHA2 Secure Server CA",
+          "validFrom": 1588636800,
+          "validTo": 1652184000,
+          "signedCertificateTimestampList": [],
+          "certificateTransparencyCompliance": "unknown"
+        }
+      },
+      "frameId": "25A2EF16DA63D669E56F8639E5EFE72C"
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.21",
+      "timestamp": 162824.603999,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Network.loadingFailed",
+    "params": {
+      "requestId": "83685.21",
+      "timestamp": 162824.604575,
+      "type": "Media",
+      "errorText": "net::ERR_ABORTED",
+      "canceled": true
+    },
+    "source": {
+      "targetId": "25A2EF16DA63D669E56F8639E5EFE72C",
+      "sessionId": "C7FE2A5A94CB95E69DFCF629824AE214"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "networkAlmostIdle",
+      "timestamp": 162824.07445
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "firstMeaningfulPaint",
+      "timestamp": 162824.098475
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "D74DD5178300A1AAB95823EC30A10ECD",
+      "loaderId": "4805C6E85721CD53E8D51A57B17593B4",
+      "name": "networkIdle",
+      "timestamp": 162824.07445
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "83685.20",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Mon, 25 May 2020 04:13:31 GMT",
+        "content-type": "image/x-icon",
+        "last-modified": "Fri, 22 May 2020 11:44:42 GMT",
+        "etag": "W/\"5ec7bb2a-3aee\"",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+        "cf-cache-status": "REVALIDATED",
+        "expires": "Mon, 25 May 2020 08:13:31 GMT",
+        "cache-control": "public, max-age=14400",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "vary": "Accept-Encoding",
+        "server": "cloudflare",
+        "cf-ray": "598c6c9e08a6fe68-SYD",
+        "content-encoding": "br",
+        "cf-request-id": "02eba236c30000fe68379db200000001"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "83685.20",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "timestamp": 162824.800404,
+      "type": "Other",
+      "response": {
+        "url": "https://qduej.csb.app/favicon.ico",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Mon, 25 May 2020 04:13:31 GMT",
+          "via": "1.1 google",
+          "cf-cache-status": "REVALIDATED",
+          "status": "200",
+          "content-encoding": "br",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-25=\":443\"; ma=86400, h3-24=\":443\"; ma=86400, h3-23=\":443\"; ma=86400",
+          "cf-request-id": "02eba236c30000fe68379db200000001",
+          "last-modified": "Fri, 22 May 2020 11:44:42 GMT",
+          "server": "cloudflare",
+          "etag": "W/\"5ec7bb2a-3aee\"",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "vary": "Accept-Encoding",
+          "content-type": "image/x-icon",
+          "cache-control": "public, max-age=14400",
+          "cf-ray": "598c6c9e08a6fe68-SYD",
+          "expires": "Mon, 25 May 2020 08:13:31 GMT"
+        },
+        "mimeType": "image/x-icon",
+        "requestHeaders": {
+          ":path": "/favicon.ico",
+          "sec-fetch-mode": "no-cors",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36",
+          "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+          "referer": "https://qduej.csb.app/",
+          "sec-fetch-dest": "image",
+          ":authority": "qduej.csb.app",
+          "cookie": "__cfduid=dd980c511f388fad37f60c6500bc554891590380010",
+          ":scheme": "https",
+          "sec-fetch-site": "same-origin",
+          ":method": "GET"
+        },
+        "connectionReused": true,
+        "connectionId": 27,
+        "remoteIPAddress": "104.18.26.114",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 165,
+        "timing": {
+          "requestTime": 162824.31131,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.47,
+          "sendEnd": 0.817,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 486.715
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": ["sni.cloudflaressl.com", "csb.app", "*.csb.app"],
+          "issuer": "CloudFlare Inc ECC CA-2",
+          "validFrom": 1563235200,
+          "validTo": 1594814400,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1563281916019,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100B59FBDDD94AEDE9A9C83539B805EFAB1416D8D977C9B85003AAF1E345E27955502205FCF9B3B5A65395AC1260BEB799FD7543B3F81D6D3D74D4F76A31AC1AEB64767"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Cloudflare 'Nimbus2020' Log",
+              "logId":
+                "5EA773F9DF56C0E7B536487DD049E0327A919A0C84A112128418759681714558",
+              "timestamp": 1563281915852,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3046022100D4D1B9D8087037081BCE37765AF9420A879AD564A00AF82F74781343F1030826022100E4014490A0A106AF3E65D2675BC3585EE37278795DE2A5C91514197469AF758C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.20",
+      "timestamp": 162824.800552,
+      "dataLength": 15086,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "83685.20",
+      "timestamp": 162824.801219,
+      "dataLength": 0,
+      "encodedDataLength": 2008
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "83685.20",
+      "timestamp": 162824.798988,
+      "encodedDataLength": 2173,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "31436884AD20CBC87477AF1D2B5A5429",
+      "loaderId": "4355017A2060DF8B961B1AD927083EAA",
+      "name": "networkIdle",
+      "timestamp": 162824.801241
+    }
+  }
+]

--- a/src/chrome-devtools/lib/har/__fixtures__/linkClickChrome.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/linkClickChrome.json
@@ -1,0 +1,666 @@
+[
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "documentURL": "https://www.sitespeed.io/documentation/",
+      "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+      "hasUserGesture": true,
+      "initiator": { "type": "other" },
+      "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+      "request": {
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"
+        },
+        "initialPriority": "VeryHigh",
+        "method": "GET",
+        "mixedContentType": "none",
+        "referrerPolicy": "no-referrer",
+        "url": "https://www.sitespeed.io/documentation/"
+      },
+      "requestId": "498739478C13F27AE4EFDA7A005918D6",
+      "timestamp": 186182.089061,
+      "type": "Document",
+      "wallTime": 1542973731.302486
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0" }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+      "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+      "requestId": "498739478C13F27AE4EFDA7A005918D6",
+      "response": {
+        "connectionId": 46,
+        "connectionReused": true,
+        "encodedDataLength": 8394,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "headers": {
+          "age": "12099",
+          "cache-control": "public, max-age=0, must-revalidate",
+          "content-encoding": "gzip",
+          "content-length": "8261",
+          "content-security-policy":
+            "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'",
+          "content-type": "text/html; charset=UTF-8",
+          "date": "Fri, 23 Nov 2018 08:27:12 GMT",
+          "etag": "\"5845d0af318484658eb606d3cdf8dec0-ssl-df\"",
+          "referrer-policy": "no-referrer",
+          "server": "Netlify",
+          "status": "200",
+          "strict-transport-security": "max-age=31536000",
+          "vary": "Accept-Encoding",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-nf-request-id": "cf03b3c7-2996-41f4-bf4a-a12fd10aefa1-11213500",
+          "x-xss-protection": "1; mode=block"
+        },
+        "mimeType": "text/html",
+        "protocol": "h2",
+        "remoteIPAddress": "142.93.108.123",
+        "remotePort": 443,
+        "requestHeaders": {
+          ":authority": "www.sitespeed.io",
+          ":method": "GET",
+          ":path": "/documentation/",
+          ":scheme": "https",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"
+        },
+        "securityDetails": {
+          "certificateId": 0,
+          "certificateTransparencyCompliance": "compliant",
+          "cipher": "AES_128_GCM",
+          "issuer": "Let's Encrypt Authority X3",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "protocol": "TLS 1.2",
+          "sanList": ["sitespeed.io", "www.sitespeed.io"],
+          "signedCertificateTimestampList": [
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Cloudflare 'Nimbus2019' Log",
+              "logId":
+                "747EDA8331AD331091219CCE254F4270C2BFFD5E422008C6373579E6107BCC56",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402203BDB0F4580F1DB83C5F676D758671D2D48F25419F502488E25D125D5DE982BA202201CD6CB5B392D634C9E07F4455D89888E70E5DF285615CDBF64449E6EC5760D3E",
+              "status": "Verified",
+              "timestamp": 1539576275075
+            },
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Google 'Icarus' log",
+              "logId":
+                "293C519654C83965BAAA50FC5807D4B76FBF587A2972DCA4C30CF4E54547F478",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220574E93F015D36086E18B842AD8EFF39286E5C4871AB06EC8900E2005A2B4AB9A022100DC0303AB50BD3B8E53602E55A45719FA11BF062F4ECF2CA0A0EA88174CA37807",
+              "status": "Verified",
+              "timestamp": 1539576275602
+            }
+          ],
+          "subjectName": "sitespeed.io",
+          "validFrom": 1539572675,
+          "validTo": 1547348675
+        },
+        "securityState": "secure",
+        "status": 200,
+        "statusText": "",
+        "timing": {
+          "connectEnd": -1,
+          "connectStart": -1,
+          "dnsEnd": -1,
+          "dnsStart": -1,
+          "proxyEnd": -1,
+          "proxyStart": -1,
+          "pushEnd": 0,
+          "pushStart": 0,
+          "receiveHeadersEnd": 33.915,
+          "requestTime": 186182.089366,
+          "sendEnd": 0.554,
+          "sendStart": 0.494,
+          "sslEnd": -1,
+          "sslStart": -1,
+          "workerReady": -1,
+          "workerStart": -1
+        },
+        "url": "https://www.sitespeed.io/documentation/"
+      },
+      "timestamp": 186182.123783,
+      "type": "Document"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "dataLength": 30175,
+      "encodedDataLength": 0,
+      "requestId": "498739478C13F27AE4EFDA7A005918D6",
+      "timestamp": 186182.125649
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+        "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+        "mimeType": "text/html",
+        "securityOrigin": "https://www.sitespeed.io",
+        "url": "https://www.sitespeed.io/documentation/"
+      }
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "encodedDataLength": 8394,
+      "requestId": "498739478C13F27AE4EFDA7A005918D6",
+      "shouldReportCorbBlocking": false,
+      "timestamp": 186182.124857
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "documentURL": "https://www.sitespeed.io/documentation/",
+      "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+      "hasUserGesture": false,
+      "initiator": {
+        "lineNumber": 0,
+        "type": "parser",
+        "url": "https://www.sitespeed.io/documentation/"
+      },
+      "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+      "request": {
+        "headers": {},
+        "initialPriority": "VeryLow",
+        "method": "GET",
+        "mixedContentType": "none",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "url": "https://www.sitespeed.io/img/sitespeed-logo-2c.png"
+      },
+      "requestId": "1000082612.19",
+      "timestamp": 186182.130475,
+      "type": "Image",
+      "wallTime": 1542973731.3439
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "1000082612.19" }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+      "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+      "requestId": "1000082612.19",
+      "response": {
+        "connectionId": 46,
+        "connectionReused": true,
+        "encodedDataLength": 3753,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "headers": {
+          "accept-ranges": "bytes",
+          "age": "12125",
+          "cache-control": "public,max-age=360000",
+          "content-length": "3619",
+          "content-security-policy":
+            "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'",
+          "content-type": "image/png",
+          "date": "Fri, 23 Nov 2018 08:26:44 GMT",
+          "etag": "\"09a1a43e633a55da6e99c644cf7ec8f5-ssl\"",
+          "referrer-policy": "no-referrer",
+          "server": "Netlify",
+          "status": "200",
+          "strict-transport-security": "max-age=31536000",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-nf-request-id": "cf03b3c7-2996-41f4-bf4a-a12fd10aefa1-11212124",
+          "x-xss-protection": "1; mode=block"
+        },
+        "mimeType": "image/png",
+        "protocol": "h2",
+        "remoteIPAddress": "142.93.108.123",
+        "remotePort": 443,
+        "requestHeaders": {
+          ":authority": "www.sitespeed.io",
+          ":method": "GET",
+          ":path": "/img/sitespeed-logo-2c.png",
+          ":scheme": "https",
+          "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"
+        },
+        "securityDetails": {
+          "certificateId": 0,
+          "certificateTransparencyCompliance": "compliant",
+          "cipher": "AES_128_GCM",
+          "issuer": "Let's Encrypt Authority X3",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "protocol": "TLS 1.2",
+          "sanList": ["sitespeed.io", "www.sitespeed.io"],
+          "signedCertificateTimestampList": [
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Cloudflare 'Nimbus2019' Log",
+              "logId":
+                "747EDA8331AD331091219CCE254F4270C2BFFD5E422008C6373579E6107BCC56",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402203BDB0F4580F1DB83C5F676D758671D2D48F25419F502488E25D125D5DE982BA202201CD6CB5B392D634C9E07F4455D89888E70E5DF285615CDBF64449E6EC5760D3E",
+              "status": "Verified",
+              "timestamp": 1539576275075
+            },
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Google 'Icarus' log",
+              "logId":
+                "293C519654C83965BAAA50FC5807D4B76FBF587A2972DCA4C30CF4E54547F478",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220574E93F015D36086E18B842AD8EFF39286E5C4871AB06EC8900E2005A2B4AB9A022100DC0303AB50BD3B8E53602E55A45719FA11BF062F4ECF2CA0A0EA88174CA37807",
+              "status": "Verified",
+              "timestamp": 1539576275602
+            }
+          ],
+          "subjectName": "sitespeed.io",
+          "validFrom": 1539572675,
+          "validTo": 1547348675
+        },
+        "securityState": "secure",
+        "status": 200,
+        "statusText": "",
+        "timing": {
+          "connectEnd": -1,
+          "connectStart": -1,
+          "dnsEnd": -1,
+          "dnsStart": -1,
+          "proxyEnd": -1,
+          "proxyStart": -1,
+          "pushEnd": 0,
+          "pushStart": 0,
+          "receiveHeadersEnd": 34.43,
+          "requestTime": 186179.871577,
+          "sendEnd": 0.868,
+          "sendStart": 0.687,
+          "sslEnd": -1,
+          "sslStart": -1,
+          "workerReady": -1,
+          "workerStart": -1
+        },
+        "url": "https://www.sitespeed.io/img/sitespeed-logo-2c.png"
+      },
+      "timestamp": 186182.130519,
+      "type": "Image"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "dataLength": 3619,
+      "encodedDataLength": 0,
+      "requestId": "1000082612.19",
+      "timestamp": 186182.130521
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "encodedDataLength": 0,
+      "requestId": "1000082612.19",
+      "shouldReportCorbBlocking": false,
+      "timestamp": 186182.130522
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "documentURL": "https://www.sitespeed.io/documentation/",
+      "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+      "hasUserGesture": false,
+      "initiator": {
+        "lineNumber": 3,
+        "type": "parser",
+        "url": "https://www.sitespeed.io/documentation/"
+      },
+      "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+      "request": {
+        "headers": {},
+        "initialPriority": "VeryLow",
+        "method": "GET",
+        "mixedContentType": "none",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "url": "https://www.sitespeed.io/img/black-logo-120.png"
+      },
+      "requestId": "1000082612.20",
+      "timestamp": 186182.130581,
+      "type": "Image",
+      "wallTime": 1542973731.34401
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "1000082612.20" }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+      "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+      "requestId": "1000082612.20",
+      "response": {
+        "connectionId": 46,
+        "connectionReused": true,
+        "encodedDataLength": 1778,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "headers": {
+          "accept-ranges": "bytes",
+          "age": "12125",
+          "cache-control": "public,max-age=360000",
+          "content-length": "1678",
+          "content-security-policy":
+            "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'",
+          "content-type": "image/png",
+          "date": "Fri, 23 Nov 2018 08:26:44 GMT",
+          "etag": "\"0c115c6889613d8d990c500e3da7c734-ssl\"",
+          "referrer-policy": "no-referrer",
+          "server": "Netlify",
+          "status": "200",
+          "strict-transport-security": "max-age=31536000",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-nf-request-id": "cf03b3c7-2996-41f4-bf4a-a12fd10aefa1-11212130",
+          "x-xss-protection": "1; mode=block"
+        },
+        "mimeType": "image/png",
+        "protocol": "h2",
+        "remoteIPAddress": "142.93.108.123",
+        "remotePort": 443,
+        "requestHeaders": {
+          ":authority": "www.sitespeed.io",
+          ":method": "GET",
+          ":path": "/img/black-logo-120.png",
+          ":scheme": "https",
+          "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"
+        },
+        "securityDetails": {
+          "certificateId": 0,
+          "certificateTransparencyCompliance": "compliant",
+          "cipher": "AES_128_GCM",
+          "issuer": "Let's Encrypt Authority X3",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "protocol": "TLS 1.2",
+          "sanList": ["sitespeed.io", "www.sitespeed.io"],
+          "signedCertificateTimestampList": [
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Cloudflare 'Nimbus2019' Log",
+              "logId":
+                "747EDA8331AD331091219CCE254F4270C2BFFD5E422008C6373579E6107BCC56",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402203BDB0F4580F1DB83C5F676D758671D2D48F25419F502488E25D125D5DE982BA202201CD6CB5B392D634C9E07F4455D89888E70E5DF285615CDBF64449E6EC5760D3E",
+              "status": "Verified",
+              "timestamp": 1539576275075
+            },
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Google 'Icarus' log",
+              "logId":
+                "293C519654C83965BAAA50FC5807D4B76FBF587A2972DCA4C30CF4E54547F478",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220574E93F015D36086E18B842AD8EFF39286E5C4871AB06EC8900E2005A2B4AB9A022100DC0303AB50BD3B8E53602E55A45719FA11BF062F4ECF2CA0A0EA88174CA37807",
+              "status": "Verified",
+              "timestamp": 1539576275602
+            }
+          ],
+          "subjectName": "sitespeed.io",
+          "validFrom": 1539572675,
+          "validTo": 1547348675
+        },
+        "securityState": "secure",
+        "status": 200,
+        "statusText": "",
+        "timing": {
+          "connectEnd": -1,
+          "connectStart": -1,
+          "dnsEnd": -1,
+          "dnsStart": -1,
+          "proxyEnd": -1,
+          "proxyStart": -1,
+          "pushEnd": 0,
+          "pushStart": 0,
+          "receiveHeadersEnd": 104.573,
+          "requestTime": 186179.873701,
+          "sendEnd": 1.054,
+          "sendStart": 0.897,
+          "sslEnd": -1,
+          "sslStart": -1,
+          "workerReady": -1,
+          "workerStart": -1
+        },
+        "url": "https://www.sitespeed.io/img/black-logo-120.png"
+      },
+      "timestamp": 186182.130615,
+      "type": "Image"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "dataLength": 1678,
+      "encodedDataLength": 0,
+      "requestId": "1000082612.20",
+      "timestamp": 186182.130617
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "encodedDataLength": 0,
+      "requestId": "1000082612.20",
+      "shouldReportCorbBlocking": false,
+      "timestamp": 186182.130618
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "documentURL": "https://www.sitespeed.io/documentation/",
+      "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+      "hasUserGesture": false,
+      "initiator": {
+        "lineNumber": 3,
+        "type": "parser",
+        "url": "https://www.sitespeed.io/documentation/"
+      },
+      "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+      "request": {
+        "headers": {},
+        "initialPriority": "VeryLow",
+        "method": "GET",
+        "mixedContentType": "none",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "url": "https://www.sitespeed.io/img/digital-ocean.png"
+      },
+      "requestId": "1000082612.21",
+      "timestamp": 186182.130667,
+      "type": "Image",
+      "wallTime": 1542973731.34409
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "1000082612.21" }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0",
+      "loaderId": "498739478C13F27AE4EFDA7A005918D6",
+      "requestId": "1000082612.21",
+      "response": {
+        "connectionId": 46,
+        "connectionReused": true,
+        "encodedDataLength": 3311,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "headers": {
+          "accept-ranges": "bytes",
+          "age": "12125",
+          "cache-control": "public,max-age=360000",
+          "content-length": "3211",
+          "content-security-policy":
+            "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'",
+          "content-type": "image/png",
+          "date": "Fri, 23 Nov 2018 08:26:44 GMT",
+          "etag": "\"9eb2e2cddcc0027b70a5dcfb7cf60025-ssl\"",
+          "referrer-policy": "no-referrer",
+          "server": "Netlify",
+          "status": "200",
+          "strict-transport-security": "max-age=31536000",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-nf-request-id": "cf03b3c7-2996-41f4-bf4a-a12fd10aefa1-11212131",
+          "x-xss-protection": "1; mode=block"
+        },
+        "mimeType": "image/png",
+        "protocol": "h2",
+        "remoteIPAddress": "142.93.108.123",
+        "remotePort": 443,
+        "requestHeaders": {
+          ":authority": "www.sitespeed.io",
+          ":method": "GET",
+          ":path": "/img/digital-ocean.png",
+          ":scheme": "https",
+          "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"
+        },
+        "securityDetails": {
+          "certificateId": 0,
+          "certificateTransparencyCompliance": "compliant",
+          "cipher": "AES_128_GCM",
+          "issuer": "Let's Encrypt Authority X3",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "protocol": "TLS 1.2",
+          "sanList": ["sitespeed.io", "www.sitespeed.io"],
+          "signedCertificateTimestampList": [
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Cloudflare 'Nimbus2019' Log",
+              "logId":
+                "747EDA8331AD331091219CCE254F4270C2BFFD5E422008C6373579E6107BCC56",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402203BDB0F4580F1DB83C5F676D758671D2D48F25419F502488E25D125D5DE982BA202201CD6CB5B392D634C9E07F4455D89888E70E5DF285615CDBF64449E6EC5760D3E",
+              "status": "Verified",
+              "timestamp": 1539576275075
+            },
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Google 'Icarus' log",
+              "logId":
+                "293C519654C83965BAAA50FC5807D4B76FBF587A2972DCA4C30CF4E54547F478",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220574E93F015D36086E18B842AD8EFF39286E5C4871AB06EC8900E2005A2B4AB9A022100DC0303AB50BD3B8E53602E55A45719FA11BF062F4ECF2CA0A0EA88174CA37807",
+              "status": "Verified",
+              "timestamp": 1539576275602
+            }
+          ],
+          "subjectName": "sitespeed.io",
+          "validFrom": 1539572675,
+          "validTo": 1547348675
+        },
+        "securityState": "secure",
+        "status": 200,
+        "statusText": "",
+        "timing": {
+          "connectEnd": -1,
+          "connectStart": -1,
+          "dnsEnd": -1,
+          "dnsStart": -1,
+          "proxyEnd": -1,
+          "proxyStart": -1,
+          "pushEnd": 0,
+          "pushStart": 0,
+          "receiveHeadersEnd": 104.584,
+          "requestTime": 186179.873852,
+          "sendEnd": 0.936,
+          "sendStart": 0.881,
+          "sslEnd": -1,
+          "sslStart": -1,
+          "workerReady": -1,
+          "workerStart": -1
+        },
+        "url": "https://www.sitespeed.io/img/digital-ocean.png"
+      },
+      "timestamp": 186182.130699,
+      "type": "Image"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "dataLength": 3211,
+      "encodedDataLength": 0,
+      "requestId": "1000082612.21",
+      "timestamp": 186182.130701
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "encodedDataLength": 0,
+      "requestId": "1000082612.21",
+      "shouldReportCorbBlocking": false,
+      "timestamp": 186182.130702
+    }
+  },
+  { "method": "Page.loadEventFired", "params": { "timestamp": 186182.142875 } },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "A0A0B8AF96AF4F9E554477C3DF4F3BE0" }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": { "timestamp": 186182.143151 }
+  }
+]

--- a/src/chrome-devtools/lib/har/__fixtures__/navigatedWithinDocument.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/navigatedWithinDocument.json
@@ -1,0 +1,1756 @@
+[
+  {
+    "method": "Page.navigatedWithinDocument",
+    "params": {
+      "frameId": "3535CE8D2ED943055DDB14AB79AF5C0C",
+      "url": "https://dvajs.github.io/dva-hackernews/#/show"
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":43,\"a\":\"q\",\"b\":{\"p\":\"/v0/showstories\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.35986
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":44,\"a\":\"n\",\"b\":{\"p\":\"/v0/topstories\"}}}"
+      },
+      "timestamp": 310790.360408
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "documentURL": "https://dvajs.github.io/dva-hackernews/",
+      "frameId": "3535CE8D2ED943055DDB14AB79AF5C0C",
+      "hasUserGesture": false,
+      "initiator": {
+        "stack": {
+          "callFrames": [
+            {
+              "columnNumber": 1542,
+              "functionName": "e.e",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 447799,
+              "functionName": "",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 450536,
+              "functionName": "value",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 450345,
+              "functionName": "n",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 152501,
+              "functionName": "constructClassInstance",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 162834,
+              "functionName": "beginWork",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 174999,
+              "functionName": "o",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 175320,
+              "functionName": "a",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 175558,
+              "functionName": "u",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 179101,
+              "functionName": "E",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 178838,
+              "functionName": "w",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 177966,
+              "functionName": "d",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 177356,
+              "functionName": "p",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 151937,
+              "functionName": "enqueueSetState",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 131240,
+              "functionName": "o.setState",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 83092,
+              "functionName": "",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 50542,
+              "functionName": "n",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 50766,
+              "functionName": "",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 50737,
+              "functionName": "notifyListeners",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 54547,
+              "functionName": "O",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 54839,
+              "functionName": "",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 50435,
+              "functionName": "n",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 54795,
+              "functionName": "T",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            },
+            {
+              "columnNumber": 54753,
+              "functionName": "S",
+              "lineNumber": 0,
+              "scriptId": "21",
+              "url":
+                "https://dvajs.github.io/dva-hackernews/static/umi.b5bc14d5.js"
+            }
+          ]
+        },
+        "type": "script"
+      },
+      "loaderId": "D8FC3A2ABAAA2E4513CAC42E8C5814EF",
+      "request": {
+        "headers": {
+          "Referer": "https://dvajs.github.io/dva-hackernews/",
+          "User-Agent":
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36"
+        },
+        "initialPriority": "Low",
+        "method": "GET",
+        "mixedContentType": "none",
+        "referrerPolicy": "no-referrer-when-downgrade",
+        "url":
+          "https://dvajs.github.io/dva-hackernews/static/src__pages__show__index.40f2c771.async.js"
+      },
+      "requestId": "1000000526.38",
+      "timestamp": 310790.368484,
+      "type": "Script",
+      "wallTime": 1539298742.38535
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "frameId": "3535CE8D2ED943055DDB14AB79AF5C0C",
+      "loaderId": "D8FC3A2ABAAA2E4513CAC42E8C5814EF",
+      "requestId": "1000000526.38",
+      "response": {
+        "connectionId": 40,
+        "connectionReused": true,
+        "encodedDataLength": 190,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "headers": {
+          "accept-ranges": "bytes",
+          "access-control-allow-origin": "*",
+          "age": "0",
+          "cache-control": "max-age=600",
+          "content-length": "156",
+          "content-type": "application/javascript; charset=utf-8",
+          "date": "Thu, 11 Oct 2018 22:59:02 GMT",
+          "etag": "\"5a91196f-9c\"",
+          "expires": "Thu, 11 Oct 2018 22:04:05 GMT",
+          "last-modified": "Sat, 24 Feb 2018 07:51:11 GMT",
+          "server": "GitHub.com",
+          "status": "200",
+          "strict-transport-security": "max-age=31557600",
+          "vary": "Accept-Encoding",
+          "via": "1.1 varnish",
+          "x-cache": "HIT",
+          "x-cache-hits": "1",
+          "x-fastly-request-id": "309f2fa6efeeb8dcc5a7b8fc86f40bc4bf4e790c",
+          "x-github-request-id": "A074:029E:CD930:107B9F:5BBFC67D",
+          "x-served-by": "cache-bma1649-BMA",
+          "x-timer": "S1539298742.367525,VS0,VE114"
+        },
+        "mimeType": "application/javascript",
+        "protocol": "h2",
+        "remoteIPAddress": "185.199.109.153",
+        "remotePort": 443,
+        "requestHeaders": {
+          ":authority": "dvajs.github.io",
+          ":method": "GET",
+          ":path":
+            "/dva-hackernews/static/src__pages__show__index.40f2c771.async.js",
+          ":scheme": "https",
+          "accept": "*/*",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-US,en;q=0.9",
+          "referer": "https://dvajs.github.io/dva-hackernews/",
+          "user-agent":
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36"
+        },
+        "securityDetails": {
+          "certificateId": 0,
+          "certificateTransparencyCompliance": "compliant",
+          "cipher": "AES_128_GCM",
+          "issuer": "DigiCert SHA2 High Assurance Server CA",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "protocol": "TLS 1.2",
+          "sanList": [
+            "www.github.com",
+            "*.github.io",
+            "*.githubusercontent.com",
+            "*.github.com",
+            "github.com",
+            "github.io",
+            "githubusercontent.com"
+          ],
+          "signedCertificateTimestampList": [
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Google 'Rocketeer' log",
+              "logId":
+                "EE4BBDB775CE60BAE142691FABE19E66A30F7E5FB072D88300C47B897AA8FDCB",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304502205ED342AB3C2DCBF43530274AD85E843E161EF450CDEB60DC93F6E2F2128D647C022100BB51EE4AD7A2EC2C8F8B39D8FD9B589892D102862EF6E70469D92E7E16352703",
+              "status": "Verified",
+              "timestamp": 1530128767154
+            },
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "DigiCert Log Server 2",
+              "logId":
+                "8775BFE7597CF88C43995FBDF36EFF568D475636FF4AB560C1B4EAFF5EA0830F",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022076C144478ED7E10CDEA5DD0F606989EEF61E71B058C920E037A8ED5DCEA3558D022100D3F2797ABAD72D60B071FF22AD9AAAFE3708C8E30D0F29D366DA360DE9B8DA0C",
+              "status": "Verified",
+              "timestamp": 1530128767155
+            },
+            {
+              "hashAlgorithm": "SHA-256",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "origin": "Embedded in certificate",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100871BA8402C90CC4A122BCFDFE005EAF9DD11677E79D28A5F704B72DE9EE01F20022016773571C2359A47EA8C3B0FFA9465C7D792E324FDA66F47DB87A15BE48B16DC",
+              "status": "Verified",
+              "timestamp": 1530128766967
+            }
+          ],
+          "subjectName": "www.github.com",
+          "validFrom": 1530057600,
+          "validTo": 1592654400
+        },
+        "securityState": "secure",
+        "status": 200,
+        "statusText": "",
+        "timing": {
+          "connectEnd": -1,
+          "connectStart": -1,
+          "dnsEnd": -1,
+          "dnsStart": -1,
+          "proxyEnd": -1,
+          "proxyStart": -1,
+          "pushEnd": 0,
+          "pushStart": 0,
+          "receiveHeadersEnd": 118.362,
+          "requestTime": 310790.369062,
+          "sendEnd": 1.092,
+          "sendStart": 0.606,
+          "sslEnd": -1,
+          "sslStart": -1,
+          "workerReady": -1,
+          "workerStart": -1
+        },
+        "url":
+          "https://dvajs.github.io/dva-hackernews/static/src__pages__show__index.40f2c771.async.js"
+      },
+      "timestamp": 310790.488166,
+      "type": "Script"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "dataLength": 156,
+      "encodedDataLength": 165,
+      "requestId": "1000000526.38",
+      "timestamp": 310790.488774
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "encodedDataLength": 355,
+      "requestId": "1000000526.38",
+      "shouldReportCorbBlocking": false,
+      "timestamp": 310790.488247
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/showstories\",\"d\":{\"0\":18193264,\"1\":18193418,\"2\":18194731,\"3\":18194340,\"4\":18192484,\"5\":18193160,\"6\":18195325,\"7\":18188302,\"8\":18185161,\"9\":18185035,\"10\":18184149,\"11\":18175656,\"12\":18190136,\"13\":18183363,\"14\":18187100,\"15\":18188643,\"16\":18183334,\"17\":18177367,\"18\":18177443,\"19\":18189017,\"20\":18175080,\"21\":18175910,\"22\":18196267,\"23\":18196252,\"24\":18195894,\"25\":18195182,\"26\":18194914,\"27\":18194374,\"28\":18194314,\"29\":18194309,\"30\":18193965,\"31\":18193885,\"32\":18193784,\"33\":18193782,\"34\":18193346,\"35\":18193190,\"36\":18192594,\"37\":18192169,\"38\":18192125,\"39\":18191729,\"40\":18191485,\"41\":18191459,\"42\":18191380,\"43\":18190877,\"44\":18189306,\"45\":18189182,\"46\":18189085,\"47\":18189012,\"48\":18188983,\"49\":18188695}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.512524
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":45,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18193264\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.514441
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":46,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18193418\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.51466
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":47,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18194731\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.514843
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":48,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18194340\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.515023
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":49,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18192484\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.515237
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":50,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18193160\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.515494
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":51,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18195325\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.515702
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":52,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18188302\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.515898
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":53,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18185161\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.516154
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":54,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18185035\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.516521
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":55,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18184149\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.516762
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":56,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18175656\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.516964
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":57,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18190136\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.517163
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":58,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18183363\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.517369
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":59,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18187100\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.517566
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":60,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18188643\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.517751
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":61,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18183334\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.517933
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":62,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18177367\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.518128
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":63,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18177443\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.518319
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":64,\"a\":\"q\",\"b\":{\"p\":\"/v0/item/18189017\",\"h\":\"\"}}}"
+      },
+      "timestamp": 310790.518508
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":43,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.51859
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":44,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.521734
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18193264\",\"d\":{\"by\":\"pallavn\",\"descendants\":82,\"id\":18193264,\"kids\":{\"0\":18193272,\"1\":18197559,\"2\":18194572,\"3\":18195126,\"4\":18194885,\"5\":18196657,\"6\":18196275,\"7\":18195581,\"8\":18196000,\"9\":18196063,\"10\":18196506,\"11\":18194895,\"12\":18194018,\"13\":18195799,\"14\":18194926,\"15\":18193931,\"16\":18195564,\"17\":18196049},\"score\":259,\"time\":1539264051,\"title\":\"Show HN: Tableau-Like Data Visualizations in JavaScript\",\"type\":\"story\",\"url\":\"https://www.charts.com/muze\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.669847
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":65,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18193264\"}}}"
+      },
+      "timestamp": 310790.670776
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":45,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.670954
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18193418\",\"d\":{\"by\":\"sbrown12\",\"descendants\":5,\"id\":18193418,\"kids\":{\"0\":18195262,\"1\":18194777,\"2\":18196496,\"3\":18194702},\"score\":26,\"time\":1539265284,\"title\":\"Show HN: StrongDM – 1 click access to any database or server in any environment\",\"type\":\"story\",\"url\":\"https://www.strongdm.com/\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.672538
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":66,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18193418\"}}}"
+      },
+      "timestamp": 310790.67319
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":46,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.673278
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18194731\",\"d\":{\"by\":\"aulrich\",\"descendants\":4,\"id\":18194731,\"kids\":{\"0\":18194735,\"1\":18194879,\"2\":18195724},\"score\":13,\"time\":1539274403,\"title\":\"Show HN: An embeddable portfolio for your (side) projects\",\"type\":\"story\",\"url\":\"https://makerwidget.com/\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.673377
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":67,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18194731\"}}}"
+      },
+      "timestamp": 310790.674094
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":47,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.674211
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18194340\",\"d\":{\"by\":\"wesbos\",\"descendants\":0,\"id\":18194340,\"score\":4,\"time\":1539271983,\"title\":\"Show HN: Advanced React and GraphQL course\",\"type\":\"story\",\"url\":\"https://AdvancedReact.com\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.674326
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":68,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18194340\"}}}"
+      },
+      "timestamp": 310790.674857
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":48,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.674993
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18192484\",\"d\":{\"by\":\"jpaulet\",\"descendants\":2,\"id\":18192484,\"kids\":{\"0\":18192501},\"score\":4,\"time\":1539256489,\"title\":\"Show HN: RoastMe – Feedback markeplace  from users and experts for your product\",\"type\":\"story\",\"url\":\"https://roastme.xyz\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.675132
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":69,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18192484\"}}}"
+      },
+      "timestamp": 310790.675654
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":49,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.675871
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18193160\",\"d\":{\"by\":\"farazhaider\",\"descendants\":0,\"id\":18193160,\"score\":5,\"time\":1539263200,\"title\":\"Show HN: Compact Sparse Merkle Trees – Build efficient Blockchains in Elixir\",\"type\":\"story\",\"url\":\"https://github.com/ZanjeerPlatform/csmt\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.676155
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":70,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18193160\"}}}"
+      },
+      "timestamp": 310790.676965
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":50,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.677099
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18195325\",\"d\":{\"by\":\"Swizec\",\"descendants\":5,\"id\":18195325,\"kids\":{\"0\":18197031,\"1\":18196412,\"2\":18195533,\"3\":18196112},\"score\":4,\"time\":1539278633,\"title\":\"Show HN: Office keeps freezing carrots so I built an app to warm CPU and thaw em\",\"type\":\"story\",\"url\":\"https://swizec.com/blog/i-built-a-node-app-to-thaw-my-favorite-snack-%F0%9F%A5%95/swizec/8660?edit-title\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.677325
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":71,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18195325\"}}}"
+      },
+      "timestamp": 310790.677898
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":51,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.677993
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18188302\",\"d\":{\"by\":\"usern\",\"descendants\":2,\"id\":18188302,\"kids\":{\"0\":18191617},\"score\":5,\"time\":1539201290,\"title\":\"Show HN: Get GitHub and GitHub Enterprise notifications in MacOS\",\"type\":\"story\",\"url\":\"https://sargsyan.github.io/github-notifier/\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.67809
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":72,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18188302\"}}}"
+      },
+      "timestamp": 310790.678581
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":52,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.678673
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18185161\",\"d\":{\"by\":\"vbordo\",\"descendants\":0,\"id\":18185161,\"score\":8,\"time\":1539181805,\"title\":\"Show HN: DevFlight – Get paid to develop your open-source projects\",\"type\":\"story\",\"url\":\"https://about.devflight.com\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.678767
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":73,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18185161\"}}}"
+      },
+      "timestamp": 310790.679191
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":53,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.679273
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18185035\",\"d\":{\"by\":\"fabiospampinato\",\"descendants\":2,\"id\":18185035,\"kids\":{\"0\":18190965,\"1\":18191499},\"score\":7,\"time\":1539181109,\"title\":\"Show HN: Autogit – automatically execute commands across multiple Git repos\",\"type\":\"story\",\"url\":\"https://github.com/fabiospampinato/autogit\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.679367
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":74,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18185035\"}}}"
+      },
+      "timestamp": 310790.679816
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":54,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.679908
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18184149\",\"d\":{\"by\":\"stooderrr\",\"descendants\":7,\"id\":18184149,\"kids\":{\"0\":18184154,\"1\":18184461,\"2\":18184426,\"3\":18185979,\"4\":18184699,\"5\":18191500},\"score\":27,\"time\":1539174177,\"title\":\"Show HN: Supercharge your front-end skills by building real projects\",\"type\":\"story\",\"url\":\"https://www.frontendmentor.io/\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.679993
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":75,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18184149\"}}}"
+      },
+      "timestamp": 310790.680563
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":55,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.680656
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18175656\",\"d\":{\"by\":\"mirthless\",\"descendants\":0,\"id\":18175656,\"score\":18,\"time\":1539090957,\"title\":\"Show HN: Shortcut Hub – siri shortcuts catalog\",\"type\":\"story\",\"url\":\"https://www.shortcuthub.app\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.680748
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":76,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18175656\"}}}"
+      },
+      "timestamp": 310790.681292
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":56,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.681379
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18190136\",\"d\":{\"by\":\"sdegutis\",\"descendants\":0,\"id\":18190136,\"score\":3,\"time\":1539218003,\"title\":\"Show HN: PerfectlyBalancedHN – Chrome extension to combat early-bird bias\",\"type\":\"story\",\"url\":\"https://github.com/sdegutis/PerfectlyBalancedHN\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.68148
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":77,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18190136\"}}}"
+      },
+      "timestamp": 310790.681918
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":57,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.682
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18183363\",\"d\":{\"by\":\"alexsideris\",\"descendants\":1,\"id\":18183363,\"kids\":{\"0\":18183366,\"1\":18183365,\"2\":18183517},\"score\":7,\"time\":1539164894,\"title\":\"Show HN: Universal Solution for Accepting Cryptocurrency Subscriptions\",\"type\":\"story\",\"url\":\"https://www.cryptosubscriptions.co\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.682095
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":78,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18183363\"}}}"
+      },
+      "timestamp": 310790.682583
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":58,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.682675
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18187100\",\"d\":{\"by\":\"srikanthsrnvs\",\"descendants\":5,\"id\":18187100,\"kids\":{\"0\":18187132,\"1\":18193984,\"2\":18190855},\"score\":6,\"time\":1539192730,\"title\":\"Show HN: An API that lets you power an e-commerce site with Uber-like deliveries\",\"type\":\"story\",\"url\":\"http://www.blip.delivery\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.682765
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":79,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18187100\"}}}"
+      },
+      "timestamp": 310790.683231
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":59,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.683322
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18188643\",\"d\":{\"by\":\"thecalvinchan\",\"descendants\":0,\"id\":18188643,\"score\":5,\"time\":1539203976,\"title\":\"Show HN: New OTC Decentralized Crypto Trading Product by AirSwap\",\"type\":\"story\",\"url\":\"https://medium.com/fluidity/spaces-is-here-a36fa6753474\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.683411
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":80,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18188643\"}}}"
+      },
+      "timestamp": 310790.684031
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":60,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.684132
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18183334\",\"d\":{\"by\":\"danburzo\",\"descendants\":2,\"id\":18183334,\"kids\":{\"0\":18183344,\"1\":18193367,\"2\":18183368},\"score\":9,\"time\":1539164569,\"title\":\"Show HN: Percollate – a command-line tool to grab web pages as PDFs\",\"type\":\"story\",\"url\":\"https://github.com/danburzo/percollate\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.684344
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":81,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18183334\"}}}"
+      },
+      "timestamp": 310790.685461
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":61,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.685597
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18177367\",\"d\":{\"by\":\"alexsicart\",\"descendants\":0,\"id\":18177367,\"score\":3,\"time\":1539102731,\"title\":\"Show HN: Shasta – Everything you need to operate with energy on Ethereum\",\"type\":\"story\",\"url\":\"https://github.com/Shasta/Shasta\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.685735
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":82,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18177367\"}}}"
+      },
+      "timestamp": 310790.695513
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":62,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.695629
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18177443\",\"d\":{\"by\":\"octosphere\",\"descendants\":3,\"id\":18177443,\"kids\":{\"0\":18183110,\"1\":18184334},\"score\":11,\"time\":1539103147,\"title\":\"Show HN: CSS Stats\",\"type\":\"story\",\"url\":\"https://cssstats.com/\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.695773
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":83,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18177443\"}}}"
+      },
+      "timestamp": 310790.696437
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":63,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.696556
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"b\":{\"p\":\"v0/item/18189017\",\"d\":{\"by\":\"stdoutrap\",\"descendants\":0,\"id\":18189017,\"score\":14,\"time\":1539206452,\"title\":\"Show HN: Nerdcore minus the cringe. A (true) rap song about time estimations\",\"type\":\"story\",\"url\":\"https://www.youtube.com/watch?v=sh7A8UChBTI\"}},\"a\":\"d\"}}"
+      },
+      "timestamp": 310790.696669
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": true,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":84,\"a\":\"n\",\"b\":{\"p\":\"/v0/item/18189017\"}}}"
+      },
+      "timestamp": 310790.697129
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":64,\"b\":{\"s\":\"ok\",\"d\":{}}}}"
+      },
+      "timestamp": 310790.724808
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":65,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.843949
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":66,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.849362
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":67,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.84957
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":68,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.849679
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":69,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.849784
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":70,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.849872
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":71,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.85018
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":72,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.850267
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":73,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.850382
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":74,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.850472
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":75,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.850554
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":76,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.850634
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":77,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.850728
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":78,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.850814
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":79,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.850913
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":80,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.851014
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":81,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.851099
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":82,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.851189
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":83,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.851273
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "1000000526.33",
+      "response": {
+        "mask": false,
+        "opcode": 1,
+        "payloadData":
+          "{\"t\":\"d\",\"d\":{\"r\":84,\"b\":{\"s\":\"ok\",\"d\":\"\"}}}"
+      },
+      "timestamp": 310790.851337
+    }
+  }
+]

--- a/src/chrome-devtools/lib/har/__fixtures__/response-blocked-cookies.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/response-blocked-cookies.json
@@ -1,0 +1,1388 @@
+[
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "commit",
+      "timestamp": 105304.825458
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "DOMContentLoaded",
+      "timestamp": 105304.825701
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "load",
+      "timestamp": 105304.826454
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "networkAlmostIdle",
+      "timestamp": 105304.827428
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "networkIdle",
+      "timestamp": 105304.827428
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "documentURL": "https://1j7om.csb.app/",
+      "request": {
+        "url": "https://1j7om.csb.app/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105304.900271,
+      "wallTime": 1595998349.332865,
+      "initiator": { "type": "other" },
+      "type": "Document",
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "1j7om.csb.app",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "none",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-user": "?1",
+        "sec-fetch-dest": "document",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 04:52:29 GMT",
+        "content-type": "text/html",
+        "set-cookie":
+          "__cfduid=da0f64c008e4700b2ef1278a954bbfaab1595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax\nsignedIn=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; max-age=0; HttpOnly",
+        "vary": "Accept-Encoding",
+        "cache-control": "private, max-age=0, no-cache, no-store",
+        "x-request-id": "FiYgCwONI2AAty-jgboB",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+        "cf-cache-status": "DYNAMIC",
+        "cf-request-id": "043a83409e000016c9312cf200000001",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "server": "cloudflare",
+        "cf-ray": "5ba43b1438bf16c9-SYD",
+        "content-encoding": "br"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "timestamp": 105305.274595,
+      "type": "Document",
+      "response": {
+        "url": "https://1j7om.csb.app/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "date": "Wed, 29 Jul 2020 04:52:29 GMT",
+          "content-type": "text/html",
+          "set-cookie":
+            "__cfduid=da0f64c008e4700b2ef1278a954bbfaab1595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax\nsignedIn=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; max-age=0; HttpOnly",
+          "vary": "Accept-Encoding",
+          "cache-control": "private, max-age=0, no-cache, no-store",
+          "x-request-id": "FiYgCwONI2AAty-jgboB",
+          "via": "1.1 google",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-request-id": "043a83409e000016c9312cf200000001",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "server": "cloudflare",
+          "cf-ray": "5ba43b1438bf16c9-SYD",
+          "content-encoding": "br"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "1j7om.csb.app",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "none",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-user": "?1",
+          "sec-fetch-dest": "document",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 27,
+        "remoteIPAddress": "104.18.26.114",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 517,
+        "timing": {
+          "requestTime": 105304.900931,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.201,
+          "dnsEnd": 18.829,
+          "connectStart": 18.829,
+          "connectEnd": 59.169,
+          "sslStart": 32.295,
+          "sslEnd": 59.124,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 60.098,
+          "sendEnd": 60.254,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 372.114
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": ["csb.app", "*.csb.app", "sni.cloudflaressl.com"],
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "validFrom": 1592092800,
+          "validTo": 1623672000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1592144349432,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100FA501C68EFDDF67D9EB87B386A1620A11B1C871C7D7ADB54BA7C0CCC2448579102207311518D0EDD72404E7E2D9AC92AB7104279095A62254CF54B066AECB27B6092"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId":
+                "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1592144349477,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220397916D2C22156CB1221120F49E296BDB88CF62644982BAEF75DF7FA185E19FB022100955E06938E6FD50DE0EB9506D2AE95010331350672DF8161ABD2D7C061DA9BB7"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "1C067E53675C2B37E7516A1C223663C1"
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "1C067E53675C2B37E7516A1C223663C1" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "init",
+      "timestamp": 105305.280594
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "1C067E53675C2B37E7516A1C223663C1",
+        "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+        "url": "https://1j7om.csb.app/",
+        "securityOrigin": "https://1j7om.csb.app",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "timestamp": 105305.288495,
+      "dataLength": 229,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "timestamp": 105305.273529,
+      "encodedDataLength": 657,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.frameAttached",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "parentFrameId": "1C067E53675C2B37E7516A1C223663C1"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "784B95F5DE8C4723138CA72939371301",
+      "name": "init",
+      "timestamp": 105305.290275
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "784B95F5DE8C4723138CA72939371301",
+      "name": "DOMContentLoaded",
+      "timestamp": 105305.290646
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "E6A6DA1FA18E836F76E84A377F1AB598" }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "documentURL": "https://ow5u1.sse.codesandbox.io/",
+      "request": {
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "Referer": "https://1j7om.csb.app/"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105305.291334,
+      "wallTime": 1595998349.723936,
+      "initiator": {
+        "type": "parser",
+        "url": "https://1j7om.csb.app/",
+        "lineNumber": 3
+      },
+      "type": "Document",
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": { "timestamp": 105305.291562 }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "DOMContentLoaded",
+      "timestamp": 105305.291562
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "ow5u1.sse.codesandbox.io",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-dest": "iframe",
+        "referer": "https://1j7om.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "firstPaint",
+      "timestamp": 105305.382575
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 105305.382575
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "blockedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookieLine":
+            "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure"
+        }
+      ],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 04:52:30 GMT",
+        "content-type": "text/html; charset=utf-8",
+        "set-cookie":
+          "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure\nsuper-secret-cookie=s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok; Path=/; Expires=Wed, 29 Jul 2020 04:53:30 GMT; HttpOnly",
+        "cf-ray": "5ba43b169e1eda52-SYD",
+        "strict-transport-security": "max-age=15724800; includeSubDomains",
+        "vary": "Accept-Encoding",
+        "cf-cache-status": "DYNAMIC",
+        "cf-request-id": "043a83421c0000da528939e200000001",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "x-powered-by": "Express",
+        "server": "cloudflare",
+        "content-encoding": "br",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105305.712927,
+      "type": "Document",
+      "response": {
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "date": "Wed, 29 Jul 2020 04:52:30 GMT",
+          "content-type": "text/html; charset=utf-8",
+          "set-cookie":
+            "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure\nsuper-secret-cookie=s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok; Path=/; Expires=Wed, 29 Jul 2020 04:53:30 GMT; HttpOnly",
+          "cf-ray": "5ba43b169e1eda52-SYD",
+          "strict-transport-security": "max-age=15724800; includeSubDomains",
+          "vary": "Accept-Encoding",
+          "cf-cache-status": "DYNAMIC",
+          "cf-request-id": "043a83421c0000da528939e200000001",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "x-powered-by": "Express",
+          "server": "cloudflare",
+          "content-encoding": "br",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "ow5u1.sse.codesandbox.io",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "cross-site",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-dest": "iframe",
+          "referer": "https://1j7om.csb.app/",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 42,
+        "remoteIPAddress": "104.18.23.207",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 583,
+        "timing": {
+          "requestTime": 105305.292368,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.236,
+          "dnsEnd": 15.649,
+          "connectStart": 15.649,
+          "connectEnd": 51.833,
+          "sslStart": 26.907,
+          "sslEnd": 51.828,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 51.99,
+          "sendEnd": 52.082,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 418.578
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "codesandbox.io",
+          "sanList": [
+            "*.codesandbox.io",
+            "*.sse.codesandbox.io",
+            "sse.codesandbox.io",
+            "codesandbox.io"
+          ],
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "validFrom": 1592524800,
+          "validTo": 1624104000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1592553700283,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402202772E2338894114508BF0E3F43848CB631E961FD53A41C8DCB884C2F7414F87302204F38406BD87367B2CED0EAD186C8F98F86AFB489D332E0447A50E962DB567FAD"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId":
+                "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1592553700317,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304502203959D63B5D969EAC4884F4A1BCF25963597DFD714B73C410C7C90A50AF570DBD022100EB7FEE5091C046E5F1AFD308CDD78BE6C5C4F9FBB07ABF3A98886858D636C27C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "init",
+      "timestamp": 105305.7144
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "E6A6DA1FA18E836F76E84A377F1AB598",
+        "parentId": "1C067E53675C2B37E7516A1C223663C1",
+        "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+        "name": "",
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "securityOrigin": "https://ow5u1.sse.codesandbox.io",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105305.717852,
+      "dataLength": 363,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105305.711621,
+      "encodedDataLength": 792,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "45305.3",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "super-secret-cookie",
+            "value":
+              "s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok",
+            "domain": "ow5u1.sse.codesandbox.io",
+            "path": "/",
+            "expires": 1595998410.143544,
+            "size": 101,
+            "httpOnly": true,
+            "secure": false,
+            "session": false,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "ow5u1.sse.codesandbox.io",
+        ":scheme": "https",
+        ":path": "/style.css",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "text/css,*/*;q=0.1",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "style",
+        "referer": "https://ow5u1.sse.codesandbox.io/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie":
+          "super-secret-cookie=s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "45305.3",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "documentURL": "https://ow5u1.sse.codesandbox.io/",
+      "request": {
+        "url": "https://ow5u1.sse.codesandbox.io/style.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://ow5u1.sse.codesandbox.io/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105305.718827,
+      "wallTime": 1595998350.151346,
+      "initiator": {
+        "type": "parser",
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "lineNumber": 5
+      },
+      "type": "Stylesheet",
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "45305.4",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "documentURL": "https://ow5u1.sse.codesandbox.io/",
+      "request": {
+        "url": "https://sse-0.codesandbox.io/client-hook-3.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://ow5u1.sse.codesandbox.io/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105305.719236,
+      "wallTime": 1595998350.151754,
+      "initiator": {
+        "type": "parser",
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "lineNumber": 6
+      },
+      "type": "Script",
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "45305.3",
+      "blockedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookieLine":
+            "__cfduid=d1a3eeb06208778c719235145dfee08521595998350; expires=Fri, 28-Aug-20 04:52:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure"
+        }
+      ],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 04:52:30 GMT",
+        "content-type": "text/css; charset=UTF-8",
+        "set-cookie":
+          "__cfduid=d1a3eeb06208778c719235145dfee08521595998350; expires=Fri, 28-Aug-20 04:52:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
+        "cf-ray": "5ba43b18e992da52-SYD",
+        "cache-control": "public, max-age=0",
+        "etag": "W/\"732-17398e8d619\"",
+        "last-modified": "Wed, 29 Jul 2020 04:51:02 GMT",
+        "strict-transport-security": "max-age=15724800; includeSubDomains",
+        "vary": "Accept-Encoding",
+        "cf-cache-status": "DYNAMIC",
+        "cf-request-id": "043a8343940000da52893ab200000001",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "x-powered-by": "Express",
+        "server": "cloudflare",
+        "content-encoding": "br",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "networkAlmostIdle",
+      "timestamp": 105305.291642
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "networkIdle",
+      "timestamp": 105305.291642
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "45305.3",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105306.088488,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://ow5u1.sse.codesandbox.io/style.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Wed, 29 Jul 2020 04:52:30 GMT",
+          "content-encoding": "br",
+          "vary": "Accept-Encoding",
+          "cf-cache-status": "DYNAMIC",
+          "x-powered-by": "Express",
+          "status": "200",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+          "cf-request-id": "043a8343940000da52893ab200000001",
+          "last-modified": "Wed, 29 Jul 2020 04:51:02 GMT",
+          "server": "cloudflare",
+          "etag": "W/\"732-17398e8d619\"",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "strict-transport-security": "max-age=15724800; includeSubDomains",
+          "content-type": "text/css; charset=UTF-8",
+          "cache-control": "public, max-age=0",
+          "cf-ray": "5ba43b18e992da52-SYD"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 42,
+        "remoteIPAddress": "104.18.23.207",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 251,
+        "timing": {
+          "requestTime": 105305.719385,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.232,
+          "sendEnd": 1.146,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 367.665
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "codesandbox.io",
+          "sanList": [
+            "*.codesandbox.io",
+            "*.sse.codesandbox.io",
+            "sse.codesandbox.io",
+            "codesandbox.io"
+          ],
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "validFrom": 1592524800,
+          "validTo": 1624104000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1592553700283,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402202772E2338894114508BF0E3F43848CB631E961FD53A41C8DCB884C2F7414F87302204F38406BD87367B2CED0EAD186C8F98F86AFB489D332E0447A50E962DB567FAD"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId":
+                "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1592553700317,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304502203959D63B5D969EAC4884F4A1BCF25963597DFD714B73C410C7C90A50AF570DBD022100EB7FEE5091C046E5F1AFD308CDD78BE6C5C4F9FBB07ABF3A98886858D636C27C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.3",
+      "timestamp": 105306.088587,
+      "dataLength": 1842,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.3",
+      "timestamp": 105306.088911,
+      "dataLength": 0,
+      "encodedDataLength": 631
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "45305.3",
+      "timestamp": 105306.087445,
+      "encodedDataLength": 882,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "45305.4",
+      "associatedCookies": [
+        {
+          "blockedReasons": ["DomainMismatch"],
+          "cookie": {
+            "name": "super-secret-cookie",
+            "value":
+              "s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok",
+            "domain": "ow5u1.sse.codesandbox.io",
+            "path": "/",
+            "expires": 1595998410.143544,
+            "size": 101,
+            "httpOnly": true,
+            "secure": false,
+            "session": false,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "sse-0.codesandbox.io",
+        ":scheme": "https",
+        ":path": "/client-hook-3.js",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "same-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "script",
+        "referer": "https://ow5u1.sse.codesandbox.io/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "45305.4",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "server": "nginx/1.17.10",
+        "date": "Wed, 29 Jul 2020 04:52:31 GMT",
+        "content-type": "application/javascript; charset=utf-8",
+        "vary": "Accept-Encoding",
+        "cache-control": "max-age=0",
+        "last-modified": "Mon, 20 Jul 2020 15:47:27 GMT",
+        "strict-transport-security": "max-age=15724800; includeSubDomains",
+        "content-encoding": "gzip"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "45305.4",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105306.674952,
+      "type": "Script",
+      "response": {
+        "url": "https://sse-0.codesandbox.io/client-hook-3.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Wed, 29 Jul 2020 04:52:31 GMT",
+          "content-encoding": "gzip",
+          "last-modified": "Mon, 20 Jul 2020 15:47:27 GMT",
+          "server": "nginx/1.17.10",
+          "vary": "Accept-Encoding",
+          "content-type": "application/javascript; charset=utf-8",
+          "status": "200",
+          "cache-control": "max-age=0",
+          "strict-transport-security": "max-age=15724800; includeSubDomains"
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": false,
+        "connectionId": 57,
+        "remoteIPAddress": "5.9.114.19",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 204,
+        "timing": {
+          "requestTime": 105305.719941,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.339,
+          "dnsEnd": 16.436,
+          "connectStart": 16.436,
+          "connectEnd": 635.747,
+          "sslStart": 316.56,
+          "sslEnd": 635.742,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 635.843,
+          "sendEnd": 635.926,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 950.745
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sse-0.codesandbox.io",
+          "sanList": ["*.sse-0.codesandbox.io", "sse-0.codesandbox.io"],
+          "issuer": "Let's Encrypt Authority X3",
+          "validFrom": 1595139821,
+          "validTo": 1602915821,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Cloudflare 'Nimbus2020' Log",
+              "logId":
+                "5EA773F9DF56C0E7B536487DD049E0327A919A0C84A112128418759681714558",
+              "timestamp": 1595143421677,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3046022100D9147E347D5C125BA03FC3F91BC373987B361CDCA61FD1CC7367C6E0EAE80778022100E9F8348E4CABA35C02F5FD2A5E7444ECDB4792B35FDC817AB1DDCFAB4ED07B17"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2020' log",
+              "logId":
+                "B21E05CC8BA2CD8A204E8766F92BB98A2520676BDAFA70E7B249532DEF8B905E",
+              "timestamp": 1595143421668,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402207C5C95F30796CE98B80911B66FA75FDBF6F6ED3785728200AE40C441F78D5BDE0220278B9945F074C28E1FD1E72F862B2C5EF6602E730AB3E903DFC6D1BE74CC5AA8"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.4",
+      "timestamp": 105306.675066,
+      "dataLength": 16384,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.4",
+      "timestamp": 105306.675503,
+      "dataLength": 2871,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.4",
+      "timestamp": 105306.675828,
+      "dataLength": 0,
+      "encodedDataLength": 6079
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "45305.4",
+      "timestamp": 105306.675498,
+      "encodedDataLength": 6283,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "load",
+      "timestamp": 105306.679513
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "E6A6DA1FA18E836F76E84A377F1AB598" }
+  },
+  { "method": "Page.loadEventFired", "params": { "timestamp": 105306.685884 } },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "load",
+      "timestamp": 105306.685884
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "1C067E53675C2B37E7516A1C223663C1" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "DOMContentLoaded",
+      "timestamp": 105306.686053
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "45305.7",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "documentURL": "https://1j7om.csb.app/",
+      "request": {
+        "url": "https://1j7om.csb.app/favicon.ico",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://1j7om.csb.app/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105306.688537,
+      "wallTime": 1595998351.121031,
+      "initiator": { "type": "other" },
+      "type": "Other",
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "45305.7",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "__cfduid",
+            "value": "da0f64c008e4700b2ef1278a954bbfaab1595998349",
+            "domain": ".csb.app",
+            "path": "/",
+            "expires": 1598590349.705596,
+            "size": 51,
+            "httpOnly": true,
+            "secure": false,
+            "session": false,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "1j7om.csb.app",
+        ":scheme": "https",
+        ":path": "/favicon.ico",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "image",
+        "referer": "https://1j7om.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "__cfduid=da0f64c008e4700b2ef1278a954bbfaab1595998349"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "firstPaint",
+      "timestamp": 105306.717356
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "firstContentfulPaint",
+      "timestamp": 105306.717356
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 105306.717356
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "45305.7",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 04:52:31 GMT",
+        "content-type": "image/x-icon",
+        "last-modified": "Mon, 27 Jul 2020 12:13:58 GMT",
+        "etag": "W/\"5f1ec506-3aee\"",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+        "cf-cache-status": "REVALIDATED",
+        "expires": "Wed, 29 Jul 2020 08:52:31 GMT",
+        "cache-control": "public, max-age=14400",
+        "cf-request-id": "043a83475c000016c931346200000001",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "vary": "Accept-Encoding",
+        "server": "cloudflare",
+        "cf-ray": "5ba43b1efb9d16c9-SYD",
+        "content-encoding": "br"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "45305.7",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "timestamp": 105307.04912,
+      "type": "Other",
+      "response": {
+        "url": "https://1j7om.csb.app/favicon.ico",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Wed, 29 Jul 2020 04:52:31 GMT",
+          "via": "1.1 google",
+          "cf-cache-status": "REVALIDATED",
+          "status": "200",
+          "content-encoding": "br",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+          "cf-request-id": "043a83475c000016c931346200000001",
+          "last-modified": "Mon, 27 Jul 2020 12:13:58 GMT",
+          "server": "cloudflare",
+          "etag": "W/\"5f1ec506-3aee\"",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "vary": "Accept-Encoding",
+          "content-type": "image/x-icon",
+          "cache-control": "public, max-age=14400",
+          "cf-ray": "5ba43b1efb9d16c9-SYD",
+          "expires": "Wed, 29 Jul 2020 08:52:31 GMT"
+        },
+        "mimeType": "image/x-icon",
+        "connectionReused": true,
+        "connectionId": 27,
+        "remoteIPAddress": "104.18.26.114",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 188,
+        "timing": {
+          "requestTime": 105306.688854,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.211,
+          "sendEnd": 0.337,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 359.058
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": ["csb.app", "*.csb.app", "sni.cloudflaressl.com"],
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "validFrom": 1592092800,
+          "validTo": 1623672000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1592144349432,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100FA501C68EFDDF67D9EB87B386A1620A11B1C871C7D7ADB54BA7C0CCC2448579102207311518D0EDD72404E7E2D9AC92AB7104279095A62254CF54B066AECB27B6092"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId":
+                "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1592144349477,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220397916D2C22156CB1221120F49E296BDB88CF62644982BAEF75DF7FA185E19FB022100955E06938E6FD50DE0EB9506D2AE95010331350672DF8161ABD2D7C061DA9BB7"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "1C067E53675C2B37E7516A1C223663C1"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.7",
+      "timestamp": 105307.049217,
+      "dataLength": 15086,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.7",
+      "timestamp": 105307.049637,
+      "dataLength": 0,
+      "encodedDataLength": 2012
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "45305.7",
+      "timestamp": 105307.048389,
+      "encodedDataLength": 2200,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "networkAlmostIdle",
+      "timestamp": 105306.686071
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "firstMeaningfulPaint",
+      "timestamp": 105306.717356
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "networkIdle",
+      "timestamp": 105306.686071
+    }
+  }
+]

--- a/src/chrome-devtools/lib/har/__fixtures__/samesite-sandbox.glitch.me.json
+++ b/src/chrome-devtools/lib/har/__fixtures__/samesite-sandbox.glitch.me.json
@@ -1,0 +1,1304 @@
+[
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "commit",
+      "timestamp": 101502.464606
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "DOMContentLoaded",
+      "timestamp": 101502.464778
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "load",
+      "timestamp": 101502.465212
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "networkAlmostIdle",
+      "timestamp": 101502.466024
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "networkIdle",
+      "timestamp": 101502.466024
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "documentURL": "https://samesite-sandbox.glitch.me/",
+      "request": {
+        "url": "https://samesite-sandbox.glitch.me/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 101502.530226,
+      "wallTime": 1595994540.608392,
+      "initiator": { "type": "other" },
+      "type": "Document",
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "samesite-sandbox.glitch.me",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "none",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-user": "?1",
+        "sec-fetch-dest": "document",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "networkAlmostIdle",
+      "timestamp": 101502.466024
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "networkIdle",
+      "timestamp": 101502.466024
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 03:49:01 GMT",
+        "content-type": "text/html; charset=UTF-8",
+        "content-length": "10494",
+        "x-powered-by": "Express",
+        "strict-transport-security":
+          "max-age=63072000; inlcudeSubdomains; preload",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "set-cookie":
+          "ck03=vl03; SameSite=InvalidValue\nck00=vl00; Path=/\nck01=vl01; Path=/; Secure; SameSite=None\nck02=vl02; Path=/; SameSite=None\nck04=vl04; Path=/; SameSite=Lax\nck05=vl05; Path=/; SameSite=Strict",
+        "accept-ranges": "bytes",
+        "cache-control": "public, max-age=0",
+        "last-modified": "Thu, 26 Mar 2020 12:31:57 GMT",
+        "etag": "W/\"28fe-17116d3e248\""
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "timestamp": 101503.419814,
+      "type": "Document",
+      "response": {
+        "url": "https://samesite-sandbox.glitch.me/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "date": "Wed, 29 Jul 2020 03:49:01 GMT",
+          "content-type": "text/html; charset=UTF-8",
+          "content-length": "10494",
+          "x-powered-by": "Express",
+          "strict-transport-security":
+            "max-age=63072000; inlcudeSubdomains; preload",
+          "referrer-policy": "strict-origin-when-cross-origin",
+          "set-cookie":
+            "ck03=vl03; SameSite=InvalidValue\nck00=vl00; Path=/\nck01=vl01; Path=/; Secure; SameSite=None\nck02=vl02; Path=/; SameSite=None\nck04=vl04; Path=/; SameSite=Lax\nck05=vl05; Path=/; SameSite=Strict",
+          "accept-ranges": "bytes",
+          "cache-control": "public, max-age=0",
+          "last-modified": "Thu, 26 Mar 2020 12:31:57 GMT",
+          "etag": "W/\"28fe-17116d3e248\""
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "samesite-sandbox.glitch.me",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "none",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-user": "?1",
+          "sec-fetch-dest": "document",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 27,
+        "remoteIPAddress": "54.164.246.13",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 464,
+        "timing": {
+          "requestTime": 101502.530878,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.219,
+          "dnsEnd": 16.358,
+          "connectStart": 16.358,
+          "connectEnd": 453.89,
+          "sslStart": 229.023,
+          "sslEnd": 453.884,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 454.664,
+          "sendEnd": 454.751,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 887.04
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "glitch.com",
+          "sanList": [
+            "glitch.com",
+            "glitch.me",
+            "gomix.com",
+            "*.glitch.com",
+            "gomix.me",
+            "*.gomix.me",
+            "*.glitch.me",
+            "hyperdev.com",
+            "*.hyperdev.com",
+            "*.gomix.com"
+          ],
+          "issuer": "Amazon",
+          "validFrom": 1581984000,
+          "validTo": 1616068800,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1582065086753,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30460221008F85EB81321626E05DFC2D21CD76F747F633F1BB2DDD08EC1B9247F09705CADD022100C40B8B3618B01225F8F1B091FC699C7986178429FF95A475066CF4567575B2CA"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Log Server 2",
+              "logId":
+                "8775BFE7597CF88C43995FBDF36EFF568D475636FF4AB560C1B4EAFF5EA0830F",
+              "timestamp": 1582065086835,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450221009BD96A9E4B69EAB9CD766C423B14902F48BA85026C8055DFD4166528DDC6C22C02205B4520A3AF7654586FC7718787A8081A3C939D757DEB0FDD32AAE80300B7ABB5"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "447C526AAC595F429B694068BE35F750"
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "447C526AAC595F429B694068BE35F750" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "init",
+      "timestamp": 101503.42367
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "447C526AAC595F429B694068BE35F750",
+        "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+        "url": "https://samesite-sandbox.glitch.me/",
+        "securityOrigin": "https://samesite-sandbox.glitch.me",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "timestamp": 101503.431291,
+      "dataLength": 10494,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "timestamp": 101503.418486,
+      "encodedDataLength": 10985,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.frameAttached",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "parentFrameId": "447C526AAC595F429B694068BE35F750",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "13",
+            "url": "https://samesite-sandbox.glitch.me/",
+            "lineNumber": 372,
+            "columnNumber": 18
+          }
+        ]
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "EBF6C7225F44E8D5DE95283F7A2A45E8",
+      "name": "init",
+      "timestamp": 101503.563853
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "EBF6C7225F44E8D5DE95283F7A2A45E8",
+      "name": "DOMContentLoaded",
+      "timestamp": 101503.565014
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4" }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "documentURL":
+        "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+      "request": {
+        "url":
+          "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "Referer": "https://samesite-sandbox.glitch.me/"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 101503.566432,
+      "wallTime": 1595994541.644641,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "",
+              "scriptId": "13",
+              "url": "https://samesite-sandbox.glitch.me/",
+              "lineNumber": 372,
+              "columnNumber": 18
+            }
+          ]
+        }
+      },
+      "type": "Document",
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": { "timestamp": 101503.566471 }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "DOMContentLoaded",
+      "timestamp": 101503.566471
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "firstPaint",
+      "timestamp": 101503.59997
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "firstContentfulPaint",
+      "timestamp": 101503.59997
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 101503.59997
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "googlechromelabs.github.io",
+        ":scheme": "https",
+        ":path": "/samesite-examples/crosssite-embed.html",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-dest": "iframe",
+        "referer": "https://samesite-sandbox.glitch.me/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "EBF6C7225F44E8D5DE95283F7A2A45E8",
+      "name": "networkAlmostIdle",
+      "timestamp": 101503.565101
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "EBF6C7225F44E8D5DE95283F7A2A45E8",
+      "name": "networkIdle",
+      "timestamp": 101503.565101
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "networkAlmostIdle",
+      "timestamp": 101503.566552
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "firstMeaningfulPaint",
+      "timestamp": 101503.59997
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "networkIdle",
+      "timestamp": 101503.566552
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "text/html; charset=utf-8",
+        "server": "GitHub.com",
+        "strict-transport-security": "max-age=31556952",
+        "last-modified": "Thu, 02 Apr 2020 11:29:48 GMT",
+        "etag": "W/\"5e85ccac-2b9\"",
+        "access-control-allow-origin": "*",
+        "expires": "Wed, 29 Jul 2020 03:48:56 GMT",
+        "cache-control": "max-age=600",
+        "content-encoding": "gzip",
+        "x-proxy-cache": "MISS",
+        "x-github-request-id": "16B8:5823:26B58:32FB9:5F20EF50",
+        "accept-ranges": "bytes",
+        "date": "Wed, 29 Jul 2020 03:49:02 GMT",
+        "via": "1.1 varnish",
+        "age": "0",
+        "x-served-by": "cache-syd10121-SYD",
+        "x-cache": "HIT",
+        "x-cache-hits": "1",
+        "x-timer": "S1595994542.820717,VS0,VE804",
+        "vary": "Accept-Encoding",
+        "x-fastly-request-id": "2a80e9628aaf66d0eac077a1eb53e623008b2cae",
+        "content-length": "409"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "timestamp": 101504.443759,
+      "type": "Document",
+      "response": {
+        "url":
+          "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "content-type": "text/html; charset=utf-8",
+          "server": "GitHub.com",
+          "strict-transport-security": "max-age=31556952",
+          "last-modified": "Thu, 02 Apr 2020 11:29:48 GMT",
+          "etag": "W/\"5e85ccac-2b9\"",
+          "access-control-allow-origin": "*",
+          "expires": "Wed, 29 Jul 2020 03:48:56 GMT",
+          "cache-control": "max-age=600",
+          "content-encoding": "gzip",
+          "x-proxy-cache": "MISS",
+          "x-github-request-id": "16B8:5823:26B58:32FB9:5F20EF50",
+          "accept-ranges": "bytes",
+          "date": "Wed, 29 Jul 2020 03:49:02 GMT",
+          "via": "1.1 varnish",
+          "age": "0",
+          "x-served-by": "cache-syd10121-SYD",
+          "x-cache": "HIT",
+          "x-cache-hits": "1",
+          "x-timer": "S1595994542.820717,VS0,VE804",
+          "vary": "Accept-Encoding",
+          "x-fastly-request-id": "2a80e9628aaf66d0eac077a1eb53e623008b2cae",
+          "content-length": "409"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "googlechromelabs.github.io",
+          ":scheme": "https",
+          ":path": "/samesite-examples/crosssite-embed.html",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "cross-site",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-dest": "iframe",
+          "referer": "https://samesite-sandbox.glitch.me/",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 42,
+        "remoteIPAddress": "185.199.108.153",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 378,
+        "timing": {
+          "requestTime": 101503.568005,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.576,
+          "dnsEnd": 26.098,
+          "connectStart": 26.098,
+          "connectEnd": 58.323,
+          "sslStart": 37.65,
+          "sslEnd": 58.317,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 58.553,
+          "sendEnd": 58.649,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 874.356
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "www.github.com",
+          "sanList": [
+            "www.github.com",
+            "*.github.com",
+            "github.com",
+            "*.github.io",
+            "github.io",
+            "*.githubusercontent.com",
+            "githubusercontent.com"
+          ],
+          "issuer": "DigiCert SHA2 High Assurance Server CA",
+          "validFrom": 1588723200,
+          "validTo": 1649937600,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Xenon2022' log",
+              "logId":
+                "46A555EB75FA912030B5A28969F4F37D112C4174BEFD49B885ABF2FC70FE6D47",
+              "timestamp": 1588788666134,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100E7DCBAC3DA1AA00A0CD9FBC5ABA2A87D8591874C519B854411A30706DB016148022016712618C0ED2196525A39ED8B251BCBBA7251E780336FA13355C351D0B53AF7"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2022 Log",
+              "logId":
+                "2245450759552456963FA12FF1F76D86E0232663ADC04B7F5DC6835C6EE20F02",
+              "timestamp": 1588788666047,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30440220661238A2A136DCD7FFE10889D8217E8EF21A61E682D1546093C6B4C17D2453DB0220673EF1DD93482909163CA38569A5B7031701D03CE116C0FA8318646E5D69D008"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Nessie2022 Log",
+              "logId":
+                "51A3B0F5FD01799C566DB837788F0CA47ACC1B27CBF79E88429A0DFED48B05E5",
+              "timestamp": 1588788666121,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220143FE8497E4C20AD5AEA29EC875EACDD3E6F29F9B03ADE4EEF97CF71A263C70B022100ED2F371F1145750850AA98E36D66C854103CF0D9FFAE269FE496FC877A0957C7"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "init",
+      "timestamp": 101504.445684
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "1CF39B1FEA7835B89AD7BC3742E338C4",
+        "parentId": "447C526AAC595F429B694068BE35F750",
+        "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+        "name": "",
+        "url":
+          "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+        "securityOrigin": "https://googlechromelabs.github.io",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "timestamp": 101504.449234,
+      "dataLength": 697,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "timestamp": 101504.442635,
+      "encodedDataLength": 796,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "13720.3",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "documentURL":
+        "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+      "request": {
+        "url": "https://samesite-sandbox.glitch.me/cookies.json",
+        "method": "GET",
+        "headers": {
+          "Referer":
+            "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 101504.450409,
+      "wallTime": 1595994542.528458,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "fetchCookies",
+              "scriptId": "17",
+              "url":
+                "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+              "lineNumber": 16,
+              "columnNumber": 8
+            },
+            {
+              "functionName": "",
+              "scriptId": "17",
+              "url":
+                "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+              "lineNumber": 19,
+              "columnNumber": 2
+            }
+          ]
+        }
+      },
+      "type": "XHR",
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "13720.3",
+      "associatedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookie": {
+            "name": "ck04",
+            "value": "vl04",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": ["SameSiteStrict"],
+          "cookie": {
+            "name": "ck05",
+            "value": "vl05",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "sameSite": "Strict",
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "ck03",
+            "value": "vl03",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "ck00",
+            "value": "vl00",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "ck01",
+            "value": "vl01",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": true,
+            "session": true,
+            "sameSite": "None",
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "ck02",
+            "value": "vl02",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "sameSite": "None",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "samesite-sandbox.glitch.me",
+        ":scheme": "https",
+        ":path": "/cookies.json",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "origin": "https://googlechromelabs.github.io",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "empty",
+        "referer":
+          "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "ck03=vl03; ck00=vl00; ck01=vl01; ck02=vl02"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "load",
+      "timestamp": 101504.451249
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4" }
+  },
+  { "method": "Page.loadEventFired", "params": { "timestamp": 101504.451833 } },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "load",
+      "timestamp": 101504.451833
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "447C526AAC595F429B694068BE35F750" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "DOMContentLoaded",
+      "timestamp": 101504.452001
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "13720.4",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "documentURL": "https://samesite-sandbox.glitch.me/",
+      "request": {
+        "url":
+          "https://cdn.glitch.com/e304e580-9956-4cb6-9f62-9e89ad6cd85f%2Fcookie.png?v=1572981153632",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://samesite-sandbox.glitch.me/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 101504.453159,
+      "wallTime": 1595994542.531207,
+      "initiator": { "type": "other" },
+      "type": "Other",
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "13720.3",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 03:49:02 GMT",
+        "content-type": "application/json; charset=utf-8",
+        "content-length": "57",
+        "x-powered-by": "Express",
+        "strict-transport-security":
+          "max-age=63072000; inlcudeSubdomains; preload",
+        "access-control-allow-origin": "https://googlechromelabs.github.io",
+        "access-control-allow-credentials": "true",
+        "etag": "W/\"39-P/NBn2GNcAA8yGJ1I79HEa1fh8I\""
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "13720.3",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "timestamp": 101504.681331,
+      "type": "XHR",
+      "response": {
+        "url": "https://samesite-sandbox.glitch.me/cookies.json",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Wed, 29 Jul 2020 03:49:02 GMT",
+          "status": "200",
+          "x-powered-by": "Express",
+          "etag": "W/\"39-P/NBn2GNcAA8yGJ1I79HEa1fh8I\"",
+          "strict-transport-security":
+            "max-age=63072000; inlcudeSubdomains; preload",
+          "content-type": "application/json; charset=utf-8",
+          "access-control-allow-origin": "https://googlechromelabs.github.io",
+          "access-control-allow-credentials": "true",
+          "content-length": "57"
+        },
+        "mimeType": "application/json",
+        "connectionReused": true,
+        "connectionId": 27,
+        "remoteIPAddress": "54.164.246.13",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 240,
+        "timing": {
+          "requestTime": 101504.450842,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.247,
+          "sendEnd": 0.375,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 228.095
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "glitch.com",
+          "sanList": [
+            "glitch.com",
+            "glitch.me",
+            "gomix.com",
+            "*.glitch.com",
+            "gomix.me",
+            "*.gomix.me",
+            "*.glitch.me",
+            "hyperdev.com",
+            "*.hyperdev.com",
+            "*.gomix.com"
+          ],
+          "issuer": "Amazon",
+          "validFrom": 1581984000,
+          "validTo": 1616068800,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1582065086753,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30460221008F85EB81321626E05DFC2D21CD76F747F633F1BB2DDD08EC1B9247F09705CADD022100C40B8B3618B01225F8F1B091FC699C7986178429FF95A475066CF4567575B2CA"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Log Server 2",
+              "logId":
+                "8775BFE7597CF88C43995FBDF36EFF568D475636FF4AB560C1B4EAFF5EA0830F",
+              "timestamp": 1582065086835,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450221009BD96A9E4B69EAB9CD766C423B14902F48BA85026C8055DFD4166528DDC6C22C02205B4520A3AF7654586FC7718787A8081A3C939D757DEB0FDD32AAE80300B7ABB5"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "13720.3",
+      "timestamp": 101504.68148,
+      "dataLength": 57,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "13720.3",
+      "timestamp": 101504.679942,
+      "encodedDataLength": 315,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "13720.4",
+      "associatedCookies": [],
+      "headers": {
+        "Host": "cdn.glitch.com",
+        "Connection": "keep-alive",
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "Accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+        "Sec-Fetch-Site": "cross-site",
+        "Sec-Fetch-Mode": "no-cors",
+        "Sec-Fetch-Dest": "image",
+        "Referer": "https://samesite-sandbox.glitch.me/",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "13720.4",
+      "blockedCookies": [],
+      "headers": {
+        "Content-Type": "image/png",
+        "Content-Length": "10010",
+        "Connection": "keep-alive",
+        "Date": "Mon, 22 Jun 2020 10:05:03 GMT",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, HEAD, POST",
+        "Access-Control-Max-Age": "86400",
+        "Cache-Control": "max-age=31536000",
+        "Last-Modified": "Tue, 05 Nov 2019 19:12:33 GMT",
+        "ETag": "\"4fc7568972cffeaa3b02ff05668179d4\"",
+        "Server": "AmazonS3",
+        "X-Cache": "Hit from cloudfront",
+        "Via":
+          "1.1 0cd88f29d8c6e29a267867c45efda9a9.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "SIN52-C2",
+        "X-Amz-Cf-Id":
+          "POKa3J20B_ZaSB17GG2WukHAyh4lRGmfUCfk-PtMyGfmGK6f7VbSYg==",
+        "Age": "3174242"
+      },
+      "headersText":
+        "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: 10010\r\nConnection: keep-alive\r\nDate: Mon, 22 Jun 2020 10:05:03 GMT\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, HEAD, POST\r\nAccess-Control-Max-Age: 86400\r\nCache-Control: max-age=31536000\r\nLast-Modified: Tue, 05 Nov 2019 19:12:33 GMT\r\nETag: \"4fc7568972cffeaa3b02ff05668179d4\"\r\nServer: AmazonS3\r\nX-Cache: Hit from cloudfront\r\nVia: 1.1 0cd88f29d8c6e29a267867c45efda9a9.cloudfront.net (CloudFront)\r\nX-Amz-Cf-Pop: SIN52-C2\r\nX-Amz-Cf-Id: POKa3J20B_ZaSB17GG2WukHAyh4lRGmfUCfk-PtMyGfmGK6f7VbSYg==\r\nAge: 3174242\r\n\r\n"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "13720.4",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "timestamp": 101504.913027,
+      "type": "Other",
+      "response": {
+        "url":
+          "https://cdn.glitch.com/e304e580-9956-4cb6-9f62-9e89ad6cd85f%2Fcookie.png?v=1572981153632",
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "Date": "Mon, 22 Jun 2020 10:05:03 GMT",
+          "Via":
+            "1.1 0cd88f29d8c6e29a267867c45efda9a9.cloudfront.net (CloudFront)",
+          "Age": "3174242",
+          "X-Cache": "Hit from cloudfront",
+          "Connection": "keep-alive",
+          "Content-Length": "10010",
+          "Last-Modified": "Tue, 05 Nov 2019 19:12:33 GMT",
+          "Server": "AmazonS3",
+          "ETag": "\"4fc7568972cffeaa3b02ff05668179d4\"",
+          "Access-Control-Max-Age": "86400",
+          "Access-Control-Allow-Methods": "GET, HEAD, POST",
+          "Content-Type": "image/png",
+          "Access-Control-Allow-Origin": "*",
+          "Cache-Control": "max-age=31536000",
+          "X-Amz-Cf-Pop": "SIN52-C2",
+          "X-Amz-Cf-Id":
+            "POKa3J20B_ZaSB17GG2WukHAyh4lRGmfUCfk-PtMyGfmGK6f7VbSYg=="
+        },
+        "mimeType": "image/png",
+        "connectionReused": false,
+        "connectionId": 57,
+        "remoteIPAddress": "13.225.5.120",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 587,
+        "timing": {
+          "requestTime": 101504.453423,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.141,
+          "dnsEnd": 19.811,
+          "connectStart": 19.811,
+          "connectEnd": 348.28,
+          "sslStart": 122.99,
+          "sslEnd": 348.267,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 348.382,
+          "sendEnd": 348.576,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 458.679
+        },
+        "protocol": "http/1.1",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "glitch.com",
+          "sanList": [
+            "glitch.com",
+            "glitch.me",
+            "gomix.com",
+            "*.glitch.com",
+            "gomix.me",
+            "*.gomix.me",
+            "*.glitch.me",
+            "hyperdev.com",
+            "*.hyperdev.com",
+            "*.gomix.com"
+          ],
+          "issuer": "Amazon",
+          "validFrom": 1581984000,
+          "validTo": 1616068800,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1582065086753,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30460221008F85EB81321626E05DFC2D21CD76F747F633F1BB2DDD08EC1B9247F09705CADD022100C40B8B3618B01225F8F1B091FC699C7986178429FF95A475066CF4567575B2CA"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Log Server 2",
+              "logId":
+                "8775BFE7597CF88C43995FBDF36EFF568D475636FF4AB560C1B4EAFF5EA0830F",
+              "timestamp": 1582065086835,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450221009BD96A9E4B69EAB9CD766C423B14902F48BA85026C8055DFD4166528DDC6C22C02205B4520A3AF7654586FC7718787A8081A3C939D757DEB0FDD32AAE80300B7ABB5"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "447C526AAC595F429B694068BE35F750"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "13720.4",
+      "timestamp": 101504.91318,
+      "dataLength": 10010,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "13720.4",
+      "timestamp": 101504.91422,
+      "dataLength": 0,
+      "encodedDataLength": 10010
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "13720.4",
+      "timestamp": 101504.913024,
+      "encodedDataLength": 10597,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "networkAlmostIdle",
+      "timestamp": 101504.452019
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "networkIdle",
+      "timestamp": 101504.682521
+    }
+  }
+]

--- a/src/chrome-devtools/lib/har/build.parity.test.ts
+++ b/src/chrome-devtools/lib/har/build.parity.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { harFromMessages } from "./build.ts";
+import type { CdpMessage } from "./types.ts";
+
+/**
+ * Parity: the TS port must reproduce upstream chrome-har v1.3.1 byte for byte
+ * on sessionless input. The goldens under __fixtures__/golden/ were generated
+ * ONCE by running the real upstream package (clone at
+ * ../_Playgrounds/chrome-har) over its own recorded-in-Chrome perflogs —
+ * regenerate with the session scratchpad's gen-goldens.ts if fixtures change.
+ */
+
+const FIXTURES = join(import.meta.dir, "__fixtures__");
+
+const PERFLOGS = [
+    "linkClickChrome.json",
+    "samesite-sandbox.glitch.me.json",
+    "response-blocked-cookies.json",
+    "navigatedWithinDocument.json",
+    "iframe-not-attached.json",
+];
+
+// biome-ignore lint/style/noRestrictedGlobals: goldens are strict JSON; SafeJSON strict-mode is the same parser
+const strict = (text: string) => JSON.parse(text);
+
+describe("chrome-har port parity (upstream goldens)", () => {
+    for (const name of PERFLOGS) {
+        test(`${name}: pages and entries equal upstream's output, and are not vacuous`, () => {
+            const log = strict(readFileSync(join(FIXTURES, name), "utf8")) as CdpMessage[];
+            const golden = strict(readFileSync(join(FIXTURES, "golden", name.replace(/\.json$/, ".har.json")), "utf8"));
+            const ours = harFromMessages(log);
+            // Non-vacuity per fixture: toEqual passes on two empty sets, which
+            // would silently bless a golden that regenerated as empty.
+            expect(ours.log.entries.length).toBeGreaterThan(0);
+            expect(ours.log.pages.length).toBeGreaterThan(0);
+            expect({ pages: ours.log.pages, entries: ours.log.entries }).toEqual(golden);
+        });
+    }
+});
+
+const TIMING = {
+    requestTime: 1000.1,
+    dnsStart: 1,
+    dnsEnd: 5,
+    connectStart: 5,
+    connectEnd: 20,
+    sslStart: 8,
+    sslEnd: 19,
+    sendStart: 21,
+    sendEnd: 22,
+    receiveHeadersEnd: 80,
+    pushStart: 0,
+};
+
+describe("caller-attached bodies", () => {
+    test("includeTextFromResponseBody inlines a body the caller set on the response", () => {
+        const messages: CdpMessage[] = [
+            { method: "Page.frameStartedLoading", params: { frameId: "F1" } },
+            {
+                method: "Network.requestWillBeSent",
+                params: {
+                    requestId: "r1",
+                    frameId: "F1",
+                    timestamp: 1000,
+                    wallTime: 1700000000,
+                    type: "Document",
+                    initiator: { type: "other" },
+                    request: { method: "GET", url: "https://app.example.com/", headers: {} },
+                },
+            },
+            {
+                method: "Network.responseReceived",
+                params: {
+                    requestId: "r1",
+                    frameId: "F1",
+                    timestamp: 1000.4,
+                    response: {
+                        url: "https://app.example.com/",
+                        protocol: "h2",
+                        status: 200,
+                        statusText: "",
+                        mimeType: "text/html",
+                        headers: {},
+                        encodedDataLength: 240,
+                        connectionId: 12,
+                        timing: TIMING,
+                        body: "<html>ok</html>",
+                    },
+                },
+            },
+            {
+                method: "Network.loadingFinished",
+                params: { requestId: "r1", timestamp: 1000.6, encodedDataLength: 500 },
+            },
+        ];
+
+        const har = harFromMessages(messages, { includeTextFromResponseBody: true });
+        expect(har.log.entries).toHaveLength(1);
+        expect(har.log.entries[0].response?.content.text).toBe("<html>ok</html>");
+        expect(har.log.entries[0].response?.content.size).toBe("<html>ok</html>".length);
+    });
+});
+
+describe("sessionId extension (not in upstream)", () => {
+    test("colliding requestIds from two sessions stay separate entries on separate pages", () => {
+        const mk = (sessionId: string, host: string): CdpMessage[] => [
+            { method: "Page.frameStartedLoading", params: { frameId: `F-${sessionId}` }, sessionId },
+            {
+                method: "Network.requestWillBeSent",
+                params: {
+                    requestId: "r1",
+                    frameId: `F-${sessionId}`,
+                    timestamp: 2000,
+                    wallTime: 1700000100,
+                    type: "Document",
+                    initiator: { type: "other" },
+                    request: { method: "GET", url: `https://${host}/`, headers: {} },
+                },
+                sessionId,
+            },
+            {
+                method: "Network.responseReceived",
+                params: {
+                    requestId: "r1",
+                    frameId: `F-${sessionId}`,
+                    timestamp: 2000.3,
+                    response: {
+                        url: `https://${host}/`,
+                        protocol: "h2",
+                        status: 200,
+                        statusText: "",
+                        mimeType: "text/html",
+                        headers: {},
+                        encodedDataLength: 100,
+                        connectionId: 1,
+                        timing: { ...TIMING, requestTime: 2000.1 },
+                    },
+                },
+                sessionId,
+            },
+            {
+                method: "Network.loadingFinished",
+                params: { requestId: "r1", timestamp: 2000.5, encodedDataLength: 100 },
+                sessionId,
+            },
+        ];
+
+        const interleaved: CdpMessage[] = [];
+        const a = mk("tab-a", "app.example.com");
+        const b = mk("tab-b", "idp.example.com");
+        for (let i = 0; i < a.length; i++) {
+            interleaved.push(a[i], b[i]);
+        }
+
+        const har = harFromMessages(interleaved);
+        expect(har.log.entries).toHaveLength(2);
+        expect(har.log.entries.map((e) => e.request.url).sort()).toEqual([
+            "https://app.example.com/",
+            "https://idp.example.com/",
+        ]);
+        expect(har.log.pages).toHaveLength(2);
+        expect(new Set(har.log.entries.map((e) => e.pageref)).size).toBe(2);
+    });
+});

--- a/src/chrome-devtools/lib/har/build.ts
+++ b/src/chrome-devtools/lib/har/build.ts
@@ -1,0 +1,649 @@
+/**
+ * Port of chrome-har index.js (sitespeedio/chrome-har v1.3.1, MIT).
+ *
+ * Three deliberate deviations from upstream, everything else is 1:1:
+ * 1. Entries are matched by a session-scoped key (`sessionId + requestId`)
+ *    instead of the bare requestId, so events from several tabs/targets
+ *    recorded into one stream cannot silently corrupt each other's entries
+ *    (upstream reads no sessionId at all — verified against its source).
+ * 2. The requests-buffered-before-any-page arrays are CLEARED once folded
+ *    into the first page; upstream re-concats them on every later page,
+ *    duplicating those entries.
+ * 3. An invalid cookie expiry date renders as no `expires` instead of
+ *    crashing `toISOString` (upstream issues #110/#122).
+ * 4. When a message carries a sessionId, pages and page timings are attributed
+ *    per session (frameId first, then that session's latest page) instead of
+ *    upstream's global `pages.at(-1)`. Sessionless messages keep the upstream
+ *    behavior exactly.
+ *
+ * Sessionless single-page input behaves exactly like upstream; the parity
+ * test (`build.parity.test.ts`) pins that against the real npm package.
+ *
+ * Inherited upstream limitation, kept for parity: blocked response cookies are
+ * filtered by NAME only (lib/entry-from-response.ts) — when one response sets
+ * the same cookie name for two paths and CDP blocks only one, both leave the
+ * HAR. Fixing it would diverge from the upstream goldens.
+ */
+
+import { randomUUID } from "node:crypto";
+import { format, parse } from "node:url";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { formatCookie, parseRequestCookies } from "./cookies.ts";
+import { entryFromResponse } from "./entry-from-response.ts";
+import { finalizeEntry } from "./finalize-entry.ts";
+import { getHeaderValue, parseHeaders } from "./headers.ts";
+import type {
+    CdpAssociatedCookie,
+    CdpMessage,
+    CdpRequestWillBeSentParams,
+    CdpResponseReceivedExtraInfoParams,
+    CdpResponseReceivedParams,
+    HarBuildOptions,
+    HarEntry,
+    HarFile,
+    HarPage,
+} from "./types.ts";
+import { formatMillis, isSupportedProtocol, parsePostData, toNameValuePairs } from "./util.ts";
+
+const log = logger.child({ component: "chrome-devtools:har" });
+
+const PORT_OF_VERSION = "1.3.1";
+
+const defaultOptions: Required<HarBuildOptions> = {
+    includeResourcesFromDiskCache: false,
+    includeTextFromResponseBody: false,
+};
+
+/** Session-scoped match key. Sessionless input degrades to the bare requestId, like upstream. */
+function keyOf(sessionId: string | undefined, requestId: string): string {
+    return sessionId ? `${sessionId}\u0000${requestId}` : requestId;
+}
+
+function deleteInternalProperties<T extends object>(o: T): T {
+    // __ properties are only for internal use, _ properties are custom HAR fields.
+    for (const prop of Object.keys(o)) {
+        if (prop.startsWith("__")) {
+            delete (o as Record<string, unknown>)[prop];
+        }
+    }
+
+    return o;
+}
+
+function addFromFirstRequest(page: HarPage, params: CdpRequestWillBeSentParams): void {
+    if (!page.__timestamp) {
+        page.__wallTime = params.wallTime;
+        page.__timestamp = params.timestamp;
+        page.startedDateTime = new Date(params.wallTime * 1000).toISOString();
+        // URL is better than blank, and it's what devtools uses.
+        page.title = page.title === "" ? params.request.url : page.title;
+    }
+}
+
+export function harFromMessages(messages: CdpMessage[], options?: HarBuildOptions): HarFile {
+    const opts = { ...defaultOptions, ...options };
+
+    const ignoredRequests = new Set<string>();
+    const rootFrameMappings = new Map<string, string>();
+
+    let pages: HarPage[] = [];
+    let entries: HarEntry[] = [];
+    const entriesWithoutPage: HarEntry[] = [];
+    const responsesWithoutPage: { key: string; params: CdpResponseReceivedParams }[] = [];
+    const paramsWithoutPage: { key: string; params: CdpRequestWillBeSentParams }[] = [];
+    const responseReceivedExtraInfos: { key: string; params: CdpResponseReceivedExtraInfoParams }[] = [];
+    let currentPageId: string | undefined;
+    const lastPageBySession = new Map<string, HarPage>();
+
+    const findEntry = (key: string): HarEntry | undefined => entries.find((entry) => entry.__key === key);
+
+    /** Deviation 4: session-scoped page attribution. Sessionless falls back to upstream's `pages.at(-1)`. */
+    const pageForRequest = (sessionId: string | undefined, frameId: string | undefined): HarPage | undefined => {
+        if (!sessionId) {
+            return pages.at(-1);
+        }
+
+        if (frameId) {
+            const rootFrame = rootFrameMappings.get(frameId) || frameId;
+            const byFrame = pages.find((p) => p.__frameId === rootFrame);
+            if (byFrame) {
+                return byFrame;
+            }
+        }
+
+        return lastPageBySession.get(sessionId) ?? pages.at(-1);
+    };
+
+    const pageForTiming = (sessionId: string | undefined): HarPage | undefined => {
+        if (!sessionId) {
+            return pages.at(-1);
+        }
+
+        return lastPageBySession.get(sessionId) ?? pages.at(-1);
+    };
+
+    const populateRedirectResponse = (
+        page: HarPage | undefined,
+        key: string,
+        params: CdpRequestWillBeSentParams
+    ): void => {
+        const previousEntry = findEntry(key);
+        if (previousEntry && params.redirectResponse) {
+            previousEntry.__key += "r";
+            previousEntry._requestId += "r";
+            entryFromResponse(previousEntry, params.redirectResponse, page ?? ({ pageTimings: {} } as HarPage), opts);
+        } else {
+            log.debug({ requestId: params.requestId }, "no original request for redirect response");
+        }
+    };
+
+    for (const message of messages) {
+        const method = message.method;
+
+        if (!/^(Page|Network|SoftNavigation)\..+/.test(method)) {
+            continue;
+        }
+
+        switch (method) {
+            case "Page.frameStartedLoading":
+            case "Page.frameRequestedNavigation":
+            case "Page.navigatedWithinDocument": {
+                const params = message.params as { frameId: string; url?: string };
+                const frameId = params.frameId;
+                const rootFrame = rootFrameMappings.get(frameId) || frameId;
+                if (pages.some((page) => page.__frameId === rootFrame)) {
+                    continue;
+                }
+
+                currentPageId = randomUUID();
+                const title = method === "Page.navigatedWithinDocument" ? (params.url ?? "") : "";
+                const page: HarPage = {
+                    id: currentPageId,
+                    startedDateTime: "",
+                    title,
+                    pageTimings: {},
+                    __frameId: rootFrame,
+                };
+                pages.push(page);
+                lastPageBySession.set(message.sessionId ?? "", page);
+
+                // do we have any unmapped requests, add them
+                if (entriesWithoutPage.length > 0) {
+                    for (const entry of entriesWithoutPage) {
+                        entry.pageref = page.id;
+                    }
+
+                    entries = entries.concat(entriesWithoutPage);
+                    entriesWithoutPage.length = 0;
+                    if (paramsWithoutPage[0]) {
+                        addFromFirstRequest(page, paramsWithoutPage[0].params);
+                    }
+
+                    for (const buffered of paramsWithoutPage) {
+                        if (buffered.params.redirectResponse) {
+                            populateRedirectResponse(page, buffered.key, buffered.params);
+                        }
+                    }
+
+                    paramsWithoutPage.length = 0;
+                }
+
+                if (responsesWithoutPage.length > 0) {
+                    for (const buffered of responsesWithoutPage) {
+                        const entry = findEntry(buffered.key);
+                        if (entry) {
+                            entryFromResponse(entry, buffered.params.response, page, opts);
+                        } else {
+                            log.debug({}, "no matching request for buffered response");
+                        }
+                    }
+
+                    responsesWithoutPage.length = 0;
+                }
+
+                break;
+            }
+
+            // Soft navigation events are injected by the caller when a SPA
+            // navigation is detected; update the current page instead of
+            // creating a new one.
+            case "SoftNavigation.detected": {
+                const params = message.params as { url?: string };
+                const page = pages.at(-1);
+                if (page) {
+                    page.title = params.url || "";
+                    page._softNavigation = true;
+                } else {
+                    currentPageId = randomUUID();
+                    pages.push({
+                        id: currentPageId,
+                        startedDateTime: "",
+                        title: params.url || "",
+                        pageTimings: {},
+                        _softNavigation: true,
+                    });
+                }
+
+                break;
+            }
+
+            case "Network.requestWillBeSent": {
+                const params = message.params as unknown as CdpRequestWillBeSentParams;
+                const key = keyOf(message.sessionId, params.requestId);
+                const request = params.request;
+
+                if (!isSupportedProtocol(request.url)) {
+                    ignoredRequests.add(key);
+                    continue;
+                }
+
+                const page = pageForRequest(message.sessionId, params.frameId);
+                const cookieHeader = getHeaderValue(request.headers, "Cookie");
+
+                // Keep the hash fragment: Firefox keeps it, and stripping it
+                // desynchronizes the HAR URL from the tested URL.
+                const url = parse(request.url + (request.urlFragment ?? ""), true);
+                const postData = parsePostData(getHeaderValue(request.headers, "Content-Type"), request.postData);
+
+                const entry: HarEntry = {
+                    cache: {},
+                    startedDateTime: "",
+                    __requestWillBeSentTime: params.timestamp,
+                    __wallTime: params.wallTime,
+                    __key: key,
+                    _requestId: params.requestId,
+                    __frameId: params.frameId,
+                    _initialPriority: request.initialPriority,
+                    _priority: request.initialPriority,
+                    pageref: page ? page.id : currentPageId,
+                    request: {
+                        method: request.method,
+                        url: format(url),
+                        queryString: toNameValuePairs(url.query),
+                        postData,
+                        headersSize: -1,
+                        bodySize: request.postData ? request.postData.length : 0,
+                        cookies: parseRequestCookies(cookieHeader),
+                        headers: parseHeaders(request.headers),
+                    },
+                    time: 0,
+                    _initiator_detail: SafeJSON.stringify(params.initiator, { strict: true }),
+                    _initiator_type: params.initiator.type,
+                    // Chrome's DevTools frontend lowercases this field.
+                    _resourceType: params.type ? params.type.toLowerCase() : undefined,
+                };
+
+                if (request.isLinkPreload) {
+                    entry.request._isLinkPreload = true;
+                }
+
+                // CDP render-blocking classification (Chrome 108+), lowercased
+                // to match waterfall tooling expectations.
+                if (params.renderBlockingBehavior) {
+                    entry._renderBlocking = params.renderBlockingBehavior.toLowerCase();
+                }
+
+                switch (params.initiator.type) {
+                    case "parser": {
+                        entry._initiator = params.initiator.url;
+                        entry._initiator_line = (params.initiator.lineNumber ?? 0) + 1;
+                        break;
+                    }
+
+                    case "script": {
+                        if (params.initiator.stack && params.initiator.stack.callFrames.length > 0) {
+                            const topCallFrame = params.initiator.stack.callFrames[0];
+                            entry._initiator = topCallFrame.url;
+                            entry._initiator_line = topCallFrame.lineNumber + 1;
+                            entry._initiator_column = topCallFrame.columnNumber + 1;
+                            entry._initiator_function_name = topCallFrame.functionName;
+                            entry._initiator_script_id = topCallFrame.scriptId;
+                        }
+
+                        break;
+                    }
+
+                    default:
+                        break;
+                }
+
+                if (params.redirectResponse) {
+                    populateRedirectResponse(page, key, params);
+                }
+
+                if (!page) {
+                    log.debug({ requestId: params.requestId }, "request with no page yet; buffering");
+                    entriesWithoutPage.push(entry);
+                    paramsWithoutPage.push({ key, params });
+                    continue;
+                }
+
+                entries.push(entry);
+                addFromFirstRequest(page, params);
+                // wallTime is not monotonic, timestamp is: derive startedDateTime from timestamp diffs.
+                const entrySecs = (page.__wallTime ?? 0) + (params.timestamp - (page.__timestamp ?? 0));
+                entry.startedDateTime = new Date(entrySecs * 1000).toISOString();
+                break;
+            }
+
+            case "Network.requestServedFromCache": {
+                const params = message.params as { requestId: string };
+                const key = keyOf(message.sessionId, params.requestId);
+
+                if (pages.length === 0 || ignoredRequests.has(key)) {
+                    continue;
+                }
+
+                const entry = findEntry(key);
+                if (!entry) {
+                    log.debug({ requestId: params.requestId }, "requestServedFromCache with no matching request");
+                    continue;
+                }
+
+                entry.__servedFromCache = true;
+                entry.cache.beforeRequest = { lastAccess: "", eTag: "", hitCount: 0 };
+                break;
+            }
+
+            case "Network.requestWillBeSentExtraInfo": {
+                const params = message.params as {
+                    requestId: string;
+                    headers?: Record<string, string>;
+                    associatedCookies?: CdpAssociatedCookie[];
+                };
+                const key = keyOf(message.sessionId, params.requestId);
+
+                if (ignoredRequests.has(key)) {
+                    continue;
+                }
+
+                const entry = findEntry(key) ?? entriesWithoutPage.find((e) => e.__key === key);
+                if (!entry) {
+                    log.debug({ requestId: params.requestId }, "extra info with no matching request");
+                    continue;
+                }
+
+                if (params.headers) {
+                    entry.request.headers = entry.request.headers.concat(parseHeaders(params.headers));
+                }
+
+                if (params.associatedCookies) {
+                    entry.request.cookies = (entry.request.cookies || []).concat(
+                        params.associatedCookies
+                            .filter(({ blockedReasons }) => blockedReasons.length === 0)
+                            .map(({ cookie }) => formatCookie(cookie))
+                    );
+                }
+
+                break;
+            }
+
+            case "Network.responseReceivedExtraInfo": {
+                const params = message.params as unknown as CdpResponseReceivedExtraInfoParams;
+                const key = keyOf(message.sessionId, params.requestId);
+
+                if (pages.length === 0 || ignoredRequests.has(key)) {
+                    continue;
+                }
+
+                const entry = findEntry(key) ?? entriesWithoutPage.find((e) => e.__key === key);
+                if (!entry) {
+                    responseReceivedExtraInfos.push({ key, params });
+                    continue;
+                }
+
+                if (!entry.response) {
+                    // Extra info arrived before the response
+                    entry.extraResponseInfo = {
+                        headers: parseHeaders(params.headers),
+                        blockedCookies: params.blockedCookies,
+                    };
+                    responseReceivedExtraInfos.push({ key, params });
+                    continue;
+                }
+
+                if (params.headers) {
+                    entry.response.headers = parseHeaders(params.headers);
+                }
+
+                break;
+            }
+
+            case "Network.responseReceived": {
+                const params = message.params as unknown as CdpResponseReceivedParams;
+                const key = keyOf(message.sessionId, params.requestId);
+
+                if (pages.length === 0) {
+                    responsesWithoutPage.push({ key, params });
+                    continue;
+                }
+
+                if (ignoredRequests.has(key)) {
+                    continue;
+                }
+
+                const entry = findEntry(key) ?? entriesWithoutPage.find((e) => e.__key === key);
+                if (!entry) {
+                    log.debug({ requestId: params.requestId }, "response with no matching request");
+                    continue;
+                }
+
+                const frameId = (params.frameId && rootFrameMappings.get(params.frameId)) || params.frameId;
+                const page = pages.find((p) => p.__frameId === frameId) || pageForTiming(message.sessionId);
+                if (!page) {
+                    log.debug({ requestId: params.requestId }, "response that maps to no page");
+                    continue;
+                }
+
+                entryFromResponse(entry, params.response, page, opts);
+
+                const extraInfo = responseReceivedExtraInfos.find((buffered) => buffered.key === key);
+                if (extraInfo?.params.headers && entry.response) {
+                    entry.response.headers = parseHeaders(extraInfo.params.headers);
+                }
+
+                break;
+            }
+
+            case "Network.dataReceived": {
+                const params = message.params as { requestId: string; timestamp: number; dataLength: number };
+                const key = keyOf(message.sessionId, params.requestId);
+
+                if (pages.length === 0 || ignoredRequests.has(key)) {
+                    continue;
+                }
+
+                const entry = findEntry(key);
+                if (!entry) {
+                    log.debug({ requestId: params.requestId }, "data received with no matching request");
+                    continue;
+                }
+
+                // An entry can lack a response (sitespeed.io#2645).
+                if (entry.response) {
+                    entry.response.content.size += params.dataLength;
+                }
+
+                const page = pages.find((p) => p.id === entry.pageref);
+                if (page) {
+                    const chunk = {
+                        ts: formatMillis((params.timestamp - (page.__timestamp ?? 0)) * 1000),
+                        bytes: params.dataLength,
+                    };
+                    if (entry._chunks) {
+                        entry._chunks.push(chunk);
+                    } else {
+                        entry._chunks = [chunk];
+                    }
+                }
+
+                break;
+            }
+
+            case "Network.loadingFinished": {
+                const params = message.params as { requestId: string; timestamp: number; encodedDataLength?: number };
+                const key = keyOf(message.sessionId, params.requestId);
+
+                if (pages.length === 0) {
+                    continue;
+                }
+
+                if (ignoredRequests.has(key)) {
+                    ignoredRequests.delete(key);
+                    continue;
+                }
+
+                const entry = findEntry(key);
+                if (!entry) {
+                    log.debug({ requestId: params.requestId }, "loading finished with no matching request");
+                    continue;
+                }
+
+                finalizeEntry(entry, params);
+                break;
+            }
+
+            case "Page.loadEventFired": {
+                const params = message.params as { timestamp?: number };
+
+                if (pages.length === 0) {
+                    continue;
+                }
+
+                const page = pageForTiming(message.sessionId);
+                if (page && params.timestamp && page.__timestamp) {
+                    page.pageTimings.onLoad = formatMillis((params.timestamp - page.__timestamp) * 1000);
+                }
+
+                break;
+            }
+
+            case "Page.domContentEventFired": {
+                const params = message.params as { timestamp?: number };
+
+                if (pages.length === 0) {
+                    continue;
+                }
+
+                const page = pageForTiming(message.sessionId);
+                if (page && params.timestamp && page.__timestamp) {
+                    page.pageTimings.onContentLoad = formatMillis((params.timestamp - page.__timestamp) * 1000);
+                }
+
+                break;
+            }
+
+            case "Page.frameAttached": {
+                const params = message.params as { frameId: string; parentFrameId: string };
+                const frameId = params.frameId;
+                const parentId = params.parentFrameId;
+
+                rootFrameMappings.set(frameId, parentId);
+
+                let grandParentId = rootFrameMappings.get(parentId);
+                while (grandParentId) {
+                    rootFrameMappings.set(frameId, grandParentId);
+                    grandParentId = rootFrameMappings.get(grandParentId);
+                }
+
+                break;
+            }
+
+            case "Network.loadingFailed": {
+                const params = message.params as {
+                    requestId: string;
+                    timestamp: number;
+                    errorText?: string;
+                    canceled?: boolean;
+                };
+                const key = keyOf(message.sessionId, params.requestId);
+
+                if (ignoredRequests.has(key)) {
+                    ignoredRequests.delete(key);
+                    continue;
+                }
+
+                const entry = findEntry(key);
+                if (!entry) {
+                    log.debug({ requestId: params.requestId }, "loading failed with no matching request");
+                    continue;
+                }
+
+                if (params.errorText === "net::ERR_ABORTED") {
+                    finalizeEntry(entry, params);
+                    log.debug({ requestId: params.requestId }, "load canceled by Chrome or user action");
+                    continue;
+                }
+
+                // A network-level failure (bad DNS etc.) has no HAR representation.
+                log.debug({ url: entry.request.url, canceled: params.canceled }, "failed load dropped from HAR");
+                entries = entries.filter((e) => e.__key !== key);
+                break;
+            }
+
+            case "Network.resourceChangedPriority": {
+                const params = message.params as { requestId: string; newPriority: string };
+                const key = keyOf(message.sessionId, params.requestId);
+
+                const entry = findEntry(key);
+                if (!entry) {
+                    log.debug({ requestId: params.requestId }, "resourceChangedPriority with no matching request");
+                    continue;
+                }
+
+                entry._priority = params.newPriority;
+                break;
+            }
+
+            default: {
+                // WebSocket frames, EventSource messages and page lifecycle
+                // noise land here; HAR 1.2 has no representation for them.
+                break;
+            }
+        }
+    }
+
+    if (!opts.includeResourcesFromDiskCache) {
+        entries = entries.filter((entry) => entry.cache.beforeRequest === undefined);
+    }
+
+    entries = entries
+        .filter((entry) => {
+            if (!entry.response) {
+                log.debug({ url: entry.request.url }, "dropping incomplete request");
+            }
+
+            return entry.response;
+        })
+        .map((element) => deleteInternalProperties(element));
+    pages = pages.map((element) => deleteInternalProperties(element));
+    pages = pages.filter((page) => entries.some((entry) => entry.pageref === page.id));
+
+    const pagerefMapping = pages.reduce<Record<string, string>>((result, page, index) => {
+        result[page.id] = `page_${index + 1}`;
+        return result;
+    }, {});
+
+    pages = pages.map((page) => {
+        page.id = pagerefMapping[page.id];
+        return page;
+    });
+    entries = entries.map((entry) => {
+        entry.pageref = entry.pageref ? pagerefMapping[entry.pageref] : entry.pageref;
+        return entry;
+    });
+
+    return {
+        log: {
+            version: "1.2",
+            creator: {
+                name: "genesis-chrome-devtools",
+                version: PORT_OF_VERSION,
+                comment: "TS port of https://github.com/sitespeedio/chrome-har",
+            },
+            pages,
+            entries,
+        },
+    };
+}

--- a/src/chrome-devtools/lib/har/cookies.ts
+++ b/src/chrome-devtools/lib/har/cookies.ts
@@ -1,0 +1,62 @@
+/**
+ * Port of chrome-har lib/cookies.js (v1.3.1, MIT). Behavior kept 1:1;
+ * tough-cookie retained.
+ *
+ * Known inherited quirk, kept for parity: a NUMERIC `expires` from CDP
+ * associatedCookies is in SECONDS, but the `new Date(expires)` branch below
+ * interprets it as MILLISECONDS — upstream does the same and the parity goldens
+ * pin that output. Do not multiply by 1000 unless upstream changes.
+ */
+import { Cookie } from "tough-cookie";
+import type { CdpAssociatedCookie, HarCookie } from "./types.ts";
+
+export function formatCookie(cookie: CdpAssociatedCookie["cookie"] | Cookie): HarCookie {
+    let expiresISO: string | undefined;
+    const expires = cookie.expires;
+
+    if (expires instanceof Date) {
+        expiresISO = expires.toISOString();
+    } else if (expires === "Infinity" || expires === null || expires === undefined) {
+        expiresISO = undefined;
+    } else {
+        const date = new Date(expires);
+        expiresISO = Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+    }
+
+    const key = "key" in cookie ? cookie.key : undefined;
+
+    return {
+        name: key || ("name" in cookie ? (cookie.name ?? "") : ""),
+        value: cookie.value,
+        path: cookie.path || undefined,
+        domain: cookie.domain || undefined,
+        expires: expiresISO,
+        httpOnly: cookie.httpOnly,
+        secure: cookie.secure,
+    };
+}
+
+function parseCookie(cookieString: string): HarCookie | undefined {
+    const cookie = Cookie.parse(cookieString);
+    if (!cookie) {
+        return undefined;
+    }
+
+    return formatCookie(cookie);
+}
+
+function splitAndParse(header: string, divider: string): HarCookie[] {
+    return header
+        .split(divider)
+        .filter(Boolean)
+        .map((element) => parseCookie(element))
+        .filter((c): c is HarCookie => Boolean(c));
+}
+
+export function parseRequestCookies(cookieHeader: string): HarCookie[] {
+    return splitAndParse(cookieHeader, ";");
+}
+
+export function parseResponseCookies(cookieHeader: string): HarCookie[] {
+    return splitAndParse(cookieHeader, "\n");
+}

--- a/src/chrome-devtools/lib/har/entry-from-response.ts
+++ b/src/chrome-devtools/lib/har/entry-from-response.ts
@@ -1,0 +1,197 @@
+/** Port of chrome-har lib/entryFromResponse.js (v1.3.1, MIT). Behavior kept 1:1. */
+import { logger } from "@genesiscz/utils/logger";
+import { parseRequestCookies, parseResponseCookies } from "./cookies.ts";
+import { calculateRequestHeaderSize, calculateResponseHeaderSize, getHeaderValue, parseHeaders } from "./headers.ts";
+import type { CdpResourceTiming, CdpResponse, HarBuildOptions, HarEntry, HarPage } from "./types.ts";
+import { formatMillis, isHttp1x } from "./util.ts";
+
+const log = logger.child({ component: "chrome-devtools:har" });
+
+function firstNonNegative(values: number[]): number {
+    for (const value of values) {
+        if (value >= 0) {
+            return value;
+        }
+    }
+
+    return -1;
+}
+
+type NumericTimingKey = {
+    [K in keyof CdpResourceTiming]-?: CdpResourceTiming[K] extends number ? K : never;
+}[keyof CdpResourceTiming];
+
+function parseOptionalTime(timing: CdpResourceTiming, start: NumericTimingKey, end: NumericTimingKey): number {
+    if (timing[start] >= 0) {
+        return formatMillis(timing[end] - timing[start]);
+    }
+
+    return -1;
+}
+
+function formatIP(ipAddress: string | undefined): string | undefined {
+    if (typeof ipAddress !== "string") {
+        return undefined;
+    }
+
+    return ipAddress.replaceAll(/^\[|]$/g, "");
+}
+
+export function entryFromResponse(
+    entry: HarEntry,
+    response: CdpResponse,
+    page: HarPage,
+    options: HarBuildOptions
+): void {
+    const responseHeaders = response.headers;
+    const cookieHeader = getHeaderValue(responseHeaders, "Set-Cookie");
+
+    let cookies = parseResponseCookies(cookieHeader);
+    const headers = parseHeaders(responseHeaders);
+
+    if (entry.extraResponseInfo) {
+        const blockedCookies = entry.extraResponseInfo.blockedCookies;
+        if (blockedCookies) {
+            cookies = cookies.filter(
+                ({ name }) =>
+                    !blockedCookies.some((blockedCookie) => {
+                        if (blockedCookie.cookie) {
+                            return blockedCookie.cookie.name === name;
+                        }
+
+                        if (blockedCookie.cookieLine) {
+                            const cookie = parseResponseCookies(blockedCookie.cookieLine)[0];
+                            if (cookie) {
+                                return cookie.name === name;
+                            }
+                        }
+
+                        return false;
+                    })
+            );
+        }
+
+        delete entry.extraResponseInfo;
+    }
+
+    // response.body must be set by the library user (Network.getResponseBody);
+    // it is not part of the CDP Response type.
+    const text = options?.includeTextFromResponseBody ? response.body : undefined;
+
+    entry.response = {
+        httpVersion: response.protocol,
+        redirectURL: "",
+        status: response.status,
+        statusText: response.statusText,
+        content: {
+            encoding: response.encoding,
+            mimeType: response.mimeType,
+            charset: response.charset,
+            size: text === undefined ? 0 : text.length,
+            text,
+        },
+        headersSize: -1,
+        bodySize: -1,
+        cookies,
+        headers,
+        _transferSize: response.encodedDataLength,
+        fromDiskCache: response.fromDiskCache || false,
+        fromEarlyHints: response.fromEarlyHints || false,
+        fromServiceWorker: response.fromServiceWorker || false,
+        fromPrefetchCache: response.fromPrefetchCache || false,
+    };
+
+    const locationHeaderValue = getHeaderValue(responseHeaders, "Location");
+    if (locationHeaderValue) {
+        entry.response.redirectURL = locationHeaderValue;
+    }
+
+    entry.request.httpVersion = response.protocol;
+
+    if (response.fromDiskCache === true && response.fromEarlyHints !== true) {
+        if (isHttp1x(response.protocol)) {
+            // In http2 headers are compressed, so calculating size from headers text wouldn't be correct.
+            entry.response.headersSize = calculateResponseHeaderSize(response);
+        }
+
+        // h2 push might cause resource to be received before parser sees and requests it.
+        if (response.timing && !((response.timing.pushStart ?? 0) > 0)) {
+            entry.cache.beforeRequest = { lastAccess: "", eTag: "", hitCount: 0 };
+        }
+    } else {
+        if (response.requestHeaders) {
+            entry.request.headers = parseHeaders(response.requestHeaders);
+            const requestCookieHeader = getHeaderValue(response.requestHeaders, "Cookie");
+            entry.request.cookies = parseRequestCookies(requestCookieHeader);
+        }
+
+        if (isHttp1x(response.protocol)) {
+            entry.response.headersSize = response.headersText
+                ? response.headersText.length
+                : calculateResponseHeaderSize(response);
+            entry.response.bodySize = response.encodedDataLength - entry.response.headersSize;
+            entry.request.headersSize = response.requestHeadersText
+                ? response.requestHeadersText.length
+                : calculateRequestHeaderSize(entry.request);
+        }
+    }
+
+    entry.connection = response.connectionId.toString();
+    entry.serverIPAddress = formatIP(response.remoteIPAddress);
+
+    const timing = response.timing;
+    if (timing) {
+        const blocked = formatMillis(firstNonNegative([timing.dnsStart, timing.connectStart, timing.sendStart]));
+        const dns = parseOptionalTime(timing, "dnsStart", "dnsEnd");
+        const connect = parseOptionalTime(timing, "connectStart", "connectEnd");
+        const send = formatMillis(timing.sendEnd - timing.sendStart);
+        const wait = formatMillis(timing.receiveHeadersEnd - timing.sendEnd);
+        const receive = 0;
+        const ssl = parseOptionalTime(timing, "sslStart", "sslEnd");
+
+        entry.timings = { blocked, dns, connect, send, wait, receive, ssl };
+        entry._requestTime = timing.requestTime;
+        entry.__receiveHeadersEnd = timing.receiveHeadersEnd;
+
+        if ((timing.pushStart ?? 0) > 0) {
+            // use the same extended field as WebPageTest
+            entry._was_pushed = 1;
+        }
+
+        entry.time = Math.max(0, blocked) + Math.max(0, dns) + Math.max(0, connect) + send + wait + receive;
+
+        // Some cached responses generate a Network.requestServedFromCache event,
+        // but fromDiskCache is still set to false.
+        if (!entry.__servedFromCache) {
+            // wallTime is not necessarily monotonic, timestamp is; derive startedDateTime from timestamp diffs.
+            const entrySecs = (page.__wallTime ?? 0) + (timing.requestTime - (page.__timestamp ?? 0));
+            try {
+                entry.startedDateTime = new Date(entrySecs * 1000).toISOString();
+            } catch (err) {
+                // upstream swallows this too (sitespeed.io#4285): keep the previous startedDateTime
+                log.debug({ err, entrySecs }, "startedDateTime out of range");
+            }
+
+            const queuedMillis = (timing.requestTime - (entry.__requestWillBeSentTime ?? 0)) * 1000;
+            if (queuedMillis > 0) {
+                entry.timings._queued = formatMillis(queuedMillis);
+            }
+        }
+
+        if (entry.cache?.beforeRequest) {
+            entry.cache.beforeRequest.lastAccess = entry.startedDateTime;
+        }
+    } else {
+        entry.timings = {
+            blocked: -1,
+            dns: -1,
+            connect: -1,
+            send: 0,
+            wait: 0,
+            receive: 0,
+            ssl: -1,
+            comment: "No timings available from Chrome",
+        };
+        entry.time = 0;
+    }
+}

--- a/src/chrome-devtools/lib/har/finalize-entry.ts
+++ b/src/chrome-devtools/lib/har/finalize-entry.ts
@@ -1,0 +1,35 @@
+/** Port of chrome-har lib/finalizeEntry.js (v1.3.1, MIT). Behavior kept 1:1. */
+import type { HarEntry } from "./types.ts";
+import { formatMillis, isHttp1x } from "./util.ts";
+
+export function finalizeEntry(entry: HarEntry, params: { timestamp: number; encodedDataLength?: number }): void {
+    const timings = entry.timings ?? ({} as NonNullable<HarEntry["timings"]>);
+    timings.receive = formatMillis(
+        (params.timestamp - (entry._requestTime ?? 0)) * 1000 - (entry.__receiveHeadersEnd ?? 0)
+    );
+    entry.time =
+        Math.max(0, timings.blocked) +
+        Math.max(0, timings.dns) +
+        Math.max(0, timings.connect) +
+        Math.max(0, timings.send) +
+        Math.max(0, timings.wait) +
+        Math.max(0, timings.receive);
+
+    // encodedDataLength will be -1 sometimes
+    if (params.encodedDataLength !== undefined && params.encodedDataLength >= 0) {
+        const response = entry.response;
+        if (response) {
+            response._transferSize = params.encodedDataLength;
+            response.bodySize = params.encodedDataLength;
+
+            if (isHttp1x(response.httpVersion) && response.headersSize > -1) {
+                response.bodySize -= response.headersSize;
+            }
+
+            const compression = Math.max(0, response.content.size - response.bodySize);
+            if (compression > 0) {
+                response.content.compression = compression;
+            }
+        }
+    }
+}

--- a/src/chrome-devtools/lib/har/headers.ts
+++ b/src/chrome-devtools/lib/har/headers.ts
@@ -1,0 +1,46 @@
+/** Port of chrome-har lib/headers.js (v1.3.1, MIT). Behavior kept 1:1. */
+import { format } from "node:util";
+import type { CdpHeaders, CdpResponse, HarNameValue, HarRequest } from "./types.ts";
+
+export function calculateRequestHeaderSize(harRequest: HarRequest): number {
+    let buffer = format("%s %s %s\r\n", harRequest.method, harRequest.url, harRequest.httpVersion);
+    const headerLines = harRequest.headers.map((header) => format("%s: %s\r\n", header.name, header.value));
+    buffer = buffer.concat(headerLines.join(""));
+    buffer = buffer.concat("\r\n");
+
+    return buffer.length;
+}
+
+export function calculateResponseHeaderSize(perflogResponse: CdpResponse): number {
+    let buffer = format("%s %d %s\r\n", perflogResponse.protocol, perflogResponse.status, perflogResponse.statusText);
+    for (const key of Object.keys(perflogResponse.headers)) {
+        buffer = buffer.concat(format("%s: %s\r\n", key, perflogResponse.headers[key]));
+    }
+
+    buffer = buffer.concat("\r\n");
+
+    return buffer.length;
+}
+
+export function parseHeaders(headers: CdpHeaders | undefined): HarNameValue[] {
+    if (!headers) {
+        return [];
+    }
+
+    return Object.keys(headers).map((key) => ({ name: key, value: headers[key] }));
+}
+
+export function getHeaderValue(headers: CdpHeaders | undefined, header: string): string {
+    if (!headers) {
+        return "";
+    }
+
+    const lowerCaseHeader = header.toLowerCase();
+
+    return (
+        Object.keys(headers)
+            .filter((key) => key.toLowerCase() === lowerCaseHeader)
+            .map((key) => headers[key])
+            .shift() || ""
+    );
+}

--- a/src/chrome-devtools/lib/har/types.ts
+++ b/src/chrome-devtools/lib/har/types.ts
@@ -1,0 +1,259 @@
+/**
+ * Types for the chrome-har TS port (upstream sitespeedio/chrome-har v1.3.1, MIT).
+ *
+ * The `__`-prefixed fields are internal bookkeeping deleted before output;
+ * single-`_` fields are custom HAR extensions kept in the output, mirroring
+ * upstream's convention (and Chrome DevTools' own `_initiator` etc.).
+ */
+
+export interface HarNameValue {
+    name: string;
+    value: string;
+}
+
+export interface HarCookie {
+    name: string;
+    value: string;
+    path?: string;
+    domain?: string;
+    expires?: string;
+    httpOnly?: boolean;
+    secure?: boolean;
+}
+
+export interface HarPostData {
+    mimeType: string;
+    params?: HarNameValue[];
+    text?: string;
+}
+
+export interface HarRequest {
+    method: string;
+    url: string;
+    httpVersion?: string;
+    queryString: HarNameValue[];
+    postData?: HarPostData;
+    headersSize: number;
+    bodySize: number;
+    cookies: HarCookie[];
+    headers: HarNameValue[];
+    _isLinkPreload?: boolean;
+}
+
+export interface HarContent {
+    encoding?: string;
+    mimeType?: string;
+    charset?: string;
+    size: number;
+    text?: string;
+    compression?: number;
+}
+
+export interface HarResponse {
+    httpVersion: string;
+    redirectURL: string;
+    status: number;
+    statusText: string;
+    content: HarContent;
+    headersSize: number;
+    bodySize: number;
+    cookies: HarCookie[];
+    headers: HarNameValue[];
+    _transferSize?: number;
+    fromDiskCache: boolean;
+    fromEarlyHints: boolean;
+    fromServiceWorker: boolean;
+    fromPrefetchCache: boolean;
+}
+
+export interface HarTimings {
+    blocked: number;
+    dns: number;
+    connect: number;
+    send: number;
+    wait: number;
+    receive: number;
+    ssl: number;
+    comment?: string;
+    _queued?: number;
+}
+
+export interface HarPageTimings {
+    onLoad?: number;
+    onContentLoad?: number;
+}
+
+export interface HarPage {
+    id: string;
+    startedDateTime: string;
+    title: string;
+    pageTimings: HarPageTimings;
+    _softNavigation?: boolean;
+    __frameId?: string;
+    __wallTime?: number;
+    __timestamp?: number;
+}
+
+export interface HarCacheState {
+    lastAccess: string;
+    eTag: string;
+    hitCount: number;
+}
+
+export interface HarEntry {
+    cache: { beforeRequest?: HarCacheState };
+    startedDateTime: string;
+    time: number;
+    pageref?: string;
+    request: HarRequest;
+    response?: HarResponse;
+    timings?: HarTimings;
+    connection?: string;
+    serverIPAddress?: string;
+    _requestId: string;
+    _initialPriority?: string;
+    _priority?: string;
+    _initiator?: string;
+    _initiator_line?: number;
+    _initiator_column?: number;
+    _initiator_function_name?: string;
+    _initiator_script_id?: string;
+    _initiator_detail?: string;
+    _initiator_type?: string;
+    _resourceType?: string;
+    _renderBlocking?: string;
+    _requestTime?: number;
+    _was_pushed?: number;
+    _chunks?: { ts: number; bytes: number }[];
+    extraResponseInfo?: { headers: HarNameValue[]; blockedCookies?: CdpBlockedCookie[] };
+    /** Session-scoped match key — the GenesisTools extension over upstream (multi-tab safety). */
+    __key: string;
+    __frameId?: string;
+    __requestWillBeSentTime?: number;
+    __wallTime?: number;
+    __receiveHeadersEnd?: number;
+    __servedFromCache?: boolean;
+}
+
+export interface HarFile {
+    log: {
+        version: "1.2";
+        creator: { name: string; version: string; comment: string };
+        pages: HarPage[];
+        entries: HarEntry[];
+    };
+}
+
+/** One recorded CDP event. `sessionId` scopes requestIds when several targets share one stream. */
+export interface CdpMessage {
+    method: string;
+    params: Record<string, unknown>;
+    sessionId?: string;
+}
+
+export type CdpHeaders = Record<string, string>;
+
+export interface CdpResourceTiming {
+    requestTime: number;
+    dnsStart: number;
+    dnsEnd: number;
+    connectStart: number;
+    connectEnd: number;
+    sslStart: number;
+    sslEnd: number;
+    sendStart: number;
+    sendEnd: number;
+    receiveHeadersEnd: number;
+    pushStart?: number;
+}
+
+export interface CdpResponse {
+    url?: string;
+    protocol: string;
+    status: number;
+    statusText: string;
+    mimeType?: string;
+    charset?: string;
+    encoding?: string;
+    headers: CdpHeaders;
+    headersText?: string;
+    requestHeaders?: CdpHeaders;
+    requestHeadersText?: string;
+    encodedDataLength: number;
+    fromDiskCache?: boolean;
+    fromEarlyHints?: boolean;
+    fromServiceWorker?: boolean;
+    fromPrefetchCache?: boolean;
+    connectionId: number | string;
+    remoteIPAddress?: string;
+    timing?: CdpResourceTiming;
+    /** Not CDP: set by the caller from Network.getResponseBody before building. */
+    body?: string;
+}
+
+export interface CdpInitiator {
+    type: string;
+    url?: string;
+    lineNumber?: number;
+    stack?: {
+        callFrames: { url: string; lineNumber: number; columnNumber: number; functionName: string; scriptId: string }[];
+    };
+}
+
+export interface CdpRequestWillBeSentParams {
+    requestId: string;
+    frameId?: string;
+    timestamp: number;
+    wallTime: number;
+    type?: string;
+    renderBlockingBehavior?: string;
+    initiator: CdpInitiator;
+    redirectResponse?: CdpResponse;
+    request: {
+        method: string;
+        url: string;
+        urlFragment?: string;
+        headers: CdpHeaders;
+        postData?: string;
+        isLinkPreload?: boolean;
+        initialPriority?: string;
+    };
+}
+
+export interface CdpBlockedCookie {
+    cookie?: { name: string };
+    cookieLine?: string;
+    blockedReasons?: string[];
+}
+
+export interface CdpAssociatedCookie {
+    cookie: {
+        name?: string;
+        key?: string;
+        value: string;
+        path?: string;
+        domain?: string;
+        expires?: number | string | Date | null;
+        httpOnly?: boolean;
+        secure?: boolean;
+    };
+    blockedReasons: string[];
+}
+
+export interface CdpResponseReceivedParams {
+    requestId: string;
+    frameId?: string;
+    timestamp: number;
+    response: CdpResponse;
+}
+
+export interface CdpResponseReceivedExtraInfoParams {
+    requestId: string;
+    headers?: CdpHeaders;
+    blockedCookies?: CdpBlockedCookie[];
+}
+
+export interface HarBuildOptions {
+    includeResourcesFromDiskCache?: boolean;
+    includeTextFromResponseBody?: boolean;
+}

--- a/src/chrome-devtools/lib/har/util.ts
+++ b/src/chrome-devtools/lib/har/util.ts
@@ -1,0 +1,58 @@
+/** Port of chrome-har lib/util.js (v1.3.1, MIT). Behavior kept 1:1; `debug` → repo logger. */
+import { parse } from "node:url";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import type { HarNameValue, HarPostData } from "./types.ts";
+
+const log = logger.child({ component: "chrome-devtools:har" });
+
+export function isHttp1x(version: string): boolean {
+    return version.toLowerCase().startsWith("http/1.");
+}
+
+export function formatMillis(time: number, fractionalDigits = 3): number {
+    return Number(Number(time).toFixed(fractionalDigits));
+}
+
+export function toNameValuePairs(object: Record<string, unknown>): HarNameValue[] {
+    return Object.keys(object).reduce<HarNameValue[]>((result, name) => {
+        const value = object[name];
+
+        return Array.isArray(value)
+            ? result.concat(value.map((v) => ({ name, value: String(v) })))
+            : result.concat([{ name, value: String(value) }]);
+    }, []);
+}
+
+export function parseUrlEncoded(data: string): HarNameValue[] {
+    const params = parse(`?${data}`, true).query;
+
+    return toNameValuePairs(params);
+}
+
+export function parsePostData(contentType: string, postData: string | undefined): HarPostData | undefined {
+    if (!contentType || !postData) {
+        return undefined;
+    }
+
+    try {
+        if (/^application\/x-www-form-urlencoded/.test(contentType)) {
+            return { mimeType: contentType, params: parseUrlEncoded(postData) };
+        }
+
+        if (/^application\/json/.test(contentType)) {
+            return {
+                mimeType: contentType,
+                params: toNameValuePairs(SafeJSON.parse(postData, { strict: true }) as Record<string, unknown>),
+            };
+        }
+    } catch {
+        log.debug({ contentType }, "unable to parse post data; falling back to text");
+    }
+
+    return { mimeType: contentType, text: postData };
+}
+
+export function isSupportedProtocol(url: string): boolean {
+    return /^https?:/.test(url);
+}

--- a/src/chrome-devtools/lib/mcp.ts
+++ b/src/chrome-devtools/lib/mcp.ts
@@ -1,0 +1,30 @@
+/**
+ * Thin door to the shared chrome-devtools-mcp client
+ * (`@genesiscz/utils/devtools/mcp-client`): call the real MCP tools against
+ * ANY CDP port, with no session config edit and no restart.
+ */
+import { toolText, withDevtoolsClient } from "@genesiscz/utils/devtools/mcp-client";
+import type { Client } from "@modelcontextprotocol/client";
+
+export interface McpOpts {
+    cdpUrl?: string;
+    port?: number;
+}
+
+export function urlOf(opts: McpOpts): string {
+    return opts.cdpUrl ?? `http://127.0.0.1:${opts.port ?? 9222}`;
+}
+
+export async function withMcp<T>(fn: (client: Client) => Promise<T>, opts: McpOpts = {}): Promise<T> {
+    return withDevtoolsClient(fn, { cdpUrl: urlOf(opts), clientName: "genesis-chrome-devtools" });
+}
+
+export async function callTool(name: string, args: Record<string, unknown> = {}, opts: McpOpts = {}) {
+    return withMcp((c) => c.callTool({ name, arguments: args }), opts);
+}
+
+export async function listTools(opts: McpOpts = {}): Promise<string[]> {
+    return withMcp(async (c) => (await c.listTools()).tools.map((t) => t.name), opts);
+}
+
+export { toolText };

--- a/src/chrome-devtools/lib/ops.test.ts
+++ b/src/chrome-devtools/lib/ops.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, rmSync } from "node:fs";
+import { writePidFile } from "@genesiscz/utils/process/pidfile";
+import { actionsFromFindings, clearStalePidfile, killRecorderPid, partitionForYes } from "./cleanup.ts";
+import { findingsFromStatus } from "./doctor.ts";
+import { ensureCaptureDir, recorderPidPath } from "./paths.ts";
+import { ancestorPids, type StatusReport } from "./status.ts";
+
+const emptySegments = { count: 0, bytes: 0, oldestMs: null, newestMs: null };
+
+describe("findingsFromStatus (doctor is pure — it can never mutate)", () => {
+    test("stale pidfile, orphan, legacy files and empty debug flag each produce a finding with a fix", () => {
+        const report: StatusReport = {
+            ports: [
+                {
+                    port: 9222,
+                    pidState: {
+                        status: "dead",
+                        pid: 4242,
+                        record: { pid: 4242, command: "bun record", startedAt: 1, writtenAt: 1 },
+                    },
+                    meta: null,
+                    sample: null,
+                    segments: { count: 3, bytes: 1000, oldestMs: 1, newestMs: 2 },
+                    endpoint: null,
+                },
+            ],
+            legacyFiles: ["/tmp/cdp-arm-9222.jsonl"],
+            orphans: [
+                {
+                    pid: 777,
+                    command: "bun .../skills/chrome-devtools/scripts/chrome-devtools.ts arm --port 9222",
+                    sample: null,
+                },
+            ],
+        };
+
+        const findings = findingsFromStatus(report, ["brave"]);
+        const ids = findings.map((f) => f.id);
+        expect(ids).toContain("stale-pidfile-9222");
+        expect(ids).toContain("leftover-buffer-9222");
+        expect(ids).toContain("orphan-777");
+        expect(ids).toContain("legacy-arm-files");
+        expect(ids).toContain("empty-debug-flag-brave");
+        for (const f of findings) {
+            if (f.severity !== "warn" || !f.id.startsWith("over-cap")) {
+                expect(f.title.length).toBeGreaterThan(0);
+            }
+        }
+
+        const orphan = findings.find((f) => f.id === "orphan-777");
+        expect(orphan?.title).toContain("OLD-skill");
+        expect(orphan?.fix).toContain("cleanup --kill 777");
+    });
+
+    test("a recycled pid is an err finding that clears the pidfile, never kills", () => {
+        const report: StatusReport = {
+            ports: [
+                {
+                    port: 9223,
+                    pidState: {
+                        status: "foreign",
+                        pid: 891,
+                        record: { pid: 891, command: "bun record", startedAt: 1, writtenAt: 1 },
+                        command: "WiFiCloudAssetsXPCService",
+                    },
+                    meta: null,
+                    sample: null,
+                    segments: emptySegments,
+                    endpoint: null,
+                },
+            ],
+            legacyFiles: [],
+            orphans: [],
+        };
+
+        const findings = findingsFromStatus(report, []);
+        const recycled = findings.find((f) => f.id === "recycled-pid-9223");
+        expect(recycled?.severity).toBe("err");
+        expect(recycled?.detail).toContain("Never kill it");
+        expect(recycled?.fix).toContain("cleanup --stale 9223");
+    });
+
+    test("a clean report yields zero findings", () => {
+        expect(findingsFromStatus({ ports: [], legacyFiles: [], orphans: [] }, [])).toEqual([]);
+    });
+});
+
+describe("killRecorderPid (the irreversible call is guarded at the primitive)", () => {
+    test("refuses to kill a pid that is not recorder-shaped, and never invokes kill", () => {
+        const killed: string[][] = [];
+        const exec = (argv: string[]) => {
+            if (argv[0] === "kill") {
+                killed.push(argv);
+                throw new Error("kill must never be reached for a non-recorder pid");
+            }
+
+            // ps -axo pid=,command= shows only innocent processes
+            return { exitCode: 0, stdout: "  777 1 /usr/libexec/WiFiCloudAssetsXPCService\n", stderr: "" };
+        };
+
+        const result = killRecorderPid(777, exec, () => new Map());
+        expect(result.ok).toBe(false);
+        expect(result.message).toContain("Refusing");
+        expect(killed).toEqual([]);
+    });
+
+    test("kills a verified recorder pid via SIGTERM", () => {
+        const killed: string[][] = [];
+        const exec = (argv: string[]) => {
+            if (argv[0] === "kill") {
+                killed.push(argv);
+
+                return { exitCode: 0, stdout: "", stderr: "" };
+            }
+
+            return {
+                exitCode: 0,
+                stdout: "  888 1 bun /repo/src/chrome-devtools/index.ts record --port 9222 --all-tabs\n",
+                stderr: "",
+            };
+        };
+
+        const result = killRecorderPid(888, exec, () => new Map());
+        expect(result.ok).toBe(true);
+        expect(killed).toEqual([["kill", "888"]]);
+    });
+
+    test("refuses to kill a LIVE pidfile-owned recorder and points at record --stop", () => {
+        const killed: string[][] = [];
+        const exec = (argv: string[]) => {
+            if (argv[0] === "kill") {
+                killed.push(argv);
+                throw new Error("must not kill a live recorder");
+            }
+
+            return {
+                exitCode: 0,
+                stdout: "  500 1 bun /repo/src/chrome-devtools/index.ts record --port 9224 --all-tabs\n",
+                stderr: "",
+            };
+        };
+
+        const result = killRecorderPid(500, exec, () => new Map([[9224, 500]]));
+        expect(result.ok).toBe(false);
+        expect(result.message).toContain("record --port 9224 --stop");
+        expect(killed).toEqual([]);
+    });
+
+    test("refuses to kill a launcher ANCESTOR of a live recorder (field-ops blocker regression)", () => {
+        // 79111 (shell) -> 79113 (tools wrapper) -> 79118 (live recorder, pidfile-owned).
+        // All three carry `record --port 9224` in their argv.
+        const killed: string[][] = [];
+        const psLines = [
+            "  79111 1 zsh -c eval 'tools chrome-devtools record --port 9224 --all-tabs'",
+            "  79113 79111 bun /repo/tools chrome-devtools record --port 9224 --all-tabs",
+            "  79118 79113 bun /repo/src/chrome-devtools/index.ts record --port 9224 --all-tabs",
+        ].join("\n");
+        const exec = (argv: string[]) => {
+            if (argv[0] === "kill") {
+                killed.push(argv);
+                throw new Error("must not kill a live recorder's launcher");
+            }
+
+            return { exitCode: 0, stdout: psLines, stderr: "" };
+        };
+
+        const result = killRecorderPid(79113, exec, () => new Map([[9224, 79118]]));
+        expect(result.ok).toBe(false);
+        expect(result.message).toContain("launcher ancestor");
+        expect(killed).toEqual([]);
+
+        const shell = killRecorderPid(79111, exec, () => new Map([[9224, 79118]]));
+        expect(shell.ok).toBe(false);
+        expect(killed).toEqual([]);
+    });
+});
+
+describe("actionsFromFindings / partitionForYes (PR #326 review — the kills-never-batch policy, pinned)", () => {
+    const FINDINGS = [
+        { id: "orphan-4242" },
+        { id: "stale-pidfile-9222" },
+        { id: "recycled-pid-9223" },
+        { id: "legacy-arm-files" },
+        { id: "leftover-buffer-9224" },
+        { id: "hot-recorder-9333" }, // informational — maps to no action
+    ];
+
+    test("maps findings to actions with the right kind tags", () => {
+        const actions = actionsFromFindings(FINDINGS);
+        expect(actions.map((a) => a.kind)).toEqual(["kill", "safe", "safe", "safe", "safe"]);
+        expect(actions[0].label).toBe("kill orphan recorder pid 4242");
+    });
+
+    test("--yes may batch only the safe subset; every kill is excluded", () => {
+        const { batchable, excludedKills } = partitionForYes(actionsFromFindings(FINDINGS));
+        expect(batchable.every((a) => a.kind === "safe")).toBe(true);
+        expect(batchable).toHaveLength(4);
+        expect(excludedKills.map((a) => a.label)).toEqual(["kill orphan recorder pid 4242"]);
+    });
+
+    test("a findings list with only kills leaves nothing batchable", () => {
+        const { batchable, excludedKills } = partitionForYes(
+            actionsFromFindings([{ id: "orphan-1" }, { id: "orphan-2" }])
+        );
+        expect(batchable).toEqual([]);
+        expect(excludedKills).toHaveLength(2);
+    });
+});
+
+describe("ancestorPids", () => {
+    test("collects the whole parent chain of owned pids, stopping at pid 1", () => {
+        const exec = (argv: string[]) => {
+            if (argv.includes("pid=,ppid=,command=")) {
+                return { exitCode: 0, stdout: "  10 1 a\n  20 10 b\n  30 20 c\n  99 1 d\n", stderr: "" };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: "" };
+        };
+
+        const ancestors = ancestorPids([30], exec);
+        expect([...ancestors].sort((a, b) => a - b)).toEqual([10, 20]);
+        expect(ancestors.has(99)).toBe(false);
+        expect(ancestors.has(1)).toBe(false);
+    });
+});
+
+describe("clearStalePidfile (ownership-safe clear)", () => {
+    // Per-run port so a developer's real recorder on a fixed port can never
+    // be touched; setup refuses to run over an existing pidfile regardless.
+    const PORT = 50000 + (process.pid % 9999);
+
+    const setup = () => {
+        ensureCaptureDir(PORT);
+        const path = recorderPidPath(PORT);
+        if (existsSync(path)) {
+            throw new Error(`refusing to test over an existing pidfile at ${path}`);
+        }
+
+        // A pid that is REALLY dead: a just-exited child's. process.execPath
+        // (bun itself) exists on every platform; `true` does not on Windows.
+        const dead = Bun.spawnSync([process.execPath, "-e", ""]).pid;
+
+        return { path, dead };
+    };
+
+    // Exclusive writes: colliding with a real recorder's claim on this port
+    // (however unlikely with the per-run port) errors instead of overwriting.
+    const plant = (path: string, pid?: number) => writePidFile(path, { pid, exclusive: true });
+
+    afterEach(() => {
+        rmSync(recorderPidPath(PORT), { force: true });
+    });
+
+    test("clears a stale record and refuses a live one", async () => {
+        const { path, dead } = setup();
+        plant(path, dead);
+        expect((await clearStalePidfile(PORT)).ok).toBe(true);
+        expect(existsSync(path)).toBe(false);
+
+        plant(path);
+        const refused = await clearStalePidfile(PORT);
+        expect(refused.ok).toBe(false);
+        expect(refused.message).toContain("LIVE");
+    });
+
+    test("a rival claim between inspect and unlink survives (rename-verify guard)", async () => {
+        const { path, dead } = setup();
+        plant(path, dead);
+
+        const result = await clearStalePidfile(PORT, {
+            afterInspect: () => {
+                // A recorder claims the port in the race window.
+                rmSync(path, { force: true });
+                plant(path);
+            },
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.message).toContain("changed while clearing");
+        // The live claim was NOT destroyed (takeover restored it).
+        expect(existsSync(path)).toBe(true);
+    });
+});

--- a/src/chrome-devtools/lib/paths.ts
+++ b/src/chrome-devtools/lib/paths.ts
@@ -1,0 +1,87 @@
+import { chmodSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@genesiscz/utils/logger";
+import { currentPlatform, tmpRoot } from "./platform.ts";
+
+const { log } = logger.scoped("chrome-devtools:paths");
+
+/**
+ * Capture layout: <tmp>/GenesisTools/ChromeDevtools/<port>/{seg-*.jsonl, meta.json, recorder.pid}.
+ * POSIX <tmp> is /tmp by contract (clears on reboot — captures are sensitive); win32 uses %TEMP%.
+ */
+export const CAPTURE_ROOT = join(tmpRoot(), "GenesisTools", "ChromeDevtools");
+
+export function captureDir(port: number): string {
+    return join(CAPTURE_ROOT, String(port));
+}
+
+export function ensureCaptureDir(port: number): string {
+    const dir = captureDir(port);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+    // Captures hold live cookies/tokens; on a multi-user POSIX box the shared
+    // /tmp root must not leak them. chmod covers dirs that already existed
+    // (mkdirSync mode only applies on creation, and is umask-filtered).
+    try {
+        chmodSync(CAPTURE_ROOT, 0o700);
+        chmodSync(dir, 0o700);
+    } catch (err) {
+        // win32 has no POSIX modes; elsewhere a failed chmod is worth a trace.
+        log.debug({ err, dir }, "capture dir chmod failed");
+    }
+
+    return dir;
+}
+
+export function metaPath(port: number): string {
+    return join(captureDir(port), "meta.json");
+}
+
+export function recorderPidPath(port: number): string {
+    return join(captureDir(port), "recorder.pid");
+}
+
+/** Ports that have a capture dir on disk (live or leftover). */
+export function knownCapturePorts(): number[] {
+    if (!existsSync(CAPTURE_ROOT)) {
+        return [];
+    }
+
+    return readdirSync(CAPTURE_ROOT)
+        .map((name) => Number(name))
+        .filter((n) => Number.isInteger(n) && n > 0)
+        .sort((a, b) => a - b);
+}
+
+/**
+ * The old skill's on-disk contract (it only ever ran on macOS, so these stay
+ * literal /tmp); doctor detects them, cleanup removes them. On win32 the dir
+ * does not exist and both helpers are no-ops.
+ */
+export function legacyArmPaths(port: number): { jsonl: string; pid: string } {
+    return {
+        // lint-rules-ignore: deliberate /tmp — the OLD macOS-only skill's fixed paths, detection only
+        jsonl: `/tmp/cdp-arm-${port}.jsonl`,
+        // lint-rules-ignore: deliberate /tmp — the OLD macOS-only skill's fixed paths, detection only
+        pid: `/tmp/cdp-arm-${port}.pid`,
+    };
+}
+
+export function listLegacyArmFiles(): string[] {
+    // Git Bash / MSYS can give a Windows host a real /tmp — files there are
+    // never the old macOS skill's leftovers, so win32 is a hard no-op.
+    if (currentPlatform() === "win32") {
+        return [];
+    }
+
+    const found: string[] = [];
+    // lint-rules-ignore: deliberate /tmp — the OLD macOS-only skill's fixed paths, detection only
+    const legacyRoot = "/tmp";
+    for (const name of existsSync(legacyRoot) ? readdirSync(legacyRoot) : []) {
+        if (/^cdp-arm-\d+\.(jsonl|pid)$/.test(name)) {
+            found.push(join(legacyRoot, name));
+        }
+    }
+
+    return found.sort();
+}

--- a/src/chrome-devtools/lib/platform.test.ts
+++ b/src/chrome-devtools/lib/platform.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import {
+    artifactPath,
+    parseCimProcesses,
+    parseCimSample,
+    parseLsofListeners,
+    parseNetstatListeners,
+    parsePsProcesses,
+    parsePsSample,
+    terminatePid,
+    tmpRoot,
+} from "./platform.ts";
+
+describe("tmpRoot / artifactPath", () => {
+    test("POSIX keeps the /tmp contract; win32 uses the OS temp dir", () => {
+        expect(tmpRoot("darwin")).toBe("/tmp");
+        expect(tmpRoot("linux")).toBe("/tmp");
+        expect(tmpRoot("win32")).not.toBe("/tmp");
+        expect(artifactPath("cdp.har", "linux")).toBe("/tmp/cdp.har");
+    });
+});
+
+describe("parsePsProcesses", () => {
+    test("parses pid/ppid/command triples and skips garbage lines", () => {
+        const entries = parsePsProcesses("    1 0 /sbin/launchd\n  842 1 /usr/bin/something --flag x\nnot a line\n");
+        expect(entries).toEqual([
+            { pid: 1, ppid: 0, command: "/sbin/launchd" },
+            { pid: 842, ppid: 1, command: "/usr/bin/something --flag x" },
+        ]);
+    });
+});
+
+describe("parseCimProcesses", () => {
+    test("parses both a JSON array and a single object, tolerating null CommandLine", () => {
+        const array = parseCimProcesses(
+            '[{"ProcessId":4321,"ParentProcessId":1,"CommandLine":"chrome.exe --type=browser","Name":"chrome.exe"},{"ProcessId":5,"ParentProcessId":4321,"CommandLine":null,"Name":"svchost.exe"}]'
+        );
+        expect(array).toEqual([
+            { pid: 4321, ppid: 1, command: "chrome.exe --type=browser" },
+            { pid: 5, ppid: 4321, command: "svchost.exe" },
+        ]);
+
+        const single = parseCimProcesses('{"ProcessId":9,"ParentProcessId":2,"CommandLine":"x","Name":"x.exe"}');
+        expect(single).toHaveLength(1);
+        expect(parseCimProcesses("not json")).toEqual([]);
+    });
+});
+
+describe("listener parsers", () => {
+    test("lsof LISTEN lines yield port + pid", () => {
+        const out = parseLsofListeners(
+            "Brave   1030 Martin  43u  IPv4 0x0      0t0  TCP 127.0.0.1:9333 (LISTEN)\nbun     1823 Martin  10u  IPv4 0x0  0t0  TCP *:9876 (LISTEN)\n"
+        );
+        expect(out).toEqual([
+            { port: 9333, pid: 1030 },
+            { port: 9876, pid: 1823 },
+        ]);
+    });
+
+    test("netstat LISTENING lines yield port + pid", () => {
+        const out = parseNetstatListeners(
+            "  TCP    127.0.0.1:9222         0.0.0.0:0              LISTENING       4321\n  TCP    [::]:445               [::]:0                 LISTENING       4\n  UDP    0.0.0.0:5353           *:*                                    999\n"
+        );
+        expect(out).toEqual([
+            { port: 9222, pid: 4321 },
+            { port: 445, pid: 4 },
+        ]);
+    });
+});
+
+describe("process samples", () => {
+    test("ps sample line parses into cpu/rss/times", () => {
+        const sample = parsePsSample(42, "  1.5 113312 0:03.15 04:32 R bun record --port 9222");
+        expect(sample).toEqual({
+            pid: 42,
+            cpuPercent: 1.5,
+            rssKb: 113312,
+            cpuTime: "0:03.15",
+            elapsed: "04:32",
+            state: "R",
+            command: "bun record --port 9222",
+        });
+    });
+
+    test("CIM sample converts 100ns ticks to cpu time and bytes to KB; %CPU is null", () => {
+        const sample = parseCimSample(
+            7,
+            '{"WorkingSetSize":104857600,"KernelModeTime":150000000,"UserModeTime":450000000,"CommandLine":"chrome.exe","Name":"chrome.exe"}'
+        );
+        expect(sample?.rssKb).toBe(102400);
+        expect(sample?.cpuTime).toBe("1:00.00");
+        expect(sample?.cpuPercent).toBeNull();
+    });
+});
+
+describe("terminatePid", () => {
+    test("POSIX sends kill; win32 sends taskkill /PID without /F", () => {
+        const calls: string[][] = [];
+        const exec = (argv: string[]) => {
+            calls.push(argv);
+
+            return { exitCode: 0, stdout: "", stderr: "" };
+        };
+
+        terminatePid(42, exec, "linux");
+        terminatePid(42, exec, "win32");
+        expect(calls).toEqual([
+            ["kill", "42"],
+            ["taskkill", "/PID", "42"],
+        ]);
+    });
+});

--- a/src/chrome-devtools/lib/platform.ts
+++ b/src/chrome-devtools/lib/platform.ts
@@ -1,0 +1,300 @@
+/**
+ * OS primitives behind the tool, one place per platform:
+ *
+ * - darwin/linux share the POSIX path (`ps`, `lsof`, `pgrep`); they differ only
+ *   in browser naming and how a browser is launched/quit (resolve-attach.ts).
+ * - win32 goes through PowerShell CIM (one call returns pid/ppid/commandline),
+ *   `netstat -ano` and `tasklist`.
+ *
+ * Every function takes an injectable ExecFn and, where behavior differs, an
+ * explicit `platform` — the pure parsers are exported so each platform's shape
+ * is unit-tested without that OS.
+ */
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+const { log } = logger.scoped("chrome-devtools:platform");
+
+export type Platform = "darwin" | "linux" | "win32";
+
+export function currentPlatform(): Platform {
+    if (process.platform === "darwin" || process.platform === "win32") {
+        return process.platform;
+    }
+
+    return "linux";
+}
+
+export type ExecResult = { exitCode: number; stdout: string; stderr: string };
+export type ExecFn = (argv: string[]) => ExecResult;
+
+export function defaultExec(argv: string[]): ExecResult {
+    const r = Bun.spawnSync(argv, { stdout: "pipe", stderr: "pipe" });
+
+    return {
+        exitCode: r.exitCode ?? 1,
+        stdout: typeof r.stdout === "string" ? r.stdout : new TextDecoder().decode(r.stdout),
+        stderr: typeof r.stderr === "string" ? r.stderr : new TextDecoder().decode(r.stderr),
+    };
+}
+
+// lint-rules-ignore: deliberate /tmp on POSIX — the capture contract (clears on reboot); Windows uses %TEMP%
+const POSIX_TMP = "/tmp";
+
+/** POSIX keeps the /tmp contract (clears on reboot — a privacy property for captures); Windows uses %TEMP%. */
+export function tmpRoot(platform: Platform = currentPlatform()): string {
+    return platform === "win32" ? tmpdir() : POSIX_TMP;
+}
+
+/** Default location for CLI artifacts (HARs, screenshots, logs). */
+export function artifactPath(name: string, platform: Platform = currentPlatform()): string {
+    return join(tmpRoot(platform), name);
+}
+
+export interface ProcessEntry {
+    pid: number;
+    ppid: number | null;
+    command: string;
+}
+
+/** Parse `ps -axo pid=,ppid=,command=` output (darwin and linux procps agree on this shape). */
+export function parsePsProcesses(stdout: string): ProcessEntry[] {
+    const entries: ProcessEntry[] = [];
+    for (const line of stdout.split("\n")) {
+        const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+        if (m) {
+            entries.push({ pid: Number(m[1]), ppid: Number(m[2]), command: m[3] });
+        }
+    }
+
+    return entries;
+}
+
+interface CimProcess {
+    ProcessId?: number;
+    ParentProcessId?: number;
+    CommandLine?: string | null;
+    Name?: string;
+}
+
+/** Parse the ConvertTo-Json output of Get-CimInstance Win32_Process (object OR array). */
+export function parseCimProcesses(stdout: string): ProcessEntry[] {
+    let parsed: unknown;
+    try {
+        parsed = SafeJSON.parse(stdout, { strict: true });
+    } catch (err) {
+        log.debug({ err }, "CIM JSON parse failed");
+
+        return [];
+    }
+
+    const list = Array.isArray(parsed) ? parsed : [parsed];
+    const entries: ProcessEntry[] = [];
+    for (const raw of list) {
+        const p = raw as CimProcess;
+        if (typeof p?.ProcessId !== "number") {
+            continue;
+        }
+
+        entries.push({
+            pid: p.ProcessId,
+            ppid: typeof p.ParentProcessId === "number" ? p.ParentProcessId : null,
+            command: p.CommandLine ?? p.Name ?? "",
+        });
+    }
+
+    return entries;
+}
+
+const CIM_PROCESS_QUERY =
+    "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CommandLine,Name | ConvertTo-Json -Depth 2";
+
+/** Every process with its full command line and parent pid. ONE exec call on every platform. */
+export function listProcesses(exec: ExecFn = defaultExec, platform: Platform = currentPlatform()): ProcessEntry[] {
+    if (platform === "win32") {
+        const r = exec(["powershell", "-NoProfile", "-Command", CIM_PROCESS_QUERY]);
+
+        return r.exitCode === 0 ? parseCimProcesses(r.stdout) : [];
+    }
+
+    const r = exec(["ps", "-axo", "pid=,ppid=,command="]);
+
+    return r.exitCode === 0 ? parsePsProcesses(r.stdout) : [];
+}
+
+export interface ListeningPort {
+    port: number;
+    pid: number | null;
+}
+
+/** Parse `lsof -nP -iTCP -sTCP:LISTEN` (POSIX). */
+export function parseLsofListeners(stdout: string): ListeningPort[] {
+    const out: ListeningPort[] = [];
+    for (const line of stdout.split("\n")) {
+        const m = line.match(/^\S+\s+(\d+)\s+.*:(\d+)\s+\(LISTEN\)/);
+        if (m) {
+            out.push({ port: Number(m[2]), pid: Number(m[1]) });
+        }
+    }
+
+    return out;
+}
+
+/** Parse `netstat -ano -p TCP` LISTENING lines (win32). */
+export function parseNetstatListeners(stdout: string): ListeningPort[] {
+    const out: ListeningPort[] = [];
+    for (const line of stdout.split("\n")) {
+        const m = line.match(/^\s*TCP\s+\S+:(\d+)\s+\S+\s+LISTENING\s+(\d+)/i);
+        if (m) {
+            out.push({ port: Number(m[1]), pid: Number(m[2]) });
+        }
+    }
+
+    return out;
+}
+
+/** Every listening TCP port with its owning pid. */
+export function listListeningTcpPorts(
+    exec: ExecFn = defaultExec,
+    platform: Platform = currentPlatform()
+): ListeningPort[] {
+    if (platform === "win32") {
+        const r = exec(["netstat", "-ano", "-p", "TCP"]);
+
+        return r.exitCode === 0 ? parseNetstatListeners(r.stdout) : [];
+    }
+
+    const r = exec(["lsof", "-nP", "-iTCP", "-sTCP:LISTEN"]);
+
+    return r.exitCode === 0 ? parseLsofListeners(r.stdout) : [];
+}
+
+/**
+ * Graceful terminate, portable. POSIX: SIGTERM (Chrome saves session state).
+ * win32: `taskkill /PID` without /F posts WM_CLOSE-style termination.
+ */
+export function terminatePid(
+    pid: number,
+    exec: ExecFn = defaultExec,
+    platform: Platform = currentPlatform()
+): ExecResult {
+    if (platform === "win32") {
+        return exec(["taskkill", "/PID", String(pid)]);
+    }
+
+    return exec(["kill", String(pid)]);
+}
+
+/** SIGPIPE does not exist on win32; registering the guard there is a no-op. */
+export function ignoreSigpipe(platform: Platform = currentPlatform()): void {
+    if (platform !== "win32") {
+        process.on("SIGPIPE", () => {});
+    }
+
+    const swallow = (err: { code?: string }) => {
+        if (err.code === "EPIPE") {
+            return;
+        }
+
+        throw err;
+    };
+    process.stdout.on("error", swallow);
+    process.stderr.on("error", swallow);
+}
+
+export interface ProcessSample {
+    pid: number;
+    /** null when the platform cannot cheaply report an instantaneous %CPU (win32). */
+    cpuPercent: number | null;
+    rssKb: number;
+    cpuTime: string;
+    elapsed: string;
+    state: string;
+    command: string;
+}
+
+/** Parse one `ps -p <pid> -o pcpu=,rss=,time=,etime=,stat=,command=` line. */
+export function parsePsSample(pid: number, line: string): ProcessSample | null {
+    const m = line.match(/^\s*([\d.]+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)$/);
+    if (!m) {
+        return null;
+    }
+
+    return {
+        pid,
+        cpuPercent: Number(m[1]),
+        rssKb: Number(m[2]),
+        cpuTime: m[3],
+        elapsed: m[4],
+        state: m[5],
+        command: m[6],
+    };
+}
+
+interface CimSample {
+    WorkingSetSize?: number;
+    KernelModeTime?: number;
+    UserModeTime?: number;
+    CommandLine?: string | null;
+    Name?: string;
+    CreationDate?: string;
+}
+
+/** Parse the CIM JSON for one process into a sample (cpu time from 100ns kernel+user ticks). */
+export function parseCimSample(pid: number, stdout: string): ProcessSample | null {
+    let parsed: unknown;
+    try {
+        parsed = SafeJSON.parse(stdout, { strict: true });
+    } catch (err) {
+        log.debug({ err, pid, stdout: stdout.slice(0, 200) }, "CIM sample JSON parse failed");
+
+        return null;
+    }
+
+    const p = (Array.isArray(parsed) ? parsed[0] : parsed) as CimSample | undefined;
+    if (!p) {
+        return null;
+    }
+
+    const cpuSeconds = ((p.KernelModeTime ?? 0) + (p.UserModeTime ?? 0)) / 10_000_000;
+    const hh = Math.floor(cpuSeconds / 3600);
+    const mm = Math.floor((cpuSeconds % 3600) / 60);
+    const ss = (cpuSeconds % 60).toFixed(2).padStart(5, "0");
+    const cpuTime = hh > 0 ? `${hh}:${String(mm).padStart(2, "0")}:${ss}` : `${mm}:${ss}`;
+
+    return {
+        pid,
+        cpuPercent: null,
+        rssKb: Math.round((p.WorkingSetSize ?? 0) / 1024),
+        cpuTime,
+        elapsed: "—",
+        state: "—",
+        command: p.CommandLine ?? p.Name ?? "",
+    };
+}
+
+export function sampleProcess(
+    pid: number,
+    exec: ExecFn = defaultExec,
+    platform: Platform = currentPlatform()
+): ProcessSample | null {
+    if (platform === "win32") {
+        const r = exec([
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            `Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" | Select-Object WorkingSetSize,KernelModeTime,UserModeTime,CommandLine,Name | ConvertTo-Json`,
+        ]);
+
+        return r.exitCode === 0 ? parseCimSample(pid, r.stdout) : null;
+    }
+
+    const r = exec(["ps", "-p", String(pid), "-o", "pcpu=,rss=,time=,etime=,stat=,command="]);
+    if (r.exitCode !== 0) {
+        return null;
+    }
+
+    return parsePsSample(pid, r.stdout.trim().split("\n")[0] ?? "");
+}

--- a/src/chrome-devtools/lib/recorder.test.ts
+++ b/src/chrome-devtools/lib/recorder.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { attemptStaleTakeover, writePidFile } from "@genesiscz/utils/process/pidfile";
+import {
+    claimRecorderPidfile,
+    extractDataReceived,
+    healthIsDead,
+    isArmableTarget,
+    isArmableUrl,
+    isRecordedMethod,
+    MAX_LIFETIME_SECONDS,
+    makePacketGate,
+    nextHealthFails,
+    pickArmTargets,
+    probeCdp,
+    recordScopeError,
+    resolveRecordSeconds,
+    waitUntilRecorderDone,
+} from "./recorder.ts";
+
+describe("isArmableUrl", () => {
+    test("keeps http(s) pages and skips DevTools and extension pages", () => {
+        expect(isArmableUrl("https://app.example.com/portal")).toBe(true);
+        expect(isArmableUrl("http://localhost:3000/")).toBe(true);
+        expect(isArmableUrl("about:blank")).toBe(true);
+        expect(isArmableUrl("devtools://devtools/bundled/devtools_app.html")).toBe(false);
+        expect(isArmableUrl("chrome-extension://abcdef/onetab.html")).toBe(false);
+        expect(isArmableUrl("chrome://settings/")).toBe(false);
+        expect(isArmableUrl("brave://rewards/")).toBe(false);
+    });
+});
+
+describe("isArmableTarget / pickArmTargets", () => {
+    test("arms http pages and iframes, skips workers and DevTools", () => {
+        expect(isArmableTarget({ type: "page", url: "https://app.example.com" })).toBe(true);
+        expect(isArmableTarget({ type: "iframe", url: "https://idp.example.com/login" })).toBe(true);
+        expect(isArmableTarget({ type: "service_worker", url: "https://app.example.com/sw.js" })).toBe(false);
+        expect(isArmableTarget({ type: "page", url: "devtools://devtools/x.html" })).toBe(false);
+        expect(
+            pickArmTargets([
+                { targetId: "a", type: "page", url: "https://app.example.com" },
+                { targetId: "b", type: "page", url: "chrome-extension://abc/x.html" },
+                { targetId: "c", type: "iframe", url: "https://idp.example.com/login" },
+            ]).map((t) => t.targetId)
+        ).toEqual(["a", "c"]);
+    });
+});
+
+describe("isRecordedMethod", () => {
+    const net = new Set(["net"] as const);
+    const withConsole = new Set(["net", "console"] as const);
+    const withWs = new Set(["net", "ws"] as const);
+
+    test("records the chrome-har diet including Page lifecycle events", () => {
+        for (const m of [
+            "Network.requestWillBeSent",
+            "Network.requestWillBeSentExtraInfo",
+            "Network.responseReceivedExtraInfo",
+            "Network.responseReceived",
+            "Network.loadingFinished",
+            "Network.loadingFailed",
+            "Network.requestServedFromCache",
+            "Network.resourceChangedPriority",
+            "Page.frameStartedLoading",
+            "Page.frameAttached",
+            "Page.loadEventFired",
+            "Page.domContentEventFired",
+            "Page.frameNavigated",
+        ]) {
+            expect(isRecordedMethod(m, net)).toBe(true);
+        }
+    });
+
+    test("never records raw dataReceived (the fast path aggregates it) and gates frames/console on channels", () => {
+        expect(isRecordedMethod("Network.dataReceived", net)).toBe(false);
+        expect(isRecordedMethod("Network.dataReceived", withWs)).toBe(false);
+        expect(isRecordedMethod("Network.webSocketFrameReceived", net)).toBe(false);
+        expect(isRecordedMethod("Network.webSocketFrameReceived", withWs)).toBe(true);
+        expect(isRecordedMethod("Runtime.consoleAPICalled", net)).toBe(false);
+        expect(isRecordedMethod("Runtime.consoleAPICalled", withConsole)).toBe(true);
+        expect(isRecordedMethod("Target.attachedToTarget", withConsole)).toBe(false);
+    });
+});
+
+describe("dataReceived fast path", () => {
+    test("extracts requestId/dataLength/timestamp/sessionId from the raw packet without JSON.parse", () => {
+        const raw =
+            '{"method":"Network.dataReceived","params":{"requestId":"1000.42","timestamp":1234.5,"dataLength":2048,"encodedDataLength":1000},"sessionId":"S1"}';
+        expect(extractDataReceived(raw)).toEqual({
+            sessionId: "S1",
+            requestId: "1000.42",
+            dataLength: 2048,
+            timestamp: 1234.5,
+        });
+        expect(extractDataReceived('{"method":"Network.dataReceived","params":{}}')).toBeNull();
+    });
+
+    test("gate drops dataReceived packets, aggregates them per session+request, and take() drains once", () => {
+        const gate = makePacketGate({ parseWsFrames: false });
+        const packet = (sid: string, id: string, len: number) =>
+            `{"method":"Network.dataReceived","params":{"requestId":"${id}","timestamp":1.5,"dataLength":${len}},"sessionId":"${sid}"}`;
+
+        expect(gate.dropRaw(packet("A", "r1", 100))).toBe(true);
+        expect(gate.dropRaw(packet("A", "r1", 200))).toBe(true);
+        expect(gate.dropRaw(packet("B", "r1", 999))).toBe(true);
+
+        expect(gate.take("A", "r1")).toEqual({ total: 300, count: 2, lastTimestamp: 1.5 });
+        expect(gate.take("A", "r1")).toBeNull();
+        expect(gate.take("B", "r1")?.total).toBe(999);
+    });
+
+    test("gate drops websocket frames unless the ws channel parses them; command replies always pass", () => {
+        const gate = makePacketGate({ parseWsFrames: false });
+        expect(gate.dropRaw('{"method":"Network.webSocketFrameReceived","params":{}}')).toBe(true);
+        expect(gate.dropRaw('{"method":"Network.webSocketFrameSent","params":{}}')).toBe(true);
+        expect(gate.dropRaw('{"method":"Network.requestWillBeSent","params":{}}')).toBe(false);
+        expect(gate.dropRaw('{"id":1,"result":{}}')).toBe(false);
+
+        const wsGate = makePacketGate({ parseWsFrames: true });
+        expect(wsGate.dropRaw('{"method":"Network.webSocketFrameReceived","params":{}}')).toBe(false);
+    });
+});
+
+describe("CDP health", () => {
+    test("three failed probes mark the browser dead", () => {
+        expect(nextHealthFails(0, true)).toBe(0);
+        expect(nextHealthFails(2, true)).toBe(0);
+        expect(nextHealthFails(2, false)).toBe(3);
+        expect(healthIsDead(2)).toBe(false);
+        expect(healthIsDead(3)).toBe(true);
+    });
+
+    test("probeCdp is false when fetch throws and true on HTTP 200", async () => {
+        expect(
+            await probeCdp(9222, async () => {
+                throw new Error("down");
+            })
+        ).toBe(false);
+        expect(await probeCdp(9222, async () => new Response("{}", { status: 200 }))).toBe(true);
+        expect(await probeCdp(9222, async () => new Response("no", { status: 500 }))).toBe(false);
+    });
+});
+
+describe("record scope + seconds", () => {
+    test("rejects a bare record and accepts --match or --all-tabs", () => {
+        expect(recordScopeError({})).toContain("record needs a scope");
+        expect(recordScopeError({ match: "  " })).toContain("record needs a scope");
+        expect(recordScopeError({ match: "app.example.com" })).toBeNull();
+        expect(recordScopeError({ allTabs: true })).toBeNull();
+    });
+
+    test("defaults to 600, keeps 0 as until-CDP-drops, and rejects negatives", () => {
+        expect(resolveRecordSeconds(undefined)).toBe(600);
+        expect(resolveRecordSeconds("")).toBe(600);
+        expect(resolveRecordSeconds("90")).toBe(90);
+        expect(resolveRecordSeconds(0)).toBe(0);
+        expect(resolveRecordSeconds("-1")).toBe(600);
+        expect(resolveRecordSeconds("nope")).toBe(600);
+    });
+});
+
+describe("waitUntilRecorderDone", () => {
+    test("resolves close when the websocket closes before the timeout", async () => {
+        expect(await waitUntilRecorderDone({ closed: Promise.resolve(), seconds: 5 })).toBe("close");
+    });
+
+    test("resolves timeout when the websocket never closes", async () => {
+        expect(await waitUntilRecorderDone({ closed: new Promise(() => {}), seconds: 0.05 })).toBe("timeout");
+    });
+
+    test("resolves signal when the abort fires", async () => {
+        const ac = new AbortController();
+        const pending = waitUntilRecorderDone({ closed: new Promise(() => {}), seconds: 5, signal: ac.signal });
+        ac.abort();
+        expect(await pending).toBe("signal");
+    });
+
+    test("seconds=0 still arms the 24h lifetime cap instead of waiting forever", () => {
+        expect(MAX_LIFETIME_SECONDS).toBe(24 * 60 * 60);
+    });
+});
+
+describe("claimRecorderPidfile (single-winner atomic claim)", () => {
+    const tmp = () => mkdtempSync(join(tmpdir(), "cdp-claim-"));
+
+    test("fresh create claims; a live foreign owner fails fast", async () => {
+        const dir = tmp();
+        const path = join(dir, "recorder.pid");
+        try {
+            await claimRecorderPidfile(path, 9999);
+            expect(existsSync(path)).toBe(true);
+            expect(readFileSync(path, "utf8")).toContain(String(process.pid));
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects a claim while a LIVE foreign process owns the pidfile", async () => {
+        const dir = tmp();
+        const path = join(dir, "recorder.pid");
+        const child = Bun.spawn([process.execPath, "-e", "await Bun.sleep(30000)"]);
+        try {
+            writePidFile(path, { pid: child.pid });
+            await expect(claimRecorderPidfile(path, 9999)).rejects.toThrow(/already up on 9999 \(pid \d+\)/);
+            // The live owner's claim survived the rejected attempt.
+            expect(readFileSync(path, "utf8")).toContain(String(child.pid));
+        } finally {
+            child.kill();
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("sweeps takeover temps of DEAD creators and spares a live creator's", async () => {
+        const dir = tmp();
+        const path = join(dir, "recorder.pid");
+        const child = Bun.spawn([process.execPath, "-e", "await Bun.sleep(30000)"]);
+        try {
+            const dead = Bun.spawnSync([process.execPath, "-e", ""]).pid;
+            const deadTemp = join(dir, `recorder.pid.stale-${dead}-deadbeef`);
+            const liveTemp = join(dir, `recorder.pid.stale-${child.pid}-cafebabe`);
+            await Bun.write(deadTemp, "residue");
+            await Bun.write(liveTemp, "mid-takeover");
+
+            await claimRecorderPidfile(path, 9999);
+            expect(existsSync(deadTemp)).toBe(false);
+            expect(existsSync(liveTemp)).toBe(true);
+        } finally {
+            child.kill();
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("takes over a stale record and self-heals over an own-pid pre-write", async () => {
+        const dir = tmp();
+        const path = join(dir, "recorder.pid");
+        try {
+            // The background spawner pre-writes the child's own pid — here,
+            // ours. The claim must steal that artifact and end up owning it.
+            writePidFile(path);
+            await claimRecorderPidfile(path, 9999);
+            expect(readFileSync(path, "utf8")).toContain(String(process.pid));
+
+            // A genuinely dead pid is also reclaimable.
+            const dead = Bun.spawnSync([process.execPath, "-e", ""]).pid;
+            rmSync(path, { force: true });
+            writePidFile(path, { pid: dead });
+            await claimRecorderPidfile(path, 9999);
+            expect(readFileSync(path, "utf8")).toContain(String(process.pid));
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("N concurrent DISCARD takeovers of one stale artifact produce EXACTLY one winner and an empty slot", async () => {
+        // The claim:true single-winner property is pinned by daemon.test.ts
+        // against the same shared function; this covers the claim:false
+        // (cleanup delete) mode it does not.
+        const dir = tmp();
+        const path = join(dir, "recorder.pid");
+        try {
+            const dead = Bun.spawnSync([process.execPath, "-e", ""]).pid;
+            const stale = writePidFile(path, { pid: dead });
+            const staleContent = readFileSync(path, "utf8");
+            expect(stale.pid).toBe(dead);
+
+            const results = await Promise.all(
+                Array.from({ length: 12 }, () => attemptStaleTakeover(path, staleContent, { claim: false }))
+            );
+            expect(results.filter(Boolean)).toHaveLength(1);
+            expect(existsSync(path)).toBe(false);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/chrome-devtools/lib/recorder.ts
+++ b/src/chrome-devtools/lib/recorder.ts
@@ -1,0 +1,750 @@
+/**
+ * The capture engine (`record` verb). One detached process per port; attaches
+ * browser-wide over CDP, auto-attaches new targets, and appends HAR-grade
+ * metadata events to time-boxed segments under the capture dir.
+ *
+ * Origin story and the whole CPU-leak forensics: the skill reference
+ * `arm-cpu-leak.md`. The load-bearing rules from that incident:
+ *  - claim the pidfile BEFORE the child connects (no duplicate parsers),
+ *  - never JSON.parse high-rate packets (dataReceived, ws frames),
+ *  - one open fd, never appendFileSync per event,
+ *  - die when CDP dies (health probe), not when someone remembers.
+ */
+import { chmodSync, existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import {
+    attemptStaleTakeover,
+    buildPidRecord,
+    clearPidFile,
+    inspectPidFile,
+    serializePidRecord,
+} from "@genesiscz/utils/process/pidfile";
+import { Conn } from "./cdp.ts";
+import type { CaptureChannel, RecordedEvent } from "./channels.ts";
+import { ensureCaptureDir, metaPath, recorderPidPath } from "./paths.ts";
+import { SegmentWriter } from "./segments.ts";
+
+const { log } = logger.scoped("chrome-devtools:recorder");
+
+/** Hard lifetime cap for recorders started with seconds=0 ("until CDP drops"). */
+export const MAX_LIFETIME_SECONDS = 24 * 60 * 60;
+
+export interface RecorderMeta {
+    pid: number;
+    port: number;
+    channels: CaptureChannel[];
+    scope: { match?: string; allTabs?: boolean };
+    startedAt: number;
+    argv: string[];
+}
+
+export function readRecorderMeta(port: number): RecorderMeta | null {
+    const path = metaPath(port);
+    if (!existsSync(path)) {
+        return null;
+    }
+
+    try {
+        const parsed = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as Partial<RecorderMeta>;
+
+        // Shape-validate: a hand-edited or truncated meta.json must read as
+        // absent, not crash doctor/status/follow downstream.
+        if (typeof parsed?.pid !== "number" || typeof parsed.port !== "number" || !Array.isArray(parsed.channels)) {
+            log.debug({ path }, "meta.json has no usable shape");
+
+            return null;
+        }
+
+        return parsed as RecorderMeta;
+    } catch (err) {
+        log.debug({ err, path }, "meta.json unreadable");
+
+        return null;
+    }
+}
+
+export function isArmableUrl(url: string): boolean {
+    const u = (url ?? "").trim().toLowerCase();
+    if (!u) {
+        return false;
+    }
+
+    if (
+        u.startsWith("devtools:") ||
+        u.startsWith("chrome:") ||
+        u.startsWith("chrome-extension:") ||
+        u.startsWith("brave:") ||
+        u.startsWith("edge:") ||
+        u.startsWith("about:srcdoc")
+    ) {
+        return false;
+    }
+
+    return u.startsWith("http:") || u.startsWith("https:") || u === "about:blank";
+}
+
+export function isArmableTarget(info: { type?: string; url?: string }): boolean {
+    const type = info.type ?? "";
+    if (type !== "page" && type !== "iframe") {
+        return false;
+    }
+
+    return isArmableUrl(info.url ?? "");
+}
+
+export function pickArmTargets<T extends { type?: string; url?: string }>(targets: T[]): T[] {
+    return targets.filter((t) => isArmableTarget(t));
+}
+
+/** The chrome-har diet (see lib/har/build.ts) plus follow's nav/ws-lifecycle needs. */
+const NET_METHODS = new Set([
+    "Network.requestWillBeSent",
+    "Network.requestServedFromCache",
+    "Network.requestWillBeSentExtraInfo",
+    "Network.responseReceivedExtraInfo",
+    "Network.responseReceived",
+    "Network.loadingFinished",
+    "Network.loadingFailed",
+    "Network.resourceChangedPriority",
+    "Network.webSocketCreated",
+    "Network.webSocketClosed",
+    "Network.webSocketWillSendHandshakeRequest",
+    "Network.webSocketHandshakeResponseReceived",
+    "Page.frameStartedLoading",
+    "Page.frameRequestedNavigation",
+    "Page.navigatedWithinDocument",
+    "Page.loadEventFired",
+    "Page.domContentEventFired",
+    "Page.frameAttached",
+    "Page.frameNavigated",
+]);
+
+const CONSOLE_METHODS = new Set(["Runtime.consoleAPICalled", "Runtime.exceptionThrown", "Log.entryAdded"]);
+
+const WS_FRAME_METHODS = new Set([
+    "Network.webSocketFrameSent",
+    "Network.webSocketFrameReceived",
+    "Network.webSocketFrameError",
+]);
+
+export function isRecordedMethod(method: string, channels: ReadonlySet<CaptureChannel>): boolean {
+    if (NET_METHODS.has(method)) {
+        return true;
+    }
+
+    if (channels.has("console") && CONSOLE_METHODS.has(method)) {
+        return true;
+    }
+
+    if (channels.has("ws") && WS_FRAME_METHODS.has(method)) {
+        return true;
+    }
+
+    return false;
+}
+
+export interface DataAggregate {
+    total: number;
+    count: number;
+    lastTimestamp: number;
+}
+
+/**
+ * The dataReceived fast path. chrome-har needs dataLength totals for accurate
+ * content sizes, but raw dataReceived packets are the CPU leak. So: never
+ * JSON.parse them — regex the three fields out of the raw string, aggregate
+ * in memory, and let the recorder emit ONE synthetic summary event when
+ * loadingFinished arrives.
+ */
+export function extractDataReceived(
+    raw: string
+): { sessionId: string; requestId: string; dataLength: number; timestamp: number } | null {
+    const requestId = raw.match(/"requestId":"([^"]+)"/)?.[1];
+    const dataLength = raw.match(/"dataLength":(\d+)/)?.[1];
+    if (!requestId || dataLength === undefined) {
+        return null;
+    }
+
+    return {
+        sessionId: raw.match(/"sessionId":"([^"]+)"/)?.[1] ?? "",
+        requestId,
+        dataLength: Number(dataLength),
+        timestamp: Number(raw.match(/"timestamp":([\d.]+)/)?.[1] ?? 0),
+    };
+}
+
+export interface PacketGate {
+    dropRaw: (raw: string) => boolean;
+    /** Drain the aggregate for one request (used at loadingFinished/Failed). */
+    take: (sessionId: string | undefined, requestId: string) => DataAggregate | null;
+}
+
+export function makePacketGate(opts: { parseWsFrames: boolean }): PacketGate {
+    const aggregates = new Map<string, DataAggregate>();
+
+    return {
+        dropRaw: (raw: string): boolean => {
+            if (raw.includes('"method":"Network.dataReceived"')) {
+                const data = extractDataReceived(raw);
+                if (data) {
+                    const key = `${data.sessionId} ${data.requestId}`;
+                    const agg = aggregates.get(key);
+                    if (agg) {
+                        agg.total += data.dataLength;
+                        agg.count += 1;
+                        agg.lastTimestamp = data.timestamp;
+                    } else {
+                        aggregates.set(key, { total: data.dataLength, count: 1, lastTimestamp: data.timestamp });
+                    }
+                }
+
+                return true;
+            }
+
+            if (!opts.parseWsFrames && raw.includes('"method":"Network.webSocketFrame')) {
+                return true;
+            }
+
+            return false;
+        },
+        take: (sessionId, requestId) => {
+            const key = `${sessionId ?? ""} ${requestId}`;
+            const agg = aggregates.get(key);
+            if (agg) {
+                aggregates.delete(key);
+                return agg;
+            }
+
+            return null;
+        },
+    };
+}
+
+export function nextHealthFails(prev: number, ok: boolean): number {
+    return ok ? 0 : prev + 1;
+}
+
+export function healthIsDead(fails: number): boolean {
+    return fails >= 3;
+}
+
+export async function probeCdp(
+    port: number,
+    get: (url: string, init?: RequestInit) => Promise<Response> = fetch
+): Promise<boolean> {
+    try {
+        const r = await get(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(1000) });
+
+        return r.ok;
+    } catch {
+        return false;
+    }
+}
+
+export function recordScopeError(opts: { match?: string; allTabs?: boolean }): string | null {
+    if (opts.allTabs) {
+        return null;
+    }
+
+    if (opts.match?.trim()) {
+        return null;
+    }
+
+    return [
+        "record needs a scope. Pick one:",
+        "  --match <url-substr>   record only tabs whose URL contains this (cheapest)",
+        "  --all-tabs             record every http(s) tab",
+    ].join("\n");
+}
+
+export function resolveRecordSeconds(raw?: string | number): number {
+    if (raw === undefined || raw === "") {
+        return 600;
+    }
+
+    const n = typeof raw === "number" ? raw : Number(raw);
+    if (!Number.isFinite(n) || n < 0) {
+        return 600;
+    }
+
+    return n;
+}
+
+export function waitUntilRecorderDone(opts: {
+    closed: Promise<void>;
+    seconds: number;
+    signal?: AbortSignal;
+}): Promise<"close" | "timeout" | "signal"> {
+    return new Promise((resolve) => {
+        let done = false;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const finish = (reason: "close" | "timeout" | "signal") => {
+            if (done) {
+                return;
+            }
+
+            done = true;
+            if (timer) {
+                clearTimeout(timer);
+            }
+
+            resolve(reason);
+        };
+
+        void opts.closed.then(() => finish("close"));
+        const effectiveSeconds = opts.seconds > 0 ? opts.seconds : MAX_LIFETIME_SECONDS;
+        timer = setTimeout(() => finish("timeout"), effectiveSeconds * 1000);
+
+        if (opts.signal) {
+            if (opts.signal.aborted) {
+                finish("signal");
+            } else {
+                opts.signal.addEventListener("abort", () => finish("signal"), { once: true });
+            }
+        }
+    });
+}
+
+function errCode(err: unknown): string | undefined {
+    return (err as NodeJS.ErrnoException).code;
+}
+
+/**
+ * Remove `recorder.pid.stale-*` temp files whose creating process is dead —
+ * residue of a takeover that crashed between rename and cleanup. The creator's
+ * pid is embedded in the name; a live creator is mid-takeover and left alone.
+ */
+export function sweepDeadTakeoverTemps(pidPath: string): void {
+    const dir = dirname(pidPath);
+    const prefix = `${basename(pidPath)}.stale-`;
+
+    let names: string[];
+    try {
+        names = readdirSync(dir);
+    } catch (err) {
+        log.debug({ err, dir }, "takeover temp sweep skipped (dir unreadable)");
+
+        return;
+    }
+
+    for (const name of names) {
+        if (!name.startsWith(prefix)) {
+            continue;
+        }
+
+        const creator = Number(name.slice(prefix.length).split("-")[0]);
+        if (!Number.isInteger(creator) || creator <= 0) {
+            continue;
+        }
+
+        let alive = false;
+        try {
+            process.kill(creator, 0);
+            alive = true;
+        } catch (err) {
+            // EPERM = alive but not ours; ESRCH = dead.
+            alive = errCode(err) === "EPERM";
+        }
+
+        if (alive) {
+            continue;
+        }
+
+        try {
+            unlinkSync(join(dir, name));
+            log.debug({ name, creator }, "swept dead takeover temp");
+        } catch (err) {
+            log.debug({ err, name }, "takeover temp sweep unlink failed");
+        }
+    }
+}
+
+/**
+ * Claim the recorder pidfile atomically via the shared pidfile protocol
+ * (async `wx` create + rename-verify stale takeover — see
+ * `attemptStaleTakeover` in src/utils/process/pidfile.ts). A live OR
+ * unverified foreign owner fails fast: `unverified` means the pid is ALIVE
+ * but the OS would not name it (the normal Windows answer), and stealing an
+ * alive recorder's claim is exactly the double-parser failure this exists to
+ * prevent. Only EEXIST enters the recovery path — permission/disk faults
+ * surface as themselves. Exported for the concurrency test.
+ */
+export async function claimRecorderPidfile(pidPath: string, port: number): Promise<void> {
+    sweepDeadTakeoverTemps(pidPath);
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+            await writeFile(pidPath, serializePidRecord(buildPidRecord()), { flag: "wx" });
+
+            return;
+        } catch (err) {
+            if (errCode(err) !== "EEXIST") {
+                throw err;
+            }
+        }
+
+        const state = inspectPidFile(pidPath);
+        if ((state.status === "live" || state.status === "unverified") && state.pid !== process.pid) {
+            throw new Error(`recorder already up on ${port} (pid ${state.pid}). Stop it: record --port ${port} --stop`);
+        }
+
+        let staleContent: string | null = null;
+        try {
+            staleContent = readFileSync(pidPath, "utf8");
+        } catch (err) {
+            log.debug({ err, pidPath }, "stale pidfile vanished; retrying fresh create");
+            continue;
+        }
+
+        if (await attemptStaleTakeover(pidPath, staleContent)) {
+            return;
+        }
+
+        log.debug({ attempt, port }, "lost pidfile takeover round; re-checking");
+    }
+
+    throw new Error(`lost the recorder claim race on ${port}; another instance is recording`);
+}
+
+export async function connectBrowser(port: number, opts?: { dropRaw?: (raw: string) => boolean }): Promise<Conn> {
+    const v = (await (await fetch(`http://127.0.0.1:${port}/json/version`)).json()) as {
+        webSocketDebuggerUrl: string;
+    };
+
+    const conn = new Conn(v.webSocketDebuggerUrl, opts);
+    // Prove the websocket actually OPENED before returning: without this, a
+    // ws failure surfaces at the first later send(), outside the caller's
+    // pidfile-clearing catch, and leaves a stale claim behind.
+    await conn.send("Browser.getVersion");
+
+    return conn;
+}
+
+export interface RunRecorderOpts {
+    port: number;
+    match?: string;
+    allTabs?: boolean;
+    seconds?: number;
+    channels: CaptureChannel[];
+}
+
+export async function runRecorder(opts: RunRecorderOpts): Promise<void> {
+    const scopeErr = recordScopeError({ match: opts.match, allTabs: opts.allTabs });
+    if (scopeErr) {
+        throw new Error(scopeErr);
+    }
+
+    const seconds = resolveRecordSeconds(opts.seconds);
+    const channels = new Set<CaptureChannel>(["net", ...opts.channels]);
+    const dir = ensureCaptureDir(opts.port);
+    const pidPath = recorderPidPath(opts.port);
+
+    const state = inspectPidFile(pidPath);
+    if (state.status === "live" && state.pid !== process.pid) {
+        throw new Error(
+            `recorder already up on ${opts.port} (pid ${state.pid}). Stop it: record --port ${opts.port} --stop`
+        );
+    }
+
+    // Claim BEFORE the connect — the incident's load-bearing rule. Two
+    // concurrent `record` calls racing through inspect+connect would otherwise
+    // both attach browser-wide (double parsers, doubled events). The claim is
+    // an async atomic `wx` create with a rename-verify takeover for stale
+    // records — see claimRecorderPidfile above for why sync fs cannot do this.
+    const gate = makePacketGate({ parseWsFrames: channels.has("ws") });
+    await claimRecorderPidfile(pidPath, opts.port);
+
+    let conn: Conn;
+    try {
+        conn = await connectBrowser(opts.port, { dropRaw: gate.dropRaw });
+    } catch (err) {
+        clearPidFile(pidPath);
+        throw new Error(
+            `no CDP endpoint on ${opts.port} (${err instanceof Error ? err.message : String(err)}). See live ports: attach`
+        );
+    }
+
+    const meta: RecorderMeta = {
+        pid: process.pid,
+        port: opts.port,
+        channels: [...channels],
+        scope: { match: opts.match, allTabs: opts.allTabs },
+        startedAt: Date.now(),
+        argv: process.argv.slice(2),
+    };
+    try {
+        await Bun.write(metaPath(opts.port), `${SafeJSON.stringify(meta, { strict: true }, 2)}\n`);
+        // Meta records the scope/argv of a capture that holds credentials — owner-only.
+        chmodSync(metaPath(opts.port), 0o600);
+    } catch (err) {
+        clearPidFile(pidPath);
+        throw err;
+    }
+
+    const writer = new SegmentWriter(dir);
+
+    const enabled = new Set<string>();
+    // One recording session per TARGET. Chrome (151+) auto-attaches existing
+    // targets on setAutoAttach AND answers the explicit attachToTarget sweep,
+    // which yields two sessions per tab and every event twice — verified live
+    // (doubled follow lines, doubled HAR entries) before this guard existed.
+    const attachedTargets = new Map<string, string>();
+    const bodyUrls = new Map<string, string>();
+    const match = opts.allTabs ? undefined : opts.match;
+    const ac = new AbortController();
+    const onStop = () => ac.abort();
+    process.once("SIGTERM", onStop);
+    process.once("SIGINT", onStop);
+    let healthFails = 0;
+    const healthTimer = setInterval(() => {
+        void probeCdp(opts.port).then((ok) => {
+            healthFails = nextHealthFails(healthFails, ok);
+            if (healthIsDead(healthFails)) {
+                ac.abort();
+            }
+        });
+    }, 2000);
+
+    // ONE teardown order, shared by the setup-failure catch and the normal
+    // finally — two copies would diverge the day a new resource is added.
+    const teardown = () => {
+        clearInterval(healthTimer);
+        process.off("SIGTERM", onStop);
+        process.off("SIGINT", onStop);
+        conn.close();
+        writer.close();
+        clearPidFile(recorderPidPath(opts.port));
+    };
+
+    const record = (event: RecordedEvent) => {
+        writer.write(event);
+    };
+
+    const enable = async (sessionId: string, url: string, type?: string, targetId?: string) => {
+        if (!isArmableTarget({ type: type ?? "page", url })) {
+            return;
+        }
+
+        if (match && !url.includes(match)) {
+            return;
+        }
+
+        if (enabled.has(sessionId)) {
+            return;
+        }
+
+        if (targetId) {
+            const owner = attachedTargets.get(targetId);
+            if (owner && owner !== sessionId) {
+                return;
+            }
+
+            attachedTargets.set(targetId, sessionId);
+        }
+
+        enabled.add(sessionId);
+        const domains = ["Network.enable", "Page.enable"];
+        if (channels.has("console")) {
+            domains.push("Runtime.enable", "Log.enable");
+        }
+
+        for (const method of domains) {
+            await conn.send(method, {}, sessionId).catch((err: unknown) => {
+                log.warn({ err, method, url }, "domain enable failed");
+                if (method === "Network.enable") {
+                    enabled.delete(sessionId);
+                }
+            });
+        }
+    };
+
+    // Register listeners BEFORE setAutoAttach, or we miss Target.attachedToTarget for existing tabs.
+    conn.on((method, params, sessionId) => {
+        if (method === "Target.attachedToTarget") {
+            const info = (params.targetInfo ?? {}) as { type?: string; url?: string; targetId?: string };
+            const sid = String(params.sessionId ?? sessionId ?? "");
+            void enable(sid, info.url ?? "", info.type, info.targetId);
+
+            return;
+        }
+
+        if (method === "Target.targetInfoChanged") {
+            const info = (params.targetInfo ?? params) as {
+                type?: string;
+                url?: string;
+                sessionId?: string;
+                targetId?: string;
+            };
+            const sid = String(sessionId ?? info.sessionId ?? "");
+            if (sid) {
+                void enable(sid, info.url ?? "", info.type, info.targetId);
+            }
+
+            return;
+        }
+
+        if (method === "Target.detachedFromTarget") {
+            const sid = String(params.sessionId ?? sessionId ?? "");
+            enabled.delete(sid);
+            for (const [targetId, owner] of attachedTargets) {
+                if (owner === sid) {
+                    attachedTargets.delete(targetId);
+                }
+            }
+
+            return;
+        }
+
+        if (!isRecordedMethod(method, channels)) {
+            return;
+        }
+
+        const url = String(
+            (params.request as { url?: string } | undefined)?.url ??
+                (params.response as { url?: string } | undefined)?.url ??
+                (params.redirectResponse as { url?: string } | undefined)?.url ??
+                ""
+        );
+
+        if (match && url && !url.includes(match)) {
+            return;
+        }
+
+        // Synthesize the aggregated dataReceived summary right before the finish
+        // event, so the HAR builder sees sizes without the packet flood.
+        if (method === "Network.loadingFinished" || method === "Network.loadingFailed") {
+            const agg = gate.take(sessionId, String(params.requestId ?? ""));
+            if (agg && method === "Network.loadingFinished") {
+                record({
+                    method: "Network.dataReceived",
+                    params: {
+                        requestId: params.requestId,
+                        timestamp: agg.lastTimestamp,
+                        dataLength: agg.total,
+                        encodedDataLength: 0,
+                    },
+                    sessionId,
+                    t: Date.now(),
+                });
+            }
+        }
+
+        record({ method, params, sessionId, t: Date.now() });
+
+        if (channels.has("body") && method === "Network.responseReceived" && url) {
+            bodyUrls.set(`${sessionId ?? ""} ${params.requestId}`, url);
+        }
+
+        if (channels.has("body") && method === "Network.loadingFinished" && sessionId) {
+            const key = `${sessionId} ${params.requestId}`;
+            const bodyUrl = bodyUrls.get(key);
+            if (bodyUrl) {
+                bodyUrls.delete(key);
+                void conn
+                    .send("Network.getResponseBody", { requestId: params.requestId }, sessionId)
+                    .then((r) => {
+                        const body = (r as { body?: string }).body ?? "";
+                        record({
+                            method: "Genesis.responseBody",
+                            params: { url: bodyUrl, requestId: params.requestId, body: String(body).slice(0, 2048) },
+                            sessionId,
+                            t: Date.now(),
+                        });
+                    })
+                    .catch((err: unknown) => {
+                        log.debug({ err, url: bodyUrl }, "body fetch failed");
+                    });
+            }
+        }
+
+        if (channels.has("storage") && method === "Page.frameNavigated" && sessionId) {
+            const frame = params.frame as { parentId?: string; url?: string } | undefined;
+            if (frame && !frame.parentId) {
+                void conn
+                    .send(
+                        "Runtime.evaluate",
+                        {
+                            expression:
+                                "JSON.stringify({ls: Object.keys(localStorage).length, ss: Object.keys(sessionStorage).length, lsKeys: Object.keys(localStorage).slice(0,8)})",
+                            returnByValue: true,
+                        },
+                        sessionId
+                    )
+                    .then((r) => {
+                        const value = (r as { result?: { value?: string } }).result?.value;
+                        if (!value) {
+                            return;
+                        }
+
+                        const snap = SafeJSON.parse(value, { strict: true }) as Record<string, unknown>;
+                        record({
+                            method: "Genesis.storageSnapshot",
+                            params: { url: frame.url, ...snap },
+                            sessionId,
+                            t: Date.now(),
+                        });
+                    })
+                    .catch((err: unknown) => {
+                        log.debug({ err }, "storage snapshot failed");
+                    });
+            }
+        }
+    });
+
+    // A throw in the setup sends must not strand the pidfile claim: tear down
+    // and clear before propagating (the normal-path finally sits further down).
+    try {
+        await conn.send("Target.setDiscoverTargets", { discover: true });
+        await conn.send("Target.setAutoAttach", { autoAttach: true, waitForDebuggerOnStart: false, flatten: true });
+        const existing = (await conn.send("Target.getTargets").catch(() => ({ targetInfos: [] }))) as {
+            targetInfos?: { targetId: string; type?: string; url?: string }[];
+        };
+
+        for (const t of pickArmTargets(existing.targetInfos ?? [])) {
+            if (match && !(t.url ?? "").includes(match)) {
+                continue;
+            }
+
+            // Auto-attach already delivered a session for most existing targets;
+            // the sweep only covers stragglers, never a second session.
+            if (attachedTargets.has(t.targetId)) {
+                continue;
+            }
+
+            try {
+                const attached = (await conn.send("Target.attachToTarget", {
+                    targetId: t.targetId,
+                    flatten: true,
+                })) as {
+                    sessionId?: string;
+                };
+                if (attached.sessionId) {
+                    await enable(attached.sessionId, t.url ?? "", t.type, t.targetId);
+                }
+            } catch (err) {
+                log.warn({ err, url: t.url }, "attachToTarget failed");
+            }
+        }
+    } catch (err) {
+        teardown();
+        throw err;
+    }
+
+    const ttl = seconds > 0 ? `ttl ${seconds}s` : `until CDP drops (max ${MAX_LIFETIME_SECONDS / 3600}h)`;
+    const scope = match ? `match ${match}` : "all http(s) tabs";
+    log.out.info(
+        `recording port ${opts.port} pid ${process.pid} -> ${dir} (${scope}, channels ${[...channels].join(",")}, ${ttl})`
+    );
+    log.out.info(`stop: record --port ${opts.port} --stop   (or kill ${process.pid})`);
+
+    try {
+        const reason = await waitUntilRecorderDone({ closed: conn.closed, seconds, signal: ac.signal });
+        record({ method: "Genesis.marker", params: { kind: "recorderExit", detail: reason }, t: Date.now() });
+        log.out.info(`recorder exiting (${reason})`);
+    } finally {
+        teardown();
+    }
+}

--- a/src/chrome-devtools/lib/resolve-attach.test.ts
+++ b/src/chrome-devtools/lib/resolve-attach.test.ts
@@ -1,0 +1,695 @@
+import { describe, expect, test } from "bun:test";
+import { env } from "@genesiscz/utils/env";
+import {
+    browserById,
+    browsersWithEmptyDebugFlag,
+    classifyProcessName,
+    discoverListeningCdpPorts,
+    isPortSpecified,
+    launchBrowser,
+    listRunningBrowsers,
+    ownerOfPort,
+    parseRemoteDebuggingPort,
+    parseTasklistImages,
+    planAttach,
+    quitBrowser,
+    readDevToolsActivePorts,
+    renderAttachPlan,
+    waitForCdp,
+} from "./resolve-attach.ts";
+
+// Regression heritage: the original skill's attach listed only CDP ports, so an
+// open Brave without --remote-debugging-port vanished and agents attached to
+// Chrome instead. These tests pin the refusal plus the per-platform primitives.
+
+const CHROME_LOCALHOST = {
+    port: 9222,
+    browser: "Chrome/151.0.7922.172",
+    owner: "chrome" as const,
+    pages: [{ title: "portal", url: "http://localhost:3000/" }],
+};
+
+const suggest = (add: string[]) => `tools chrome-devtools ${add.join(" ")}`;
+
+/** One combined ps/lsof fake: pid ppid command triples + lsof listener lines. */
+function posixExec(opts: { procs?: string; lsof?: string }) {
+    return (argv: string[]) => {
+        if (argv[0] === "ps" && argv.includes("pid=,ppid=,command=")) {
+            return { exitCode: 0, stdout: opts.procs ?? "", stderr: "" };
+        }
+
+        if (argv[0] === "lsof") {
+            return { exitCode: 0, stdout: opts.lsof ?? "", stderr: "" };
+        }
+
+        return { exitCode: 1, stdout: "", stderr: `unexpected ${argv.join(" ")}` };
+    };
+}
+
+describe("listRunningBrowsers", () => {
+    test("darwin: includes Brave from pgrep -x on the app name even when it has no CDP port", () => {
+        const exec = (argv: string[]) => {
+            const name = argv.at(-1);
+            if (argv[0] === "pgrep" && argv.includes("-x") && (name === "Google Chrome" || name === "Brave Browser")) {
+                return { exitCode: 0, stdout: "123\n", stderr: "" };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: "" };
+        };
+
+        expect(listRunningBrowsers(exec, "darwin")).toEqual(["chrome", "brave"]);
+    });
+
+    test("darwin: omits Brave when pgrep -x does not find it", () => {
+        const exec = (argv: string[]) => {
+            if (argv[0] === "pgrep" && argv.at(-1) === "Google Chrome") {
+                return { exitCode: 0, stdout: "1\n", stderr: "" };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: "" };
+        };
+
+        expect(listRunningBrowsers(exec, "darwin")).toEqual(["chrome"]);
+    });
+
+    test("linux: matches bin names, not macOS app names", () => {
+        const exec = (argv: string[]) => {
+            if (argv[0] === "pgrep" && (argv.at(-1) === "google-chrome" || argv.at(-1) === "brave-browser")) {
+                return { exitCode: 0, stdout: "42\n", stderr: "" };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: "" };
+        };
+
+        expect(listRunningBrowsers(exec, "linux")).toEqual(["chrome", "brave"]);
+    });
+
+    test("win32: matches tasklist image names", () => {
+        const exec = (argv: string[]) => {
+            if (argv[0] === "tasklist") {
+                return {
+                    exitCode: 0,
+                    stdout: '"chrome.exe","1234","Console","1","150,000 K"\n"msedge.exe","77","Console","1","90,000 K"\n"notepad.exe","5","Console","1","9,000 K"\n',
+                    stderr: "",
+                };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: "" };
+        };
+
+        expect(listRunningBrowsers(exec, "win32")).toEqual(["chrome", "edge"]);
+        expect(parseTasklistImages('"brave.exe","9"\n')).toEqual(new Set(["brave.exe"]));
+    });
+});
+
+describe("ownerOfPort", () => {
+    test("classifies via the process command line of the listening pid", () => {
+        const exec = posixExec({
+            lsof: "Google   52730 Martin  43u  IPv4 TCP 127.0.0.1:9222 (LISTEN)\n",
+            procs: "  52730 1 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --type=browser\n",
+        });
+
+        expect(ownerOfPort(9222, exec, "darwin")).toBe("chrome");
+    });
+
+    test("maps a Brave listening pid to brave, and a linux chrome path to chrome", () => {
+        const braveExec = posixExec({
+            lsof: "Brave   1030 Martin  43u  IPv4 TCP 127.0.0.1:9224 (LISTEN)\n",
+            procs: "  1030 1 /Applications/Brave Browser.app/Contents/MacOS/Brave Browser\n",
+        });
+        expect(ownerOfPort(9224, braveExec, "darwin")).toBe("brave");
+
+        const linuxExec = posixExec({
+            lsof: "chrome   77 martin  43u  IPv4 TCP 127.0.0.1:9222 (LISTEN)\n",
+            procs: "  77 1 /opt/google/chrome/chrome --remote-debugging-port=9222\n",
+        });
+        expect(ownerOfPort(9222, linuxExec, "linux")).toBe("chrome");
+    });
+
+    test("returns null when nothing listens on the port", () => {
+        expect(ownerOfPort(9222, posixExec({}), "darwin")).toBe(null);
+    });
+});
+
+describe("classifyProcessName", () => {
+    test("maps macOS bundle paths and bare names", () => {
+        expect(classifyProcessName("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")).toBe("chrome");
+        expect(classifyProcessName("/Applications/Brave Browser.app/Contents/MacOS/Brave Browser")).toBe("brave");
+        expect(classifyProcessName("Google Chrome")).toBe("chrome");
+        expect(classifyProcessName("Brave Browser")).toBe("brave");
+        expect(classifyProcessName("Safari")).toBe(null);
+    });
+
+    test("maps linux binaries and windows image names", () => {
+        expect(classifyProcessName("/opt/google/chrome/chrome --type=renderer")).toBe("chrome");
+        expect(classifyProcessName("/usr/bin/brave-browser --remote-debugging-port=9222")).toBe("brave");
+        expect(classifyProcessName("C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe --type=browser")).toBe(
+            "chrome"
+        );
+        expect(classifyProcessName("C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe")).toBe("edge");
+        expect(classifyProcessName("Firefox")).toBe(null);
+    });
+
+    test("maps Edge, Arc, and Chrome Canary; does not treat Safari as attachable", () => {
+        expect(classifyProcessName("/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge")).toBe("edge");
+        expect(classifyProcessName("Arc")).toBe("arc");
+        expect(classifyProcessName("/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary")).toBe(
+            "chrome-canary"
+        );
+    });
+});
+
+describe("planAttach", () => {
+    test("refuses to pick a browser when Chrome has CDP and Brave is open without it", () => {
+        const plan = planAttach({
+            running: ["chrome", "brave"],
+            endpoints: [CHROME_LOCALHOST],
+        });
+
+        expect(plan.status).toBe("ambiguous");
+        expect(plan.undebugged).toEqual(["brave"]);
+
+        const { text, exitCode } = renderAttachPlan(plan, {
+            cmd: "tools chrome-devtools",
+            suggestCommand: suggest,
+            platform: "darwin",
+        });
+
+        expect(exitCode).toBe(1);
+        expect(text).toContain("Brave Browser");
+        expect(text).toContain("debugging port is not on");
+        expect(text).toContain("osascript -e 'quit app \"Brave Browser\"'");
+        expect(text).toContain('open -na "Brave Browser" --args --remote-debugging-port=9223');
+        expect(text).toContain("tools chrome-devtools attach --port 9222");
+    });
+
+    test("non-darwin render offers the tool's restart, not osascript", () => {
+        const plan = planAttach({ running: ["chrome", "brave"], endpoints: [CHROME_LOCALHOST] });
+        const { text } = renderAttachPlan(plan, {
+            cmd: "tools chrome-devtools",
+            suggestCommand: suggest,
+            platform: "linux",
+        });
+
+        expect(text).toContain("restart --browser brave");
+        expect(text).not.toContain("osascript");
+        expect(text).not.toContain("open -na");
+    });
+
+    test("explicit --port lists that endpoint instead of refusing", () => {
+        const plan = planAttach(
+            { running: ["chrome", "brave"], endpoints: [CHROME_LOCALHOST] },
+            { explicitPort: 9222 }
+        );
+
+        expect(plan.status).toBe("list");
+        expect(
+            renderAttachPlan(plan, { cmd: "tools chrome-devtools", suggestCommand: suggest, platform: "darwin" })
+                .exitCode
+        ).toBe(0);
+    });
+
+    test("explicit --port does not list the other browser as debugging on with no pages", () => {
+        const plan = planAttach(
+            {
+                running: ["chrome", "brave"],
+                endpoints: [
+                    {
+                        port: 9223,
+                        browser: "Chrome/151.0.7922.138",
+                        owner: "chrome",
+                        pages: [{ title: "IdP", url: "https://idp.example.com/" }],
+                    },
+                    {
+                        port: 9222,
+                        browser: "Chrome/151.0.7922.173",
+                        owner: "brave",
+                        pages: [{ title: "portal", url: "https://app.example.com/portal" }],
+                    },
+                ],
+            },
+            { explicitPort: 9223 }
+        );
+
+        const { text, exitCode } = renderAttachPlan(plan, {
+            cmd: "tools chrome-devtools",
+            suggestCommand: suggest,
+            platform: "darwin",
+        });
+        expect(exitCode).toBe(0);
+        expect(text).toContain("9223");
+        expect(text).not.toContain("Brave Browser");
+        expect(text).not.toContain("app.example.com");
+    });
+
+    test("refuses when both Chrome and Brave have CDP", () => {
+        const plan = planAttach({
+            running: ["chrome", "brave"],
+            endpoints: [
+                {
+                    port: 9223,
+                    browser: "Chrome/151.0.7922.138",
+                    owner: "chrome",
+                    pages: [{ title: "IdP", url: "https://idp.example.com/" }],
+                },
+                {
+                    port: 9222,
+                    browser: "Chrome/151.0.7922.173",
+                    owner: "brave",
+                    pages: [{ title: "portal", url: "https://app.example.com/portal" }],
+                },
+            ],
+        });
+
+        expect(plan.status).toBe("ambiguous");
+        expect(plan.undebugged).toEqual([]);
+        const { text, exitCode } = renderAttachPlan(plan, {
+            cmd: "tools chrome-devtools",
+            suggestCommand: suggest,
+            platform: "darwin",
+        });
+        expect(exitCode).toBe(1);
+        expect(text).toContain("Google Chrome");
+        expect(text).toContain("Brave Browser");
+        expect(text).toContain("tools chrome-devtools attach --port 9222");
+        expect(text).toContain("tools chrome-devtools attach --port 9223");
+        expect(text).not.toContain("debugging port is not on");
+    });
+
+    test("refuses Chrome plus Edge the same way as Chrome plus Brave", () => {
+        const plan = planAttach({
+            running: ["chrome", "edge"],
+            endpoints: [CHROME_LOCALHOST],
+        });
+
+        expect(plan.status).toBe("ambiguous");
+        expect(plan.undebugged).toEqual(["edge"]);
+
+        const { text, exitCode } = renderAttachPlan(plan, {
+            cmd: "tools chrome-devtools",
+            suggestCommand: suggest,
+            platform: "darwin",
+        });
+
+        expect(exitCode).toBe(1);
+        expect(text).toContain("Microsoft Edge");
+        expect(text).toContain("debugging port is not on");
+        expect(text).toContain("nothing is picked silently");
+    });
+
+    test("does not refuse when only Chrome is running", () => {
+        const plan = planAttach({ running: ["chrome"], endpoints: [CHROME_LOCALHOST] });
+
+        expect(plan.status).toBe("list");
+        const { text, exitCode } = renderAttachPlan(plan, {
+            cmd: "tools chrome-devtools",
+            suggestCommand: suggest,
+            platform: "darwin",
+        });
+        expect(exitCode).toBe(0);
+        expect(text).not.toContain("nothing is picked silently");
+    });
+});
+
+describe("isPortSpecified", () => {
+    test("treats --port and --port= as an explicit choice", () => {
+        expect(isPortSpecified(["bun", "index.ts", "attach"])).toBe(false);
+        expect(isPortSpecified(["bun", "index.ts", "cookies", "--port", "9222"])).toBe(true);
+        expect(isPortSpecified(["bun", "index.ts", "eval", "--port=9223", "() => 1"])).toBe(true);
+    });
+});
+
+describe("parseRemoteDebuggingPort", () => {
+    test("treats --remote-debugging-port= with no value as empty", () => {
+        expect(parseRemoteDebuggingPort("Brave Browser --remote-debugging-port=")).toEqual({
+            present: true,
+            empty: true,
+            port: null,
+        });
+        expect(parseRemoteDebuggingPort("Brave Browser --remote-debugging-port=9222")).toEqual({
+            present: true,
+            empty: false,
+            port: 9222,
+        });
+        expect(parseRemoteDebuggingPort("Brave Browser --no-first-run")).toEqual({
+            present: false,
+            empty: false,
+            port: null,
+        });
+    });
+});
+
+describe("browsersWithEmptyDebugFlag", () => {
+    test("finds Brave when the process list shows --remote-debugging-port= with no value", () => {
+        const exec = posixExec({
+            procs: [
+                "  10 1 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --remote-debugging-port=9223",
+                "  11 1 /Applications/Brave Browser.app/Contents/MacOS/Brave Browser --remote-debugging-port=",
+                "  12 1 /usr/local/bin/bun --watch",
+            ].join("\n"),
+        });
+
+        expect(browsersWithEmptyDebugFlag(exec, "darwin")).toEqual(["brave"]);
+    });
+});
+
+describe("discoverListeningCdpPorts", () => {
+    test("includes a browser listener on 9333 and skips bun on 9876", () => {
+        const exec = posixExec({
+            lsof: [
+                "Brave   1030 Martin  43u  IPv4 TCP 127.0.0.1:9333 (LISTEN)",
+                "bun     1823 Martin  10u  IPv4 TCP 127.0.0.1:9876 (LISTEN)",
+            ].join("\n"),
+            procs: [
+                "  1030 1 /Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+                "  1823 1 bun run something",
+            ].join("\n"),
+        });
+
+        expect(discoverListeningCdpPorts(exec, "darwin")).toEqual([9333]);
+    });
+
+    test("win32 uses netstat listeners with the same classification", () => {
+        const exec = (argv: string[]) => {
+            if (argv[0] === "netstat") {
+                return {
+                    exitCode: 0,
+                    stdout: "  TCP    127.0.0.1:9222         0.0.0.0:0              LISTENING       4321\n",
+                    stderr: "",
+                };
+            }
+
+            if (argv[0] === "powershell") {
+                return {
+                    exitCode: 0,
+                    stdout: '[{"ProcessId":4321,"ParentProcessId":1,"CommandLine":"C:\\\\Program Files\\\\Google\\\\Chrome\\\\Application\\\\chrome.exe --remote-debugging-port=9222","Name":"chrome.exe"}]',
+                    stderr: "",
+                };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: "" };
+        };
+
+        expect(discoverListeningCdpPorts(exec, "win32")).toEqual([9222]);
+    });
+});
+
+describe("readDevToolsActivePorts", () => {
+    test("reads the first line of a Brave DevToolsActivePort file (darwin)", () => {
+        const ports = readDevToolsActivePorts({
+            home: "/Users/someone",
+            platform: "darwin",
+            readFile: (abs) => {
+                if (abs.endsWith("BraveSoftware/Brave-Browser/DevToolsActivePort")) {
+                    return "9333\n/devtools/browser/abc\n";
+                }
+
+                return null;
+            },
+        });
+
+        expect(ports).toEqual([9333]);
+    });
+
+    test("linux and windows use their own relpaths", () => {
+        const linux = readDevToolsActivePorts({
+            home: "/home/someone",
+            platform: "linux",
+            readFile: (abs) => (abs.endsWith(".config/google-chrome/DevToolsActivePort") ? "9222\nx\n" : null),
+        });
+        expect(linux).toEqual([9222]);
+
+        const win = readDevToolsActivePorts({
+            home: "C:/Users/someone/AppData/Local",
+            platform: "win32",
+            readFile: (abs) => (abs.endsWith("Google/Chrome/User Data/DevToolsActivePort") ? "9224\nx\n" : null),
+        });
+        expect(win).toEqual([9224]);
+    });
+});
+
+describe("waitForCdp", () => {
+    test("polls until probe succeeds instead of sleeping once", async () => {
+        let n = 0;
+        const ok = await waitForCdp({
+            port: 9222,
+            timeoutMs: 5000,
+            probe: async () => {
+                n++;
+                return n >= 3;
+            },
+            sleep: async () => {},
+        });
+
+        expect(ok).toBe(true);
+        expect(n).toBe(3);
+    });
+});
+
+describe("quitBrowser", () => {
+    test("darwin: returns after pgrep goes quiet without sending KILL", async () => {
+        let pgrepCalls = 0;
+        const argvLog: string[][] = [];
+        const exec = (argv: string[]) => {
+            argvLog.push(argv);
+            if (argv[0] === "osascript") {
+                return { exitCode: 0, stdout: "", stderr: "" };
+            }
+
+            if (argv[0] === "pgrep") {
+                pgrepCalls++;
+                if (pgrepCalls < 3) {
+                    return { exitCode: 0, stdout: "1030\n", stderr: "" };
+                }
+
+                return { exitCode: 1, stdout: "", stderr: "" };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: `unexpected ${argv.join(" ")}` };
+        };
+
+        expect(await quitBrowser({ app: "Brave Browser", exec, sleep: async () => {}, platform: "darwin" })).toEqual({
+            exited: true,
+            usedForce: false,
+        });
+        expect(argvLog.some((a) => a[0] === "kill")).toBe(false);
+    });
+
+    test("darwin: sends kill -KILL only when force is set and quit stuck", async () => {
+        let live = true;
+        const exec = (argv: string[]) => {
+            if (argv[0] === "osascript") {
+                return { exitCode: 0, stdout: "", stderr: "" };
+            }
+
+            if (argv[0] === "pgrep") {
+                return live ? { exitCode: 0, stdout: "1030\n", stderr: "" } : { exitCode: 1, stdout: "", stderr: "" };
+            }
+
+            if (argv[0] === "kill" && argv.includes("-KILL") && argv.includes("1030")) {
+                live = false;
+                return { exitCode: 0, stdout: "", stderr: "" };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: `unexpected ${argv.join(" ")}` };
+        };
+
+        expect(
+            await quitBrowser({
+                app: "Brave Browser",
+                force: true,
+                timeoutMs: 0,
+                exec,
+                sleep: async () => {},
+                platform: "darwin",
+            })
+        ).toEqual({ exited: true, usedForce: true });
+    });
+
+    test("linux: pkill -TERM the bins, then pgrep until quiet", async () => {
+        const argvLog: string[][] = [];
+        let alive = true;
+        const exec = (argv: string[]) => {
+            argvLog.push(argv);
+            if (argv[0] === "pkill") {
+                alive = false;
+                return { exitCode: 0, stdout: "", stderr: "" };
+            }
+
+            if (argv[0] === "pgrep") {
+                return alive ? { exitCode: 0, stdout: "5\n", stderr: "" } : { exitCode: 1, stdout: "", stderr: "" };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: "" };
+        };
+
+        const brave = { id: "brave", app: "Brave Browser", match: ["brave"], linuxBins: ["brave-browser", "brave"] };
+        expect(
+            await quitBrowser({ app: "Brave Browser", browser: brave, exec, sleep: async () => {}, platform: "linux" })
+        ).toEqual({ exited: true, usedForce: false });
+        expect(argvLog.some((a) => a[0] === "pkill" && a.includes("-TERM"))).toBe(true);
+        expect(argvLog.some((a) => a[0] === "osascript")).toBe(false);
+    });
+
+    test("win32: taskkill /IM without /F, then tasklist until the image is gone", async () => {
+        const argvLog: string[][] = [];
+        let alive = true;
+        const exec = (argv: string[]) => {
+            argvLog.push(argv);
+            if (argv[0] === "taskkill") {
+                alive = false;
+                return { exitCode: 0, stdout: "", stderr: "" };
+            }
+
+            if (argv[0] === "tasklist") {
+                return {
+                    exitCode: 0,
+                    stdout: alive ? '"chrome.exe","1234"\n' : "INFO: No tasks are running.\n",
+                    stderr: "",
+                };
+            }
+
+            return { exitCode: 1, stdout: "", stderr: "" };
+        };
+
+        const chrome = { id: "chrome", app: "Google Chrome", match: ["chrome"], winExes: ["chrome.exe"] };
+        expect(
+            await quitBrowser({ app: "Google Chrome", browser: chrome, exec, sleep: async () => {}, platform: "win32" })
+        ).toEqual({ exited: true, usedForce: false });
+        const kill = argvLog.find((a) => a[0] === "taskkill");
+        expect(kill).toEqual(["taskkill", "/IM", "chrome.exe"]);
+    });
+});
+
+describe("empty debug flag render", () => {
+    test("says the debugging flag is empty when Brave has --remote-debugging-port=", () => {
+        const plan = planAttach({
+            running: ["chrome", "brave"],
+            endpoints: [CHROME_LOCALHOST],
+            emptyDebugFlag: ["brave"],
+        });
+        const { text } = renderAttachPlan(plan, {
+            cmd: "tools chrome-devtools",
+            suggestCommand: suggest,
+            platform: "darwin",
+        });
+        expect(text).toContain("debugging flag is empty");
+        expect(text).toContain("restart --browser brave --port 9223");
+    });
+});
+
+describe("launchBrowser", () => {
+    const chrome = browserById("chrome");
+    if (!chrome) {
+        throw new Error("chrome missing from BROWSERS");
+    }
+
+    const okExec = () => ({ exitCode: 0, stdout: "", stderr: "" });
+
+    test("darwin: goes through `open -na <app> --args`", () => {
+        const argvLog: string[][] = [];
+        const exec = (argv: string[]) => {
+            argvLog.push(argv);
+
+            return okExec();
+        };
+
+        const r = launchBrowser({
+            browser: chrome,
+            args: ["--remote-debugging-port=9222"],
+            url: "about:blank",
+            exec,
+            platform: "darwin",
+            spawnDetached: () => {
+                throw new Error("darwin must not Bun.spawn");
+            },
+        });
+        expect(r.ok).toBe(true);
+        expect(argvLog[0]).toEqual([
+            "open",
+            "-na",
+            "Google Chrome",
+            "--args",
+            "--remote-debugging-port=9222",
+            "about:blank",
+        ]);
+    });
+
+    test("linux: picks the first bin that `which` finds and spawns it detached", () => {
+        const spawned: string[][] = [];
+        const exec = (argv: string[]) =>
+            argv[0] === "which" && argv[1] === "google-chrome-stable"
+                ? okExec()
+                : { exitCode: 1, stdout: "", stderr: "" };
+
+        const r = launchBrowser({
+            browser: chrome,
+            args: ["--remote-debugging-port=9222"],
+            url: "about:blank",
+            exec,
+            platform: "linux",
+            spawnDetached: (cmd) => spawned.push(cmd),
+        });
+        expect(r.ok).toBe(true);
+        expect(spawned[0]).toEqual(["google-chrome-stable", "--remote-debugging-port=9222", "about:blank"]);
+    });
+
+    test("linux: no bin on PATH is an error naming every candidate, and spawns nothing", () => {
+        const r = launchBrowser({
+            browser: chrome,
+            args: [],
+            url: "about:blank",
+            exec: () => ({ exitCode: 1, stdout: "", stderr: "" }),
+            platform: "linux",
+            spawnDetached: () => {
+                throw new Error("must not spawn without a bin");
+            },
+        });
+        expect(r.ok).toBe(false);
+        expect(r.message).toContain("google-chrome");
+        expect(r.message).toContain("google-chrome-stable");
+    });
+
+    test("win32: uses the known install path when it exists", async () => {
+        const spawned: string[][] = [];
+        await env.testing.withOverrides({ ProgramFiles: "C:/Program Files" }, () => {
+            launchBrowser({
+                browser: chrome,
+                args: ["--remote-debugging-port=9222"],
+                url: "about:blank",
+                platform: "win32",
+                spawnDetached: (cmd) => spawned.push(cmd),
+                fileExists: (p) => p.includes("Google/Chrome/Application/chrome.exe"),
+            });
+        });
+        expect(spawned[0]?.[0]).toContain("Google/Chrome/Application/chrome.exe");
+    });
+
+    test("win32: falls back to the bare exe name (PATH) when no install root has it", () => {
+        const spawned: string[][] = [];
+        const r = launchBrowser({
+            browser: chrome,
+            args: [],
+            url: "about:blank",
+            platform: "win32",
+            spawnDetached: (cmd) => spawned.push(cmd),
+            fileExists: () => false,
+        });
+        expect(r.ok).toBe(true);
+        expect(spawned[0]?.[0]).toBe("chrome.exe");
+    });
+
+    test("win32: a browser with no exe mapping errors instead of guessing", () => {
+        const r = launchBrowser({
+            browser: { id: "chromium", app: "Chromium", match: ["chromium"] },
+            args: [],
+            url: "about:blank",
+            platform: "win32",
+            spawnDetached: () => {
+                throw new Error("must not spawn without a mapping");
+            },
+        });
+        expect(r.ok).toBe(false);
+        expect(r.message).toContain("no Windows executable mapping");
+    });
+});

--- a/src/chrome-devtools/lib/resolve-attach.ts
+++ b/src/chrome-devtools/lib/resolve-attach.ts
@@ -1,0 +1,727 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { logger } from "@genesiscz/utils/logger";
+import {
+    currentPlatform,
+    defaultExec,
+    type ExecFn,
+    type ExecResult,
+    listListeningTcpPorts,
+    listProcesses,
+    type Platform,
+    tmpRoot,
+} from "./platform.ts";
+
+export type { ExecFn, ExecResult };
+export { defaultExec };
+
+const { log } = logger.scoped("chrome-devtools:resolve-attach");
+
+export type BrowserId = string;
+
+export type BrowserKind = {
+    id: BrowserId;
+    /** macOS app name (also the pgrep -x / osascript target there). */
+    app: string;
+    /** Lowercase substrings that classify a command line as this browser, on any platform. */
+    match: string[];
+    /** Linux executable names, tried in order on PATH. */
+    linuxBins?: string[];
+    /** Windows image names (tasklist / taskkill targets), first one is the launch target. */
+    winExes?: string[];
+};
+
+/** Chromium-family browsers that accept --remote-debugging-port. Same refuse/restart treatment. */
+export const BROWSERS: BrowserKind[] = [
+    {
+        id: "chrome-canary",
+        app: "Google Chrome Canary",
+        match: ["google chrome canary", "chrome-canary"],
+        linuxBins: ["google-chrome-canary"],
+    },
+    {
+        id: "chrome-beta",
+        app: "Google Chrome Beta",
+        match: ["google chrome beta", "chrome-beta"],
+        linuxBins: ["google-chrome-beta"],
+    },
+    {
+        id: "chrome-dev",
+        app: "Google Chrome Dev",
+        match: ["google chrome dev", "chrome-unstable"],
+        linuxBins: ["google-chrome-unstable"],
+    },
+    {
+        id: "chrome",
+        app: "Google Chrome",
+        match: ["google chrome", "google-chrome", "/opt/google/chrome/", "chrome.exe"],
+        linuxBins: ["google-chrome", "google-chrome-stable"],
+        winExes: ["chrome.exe"],
+    },
+    {
+        id: "brave-beta",
+        app: "Brave Browser Beta",
+        match: ["brave browser beta", "brave-browser-beta"],
+        linuxBins: ["brave-browser-beta"],
+    },
+    {
+        id: "brave-nightly",
+        app: "Brave Browser Nightly",
+        match: ["brave browser nightly", "brave-browser-nightly"],
+        linuxBins: ["brave-browser-nightly"],
+    },
+    {
+        id: "brave",
+        app: "Brave Browser",
+        match: ["brave browser", "brave", "brave-browser", "brave.exe"],
+        linuxBins: ["brave-browser", "brave"],
+        winExes: ["brave.exe"],
+    },
+    {
+        id: "edge-canary",
+        app: "Microsoft Edge Canary",
+        match: ["microsoft edge canary", "microsoft-edge-canary"],
+        linuxBins: ["microsoft-edge-canary"],
+    },
+    {
+        id: "edge-dev",
+        app: "Microsoft Edge Dev",
+        match: ["microsoft edge dev", "microsoft-edge-dev"],
+        linuxBins: ["microsoft-edge-dev"],
+    },
+    {
+        id: "edge-beta",
+        app: "Microsoft Edge Beta",
+        match: ["microsoft edge beta", "microsoft-edge-beta"],
+        linuxBins: ["microsoft-edge-beta"],
+    },
+    {
+        id: "edge",
+        app: "Microsoft Edge",
+        match: ["microsoft edge", "microsoft-edge", "msedge.exe"],
+        linuxBins: ["microsoft-edge", "microsoft-edge-stable"],
+        winExes: ["msedge.exe"],
+    },
+    {
+        id: "chromium",
+        app: "Chromium",
+        match: ["chromium", "chromium.exe"],
+        linuxBins: ["chromium", "chromium-browser"],
+        winExes: ["chromium.exe"],
+    },
+    { id: "arc", app: "Arc", match: ["arc.app"] },
+    {
+        id: "vivaldi",
+        app: "Vivaldi",
+        match: ["vivaldi", "vivaldi.exe"],
+        linuxBins: ["vivaldi", "vivaldi-stable"],
+        winExes: ["vivaldi.exe"],
+    },
+    { id: "opera-gx", app: "Opera GX", match: ["opera gx"] },
+    { id: "opera", app: "Opera", match: ["opera", "opera.exe"], linuxBins: ["opera"], winExes: ["opera.exe"] },
+    { id: "dia", app: "Dia", match: ["dia.app"] },
+    { id: "comet", app: "Comet", match: ["comet.app"] },
+];
+
+export const BROWSER_APPS: Record<string, string> = Object.fromEntries(BROWSERS.map((b) => [b.id, b.app]));
+
+export function browserById(id: BrowserId): BrowserKind | undefined {
+    return BROWSERS.find((b) => b.id === id);
+}
+
+export const CDP_PORTS = [9222, 9223, 9224, 9225, 9226, 9227, 9228, 9229, 9230];
+
+export const DEVTOOLS_PORT_RELPATHS: { id: BrowserId; rel: string }[] = [
+    { id: "chrome", rel: "Library/Application Support/Google/Chrome/DevToolsActivePort" },
+    { id: "chrome-canary", rel: "Library/Application Support/Google/Chrome Canary/DevToolsActivePort" },
+    { id: "chrome-beta", rel: "Library/Application Support/Google/Chrome Beta/DevToolsActivePort" },
+    { id: "chrome-dev", rel: "Library/Application Support/Google/Chrome Dev/DevToolsActivePort" },
+    { id: "brave", rel: "Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort" },
+    { id: "edge", rel: "Library/Application Support/Microsoft Edge/DevToolsActivePort" },
+    { id: "chromium", rel: "Library/Application Support/Chromium/DevToolsActivePort" },
+    { id: "arc", rel: "Library/Application Support/Arc/User Data/DevToolsActivePort" },
+    { id: "vivaldi", rel: "Library/Application Support/Vivaldi/DevToolsActivePort" },
+    { id: "opera", rel: "Library/Application Support/com.operasoftware.Opera/DevToolsActivePort" },
+];
+
+const DEVTOOLS_PORT_RELPATHS_LINUX: { id: BrowserId; rel: string }[] = [
+    { id: "chrome", rel: ".config/google-chrome/DevToolsActivePort" },
+    { id: "chrome-beta", rel: ".config/google-chrome-beta/DevToolsActivePort" },
+    { id: "chrome-dev", rel: ".config/google-chrome-unstable/DevToolsActivePort" },
+    { id: "brave", rel: ".config/BraveSoftware/Brave-Browser/DevToolsActivePort" },
+    { id: "edge", rel: ".config/microsoft-edge/DevToolsActivePort" },
+    { id: "chromium", rel: ".config/chromium/DevToolsActivePort" },
+    { id: "vivaldi", rel: ".config/vivaldi/DevToolsActivePort" },
+];
+
+const DEVTOOLS_PORT_RELPATHS_WIN: { id: BrowserId; rel: string }[] = [
+    { id: "chrome", rel: "Google/Chrome/User Data/DevToolsActivePort" },
+    { id: "brave", rel: "BraveSoftware/Brave-Browser/User Data/DevToolsActivePort" },
+    { id: "edge", rel: "Microsoft/Edge/User Data/DevToolsActivePort" },
+    { id: "chromium", rel: "Chromium/User Data/DevToolsActivePort" },
+];
+
+export function devtoolsPortRelpaths(platform: Platform): { id: BrowserId; rel: string }[] {
+    if (platform === "linux") {
+        return DEVTOOLS_PORT_RELPATHS_LINUX;
+    }
+
+    if (platform === "win32") {
+        return DEVTOOLS_PORT_RELPATHS_WIN;
+    }
+
+    return DEVTOOLS_PORT_RELPATHS;
+}
+
+export function classifyProcessName(comm: string): BrowserId | null {
+    const n = comm.toLowerCase();
+    const base = (n.split(/[/\\]/).pop() ?? n).trim();
+    let best: { id: BrowserId; len: number } | null = null;
+
+    for (const b of BROWSERS) {
+        const app = b.app.toLowerCase();
+        if (base === app || base === b.id) {
+            if (app.length >= (best?.len ?? 0)) {
+                best = { id: b.id, len: app.length };
+            }
+            continue;
+        }
+
+        for (const m of [...b.match, ...(b.linuxBins ?? []), ...(b.winExes ?? [])]) {
+            if (n.includes(m) && m.length >= (best?.len ?? 0)) {
+                best = { id: b.id, len: m.length };
+            }
+        }
+    }
+
+    return best?.id ?? null;
+}
+
+/** Parse `tasklist /FO CSV /NH` image names. Exported for tests. */
+export function parseTasklistImages(stdout: string): Set<string> {
+    const names = new Set<string>();
+    for (const line of stdout.split("\n")) {
+        const m = line.match(/^"([^"]+)"/);
+        if (m) {
+            names.add(m[1].toLowerCase());
+        }
+    }
+
+    return names;
+}
+
+export function listRunningBrowsers(exec: ExecFn = defaultExec, platform: Platform = currentPlatform()): BrowserId[] {
+    if (platform === "win32") {
+        const r = exec(["tasklist", "/FO", "CSV", "/NH"]);
+        const images = r.exitCode === 0 ? parseTasklistImages(r.stdout) : new Set<string>();
+
+        return BROWSERS.filter((b) => (b.winExes ?? []).some((exe) => images.has(exe))).map((b) => b.id);
+    }
+
+    if (platform === "linux") {
+        return BROWSERS.filter((b) => (b.linuxBins ?? []).some((bin) => exec(["pgrep", "-x", bin]).exitCode === 0)).map(
+            (b) => b.id
+        );
+    }
+
+    const found: BrowserId[] = [];
+    for (const b of BROWSERS) {
+        const r = exec(["pgrep", "-x", b.app]);
+        if (r.exitCode === 0) {
+            found.push(b.id);
+        }
+    }
+
+    return found;
+}
+
+export function isPortSpecified(argv: string[] = process.argv): boolean {
+    return argv.some((a) => a === "--port" || a.startsWith("--port="));
+}
+
+export function parseRemoteDebuggingPort(commandLine: string): {
+    present: boolean;
+    empty: boolean;
+    port: number | null;
+} {
+    const eq = commandLine.match(/--remote-debugging-port=(\S*)/);
+    if (eq) {
+        const raw = eq[1];
+        if (!raw) {
+            return { present: true, empty: true, port: null };
+        }
+
+        const port = Number(raw);
+        if (Number.isFinite(port) && port > 0) {
+            return { present: true, empty: false, port };
+        }
+
+        return { present: true, empty: true, port: null };
+    }
+
+    if (commandLine.includes("--remote-debugging-port")) {
+        const spaced = commandLine.match(/--remote-debugging-port(?:\s+|$)(\d+)?/);
+        const raw = spaced?.[1];
+        if (raw) {
+            return { present: true, empty: false, port: Number(raw) };
+        }
+
+        return { present: true, empty: true, port: null };
+    }
+
+    return { present: false, empty: false, port: null };
+}
+
+export function browsersWithEmptyDebugFlag(
+    exec: ExecFn = defaultExec,
+    platform: Platform = currentPlatform()
+): BrowserId[] {
+    const found: BrowserId[] = [];
+    for (const proc of listProcesses(exec, platform)) {
+        const flag = parseRemoteDebuggingPort(proc.command);
+        if (!flag.present || !flag.empty) {
+            continue;
+        }
+
+        const id = classifyProcessName(proc.command);
+        if (id && !found.includes(id)) {
+            found.push(id);
+        }
+    }
+
+    return found;
+}
+
+export function discoverListeningCdpPorts(
+    exec: ExecFn = defaultExec,
+    platform: Platform = currentPlatform()
+): number[] {
+    const listeners = listListeningTcpPorts(exec, platform).filter((l) => l.port >= 9000 && l.port <= 9999);
+    if (listeners.length === 0) {
+        return [];
+    }
+
+    const commandOf = new Map(listProcesses(exec, platform).map((p) => [p.pid, p.command]));
+    const ports = new Set<number>();
+    for (const l of listeners) {
+        const command = l.pid !== null ? commandOf.get(l.pid) : undefined;
+        if (command && classifyProcessName(command)) {
+            ports.add(l.port);
+        }
+    }
+
+    return [...ports].sort((a, b) => a - b);
+}
+
+export function ownerOfPort(
+    port: number,
+    exec: ExecFn = defaultExec,
+    platform: Platform = currentPlatform()
+): BrowserId | null {
+    const listener = listListeningTcpPorts(exec, platform).find((l) => l.port === port);
+    if (!listener || listener.pid === null) {
+        return null;
+    }
+
+    const command = listProcesses(exec, platform).find((p) => p.pid === listener.pid)?.command;
+
+    return command ? classifyProcessName(command) : null;
+}
+
+export function readDevToolsActivePorts(opts: {
+    home: string;
+    readFile: (abs: string) => string | null;
+    platform?: Platform;
+}): number[] {
+    const ports: number[] = [];
+    for (const { rel } of devtoolsPortRelpaths(opts.platform ?? currentPlatform())) {
+        const text = opts.readFile(`${opts.home}/${rel}`);
+        if (!text) {
+            continue;
+        }
+
+        const port = Number(text.split("\n")[0]?.trim());
+        if (Number.isFinite(port) && port > 0) {
+            ports.push(port);
+        }
+    }
+
+    return ports;
+}
+
+export function mergeProbePorts(...groups: number[][]): number[] {
+    return [...new Set(groups.flat())].sort((a, b) => a - b);
+}
+
+export function readDevToolsActivePortsFromDisk(home?: string, platform: Platform = currentPlatform()): number[] {
+    const base = home ?? (platform === "win32" ? (env.get("LOCALAPPDATA") ?? "") : env.paths.getHome());
+
+    return readDevToolsActivePorts({
+        home: base,
+        platform,
+        readFile: (abs) => {
+            if (!existsSync(abs)) {
+                return null;
+            }
+
+            try {
+                return readFileSync(abs, "utf8");
+            } catch (err) {
+                // A permissions/IO failure here makes a RUNNING browser
+                // undiscoverable — worth a trace even though it is non-fatal.
+                log.debug({ err, path: abs }, "DevToolsActivePort read failed");
+
+                return null;
+            }
+        },
+    });
+}
+
+export async function waitForCdp(opts: {
+    port: number;
+    timeoutMs?: number;
+    probe: (port: number) => Promise<unknown>;
+    sleep?: (ms: number) => Promise<void>;
+}): Promise<boolean> {
+    const timeoutMs = opts.timeoutMs ?? 20000;
+    const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (await opts.probe(opts.port)) {
+            return true;
+        }
+
+        await sleep(500);
+    }
+
+    return false;
+}
+
+export async function quitBrowser(opts: {
+    app: string;
+    browser?: BrowserKind;
+    force?: boolean;
+    timeoutMs?: number;
+    exec?: ExecFn;
+    sleep?: (ms: number) => Promise<void>;
+    platform?: Platform;
+}): Promise<{ exited: boolean; usedForce: boolean }> {
+    const exec = opts.exec ?? defaultExec;
+    const platform = opts.platform ?? currentPlatform();
+    const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    const timeoutMs = opts.timeoutMs ?? 15000;
+
+    const linuxBins = opts.browser?.linuxBins ?? [];
+    const winExe = opts.browser?.winExes?.[0];
+
+    const dead = (): boolean => {
+        if (platform === "win32") {
+            if (!winExe) {
+                return true;
+            }
+
+            const r = exec(["tasklist", "/FO", "CSV", "/NH", "/FI", `IMAGENAME eq ${winExe}`]);
+
+            return !parseTasklistImages(r.stdout).has(winExe);
+        }
+
+        if (platform === "linux") {
+            return linuxBins.every((bin) => exec(["pgrep", "-x", bin]).exitCode !== 0);
+        }
+
+        return exec(["pgrep", "-x", opts.app]).exitCode !== 0;
+    };
+
+    if (platform === "win32") {
+        if (winExe) {
+            exec(["taskkill", "/IM", winExe]);
+        }
+    } else if (platform === "linux") {
+        for (const bin of linuxBins) {
+            exec(["pkill", "-TERM", "-x", bin]);
+        }
+    } else {
+        exec(["osascript", "-e", `quit app "${opts.app}"`]);
+    }
+
+    const until = Date.now() + timeoutMs;
+    while (Date.now() < until) {
+        if (dead()) {
+            return { exited: true, usedForce: false };
+        }
+
+        await sleep(250);
+    }
+
+    if (!opts.force) {
+        return { exited: dead(), usedForce: false };
+    }
+
+    if (platform === "win32") {
+        if (winExe) {
+            exec(["taskkill", "/F", "/IM", winExe]);
+        }
+    } else if (platform === "linux") {
+        for (const bin of linuxBins) {
+            exec(["pkill", "-KILL", "-x", bin]);
+        }
+    } else {
+        const pids = exec(["pgrep", "-x", opts.app]).stdout.trim().split("\n").filter(Boolean);
+        if (pids.length) {
+            exec(["kill", "-KILL", ...pids]);
+        }
+    }
+
+    const forceUntil = Date.now() + 5000;
+    while (Date.now() < forceUntil) {
+        if (dead()) {
+            return { exited: true, usedForce: true };
+        }
+
+        await sleep(250);
+    }
+
+    return { exited: dead(), usedForce: true };
+}
+
+const WIN_INSTALL_ROOTS = () =>
+    [env.get("ProgramFiles"), env.get("ProgramFiles(x86)"), env.get("LOCALAPPDATA")].filter((v): v is string =>
+        Boolean(v)
+    );
+
+const WIN_EXE_RELPATHS: Record<string, string> = {
+    "chrome.exe": "Google/Chrome/Application/chrome.exe",
+    "brave.exe": "BraveSoftware/Brave-Browser/Application/brave.exe",
+    "msedge.exe": "Microsoft/Edge/Application/msedge.exe",
+};
+
+/** Detached fire-and-forget spawn — injectable so tests can pin argv per platform. */
+export type SpawnDetachedFn = (cmd: string[]) => void;
+
+const defaultSpawnDetached: SpawnDetachedFn = (cmd) => {
+    const child = Bun.spawn(cmd, { stdin: "ignore", stdout: "ignore", stderr: "ignore" });
+    child.unref();
+};
+
+/**
+ * Launch a browser with the given args, per platform. darwin: `open -na` (the
+ * only way that respects app bundles); linux: first bin on PATH, detached;
+ * win32: known install path or the exe name.
+ */
+export function launchBrowser(opts: {
+    browser: BrowserKind;
+    args: string[];
+    url: string;
+    exec?: ExecFn;
+    platform?: Platform;
+    spawnDetached?: SpawnDetachedFn;
+    fileExists?: (path: string) => boolean;
+}): { ok: boolean; message: string } {
+    const exec = opts.exec ?? defaultExec;
+    const platform = opts.platform ?? currentPlatform();
+    const spawnDetached = opts.spawnDetached ?? defaultSpawnDetached;
+
+    if (platform === "darwin") {
+        const r = exec(["open", "-na", opts.browser.app, "--args", ...opts.args, opts.url]);
+
+        return { ok: r.exitCode === 0, message: r.exitCode === 0 ? `launched ${opts.browser.app}` : r.stderr.trim() };
+    }
+
+    if (platform === "linux") {
+        const bin = (opts.browser.linuxBins ?? []).find((b) => exec(["which", b]).exitCode === 0);
+        if (!bin) {
+            return {
+                ok: false,
+                message: `none of [${(opts.browser.linuxBins ?? []).join(", ")}] found on PATH for ${opts.browser.id}`,
+            };
+        }
+
+        spawnDetached([bin, ...opts.args, opts.url]);
+
+        return { ok: true, message: `launched ${bin}` };
+    }
+
+    const exe = opts.browser.winExes?.[0];
+    if (!exe) {
+        return { ok: false, message: `${opts.browser.id} has no Windows executable mapping` };
+    }
+
+    const fileExists = opts.fileExists ?? existsSync;
+    const rel = WIN_EXE_RELPATHS[exe];
+    const full = rel
+        ? WIN_INSTALL_ROOTS()
+              .map((root) => join(root, rel))
+              .find((p) => fileExists(p))
+        : undefined;
+    spawnDetached([full ?? exe, ...opts.args, opts.url]);
+
+    return { ok: true, message: `launched ${full ?? exe}` };
+}
+
+/** The isolated profile dir `open --fresh` / `--extension` uses. */
+export function freshProfileDir(port: number, platform: Platform = currentPlatform()): string {
+    return join(tmpRoot(platform), `cdp-profile-${port}`);
+}
+
+export type Endpoint = {
+    port: number;
+    browser: string;
+    owner: BrowserId | null;
+    pages: { title: string; url: string }[];
+};
+
+export type Inventory = {
+    running: BrowserId[];
+    endpoints: Endpoint[];
+    emptyDebugFlag?: BrowserId[];
+};
+
+export type AttachPlan = {
+    status: "list" | "none" | "ambiguous";
+    running: BrowserId[];
+    endpoints: Endpoint[];
+    undebugged: BrowserId[];
+    emptyDebugFlag: BrowserId[];
+    restartPort: number;
+};
+
+export function pickRestartPort(used: number[]): number {
+    for (const port of [...CDP_PORTS, 9226, 9227]) {
+        if (!used.includes(port)) {
+            return port;
+        }
+    }
+
+    return Math.max(0, ...used) + 1;
+}
+
+export function planAttach(inventory: Inventory, opts?: { explicitPort?: number }): AttachPlan {
+    const undebugged = inventory.running.filter((id) => !inventory.endpoints.some((e) => e.owner === id));
+    const emptyDebugFlag = (inventory.emptyDebugFlag ?? []).filter((id) => undebugged.includes(id));
+    const restartPort = pickRestartPort(inventory.endpoints.map((e) => e.port));
+    const kinds = new Set<BrowserId>([
+        ...inventory.running,
+        ...inventory.endpoints.map((e) => e.owner).filter((id): id is BrowserId => id != null),
+    ]);
+    const base = {
+        running: inventory.running,
+        undebugged,
+        emptyDebugFlag,
+        restartPort,
+    };
+
+    if (opts?.explicitPort != null) {
+        const endpoints = inventory.endpoints.filter((e) => e.port === opts.explicitPort);
+
+        return {
+            ...base,
+            status: endpoints.length ? "list" : "none",
+            endpoints,
+        };
+    }
+
+    if (kinds.size >= 2) {
+        return { ...base, status: "ambiguous", endpoints: inventory.endpoints };
+    }
+
+    if (!inventory.endpoints.length) {
+        return { ...base, status: "none", endpoints: [] };
+    }
+
+    return { ...base, status: "list", endpoints: inventory.endpoints };
+}
+
+function truncate(s: string, n: number) {
+    return s.length > n ? s.slice(0, n) : s;
+}
+
+function renderEndpoint(e: Endpoint): string[] {
+    const lines = [`  port ${e.port}: ${e.browser}: ${e.pages.length} page(s)`];
+    e.pages.forEach((p, i) => {
+        lines.push(`    [${i}] ${truncate(p.title ?? "", 50)} :: ${truncate(p.url, 110)}`);
+    });
+
+    return lines;
+}
+
+function restartLines(id: BrowserId, port: number, cmd: string, platform: Platform): string[] {
+    const app = BROWSER_APPS[id];
+    const lines = [
+        `  --remote-debugging-port is read at startup only. Restart ${app} with it (costs open tabs):`,
+        `    ${cmd} restart --browser ${id} --port ${port}`,
+    ];
+
+    if (platform === "darwin") {
+        lines.push(
+            `    osascript -e 'quit app "${app}"'`,
+            `    open -na "${app}" --args --remote-debugging-port=${port}`,
+            `    ${cmd} attach --port ${port}`
+        );
+    }
+
+    lines.push(
+        `  Or a throwaway profile (logins not kept):`,
+        `    ${cmd} open --browser ${id} --port ${port} --fresh <url>`
+    );
+
+    return lines;
+}
+
+export function renderAttachPlan(
+    plan: AttachPlan,
+    opts: { cmd: string; suggestCommand: (add: string[]) => string; platform?: Platform }
+): { text: string; exitCode: number } {
+    const lines: string[] = [];
+    const want = new Set<BrowserId>([
+        ...plan.running,
+        ...plan.endpoints.map((e) => e.owner).filter((id): id is BrowserId => id != null),
+    ]);
+    const ids: BrowserId[] = [];
+    for (const b of BROWSERS) {
+        if (want.has(b.id)) {
+            ids.push(b.id);
+        }
+    }
+    for (const id of want) {
+        if (!ids.includes(id)) {
+            ids.push(id);
+        }
+    }
+
+    if (plan.status === "ambiguous") {
+        const names = ids.map((id) => BROWSER_APPS[id] ?? id);
+        const who = names.length === 2 ? `${names[0]} and ${names[1]}` : names.join(", ");
+        lines.push(`${who} are both open. Your bug could live in either, so nothing is picked silently. Pick one:`);
+        lines.push("");
+    }
+
+    for (const id of ids) {
+        const app = BROWSER_APPS[id];
+        const owned = plan.endpoints.filter((e) => e.owner === id);
+        const off = plan.undebugged.includes(id);
+
+        if (off && !owned.length) {
+            const empty = plan.emptyDebugFlag.includes(id);
+            lines.push(
+                empty
+                    ? `=== ${app}: open, debugging flag is empty, nothing listens ===`
+                    : `=== ${app}: open, debugging port is not on ===`
+            );
+            lines.push(...restartLines(id, plan.restartPort, opts.cmd, opts.platform ?? currentPlatform()));
+        } else if (owned.length) {
+            lines.push(`=== ${app}: debugging on ===`);
+            for (const e of owned) {
+                lines.push(...renderEndpoint(e));
+                lines.push(`  attach:`);
+                lines.push(`    ${opts.suggestCommand(["attach", "--port", String(e.port)])}`);
+            }
+        }
+
+        lines.push("");
+    }
+
+    const exitCode = plan.status === "list" ? 0 : 1;
+
+    return { text: lines.join("\n").trimEnd(), exitCode };
+}

--- a/src/chrome-devtools/lib/scaffold.ts
+++ b/src/chrome-devtools/lib/scaffold.ts
@@ -1,0 +1,207 @@
+/**
+ * `scaffold` — create a CDP scratch script INTO the `tools scripts` store, so
+ * it is versioned, listable and runnable there (`tools scripts run <name>`).
+ * Bindings-free: the templates import the cdp lib via the `@gt/chrome-devtools/*`
+ * tsconfig mapping that the store scaffold writes (see src/scripts/lib/store.ts).
+ */
+import { chmod, mkdir } from "node:fs/promises";
+import { inferProject, SCRIPT_NAME_RE, type ScriptEntry, scriptPaths, upsertEntry } from "../../scripts/lib/journal.ts";
+import { commitStore, ensureStoreScaffold } from "../../scripts/lib/store.ts";
+
+export interface Recipe {
+    name: string;
+    description: string;
+    body: (scriptName: string) => string;
+}
+
+const HEADER = (what: string, imports = "attach") => `#!/usr/bin/env bun
+/**
+ * ${what}
+ * Run: tools scripts run <name> -- --port 9222 [--match <url-substr>]
+ * 9222 is a placeholder — \`tools chrome-devtools attach\` lists the live ports.
+ * The cdp lib resolves via the store tsconfig's @gt/chrome-devtools/* mapping.
+ */
+import { ${imports} } from "@gt/chrome-devtools/cdp";
+
+const arg = (flag: string, fallback?: string): string | undefined => {
+    const i = process.argv.indexOf(flag);
+    return i >= 0 ? process.argv[i + 1] : fallback;
+};
+const port = Number(arg("--port", "9222"));
+`;
+
+export const RECIPES: Recipe[] = [
+    {
+        name: "redirect-chain",
+        description: "record the live redirect chain (status, from, Location) while you reproduce a flow",
+        body: () => `${HEADER("Record the redirect chain of a flow — the data a flat request list hides.")}
+const match = arg("--match");
+const seconds = Number(arg("--seconds", "30"));
+const page = await attach({ port, url: match });
+console.error(\`attached to \${page.target.url} — reproduce the flow now (\${seconds}s)...\`);
+const events = page.recordNetwork(match ? (u) => u.includes(match) : undefined);
+await Bun.sleep(seconds * 1000);
+for (const e of events) {
+    if (e.kind === "redirect") {
+        console.log(\`\${e.status} \${e.from}\\n    -> \${e.location}\`);
+    }
+    if (e.kind === "nav") {
+        console.log(\`NAV \${e.url}\`);
+    }
+}
+page.close();
+`,
+    },
+    {
+        name: "cookie-diff",
+        description: "diff cookies between two browsers by (name, domain, path) — the session-poison finder",
+        body: () => `${HEADER("Diff cookies between two CDP browsers: broken (--port) vs fresh (--port-b).", "browser")}
+const portB = Number(arg("--port-b", "9223"));
+const domain = arg("--domain") ?? "";
+const key = (c: { name: string; domain: string; path: string }) => \`\${c.name}|\${c.domain}|\${c.path}\`;
+const [a, b] = await Promise.all([browser(port), browser(portB)]);
+const [A, B] = await Promise.all([a.cookies(domain), b.cookies(domain)]);
+const mapB = new Map(B.map((c) => [key(c), c]));
+for (const c of A) {
+    if (!mapB.has(key(c))) {
+        console.log(\`BROKEN-ONLY \${key(c)} httpOnly=\${c.httpOnly} len=\${c.value.length}\`);
+    }
+}
+const names = new Map<string, number>();
+for (const c of A) {
+    names.set(c.name, (names.get(c.name) ?? 0) + 1);
+}
+for (const [n, count] of names) {
+    if (count > 1) {
+        console.log(\`DUPLICATE NAME: \${n}  <-- longer path is sent FIRST (RFC 6265); stale sessions win\`);
+    }
+}
+a.close();
+b.close();
+`,
+    },
+    {
+        name: "storage-snapshot",
+        description: "dump localStorage/sessionStorage of a tab (spot per-attempt retry-key buildup)",
+        body: () => `${HEADER("Snapshot local/sessionStorage of one tab.")}
+const match = arg("--match");
+const page = await attach({ port, url: match });
+console.log(
+    JSON.stringify(
+        await page.evaluate(\`() => ({
+            url: location.href,
+            ls: Object.fromEntries(Object.entries(localStorage).map(([k, v]) => [k, String(v).slice(0, 120)])),
+            ss: Object.fromEntries(Object.entries(sessionStorage).map(([k, v]) => [k, String(v).slice(0, 120)])),
+        })\`),
+        null,
+        1,
+    ),
+);
+page.close();
+`,
+    },
+    {
+        name: "body-fetch",
+        description: "capture responses matching a URL and print their bodies",
+        body: () => `${HEADER("Fetch response bodies for requests hitting --match while you reproduce.")}
+const match = arg("--match") ?? "/api/";
+const seconds = Number(arg("--seconds", "20"));
+const page = await attach({ port });
+const events = page.recordNetwork((u) => u.includes(match));
+console.error(\`recording \${match} on \${page.target.url} for \${seconds}s — trigger the request now...\`);
+await Bun.sleep(seconds * 1000);
+for (const e of events) {
+    if (e.kind === "response") {
+        const body = await page.responseBody(String(e.requestId)).catch(() => null);
+        console.log(\`\\n=== \${e.status} \${e.url}\`);
+        console.log(String(body?.body ?? "<no body — navigated away?>").slice(0, 800));
+    }
+}
+page.close();
+`,
+    },
+    {
+        name: "console-trap",
+        description: "capture console messages and exceptions around an action (attaches first, so nothing is missed)",
+        body: () => `${HEADER("Trap console output of a tab; --reload replays load-time messages.")}
+const match = arg("--match");
+const seconds = Number(arg("--seconds", "15"));
+const page = await attach({ port, url: match });
+const lines: string[] = [];
+page.onConsole((level, text) => lines.push(\`[\${level}] \${text}\`));
+if (process.argv.includes("--reload")) {
+    await page.reload();
+}
+console.error(\`listening on \${page.target.url} for \${seconds}s...\`);
+await Bun.sleep(seconds * 1000);
+console.log(lines.length ? lines.join("\\n") : "<nothing logged in that window — try --reload>");
+page.close();
+`,
+    },
+    {
+        name: "blank",
+        description: "empty scratch script with the cdp lib imported and a target list to start from",
+        body: () => `${HEADER("Blank CDP scratch script.", "attach, browser, targets")}
+console.log(JSON.stringify(await targets(port), null, 1));
+// const page = await attach({ port, url: "example.com" });
+// const b = await browser(port);
+`,
+    },
+];
+
+export function recipeNames(): string[] {
+    return RECIPES.map((r) => r.name);
+}
+
+export function recipeHelpLines(): string[] {
+    return RECIPES.map((r) => `  ${r.name.padEnd(18)} ${r.description}`);
+}
+
+export function findRecipe(name: string): Recipe | undefined {
+    return RECIPES.find((r) => r.name === name);
+}
+
+export interface ScaffoldResult {
+    file: string;
+    runHint: string;
+}
+
+export async function scaffoldRecipeScript(opts: { name: string; recipe: Recipe }): Promise<ScaffoldResult> {
+    if (!SCRIPT_NAME_RE.test(opts.name)) {
+        throw new Error(
+            `Invalid script name '${opts.name}'. Use letters, digits, dash, underscore; start with a letter.`
+        );
+    }
+
+    const { dir, file } = scriptPaths(opts.name);
+
+    if (await Bun.file(file).exists()) {
+        throw new Error(`${file} already exists. Pick another name, or edit it in place.`);
+    }
+
+    await ensureStoreScaffold();
+    await mkdir(dir, { recursive: true });
+    await Bun.write(file, opts.recipe.body(opts.name));
+    await chmod(file, 0o755);
+
+    const now = new Date().toISOString();
+    const cwd = process.cwd();
+    const entry: ScriptEntry = {
+        name: opts.name,
+        file,
+        description: opts.recipe.description,
+        imports: [],
+        tools: [],
+        servers: [],
+        tags: ["chrome-devtools", opts.recipe.name],
+        project: inferProject(cwd),
+        createdFrom: cwd,
+        createdAt: now,
+        updatedAt: now,
+        runs: 0,
+    };
+    await upsertEntry(entry);
+    await commitStore(`feat: scaffold chrome-devtools ${opts.recipe.name} script ${opts.name}`);
+
+    return { file, runHint: `tools scripts run ${opts.name} -- --port 9222` };
+}

--- a/src/chrome-devtools/lib/segments.test.ts
+++ b/src/chrome-devtools/lib/segments.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    listSegments,
+    parseSegmentStart,
+    pruneDecision,
+    readEvents,
+    type SegmentInfo,
+    SegmentWriter,
+    segmentName,
+} from "./segments.ts";
+
+const dirs: string[] = [];
+
+function tmp(): string {
+    const dir = mkdtempSync(join(tmpdir(), "cdp-seg-"));
+    dirs.push(dir);
+
+    return dir;
+}
+
+afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+const seg = (startMs: number, bytes: number): SegmentInfo => ({
+    path: `/x/${segmentName(startMs)}`,
+    name: segmentName(startMs),
+    startMs,
+    bytes,
+});
+
+describe("segment names", () => {
+    test("round-trip", () => {
+        expect(parseSegmentStart(segmentName(1700000000000))).toBe(1700000000000);
+        expect(parseSegmentStart("meta.json")).toBeNull();
+        expect(parseSegmentStart("recorder.pid")).toBeNull();
+    });
+});
+
+describe("pruneDecision", () => {
+    const HOUR = 3_600_000;
+
+    test("drops segments whose content is entirely older than maxAge, keeps the current one", () => {
+        const now = 10 * HOUR;
+        const segments = [seg(1 * HOUR, 10), seg(2 * HOUR, 10), seg(9 * HOUR, 10), seg(10 * HOUR - 1, 10)];
+        const { drop, capDropped } = pruneDecision(segments, now, { maxAgeMs: 4 * HOUR, capBytes: 1e9 });
+        expect(drop.map((s) => s.startMs)).toEqual([1 * HOUR, 2 * HOUR]);
+        expect(capDropped).toBe(false);
+    });
+
+    test("byte cap drops the oldest early and reports it", () => {
+        const now = 2 * HOUR;
+        const segments = [seg(0, 600), seg(1 * HOUR, 300), seg(2 * HOUR - 1, 200)];
+        const { drop, capDropped } = pruneDecision(segments, now, { maxAgeMs: 100 * HOUR, capBytes: 550 });
+        expect(drop.map((s) => s.bytes)).toEqual([600]);
+        expect(capDropped).toBe(true);
+    });
+
+    test("never drops the only remaining segment", () => {
+        const { drop } = pruneDecision([seg(0, 9999)], 1, { maxAgeMs: 1, capBytes: 10 });
+        expect(drop).toEqual([]);
+    });
+});
+
+describe("SegmentWriter", () => {
+    test("rotates on the interval and prunes old segments with one unlink at rotation", () => {
+        const dir = tmp();
+        let now = 1_000_000;
+        const writer = new SegmentWriter(dir, { rotateMs: 1000, maxAgeMs: 2500, now: () => now });
+
+        writer.write({ method: "A", params: {}, t: now });
+        now += 1100;
+        writer.write({ method: "B", params: {}, t: now });
+        now += 1100;
+        writer.write({ method: "C", params: {}, t: now });
+        expect(listSegments(dir)).toHaveLength(3);
+
+        // Jump far enough that everything but the fresh segment ages out.
+        now += 5000;
+        writer.write({ method: "D", params: {}, t: now });
+        writer.close();
+
+        const names = readdirSync(dir);
+        expect(names).toHaveLength(1);
+        const events = readEvents(dir);
+        expect(events.map((e) => e.method)).toEqual(["D"]);
+    });
+
+    test("writes land in the buffer and read back in order across segments", () => {
+        const dir = tmp();
+        let now = 5_000_000;
+        const writer = new SegmentWriter(dir, { rotateMs: 1000, maxAgeMs: 1e9, now: () => now });
+        writer.write({ method: "one", params: { n: 1 }, t: now });
+        now += 1500;
+        writer.write({ method: "two", params: { n: 2 }, t: now });
+        writer.close();
+
+        expect(listSegments(dir)).toHaveLength(2);
+        expect(readEvents(dir).map((e) => e.method)).toEqual(["one", "two"]);
+        expect(readEvents(dir, { sinceMs: now - 100 }).map((e) => e.method)).toEqual(["two"]);
+    });
+
+    test("cap is a TOTAL-on-disk bound: active rotates at cap/2 and closed segments prune to cap/2", () => {
+        const dir = tmp();
+        const capBytes = 4000;
+        let now = 9_000_000;
+        // Clock advances 1ms per write so size-triggered rotations land in
+        // DISTINCT segment files (rotateMs stays unreachable).
+        const writer = new SegmentWriter(dir, { rotateMs: 1e9, maxAgeMs: 1e12, capBytes, now: () => now });
+
+        for (let n = 0; n < 300; n++) {
+            now += 1;
+            writer.write({ method: "E", params: { pad: "x".repeat(20), n }, t: now });
+        }
+
+        writer.close();
+
+        const totalBytes = listSegments(dir).reduce((sum, s) => sum + s.bytes, 0);
+        // The on-disk total stays within the cap (small per-event slack) —
+        // the old rotate-at-full-cap behavior peaked near 2x cap here.
+        expect(totalBytes).toBeLessThanOrEqual(capBytes * 1.1);
+
+        const events = readEvents(dir);
+        // oldest events were cap-dropped and a marker recorded it
+        expect(events.some((e) => e.method === "Genesis.marker")).toBe(true);
+        expect(events.some((e) => (e.params as { n?: number }).n === 299)).toBe(true);
+        expect(events.some((e) => (e.params as { n?: number }).n === 0)).toBe(false);
+    });
+});
+
+describe("readEvents", () => {
+    test("skips a broken jsonl line instead of aborting the dump", () => {
+        const dir = tmp();
+        writeFileSync(
+            join(dir, segmentName(1)),
+            ['{"method":"ok","params":{},"t":1}', "{not json", '{"method":"ok2","params":{},"t":2}'].join("\n")
+        );
+        expect(readEvents(dir).map((e) => e.method)).toEqual(["ok", "ok2"]);
+    });
+});

--- a/src/chrome-devtools/lib/segments.ts
+++ b/src/chrome-devtools/lib/segments.ts
@@ -1,0 +1,227 @@
+/**
+ * Time-boxed capture segments. One writer per recorder: 30-minute jsonl
+ * segments, opportunistic pruning at rotation (a single unlink inside the
+ * recorder — no timer process, never blocks event writes), and a per-port
+ * byte cap that drops the OLDEST segment early and leaves a marker event.
+ */
+import { closeSync, existsSync, openSync, readdirSync, readFileSync, statSync, unlinkSync, writeSync } from "node:fs";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import type { RecordedEvent } from "./channels.ts";
+
+const log = logger.child({ component: "chrome-devtools:segments" });
+
+export const SEGMENT_ROTATE_MS = 30 * 60 * 1000;
+export const SEGMENT_MAX_AGE_MS = 4 * 60 * 60 * 1000;
+export const CAPTURE_CAP_BYTES = 500 * 1024 * 1024;
+
+const SEGMENT_RE = /^seg-(\d+)\.jsonl$/;
+
+export function segmentName(startMs: number): string {
+    return `seg-${startMs}.jsonl`;
+}
+
+export function parseSegmentStart(name: string): number | null {
+    const m = name.match(SEGMENT_RE);
+
+    return m ? Number(m[1]) : null;
+}
+
+export interface SegmentInfo {
+    path: string;
+    name: string;
+    startMs: number;
+    bytes: number;
+}
+
+export function listSegments(dir: string): SegmentInfo[] {
+    if (!existsSync(dir)) {
+        return [];
+    }
+
+    const out: SegmentInfo[] = [];
+    for (const name of readdirSync(dir)) {
+        const startMs = parseSegmentStart(name);
+        if (startMs === null) {
+            continue;
+        }
+
+        const path = join(dir, name);
+        try {
+            out.push({ path, name, startMs, bytes: statSync(path).size });
+        } catch (err) {
+            log.debug({ err, path }, "segment stat failed (raced a prune?)");
+        }
+    }
+
+    return out.sort((a, b) => a.startMs - b.startMs);
+}
+
+/**
+ * Pure decision: which segments to delete for age and cap. Exported for tests.
+ *
+ * Age: rotation happens ON WRITE, so a segment's content ends at most
+ * `rotateMs` after its start — it is prunable once `startMs + rotateMs` is
+ * older than maxAge. The writer calls this at rotation time, when every
+ * listed segment is already closed, so age may drop all of them.
+ * Cap: drops the oldest but always keeps at least one (the active segment).
+ */
+export function pruneDecision(
+    segments: SegmentInfo[],
+    now: number,
+    opts: { maxAgeMs: number; capBytes: number; rotateMs?: number }
+): { drop: SegmentInfo[]; capDropped: boolean } {
+    const rotateMs = opts.rotateMs ?? SEGMENT_ROTATE_MS;
+    const drop = segments.filter((s) => now - s.startMs > opts.maxAgeMs + rotateMs);
+    const rest = segments.filter((s) => !drop.includes(s));
+
+    let capDropped = false;
+    let total = rest.reduce((sum, s) => sum + s.bytes, 0);
+    while (total > opts.capBytes && rest.length > 1) {
+        const oldest = rest.shift();
+        if (!oldest) {
+            break;
+        }
+
+        drop.push(oldest);
+        total -= oldest.bytes;
+        capDropped = true;
+    }
+
+    return { drop, capDropped };
+}
+
+export class SegmentWriter {
+    private fd: number | null = null;
+    private segStartMs = 0;
+    private currentPath = "";
+    private bytesInSegment = 0;
+
+    constructor(
+        private readonly dir: string,
+        private readonly opts: {
+            rotateMs?: number;
+            maxAgeMs?: number;
+            capBytes?: number;
+            now?: () => number;
+        } = {}
+    ) {}
+
+    private now(): number {
+        return this.opts.now ? this.opts.now() : Date.now();
+    }
+
+    write(event: RecordedEvent): void {
+        const now = this.now();
+        const capBytes = this.opts.capBytes ?? CAPTURE_CAP_BYTES;
+
+        // Rotate on the clock, or early when the ACTIVE segment alone reaches
+        // HALF the cap. Half, because the cap is a TOTAL-on-disk promise:
+        // closed segments are pruned to <= cap/2 (see rotate), and the active
+        // segment is bounded to <= cap/2 here, so the sum never exceeds cap.
+        if (
+            this.fd === null ||
+            now - this.segStartMs >= (this.opts.rotateMs ?? SEGMENT_ROTATE_MS) ||
+            this.bytesInSegment >= capBytes / 2
+        ) {
+            this.rotate(now);
+        }
+
+        if (this.fd !== null) {
+            const line = `${SafeJSON.stringify(event, { strict: true })}\n`;
+            writeSync(this.fd, line);
+            this.bytesInSegment += line.length;
+        }
+    }
+
+    private rotate(now: number): void {
+        if (this.fd !== null) {
+            closeSync(this.fd);
+            this.fd = null;
+        }
+
+        this.bytesInSegment = 0;
+
+        // Closed segments get half the total budget; the other half belongs to
+        // the active segment (write() rotates it at cap/2), so the on-disk sum
+        // stays within the promised cap instead of transiently doubling it.
+        const { drop, capDropped } = pruneDecision(listSegments(this.dir), now, {
+            maxAgeMs: this.opts.maxAgeMs ?? SEGMENT_MAX_AGE_MS,
+            capBytes: (this.opts.capBytes ?? CAPTURE_CAP_BYTES) / 2,
+            rotateMs: this.opts.rotateMs ?? SEGMENT_ROTATE_MS,
+        });
+
+        for (const seg of drop) {
+            try {
+                unlinkSync(seg.path);
+            } catch (err) {
+                log.debug({ err, path: seg.path }, "segment prune failed");
+            }
+        }
+
+        this.segStartMs = now;
+        this.currentPath = join(this.dir, segmentName(now));
+        // 0600: segments carry live cookies/tokens; other local users must not read them.
+        this.fd = openSync(this.currentPath, "a", 0o600);
+
+        if (capDropped) {
+            writeSync(
+                this.fd,
+                `${SafeJSON.stringify(
+                    {
+                        method: "Genesis.marker",
+                        params: { kind: "capDropped", detail: "oldest segment dropped over the byte cap" },
+                        t: now,
+                    },
+                    { strict: true }
+                )}\n`
+            );
+        }
+    }
+
+    get segmentPath(): string {
+        return this.currentPath;
+    }
+
+    close(): void {
+        if (this.fd !== null) {
+            closeSync(this.fd);
+            this.fd = null;
+        }
+    }
+}
+
+/** Read buffered events across all segments, oldest first. Broken lines are skipped, never fatal. */
+export function readEvents(dir: string, opts: { sinceMs?: number } = {}): RecordedEvent[] {
+    const events: RecordedEvent[] = [];
+
+    for (const seg of listSegments(dir)) {
+        let text: string;
+        try {
+            text = readFileSync(seg.path, "utf8");
+        } catch (err) {
+            log.debug({ err, path: seg.path }, "segment read failed (raced a prune?)");
+            continue;
+        }
+
+        for (const line of text.split("\n")) {
+            if (!line.trim()) {
+                continue;
+            }
+
+            try {
+                const parsed = SafeJSON.parse(line, { strict: true }) as RecordedEvent;
+                if (opts.sinceMs !== undefined && parsed.t < opts.sinceMs) {
+                    continue;
+                }
+
+                events.push(parsed);
+            } catch (err) {
+                log.debug({ err, path: seg.path }, "broken jsonl line skipped");
+            }
+        }
+    }
+
+    return events;
+}

--- a/src/chrome-devtools/lib/status.ts
+++ b/src/chrome-devtools/lib/status.ts
@@ -1,0 +1,163 @@
+/**
+ * Data collection for `status`: recorders (with live CPU/memory samples),
+ * capture buffers, CDP endpoints, legacy leftovers, and recorder-shaped
+ * processes that no pidfile owns. Read-only by definition.
+ */
+import { inspectPidFile, type PidFileState } from "@genesiscz/utils/process/pidfile";
+import { captureDir, knownCapturePorts, listLegacyArmFiles, recorderPidPath } from "./paths.ts";
+import {
+    currentPlatform,
+    defaultExec,
+    type ExecFn,
+    listProcesses,
+    type Platform,
+    type ProcessSample,
+    sampleProcess,
+} from "./platform.ts";
+import { type RecorderMeta, readRecorderMeta } from "./recorder.ts";
+import { listSegments } from "./segments.ts";
+
+export { type ProcessSample, sampleProcess };
+
+/** Every process that looks like a capture recorder — the new tool's or the old skill's. */
+export function findRecorderProcesses(
+    exec: ExecFn = defaultExec,
+    platform: Platform = currentPlatform()
+): { pid: number; command: string }[] {
+    const found: { pid: number; command: string }[] = [];
+
+    for (const proc of listProcesses(exec, platform)) {
+        const command = proc.command;
+        const isNew =
+            /chrome-devtools[/\\](index\.ts|commands|lib)?.*\brecord\b/.test(command) ||
+            /tools chrome-devtools record/.test(command);
+        const isOld = /skills\/chrome-devtools\/scripts\/chrome-devtools\.ts\s+arm\b/.test(command);
+        const isSelfLib = /src[/\\]chrome-devtools[/\\]index\.ts\s+record\b/.test(command);
+
+        if (isNew || isOld || isSelfLib) {
+            found.push({ pid: proc.pid, command });
+        }
+    }
+
+    return found;
+}
+
+/**
+ * Pids that are ancestors of any owned pid. A live recorder's launch chain
+ * (`zsh -c 'tools chrome-devtools record …'` → `tools` wrapper → recorder)
+ * carries the same argv, so command-shape matching alone flags the PARENTS of
+ * a healthy recorder as killable orphans — a field test proved doctor would
+ * have suggested killing the live 9224 recorder's own launcher.
+ */
+export function ancestorPids(
+    ownedPids: Iterable<number>,
+    exec: ExecFn = defaultExec,
+    platform: Platform = currentPlatform()
+): Set<number> {
+    const parentOf = new Map<number, number>();
+    for (const proc of listProcesses(exec, platform)) {
+        if (proc.ppid !== null) {
+            parentOf.set(proc.pid, proc.ppid);
+        }
+    }
+
+    const ancestors = new Set<number>();
+    for (const owned of ownedPids) {
+        let current = parentOf.get(owned);
+        let hops = 0;
+        while (current !== undefined && current > 1 && hops < 50) {
+            ancestors.add(current);
+            current = parentOf.get(current);
+            hops++;
+        }
+    }
+
+    return ancestors;
+}
+
+export interface SegmentStats {
+    count: number;
+    bytes: number;
+    oldestMs: number | null;
+    newestMs: number | null;
+}
+
+export function segmentStats(port: number): SegmentStats {
+    const segs = listSegments(captureDir(port));
+
+    return {
+        count: segs.length,
+        bytes: segs.reduce((sum, s) => sum + s.bytes, 0),
+        oldestMs: segs[0]?.startMs ?? null,
+        newestMs: segs.at(-1)?.startMs ?? null,
+    };
+}
+
+export interface EndpointProbe {
+    browser: string;
+    pages: number;
+}
+
+export async function probeEndpoint(port: number): Promise<EndpointProbe | null> {
+    try {
+        const [versionRes, listRes] = await Promise.all([
+            fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(1200) }),
+            fetch(`http://127.0.0.1:${port}/json/list`, { signal: AbortSignal.timeout(1200) }),
+        ]);
+        const v = (await versionRes.json()) as { Browser?: string };
+        const list = (await listRes.json()) as { type: string }[];
+
+        return { browser: v.Browser ?? "unknown", pages: list.filter((t) => t.type === "page").length };
+    } catch {
+        return null;
+    }
+}
+
+export interface PortStatus {
+    port: number;
+    pidState: PidFileState;
+    meta: RecorderMeta | null;
+    sample: ProcessSample | null;
+    segments: SegmentStats;
+    endpoint: EndpointProbe | null;
+}
+
+export interface StatusReport {
+    ports: PortStatus[];
+    legacyFiles: string[];
+    /** Recorder-shaped processes not owned by any live pidfile. */
+    orphans: { pid: number; command: string; sample: ProcessSample | null }[];
+}
+
+export async function collectStatus(): Promise<StatusReport> {
+    const ports = knownCapturePorts();
+    const ownedPids = new Set<number>();
+
+    // Probe all ports concurrently — dead ports cost a full timeout each, and
+    // serial probing made status/doctor block for seconds per leftover dir.
+    const portStatuses: PortStatus[] = await Promise.all(
+        ports.map(async (port) => {
+            const pidState = inspectPidFile(recorderPidPath(port));
+            const livePid = pidState.status === "live" ? pidState.pid : null;
+            if (livePid) {
+                ownedPids.add(livePid);
+            }
+
+            return {
+                port,
+                pidState,
+                meta: readRecorderMeta(port),
+                sample: livePid ? sampleProcess(livePid) : null,
+                segments: segmentStats(port),
+                endpoint: await probeEndpoint(port),
+            };
+        })
+    );
+
+    const launcherPids = ancestorPids(ownedPids);
+    const orphans = findRecorderProcesses()
+        .filter((p) => !ownedPids.has(p.pid) && !launcherPids.has(p.pid) && p.pid !== process.pid)
+        .map((p) => ({ ...p, sample: sampleProcess(p.pid) }));
+
+    return { ports: portStatuses, legacyFiles: listLegacyArmFiles(), orphans };
+}

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, readFileSync, unlinkSync } from "node:fs";
-import { readFile, rename, writeFile } from "node:fs/promises";
+import { mkdirSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { configureLogger, logger } from "@genesiscz/utils/logger";
 import {
+    attemptStaleTakeover,
     buildPidRecord,
     clearPidFile,
     ownsPidFile,
@@ -27,98 +28,9 @@ function isEexist(err: unknown): boolean {
     return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EEXIST";
 }
 
-function isEnoent(err: unknown): boolean {
-    return err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
-}
-
-/**
- * Atomically steal a stale pidfile whose content was pre-validated as dead.
- *
- * Renames it to a unique temp path first — rename is atomic on POSIX, so
- * under N concurrent racers (e.g. a launchd respawn storm) exactly one
- * rename succeeds; every loser gets ENOENT (the source is already gone
- * under them) and returns false rather than also "winning".
- *
- * The rename alone is NOT sufficient: rename steals whatever currently sits
- * at the path, so a late racer can grab the pidfile the previous winner just
- * wrote (validated-stale at check time, fresh at rename time — TOCTOU; a
- * 12-racer test reproduced two "winners" without this guard). So after the
- * rename, the stolen content must still equal `expectedContent` — the exact
- * stale artifact the caller validated. A mismatch means a fresh file was
- * grabbed: restore it (best-effort `wx`; if someone claimed the slot
- * meanwhile, the robbed owner's per-tick `verifyPidfileOwnership` self-exit
- * is the backstop) and lose.
- *
- * Uses the async `rename()` (not `renameSync`): Bun's synchronous fs calls
- * are reentrant under concurrent async-driven load (verified empirically —
- * many concurrent `renameSync` callers in one process can each observe a
- * "successful" rename of the same source), which breaks the single-winner
- * guarantee this function exists to provide. The async version dispatches
- * through the normal I/O completion queue with no such reentrancy.
- *
- * Exported for direct concurrency testing (see daemon.test.ts).
- */
-export async function attemptStaleTakeover(pidFile: string, expectedContent: string): Promise<boolean> {
-    const tempPath = `${pidFile}.stale-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
-
-    try {
-        await rename(pidFile, tempPath);
-    } catch (err) {
-        if (isEnoent(err)) {
-            return false;
-        }
-
-        throw err;
-    }
-
-    let stolen: string | null = null;
-
-    try {
-        stolen = await readFile(tempPath, "utf-8");
-    } catch {
-        stolen = null;
-    }
-
-    if (stolen === null || stolen.trim() !== expectedContent.trim()) {
-        // We grabbed something other than the validated-stale file — a fresh
-        // owner wrote between our check and our rename. Put it back and lose.
-        if (stolen !== null) {
-            try {
-                await writeFile(pidFile, stolen, { flag: "wx" });
-            } catch (err) {
-                // Slot already re-claimed — the robbed owner self-heals via
-                // its per-tick ownership check.
-                logger.debug({ err, pidFile }, "[daemon] stale-takeover restore skipped (slot re-claimed)");
-            }
-        }
-
-        try {
-            unlinkSync(tempPath);
-        } catch {
-            // best-effort cleanup
-        }
-
-        return false;
-    }
-
-    try {
-        await writeFile(pidFile, serializePidRecord(buildPidRecord()), { flag: "wx" });
-    } catch (err) {
-        if (isEexist(err)) {
-            return false;
-        }
-
-        throw err;
-    } finally {
-        try {
-            unlinkSync(tempPath);
-        } catch {
-            // best-effort cleanup; ENOENT if somehow already gone
-        }
-    }
-
-    return true;
-}
+// The atomic stale-takeover protocol now lives in the shared pidfile util;
+// re-exported so daemon.test.ts (and older callers) keep their import path.
+export { attemptStaleTakeover };
 
 /**
  * Claim the daemon pidfile as our own.

--- a/src/scripts/lib/store.ts
+++ b/src/scripts/lib/store.ts
@@ -290,6 +290,8 @@ export async function ensureStoreScaffold(root = storeRoot()): Promise<void> {
         compilerOptions: {
             paths: {
                 "@gt/scripts/*": [join(LIB_DIR, "*")],
+                // chrome-devtools scaffold recipes import the cdp lib this way
+                "@gt/chrome-devtools/*": [join(LIB_DIR, "..", "..", "chrome-devtools", "lib", "*")],
             },
         },
     };

--- a/src/utils/process/pidfile.ts
+++ b/src/utils/process/pidfile.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
@@ -277,4 +278,100 @@ export function clearPidFile(path: string, opts: { force?: boolean } = {}): bool
         logger.debug({ err, path }, "[pidfile] could not remove file");
         return false;
     }
+}
+
+function errnoCode(err: unknown): string | undefined {
+    return err instanceof Error && "code" in err ? (err as NodeJS.ErrnoException).code : undefined;
+}
+
+/**
+ * Atomically steal a pidfile whose content the caller pre-validated as STALE.
+ *
+ * Rename into a unique temp name, verify the stolen bytes are exactly the
+ * validated artifact (a mismatch means a fresh owner claimed between check and
+ * rename — restore it best-effort and lose), then either `wx`-create our own
+ * record (`claim: true`, the default) or leave the slot empty (`claim: false`,
+ * a race-safe DELETE for cleanup paths). Returns true only for the single
+ * racer that stole the validated artifact.
+ *
+ * Async on purpose: Bun's synchronous fs calls reenter under concurrent
+ * async-driven load (many concurrent `renameSync` callers can each observe a
+ * "successful" rename of one source — verified empirically in the daemon),
+ * which breaks the single-winner guarantee this function exists to provide.
+ * The sync `writePidFile({ exclusive })` above is therefore NOT a race
+ * primitive; racing callers belong here.
+ */
+export async function attemptStaleTakeover(
+    path: string,
+    expectedContent: string,
+    opts: { claim?: boolean } = {}
+): Promise<boolean> {
+    const tempPath = `${path}.stale-${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
+
+    try {
+        await rename(path, tempPath);
+    } catch (err) {
+        if (errnoCode(err) === "ENOENT") {
+            return false;
+        }
+
+        throw err;
+    }
+
+    let stolen: string | null = null;
+    try {
+        stolen = await readFile(tempPath, "utf-8");
+    } catch (err) {
+        logger.debug({ err, tempPath }, "[pidfile] stolen file unreadable");
+    }
+
+    if (stolen === null || stolen.trim() !== expectedContent.trim()) {
+        // We grabbed something other than the validated-stale file — a fresh
+        // owner wrote between the caller's check and our rename. Put it back
+        // and lose; if the slot was re-claimed meanwhile, the robbed owner's
+        // own liveness checks are the backstop.
+        if (stolen !== null) {
+            try {
+                await writeFile(path, stolen, { flag: "wx" });
+            } catch (err) {
+                logger.debug({ err, path }, "[pidfile] stale-takeover restore skipped (slot re-claimed)");
+            }
+        }
+
+        try {
+            unlinkSync(tempPath);
+        } catch (err) {
+            logger.debug({ err, tempPath }, "[pidfile] takeover temp cleanup failed");
+        }
+
+        return false;
+    }
+
+    if (opts.claim !== false) {
+        try {
+            await writeFile(path, serializePidRecord(buildPidRecord()), { flag: "wx" });
+        } catch (err) {
+            if (errnoCode(err) === "EEXIST") {
+                return false;
+            }
+
+            throw err;
+        } finally {
+            try {
+                unlinkSync(tempPath);
+            } catch (err) {
+                logger.debug({ err, tempPath }, "[pidfile] takeover temp cleanup failed");
+            }
+        }
+
+        return true;
+    }
+
+    try {
+        unlinkSync(tempPath);
+    } catch (err) {
+        logger.debug({ err, tempPath }, "[pidfile] takeover temp cleanup failed");
+    }
+
+    return true;
 }


### PR DESCRIPTION
Ports the `~/.agents/skills/chrome-devtools` skill into GenesisTools as a first-class tool, redesigned around the 2026-08-25 CPU-leak incident (a stray recorder burned 50-87% CPU for 4.5h with no browser attached; full forensics ship as `references/arm-cpu-leak.md`).

## Shape

**One capture engine, two views.** `record` is the only recorder: one detached process per port, browser-wide auto-attach (or `--match` scope), HAR-grade metadata into a rolling 4-hour segment buffer under `/tmp/GenesisTools/ChromeDevtools/<port>/`. `follow` is the live view (channel rendering + Monitor-ready commands, rotation-aware — the only sanctioned tail of the buffer). `har` is the retroactive view (`--last 30m`) or a live window with bodies (`--now --reload`). The old skill's `watch` verb is a tombstone that explains the split.

**HAR pipeline: a zero-dependency TS port of chrome-har v1.3.1** (`lib/har/`, sitespeedio/chrome-har, MIT) with four documented deviations — the important one is sessionId-aware entry keying so multi-tab captures cannot corrupt each other (upstream reads no sessionId at all). Parity is pinned byte-for-byte against goldens generated from upstream over its own real-Chrome perflogs (`lib/har/__fixtures__/`). Research showing no native export exists at any layer (CDP, chrome-devtools-mcp, Playwright-on-attached-context): the session's research doc. Only `tough-cookie` was added as a dependency (Set-Cookie parsing fidelity).

**The incident, encoded structurally:**
- pid-recycling-safe pidfiles (`@genesiscz/utils/process/pidfile`) claimed before the child connects — N concurrent `attach` calls yield exactly one recorder per port
- websocket frames and `Network.dataReceived` are never `JSON.parse`d; dataReceived goes through a regex byte-count aggregator emitting one synthetic summary event per request, so HAR content sizes stay correct at near-zero cost
- one fd per segment, prune-at-rotation (a single inline unlink, no timer process), 500 MB/port cap with a marker event
- dies with its browser: `/json/version` probe, ws-close, SIGTERM, `--stop`, 24h lifetime cap

**Ops:** `status` (live CPU/mem/cpu-time per recorder, buffers, endpoints, orphans, legend), `doctor` (read-only, prints one fix command per finding), `cleanup` (guided; kills are triple-guarded — recorder-shaped check, live-recorder refusal, launcher-ancestor refusal — and never batched into `--yes`).

**Scripting:** `scaffold <name> --recipe redirect-chain|cookie-diff|storage-snapshot|body-fetch|console-trap|blank` creates versioned scratch scripts in the `tools scripts` store (new `@gt/chrome-devtools/*` tsconfig mapping); `cheatsheet` prints the CDP API reference; `mcp` calls real chrome-devtools-mcp tools against any port.

**Plugin skill** (`plugins/genesis-tools/skills/chrome-devtools/`): SKILL.md rewritten around the tool with the do-not-pipe table; all 8 references carried over and cleaned up; new `cdp-cheatsheet.md`. The old `~/.agents` skill is now a thin pointer.

## Verification

- 88 unit/integration tests (parity goldens, claim races, segment rotation/prune/cap, follow-across-rotation, kill guards, CLI guidance), `bun run test`, tsgo, biome, `lint:rules` all green.
- Live against real browsers: found and cleaned a real 17-hour orphan from the old skill; retroactive `har --last` → `tools har-analyzer` clean on 1366 real entries; `follow` replayed a real OAuth authorize→callback chain. Two live-found bugs fixed (Chrome 151 double target attach; `out.print` vs `println`).
- Benchmarks (interleaved windows, cpu-time deltas): ~0.8% CPU idle beside an active SPA, ~0.2% over ten quiet tabs, ~4% during triple-reload bursts; **Brave stress: 84 restored tabs, 66 emitting sessions, median 0.3% CPU / 88 MB RSS**, ~0.4s boot. Brave 151 opens CDP on the default profile (the Chrome ≥136 block does not apply).
- Field-tested by three independent agents (junior/ops/scripter briefs, CLI-output-only); all 12 findings fixed, including one real blocker (doctor suggested killing a live recorder's launcher ancestors — now structurally impossible).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Chrome DevTools toolkit for launching, attaching to, recording, inspecting, and diagnosing Chromium-based browsers.
  * Added network capture, HAR export, filtering, response-body capture, and sensitive-data sanitization.
  * Added live event following, screenshots, cookie and storage inspection, console capture, scripting recipes, and MCP access.
  * Added cross-platform support, safe cleanup, status reporting, and diagnostic guidance.

* **Documentation**
  * Added usage guides, troubleshooting playbooks, protocol references, and network-forensics documentation.

* **Tests**
  * Added broad coverage for commands, recording, attachment, HAR generation, cleanup, and event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->