### PR TITLE
feat(cmux): livelock rescue tooling — doctor, offline save, foreground command capture, drift-aware restore

### DIFF
--- a/src/cmux/README.md
+++ b/src/cmux/README.md
@@ -11,6 +11,8 @@ Crash recovery and repeatable layouts for cmux. A profile captures the workspace
 | Command | Description |
 |---------|-------------|
 | `profiles` | Manage saved workspace profiles |
+| `doctor` | Read-only health probe: is cmux running, does its socket answer, is the UI thread starved |
+| `rescue [name]` | Guided recovery from a livelocked cmux — offline capture, confirmed kill, clean relaunch, command replay |
 | `send-self <text>` | Type text into the terminal surface this process is running in, then press Enter |
 
 ### `profiles` subcommands
@@ -49,6 +51,12 @@ tools cmux profiles save work --force            # overwrite
 | `--no-history` | Skip last-shell-command capture |
 | `--note <text>` | Free-form note stored on the profile |
 | `-f, --force` | Overwrite an existing profile of the same name |
+| `--offline` | Build the profile from the autosave file plus the process table instead of the socket |
+
+`--offline` exists for the case the socket cannot answer, which is exactly when you most
+need a capture. ⚠️ It is a **weaker** capture: no visible screen and no scrollback, so the
+per-pane command comes from the process table rather than from history. `save` falls back to
+it automatically when the UI is starved, and says so.
 
 ---
 
@@ -63,6 +71,41 @@ Three capture behaviours are **on by default**, and they are what makes a restor
 Pre-typing rather than auto-running is deliberate. Restoring a layout should not silently re-execute commands.
 
 `restore` is always non-destructive: it creates workspaces, it never closes yours.
+
+`restore --enter` opts into **executing** each captured command instead of pre-typing it.
+That reverses the safe default above, so it is opt-in and never implied.
+
+Captured commands are reported with their **drift**: every difference between what the
+process table showed and what will actually be replayed (an account added, a
+`-- --resume <id>` appended). Restore prints the diff rather than hiding the rewrite.
+
+## Recovery: `doctor` and `rescue`
+
+```bash
+tools cmux doctor                  # is it healthy, starved, or gone
+tools cmux rescue --dry-run        # the full plan, touching nothing
+tools cmux rescue before-reboot    # asks before it kills anything
+```
+
+`doctor` only reads. It reports whether the app is running, whether the socket answers a
+ping and an identify inside their timeouts, and the app's CPU — a pegged UI thread that
+still answers pings is the livelock signature.
+
+`rescue` is the destructive counterpart and runs in this order:
+
+1. capture an offline profile **before** anything else, so an abort still leaves it saved;
+2. ask for confirmation (`--yes` to skip, and in a non-interactive shell `--yes` is
+   **required** — it refuses rather than assuming);
+3. `SIGTERM` the app, escalating to `SIGKILL` only after a 5 s grace window;
+4. relaunch with a deliberately minimal environment, so agent markers like `CLAUDECODE`
+   do not leak into every pane's login shell;
+5. wait for the app to reopen its own workspaces, then type each captured command into the
+   matching surface.
+
+Replay is **title-checked per surface**: equal surface counts do not prove the panes still
+correspond, so a surface whose reopened title differs from the captured one is skipped and
+reported rather than typed into. Whatever a pane shows afterwards (an account gate, a resume
+dialog) is reported, never answered — `rescue` types commands, it does not answer prompts.
 
 ## `send-self`
 

--- a/src/cmux/commands/doctor.ts
+++ b/src/cmux/commands/doctor.ts
@@ -40,7 +40,9 @@ async function runDoctor(flags: DoctorFlags): Promise<void> {
             ui.ok(`healthy — socket and UI thread both answer`);
             break;
         case "not-running":
-            ui.warn("cmux is not running. Start it from the Dock/Finder (NOT via `open` from an agent shell — see below).");
+            ui.warn(
+                "cmux is not running. Start it from the Dock/Finder (NOT via `open` from an agent shell — see below)."
+            );
             break;
         case "socket-dead":
             ui.err("the app is running but the socket does not answer. A restart of cmux is likely required.");

--- a/src/cmux/commands/doctor.ts
+++ b/src/cmux/commands/doctor.ts
@@ -1,0 +1,79 @@
+import { ui } from "@genesiscz/utils/cli/ui";
+import { type CmuxHealth, type CmuxProbeResult, probeCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+interface DoctorFlags {
+    json?: boolean;
+}
+
+export function registerDoctorCommand(parent: Command): void {
+    parent
+        .command("doctor")
+        .description("Diagnose cmux health: socket vs UI-thread responsiveness, app CPU, rescue recipe. Read-only.")
+        .option("--json", "Emit the raw health object")
+        .action(async (flags: DoctorFlags) => {
+            await runDoctor(flags);
+        });
+}
+
+async function runDoctor(flags: DoctorFlags): Promise<void> {
+    const health = await probeCmuxHealth({ full: true, identifyTimeoutMs: 5000 });
+
+    if (flags.json) {
+        out.result(health);
+        setExitCode(health);
+        return;
+    }
+
+    ui.header("cmux doctor");
+    ui.kv("app", health.appPid ? `running (pid ${health.appPid}, ${health.appCpu ?? "?"}% CPU)` : "not running");
+    ui.kv("ping", probeLine(health.probes.ping));
+    if (health.probes.capabilities) {
+        ui.kv("capabilities", probeLine(health.probes.capabilities));
+    }
+
+    ui.kv("identify", probeLine(health.probes.identify));
+
+    switch (health.state) {
+        case "healthy":
+            ui.ok(`healthy — socket and UI thread both answer`);
+            break;
+        case "not-running":
+            ui.warn("cmux is not running. Start it from the Dock/Finder (NOT via `open` from an agent shell — see below).");
+            break;
+        case "socket-dead":
+            ui.err("the app is running but the socket does not answer. A restart of cmux is likely required.");
+            break;
+        case "ui-starved":
+            ui.err(
+                "UI-thread livelock signature: ping answers but identify starves" +
+                    (health.appCpu !== undefined ? ` while the app burns ${health.appCpu}% CPU` : "") +
+                    ". UI clicks and every state command are stuck."
+            );
+            ui.section("Rescue recipe");
+            ui.raw("  1. tools cmux profiles save rescue --offline   # capture layout+commands without the socket");
+            ui.raw("  2. kill -TERM <app pid>   # plain TERM works; wait, then kill -9 if it survives");
+            ui.raw("  3. Relaunch with a CLEAN env — never `open -a cmux` from an agent shell:");
+            ui.raw('     env -i HOME="$HOME" USER="$USER" PATH=/usr/bin:/bin:/usr/sbin:/sbin open -a cmux');
+            ui.raw("     (`open` forwards its env; agent markers make resumed claudes disable transcript saving)");
+            ui.raw("  4. tools cmux profiles restore rescue --enter   # review the drift diff it prints");
+            break;
+    }
+
+    setExitCode(health);
+}
+
+function setExitCode(health: CmuxHealth): void {
+    if (health.state !== "healthy") {
+        process.exitCode = 1;
+    }
+}
+
+function probeLine(probe: CmuxProbeResult): string {
+    if (probe.ok) {
+        return `ok (${probe.ms} ms)`;
+    }
+
+    return `FAIL (${probe.ms} ms${probe.detail ? ` — ${probe.detail}` : ""})`;
+}

--- a/src/cmux/commands/profiles/restore.ts
+++ b/src/cmux/commands/profiles/restore.ts
@@ -1,5 +1,5 @@
 import { renderProfileCommandDetail } from "@app/cmux/lib/format";
-import { buildPlan, type RestoreOptions, restoreProfile, scanForInteractivePrompts } from "@app/cmux/lib/restore";
+import { buildPlan, type RestoreOptions, reportWaitingPrompts, restoreProfile } from "@app/cmux/lib/restore";
 import { ProfileNotFoundError, ProfileStore } from "@app/cmux/lib/store";
 import type { Profile } from "@app/cmux/lib/types";
 import * as p from "@clack/prompts";
@@ -30,29 +30,6 @@ export function registerRestoreCommand(parent: Command): void {
         .action(async (name: string, flags: RestoreFlags) => {
             await runRestore(name, flags);
         });
-}
-
-/**
- * After an --enter run, list panes stopped at an interactive prompt (account
- * headroom gate, resume-mode dialog, session picker). Restore never answers
- * them — confirming is deliberately left to the user.
- */
-async function reportWaitingPrompts(workspaceRefs: string[]): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, 4000));
-
-    try {
-        const waiting = await scanForInteractivePrompts(workspaceRefs);
-        if (waiting.length === 0) {
-            p.log.info("No panes are waiting at an interactive prompt.");
-            return;
-        }
-
-        const lines = waiting.map((w) => `  ${pc.yellow("⚠")} ${w.workspaceRef} ${w.surfaceRef} — ${w.prompt}`);
-        lines.push(pc.dim("  Restore does not auto-confirm these; answer each pane yourself."));
-        p.note(lines.join("\n"), "Panes waiting for you");
-    } catch (error) {
-        logger.debug({ error }, "[cmux restore] waiting-prompt scan failed");
-    }
 }
 
 async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
@@ -142,7 +119,10 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
         p.note(summary, "Result");
 
         if (opts.enter) {
-            await reportWaitingPrompts(outcome.workspaces.map((w) => w.ref));
+            await reportWaitingPrompts(
+                outcome.workspaces.map((w) => w.ref),
+                "Restore"
+            );
         }
 
         p.outro(pc.green("Done."));

--- a/src/cmux/commands/profiles/restore.ts
+++ b/src/cmux/commands/profiles/restore.ts
@@ -1,8 +1,10 @@
-import { buildPlan, type RestoreOptions, restoreProfile } from "@app/cmux/lib/restore";
+import { renderProfileCommandDetail } from "@app/cmux/lib/format";
+import { buildPlan, type RestoreOptions, restoreProfile, scanForInteractivePrompts } from "@app/cmux/lib/restore";
 import { ProfileNotFoundError, ProfileStore } from "@app/cmux/lib/store";
 import type { Profile } from "@app/cmux/lib/types";
 import * as p from "@clack/prompts";
 import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { ensureCmuxResponsive } from "@genesiscz/utils/cmux/lib/health";
 import { logger, out } from "@genesiscz/utils/logger";
 import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
 import type { Command } from "commander";
@@ -11,6 +13,7 @@ import pc from "picocolors";
 interface RestoreFlags {
     prefix?: string;
     replay?: boolean;
+    enter?: boolean;
     yes?: boolean;
     dryRun?: boolean;
 }
@@ -21,11 +24,35 @@ export function registerRestoreCommand(parent: Command): void {
         .description("Recreate cmux workspaces from a saved profile (always non-destructive)")
         .option("--prefix <str>", "Workspace name prefix to apply on restore (default '<name>-')")
         .option("--no-replay", "Skip queueing the captured shell command — only cd into cwd")
+        .option("--enter", "Press Enter after typing each replayed command, so it executes immediately")
         .option("-y, --yes", "Do not ask for confirmation")
         .option("--dry-run", "Print the plan without modifying cmux")
         .action(async (name: string, flags: RestoreFlags) => {
             await runRestore(name, flags);
         });
+}
+
+/**
+ * After an --enter run, list panes stopped at an interactive prompt (account
+ * headroom gate, resume-mode dialog, session picker). Restore never answers
+ * them — confirming is deliberately left to the user.
+ */
+async function reportWaitingPrompts(workspaceRefs: string[]): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 4000));
+
+    try {
+        const waiting = await scanForInteractivePrompts(workspaceRefs);
+        if (waiting.length === 0) {
+            p.log.info("No panes are waiting at an interactive prompt.");
+            return;
+        }
+
+        const lines = waiting.map((w) => `  ${pc.yellow("⚠")} ${w.workspaceRef} ${w.surfaceRef} — ${w.prompt}`);
+        lines.push(pc.dim("  Restore does not auto-confirm these; answer each pane yourself."));
+        p.note(lines.join("\n"), "Panes waiting for you");
+    } catch (error) {
+        logger.debug({ error }, "[cmux restore] waiting-prompt scan failed");
+    }
 }
 
 async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
@@ -45,9 +72,14 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
     const opts: RestoreOptions = {
         prefix: flags.prefix !== undefined ? flags.prefix : `${name}-`,
         replay: flags.replay !== false,
+        enter: !!flags.enter && flags.replay !== false,
         yes: !!flags.yes,
         dryRun: !!flags.dryRun,
     };
+
+    if (flags.enter && flags.replay === false) {
+        out.log.warn("--enter has no effect with --no-replay; commands are not typed at all.");
+    }
 
     const plan = buildPlan(profile, opts);
 
@@ -56,6 +88,11 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
         return `  ${pc.cyan(ws.targetTitle)} ${pc.dim(`(${ws.paneCount} pane(s), ${ws.surfaceCount} surface(s))`)}`;
     });
     p.note(planLines.join("\n") || "(empty profile)", `Restore plan for ${pc.cyan(name)}`);
+
+    const detail = renderProfileCommandDetail(profile);
+    if (detail.length > 0) {
+        p.note(detail.join("\n"), "Panes · commands · drift");
+    }
 
     if (opts.dryRun) {
         p.outro(pc.dim("Dry run — nothing changed."));
@@ -79,6 +116,8 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
         }
     }
 
+    await ensureCmuxResponsive("profiles restore");
+
     const spinner = p.spinner();
     spinner.start("Recreating workspaces…");
     const startedAt = Date.now();
@@ -101,6 +140,11 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
             })
             .join("\n");
         p.note(summary, "Result");
+
+        if (opts.enter) {
+            await reportWaitingPrompts(outcome.workspaces.map((w) => w.ref));
+        }
+
         p.outro(pc.green("Done."));
     } catch (error) {
         spinner.stop("Restore failed.");

--- a/src/cmux/commands/profiles/save.ts
+++ b/src/cmux/commands/profiles/save.ts
@@ -55,7 +55,9 @@ async function runSave(rawName: string | undefined, flags: SaveFlags): Promise<v
     let offline = !!flags.offline;
 
     if (offline && (flags.workspace || flags.window || flags.scope)) {
-        throw new Error("--offline captures everything in the autosave; it cannot combine with --scope/--workspace/--window");
+        throw new Error(
+            "--offline captures everything in the autosave; it cannot combine with --scope/--workspace/--window"
+        );
     }
 
     const scope = offline ? "all" : await resolveScope(flags, interactive);
@@ -69,6 +71,16 @@ async function runSave(rawName: string | undefined, flags: SaveFlags): Promise<v
         // Fail fast + degrade: a livelocked UI thread would starve every capture call.
         const health = await probeCmuxHealth({ identifyTimeoutMs: 3500 });
         if (health.state !== "healthy") {
+            // Offline capture always covers everything in the autosave, with cwd and
+            // process-table commands — degrading silently would ignore these flags.
+            if (scope !== "all" || !captureCwd || !captureHistory) {
+                throw new Error(
+                    `cmux is ${health.state}, and live capture is unavailable. The requested flags ` +
+                        "(--scope/--workspace/--window/--no-cwd/--no-history) are not supported by offline capture. " +
+                        "Retry without them, use --offline explicitly, or run `tools cmux doctor` for triage."
+                );
+            }
+
             offline = true;
             out.log.warn(
                 `cmux is ${health.state} — falling back to OFFLINE capture (autosave + process table). ` +

--- a/src/cmux/commands/profiles/save.ts
+++ b/src/cmux/commands/profiles/save.ts
@@ -1,8 +1,10 @@
+import { captureOfflineProfile } from "@app/cmux/lib/offline-snapshot";
 import { captureProfile, getCmuxVersion, type SnapshotOptions } from "@app/cmux/lib/snapshot";
 import { ProfileExistsError, ProfileStore } from "@app/cmux/lib/store";
 import type { ProfileScope, Window } from "@app/cmux/lib/types";
 import * as p from "@clack/prompts";
 import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { probeCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
 import { logger, out } from "@genesiscz/utils/logger";
 import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
 import type { Command } from "commander";
@@ -17,6 +19,7 @@ interface SaveFlags {
     history?: boolean;
     note?: string;
     force?: boolean;
+    offline?: boolean;
 }
 
 export function registerSaveCommand(parent: Command): void {
@@ -37,6 +40,10 @@ export function registerSaveCommand(parent: Command): void {
         )
         .option("--note <text>", "Free-form note stored on the profile")
         .option("-f, --force", "Overwrite an existing profile of the same name")
+        .option(
+            "--offline",
+            "Capture WITHOUT the cmux socket: layout from the app's autosave file, commands from the process table. The automatic fallback when cmux's UI thread is starved. No screen contents; scope is always everything in the autosave."
+        )
         .action(async (name: string | undefined, flags: SaveFlags) => {
             await runSave(name, flags);
         });
@@ -45,11 +52,30 @@ export function registerSaveCommand(parent: Command): void {
 async function runSave(rawName: string | undefined, flags: SaveFlags): Promise<void> {
     const interactive = isInteractive();
     let forceWrite = !!flags.force;
+    let offline = !!flags.offline;
 
-    const scope = await resolveScope(flags, interactive);
+    if (offline && (flags.workspace || flags.window || flags.scope)) {
+        throw new Error("--offline captures everything in the autosave; it cannot combine with --scope/--workspace/--window");
+    }
+
+    const scope = offline ? "all" : await resolveScope(flags, interactive);
     rejectIncompatibleScopeFlags(scope, flags);
-    const { captureCwd, captureScreen, captureHistory } = await resolveCaptureFlags(flags, interactive);
+    const { captureCwd, captureScreen, captureHistory } = offline
+        ? { captureCwd: true, captureScreen: false, captureHistory: true }
+        : await resolveCaptureFlags(flags, interactive);
     const name = await resolveName(rawName, scope, interactive);
+
+    if (!offline) {
+        // Fail fast + degrade: a livelocked UI thread would starve every capture call.
+        const health = await probeCmuxHealth({ identifyTimeoutMs: 3500 });
+        if (health.state !== "healthy") {
+            offline = true;
+            out.log.warn(
+                `cmux is ${health.state} — falling back to OFFLINE capture (autosave + process table). ` +
+                    "Screen contents are not captured this way. Run `tools cmux doctor` for triage."
+            );
+        }
+    }
 
     const store = new ProfileStore();
     if (store.exists(name) && !forceWrite) {
@@ -90,11 +116,13 @@ async function runSave(rawName: string | undefined, flags: SaveFlags): Promise<v
     const startedAt = Date.now();
 
     try {
-        const profile = await captureProfile(options, {
-            onWorkspaceStart: ({ title, index, total }) => {
-                spinner.message(`Capturing workspace ${index}/${total}: ${title}`);
-            },
-        });
+        const profile = offline
+            ? await captureOfflineProfile({ name, note: flags.note })
+            : await captureProfile(options, {
+                  onWorkspaceStart: ({ title, index, total }) => {
+                      spinner.message(`Capturing workspace ${index}/${total}: ${title}`);
+                  },
+              });
 
         const path = store.write(name, profile, { force: forceWrite });
         spinner.stop(`Captured ${countWorkspaces(profile.windows)} workspace(s) in ${Date.now() - startedAt} ms`);

--- a/src/cmux/commands/rescue.command.test.ts
+++ b/src/cmux/commands/rescue.command.test.ts
@@ -31,6 +31,9 @@ mock.module("@clack/prompts", () => ({
 
 mock.module("@genesiscz/utils/cmux/lib/health", () => ({
     probeCmuxHealth: async () => ({ state: "starved", appPid: 4242, appCpu: 99 }),
+    // Mocking a module replaces ALL of its exports; the rescue lib reads this one
+    // to re-check a pid's identity before signalling, so it has to be here too.
+    APP_BINARY_SUFFIX: "cmux.app/Contents/MacOS/cmux",
 }));
 
 mock.module("@app/cmux/lib/offline-snapshot", () => ({
@@ -56,16 +59,22 @@ mock.module("@app/cmux/lib/store", () => ({
 const { runRescue } = await import("./rescue");
 
 let killed: number[] = [];
+let relaunched = 0;
 
 const explodingDeps = {
     killApp: async (pid: number) => {
         killed.push(pid);
         throw new Error("the kill path must not be reached on this run");
     },
+    relaunch: async () => {
+        relaunched += 1;
+        throw new Error("the relaunch path must not be reached on this run");
+    },
 };
 
 beforeEach(() => {
     killed = [];
+    relaunched = 0;
     interactive = true;
     confirmAnswer = true;
 });
@@ -101,4 +110,39 @@ test("NEGATIVE CONTROL — a confirmed run does reach the kill", async () => {
 
     await expect(runRescue("rescue", {}, explodingDeps)).rejects.toThrow("the kill path must not be reached");
     expect(killed).toEqual([4242]);
+});
+
+test("a cmux that survives the kill stops the rescue before the relaunch", async () => {
+    // `open -a cmux` would activate the still-livelocked app, the health wait
+    // would pass against that old instance, and replay would type every captured
+    // command into the frozen surfaces.
+    const survivingDeps = {
+        killApp: async (pid: number) => {
+            killed.push(pid);
+
+            return { signals: ["SIGTERM", "SIGKILL"] as NodeJS.Signals[], exited: false };
+        },
+        relaunch: explodingDeps.relaunch,
+    };
+
+    await expect(runRescue("rescue", {}, survivingDeps)).rejects.toThrow("did not terminate");
+    expect(killed).toEqual([4242]);
+    expect(relaunched).toBe(0);
+});
+
+test("NEGATIVE CONTROL — a cmux that DID exit reaches the relaunch", async () => {
+    // Without this, a guard that blocked the normal path would satisfy the test
+    // above while breaking every real rescue.
+    const exitedDeps = {
+        killApp: async (pid: number) => {
+            killed.push(pid);
+
+            return { signals: ["SIGTERM"] as NodeJS.Signals[], exited: true };
+        },
+        relaunch: explodingDeps.relaunch,
+    };
+
+    await expect(runRescue("rescue", {}, exitedDeps)).rejects.toThrow("the relaunch path must not be reached");
+    expect(killed).toEqual([4242]);
+    expect(relaunched).toBe(1);
 });

--- a/src/cmux/commands/rescue.command.test.ts
+++ b/src/cmux/commands/rescue.command.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+/**
+ * The confirmation gate is the only thing between `tools cmux rescue` and
+ * killing the user's terminal app. Per the repo's side-effects rule the spy
+ * both RECORDS and THROWS, so a path that reaches the kill fails loudly rather
+ * than passing quietly — and the last test is the negative control proving a
+ * confirmed run still gets there.
+ */
+
+let interactive = true;
+let confirmAnswer: boolean | symbol = true;
+
+mock.module("@genesiscz/utils/cli", () => ({
+    isInteractive: () => interactive,
+    suggestCommand: (cmd: string) => cmd,
+}));
+
+mock.module("@genesiscz/utils/prompts/clack/helpers", () => ({
+    withCancel: async (value: unknown) => await value,
+}));
+
+mock.module("@clack/prompts", () => ({
+    intro: () => {},
+    outro: () => {},
+    note: () => {},
+    cancel: () => {},
+    confirm: async () => confirmAnswer,
+    log: { info: () => {}, warn: () => {}, step: () => {}, error: () => {}, success: () => {} },
+}));
+
+mock.module("@genesiscz/utils/cmux/lib/health", () => ({
+    probeCmuxHealth: async () => ({ state: "starved", appPid: 4242, appCpu: 99 }),
+}));
+
+mock.module("@app/cmux/lib/offline-snapshot", () => ({
+    captureOfflineProfile: async () => ({
+        version: 1,
+        name: "rescue",
+        scope: "all",
+        captured_at: "2026-08-27T12:00:00.000Z",
+        cmux_version: "test",
+        windows: [],
+    }),
+}));
+
+mock.module("@app/cmux/lib/store", () => ({
+    ProfileStore: class {
+        write() {
+            return "/tmp/does-not-matter.json";
+        }
+    },
+    ProfileExistsError: class extends Error {},
+}));
+
+const { runRescue } = await import("./rescue");
+
+let killed: number[] = [];
+
+const explodingDeps = {
+    killApp: async (pid: number) => {
+        killed.push(pid);
+        throw new Error("the kill path must not be reached on this run");
+    },
+};
+
+beforeEach(() => {
+    killed = [];
+    interactive = true;
+    confirmAnswer = true;
+});
+
+test("--dry-run never reaches the kill", async () => {
+    await runRescue("rescue", { dryRun: true }, explodingDeps);
+
+    expect(killed).toEqual([]);
+});
+
+test("non-interactive without --yes never reaches the kill", async () => {
+    interactive = false;
+
+    await runRescue("rescue", {}, explodingDeps);
+
+    expect(killed).toEqual([]);
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+});
+
+test("a declined confirmation never reaches the kill", async () => {
+    confirmAnswer = false;
+
+    await runRescue("rescue", {}, explodingDeps);
+
+    expect(killed).toEqual([]);
+});
+
+test("NEGATIVE CONTROL — a confirmed run does reach the kill", async () => {
+    // Without this, a guard that accidentally blocks the normal path would pass
+    // every test above while breaking the command outright.
+    confirmAnswer = true;
+
+    await expect(runRescue("rescue", {}, explodingDeps)).rejects.toThrow("the kill path must not be reached");
+    expect(killed).toEqual([4242]);
+});

--- a/src/cmux/commands/rescue.ts
+++ b/src/cmux/commands/rescue.ts
@@ -1,5 +1,12 @@
 import { renderProfileCommandDetail } from "@app/cmux/lib/format";
 import { captureOfflineProfile } from "@app/cmux/lib/offline-snapshot";
+import {
+    cleanRelaunchEnv,
+    collectReplayEntries,
+    killApp,
+    mayReplayIntoSurface,
+    type ReplayEntry,
+} from "@app/cmux/lib/rescue";
 import { scanForInteractivePrompts } from "@app/cmux/lib/restore";
 import { ProfileExistsError, ProfileStore } from "@app/cmux/lib/store";
 import type { Profile } from "@app/cmux/lib/types";
@@ -8,7 +15,6 @@ import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
 import { probeCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
 import { paneList, workspaceList } from "@genesiscz/utils/cmux/lib/socket";
-import { env } from "@genesiscz/utils/env";
 import { logger, out } from "@genesiscz/utils/logger";
 import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
 import type { Command } from "commander";
@@ -30,6 +36,13 @@ interface RescueFlags {
     dryRun?: boolean;
 }
 
+export interface RescueDeps {
+    /** Injected so a test can spy on the irreversible call and make it throw. */
+    killApp: typeof killApp;
+}
+
+const defaultDeps: RescueDeps = { killApp };
+
 export function registerRescueCommand(parent: Command): void {
     parent
         .command("rescue [name]")
@@ -43,41 +56,7 @@ export function registerRescueCommand(parent: Command): void {
         });
 }
 
-interface ReplayEntry {
-    workspaceIndex: number;
-    workspaceTitle: string;
-    paneRef: string;
-    tabIndex: number;
-    title: string;
-    command?: string;
-}
-
-function collectReplayEntries(profile: Profile): ReplayEntry[] {
-    const entries: ReplayEntry[] = [];
-    let workspaceIndex = 0;
-
-    for (const window of profile.windows) {
-        for (const ws of window.workspaces) {
-            for (const pane of ws.panes) {
-                pane.surfaces.forEach((surface, tabIndex) => {
-                    entries.push({
-                        workspaceIndex,
-                        workspaceTitle: ws.title,
-                        paneRef: pane.ref,
-                        tabIndex,
-                        title: surface.title,
-                        command: surface.type === "terminal" ? surface.command : undefined,
-                    });
-                });
-            }
-            workspaceIndex += 1;
-        }
-    }
-
-    return entries;
-}
-
-async function runRescue(name: string, flags: RescueFlags): Promise<void> {
+export async function runRescue(name: string, flags: RescueFlags, deps: RescueDeps = defaultDeps): Promise<void> {
     p.intro(pc.bgRed(pc.white(" cmux rescue ")));
 
     const health = await probeCmuxHealth({ full: true, identifyTimeoutMs: 5000 });
@@ -149,7 +128,10 @@ async function runRescue(name: string, flags: RescueFlags): Promise<void> {
     }
 
     if (health.appPid) {
-        await killApp(health.appPid);
+        const outcome = await deps.killApp(health.appPid, { onStep: (message) => p.log.step(message) });
+        p.log.info(
+            `Sent ${outcome.signals.join(" then ") || "no signal"}; cmux ${outcome.exited ? "exited" : "may still be alive"}.`
+        );
     } else {
         p.log.warn("No running cmux app found — skipping the kill step.");
     }
@@ -181,61 +163,15 @@ async function runRescue(name: string, flags: RescueFlags): Promise<void> {
     p.outro(pc.green("Rescue complete."));
 }
 
-async function killApp(pid: number): Promise<void> {
-    p.log.step(`Sending SIGTERM to cmux (pid ${pid})…`);
-    try {
-        process.kill(pid, "SIGTERM");
-    } catch (error) {
-        logger.warn({ error, pid }, "[rescue] SIGTERM failed");
-    }
-
-    for (let i = 0; i < 10; i += 1) {
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        if (!isAlive(pid)) {
-            p.log.info("cmux terminated on SIGTERM.");
-            return;
-        }
-    }
-
-    p.log.warn("Still alive after 5 s — sending SIGKILL.");
-    try {
-        process.kill(pid, "SIGKILL");
-    } catch (error) {
-        logger.warn({ error, pid }, "[rescue] SIGKILL failed");
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-}
-
-function isAlive(pid: number): boolean {
-    try {
-        process.kill(pid, 0);
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-/**
- * `open` forwards its ENTIRE environment to the launched app, and every pane's
- * login shell inherits it. Launched from an agent session that would propagate
- * CLAUDECODE/CLAUDE_CODE_* markers and silently disable transcript saving in
- * every resumed claude — so the relaunch runs with a minimal clean environment.
- */
 async function cleanRelaunch(): Promise<void> {
-    const user = env.device.getUser() ?? "";
-    const childEnv: Record<string, string> = {
-        HOME: env.paths.getHome(),
-        USER: user,
-        LOGNAME: env.device.getLogname() ?? user,
-        PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
-    };
     const proc = Bun.spawn(["/usr/bin/open", "-a", "cmux"], {
-        env: childEnv,
+        env: cleanRelaunchEnv(),
         stdin: "ignore",
         stdout: "ignore",
         stderr: "pipe",
     });
     const code = await proc.exited;
+
     if (code !== 0) {
         const stderr = await new Response(proc.stderr).text();
         throw new Error(`Relaunch failed (open exit ${code}): ${stderr.trim()}`);
@@ -315,6 +251,7 @@ async function replayIntoReopenedSurfaces(profile: Profile, entries: ReplayEntry
         }
 
         let sent = 0;
+        let skipped = 0;
         for (let i = 0; i < wsEntries.length; i += 1) {
             const entry = wsEntries[i];
             const target = liveSurfaces[i];
@@ -322,12 +259,22 @@ async function replayIntoReopenedSurfaces(profile: Profile, entries: ReplayEntry
                 continue;
             }
 
-            const titleMatches = !target.title || !entry.title || target.title === entry.title;
+            // The contract says surfaces are title-checked, and equal surface
+            // COUNTS do not prove the panes still correspond. Replaying by
+            // position into a renamed surface types a captured command into a
+            // different terminal than the reviewed plan showed, so a real
+            // mismatch refuses this surface exactly as a count mismatch does.
+            const titleMatches = mayReplayIntoSurface(entry, target);
             if (!titleMatches) {
                 logger.debug(
                     { saved: entry.title, live: target.title, surface: target.ref },
-                    "[rescue] title mismatch — replaying by position anyway"
+                    "[rescue] title mismatch — refusing to type into this surface"
                 );
+                p.log.warn(
+                    `  skipped ${target.ref}: saved "${entry.title}" but the reopened surface is "${target.title}".`
+                );
+                skipped += 1;
+                continue;
             }
 
             await runCmuxOk(["send", "--workspace", liveWs.ref, "--surface", target.ref, `${entry.command}\n`]);
@@ -335,7 +282,9 @@ async function replayIntoReopenedSurfaces(profile: Profile, entries: ReplayEntry
             await new Promise((resolve) => setTimeout(resolve, 300));
         }
 
-        p.log.info(`Workspace "${saved.title}": replayed ${sent} command(s) into ${wsEntries.length} surface(s).`);
+        p.log.info(
+            `Workspace "${saved.title}": replayed ${sent} command(s) into ${wsEntries.length} surface(s)${skipped ? `, skipped ${skipped} on a title mismatch` : ""}.`
+        );
     }
 
     return workspaceRefs;

--- a/src/cmux/commands/rescue.ts
+++ b/src/cmux/commands/rescue.ts
@@ -1,13 +1,14 @@
 import { renderProfileCommandDetail } from "@app/cmux/lib/format";
 import { captureOfflineProfile } from "@app/cmux/lib/offline-snapshot";
 import { scanForInteractivePrompts } from "@app/cmux/lib/restore";
-import { ProfileStore } from "@app/cmux/lib/store";
+import { ProfileExistsError, ProfileStore } from "@app/cmux/lib/store";
 import type { Profile } from "@app/cmux/lib/types";
 import * as p from "@clack/prompts";
 import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
 import { probeCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
 import { paneList, workspaceList } from "@genesiscz/utils/cmux/lib/socket";
+import { env } from "@genesiscz/utils/env";
 import { logger, out } from "@genesiscz/utils/logger";
 import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
 import type { Command } from "commander";
@@ -90,9 +91,6 @@ async function runRescue(name: string, flags: RescueFlags): Promise<void> {
 
     p.log.step("Capturing offline profile (autosave + process table)…");
     const profile = await captureOfflineProfile({ name, note: `rescue capture (cmux was ${health.state})` });
-    const store = new ProfileStore();
-    const profilePath = store.write(name, profile, { force: true });
-    p.log.info(`Profile saved: ${pc.dim(profilePath)}`);
 
     const detail = renderProfileCommandDetail(profile);
     if (detail.length > 0) {
@@ -112,6 +110,26 @@ async function runRescue(name: string, flags: RescueFlags): Promise<void> {
         p.outro(pc.dim("Dry run — nothing changed."));
         return;
     }
+
+    // Persist the capture BEFORE the kill (and before the confirm, so an abort
+    // still leaves it recoverable). Never clobber an existing profile: `name` is
+    // user-supplied and may collide with a hand-curated save.
+    const store = new ProfileStore();
+    let profilePath: string;
+
+    try {
+        profilePath = store.write(name, profile);
+    } catch (error) {
+        if (!(error instanceof ProfileExistsError)) {
+            throw error;
+        }
+
+        const stamped = `${name}-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+        p.log.warn(`Profile "${name}" already exists — saving as "${stamped}" instead.`);
+        profilePath = store.write(stamped, profile);
+    }
+
+    p.log.info(`Profile saved: ${pc.dim(profilePath)}`);
 
     if (!flags.yes) {
         if (!isInteractive()) {
@@ -204,13 +222,19 @@ function isAlive(pid: number): boolean {
  * every resumed claude — so the relaunch runs with a minimal clean environment.
  */
 async function cleanRelaunch(): Promise<void> {
-    const env: Record<string, string> = {
-        HOME: process.env.HOME ?? "",
-        USER: process.env.USER ?? "",
-        LOGNAME: process.env.LOGNAME ?? process.env.USER ?? "",
+    const user = env.device.getUser() ?? "";
+    const childEnv: Record<string, string> = {
+        HOME: env.paths.getHome(),
+        USER: user,
+        LOGNAME: env.device.getLogname() ?? user,
         PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
     };
-    const proc = Bun.spawn(["/usr/bin/open", "-a", "cmux"], { env, stdin: "ignore", stdout: "ignore", stderr: "pipe" });
+    const proc = Bun.spawn(["/usr/bin/open", "-a", "cmux"], {
+        env: childEnv,
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "pipe",
+    });
     const code = await proc.exited;
     if (code !== 0) {
         const stderr = await new Response(proc.stderr).text();
@@ -250,16 +274,23 @@ interface ListPaneSurfacesResponse {
 async function replayIntoReopenedSurfaces(profile: Profile, entries: ReplayEntry[]): Promise<string[]> {
     const live = await workspaceList();
     const workspaceRefs: string[] = [];
+    // cmux titles derive from directories/branches, so two workspaces can share a
+    // title — an already-claimed live workspace must never match a second saved one.
+    const claimed = new Set<string>();
     const profileWorkspaces = profile.windows.flatMap((w) => w.workspaces);
 
     for (let wsIndex = 0; wsIndex < profileWorkspaces.length; wsIndex += 1) {
         const saved = profileWorkspaces[wsIndex];
-        const liveWs = live.workspaces.find((ws) => ws.title === saved.title) ?? live.workspaces[wsIndex];
+        const positional = live.workspaces[wsIndex];
+        const liveWs =
+            live.workspaces.find((ws) => !claimed.has(ws.ref) && ws.title === saved.title) ??
+            (positional && !claimed.has(positional.ref) ? positional : undefined);
         if (!liveWs) {
             p.log.warn(`No reopened workspace matches "${saved.title}" — skipped.`);
             continue;
         }
 
+        claimed.add(liveWs.ref);
         workspaceRefs.push(liveWs.ref);
         const wsEntries = entries.filter((e) => e.workspaceIndex === wsIndex);
 

--- a/src/cmux/commands/rescue.ts
+++ b/src/cmux/commands/rescue.ts
@@ -7,7 +7,7 @@ import {
     mayReplayIntoSurface,
     type ReplayEntry,
 } from "@app/cmux/lib/rescue";
-import { scanForInteractivePrompts } from "@app/cmux/lib/restore";
+import { reportWaitingPrompts } from "@app/cmux/lib/restore";
 import { ProfileExistsError, ProfileStore } from "@app/cmux/lib/store";
 import type { Profile } from "@app/cmux/lib/types";
 import * as p from "@clack/prompts";
@@ -162,15 +162,7 @@ export async function runRescue(name: string, flags: RescueFlags, deps: RescueDe
     const entries = collectReplayEntries(profile);
     const workspaceRefs = await replayIntoReopenedSurfaces(profile, entries);
 
-    await new Promise((resolve) => setTimeout(resolve, 4000));
-    const waiting = await scanForInteractivePrompts(workspaceRefs).catch(() => []);
-    if (waiting.length > 0) {
-        const lines = waiting.map((w) => `  ${pc.yellow("⚠")} ${w.workspaceRef} ${w.surfaceRef} — ${w.prompt}`);
-        lines.push(pc.dim("  Rescue does not auto-confirm these; answer each pane yourself."));
-        p.note(lines.join("\n"), "Panes waiting for you");
-    } else {
-        p.log.info("No panes are waiting at an interactive prompt.");
-    }
+    await reportWaitingPrompts(workspaceRefs, "Rescue");
 
     p.outro(pc.green("Rescue complete."));
 }

--- a/src/cmux/commands/rescue.ts
+++ b/src/cmux/commands/rescue.ts
@@ -1,0 +1,311 @@
+import { renderProfileCommandDetail } from "@app/cmux/lib/format";
+import { captureOfflineProfile } from "@app/cmux/lib/offline-snapshot";
+import { scanForInteractivePrompts } from "@app/cmux/lib/restore";
+import { ProfileStore } from "@app/cmux/lib/store";
+import type { Profile } from "@app/cmux/lib/types";
+import * as p from "@clack/prompts";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { probeCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
+import { paneList, workspaceList } from "@genesiscz/utils/cmux/lib/socket";
+import { logger, out } from "@genesiscz/utils/logger";
+import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+/**
+ * Guided recovery from a cmux UI-thread livelock: offline capture → confirmed
+ * kill → CLEAN-ENV relaunch → wait for the app's own session reopen → replay each
+ * pane's launch command into the reopened surfaces. The app restores the layout
+ * itself, so no duplicate workspace is created.
+ *
+ * Interaction policy (t9): the only automation is typing each command + Enter.
+ * Whatever appears afterwards (account-headroom gate, resume-mode dialog, session
+ * picker) is reported, never answered.
+ */
+
+interface RescueFlags {
+    yes?: boolean;
+    dryRun?: boolean;
+}
+
+export function registerRescueCommand(parent: Command): void {
+    parent
+        .command("rescue [name]")
+        .description(
+            "Recover from a livelocked cmux: offline profile save, confirmed kill, clean-env relaunch, replay of each pane's command into the reopened surfaces"
+        )
+        .option("-y, --yes", "Do not ask for confirmation before killing cmux")
+        .option("--dry-run", "Print the full plan (steps + per-pane commands and drift) without touching anything")
+        .action(async (name: string | undefined, flags: RescueFlags) => {
+            await runRescue(name ?? "rescue", flags);
+        });
+}
+
+interface ReplayEntry {
+    workspaceIndex: number;
+    workspaceTitle: string;
+    paneRef: string;
+    tabIndex: number;
+    title: string;
+    command?: string;
+}
+
+function collectReplayEntries(profile: Profile): ReplayEntry[] {
+    const entries: ReplayEntry[] = [];
+    let workspaceIndex = 0;
+
+    for (const window of profile.windows) {
+        for (const ws of window.workspaces) {
+            for (const pane of ws.panes) {
+                pane.surfaces.forEach((surface, tabIndex) => {
+                    entries.push({
+                        workspaceIndex,
+                        workspaceTitle: ws.title,
+                        paneRef: pane.ref,
+                        tabIndex,
+                        title: surface.title,
+                        command: surface.type === "terminal" ? surface.command : undefined,
+                    });
+                });
+            }
+            workspaceIndex += 1;
+        }
+    }
+
+    return entries;
+}
+
+async function runRescue(name: string, flags: RescueFlags): Promise<void> {
+    p.intro(pc.bgRed(pc.white(" cmux rescue ")));
+
+    const health = await probeCmuxHealth({ full: true, identifyTimeoutMs: 5000 });
+    p.log.info(
+        `cmux state: ${pc.bold(health.state)}${health.appPid ? ` (pid ${health.appPid}, ${health.appCpu}% CPU)` : ""}`
+    );
+
+    if (health.state === "healthy") {
+        p.log.warn("cmux looks healthy — rescue will still kill and relaunch it if you continue.");
+    }
+
+    p.log.step("Capturing offline profile (autosave + process table)…");
+    const profile = await captureOfflineProfile({ name, note: `rescue capture (cmux was ${health.state})` });
+    const store = new ProfileStore();
+    const profilePath = store.write(name, profile, { force: true });
+    p.log.info(`Profile saved: ${pc.dim(profilePath)}`);
+
+    const detail = renderProfileCommandDetail(profile);
+    if (detail.length > 0) {
+        p.note(detail.join("\n"), "Commands that will be replayed (with drift)");
+    }
+
+    const steps = [
+        `  1. kill -TERM ${health.appPid ?? "<cmux pid>"} (escalate to -KILL after 5 s)`,
+        "  2. relaunch with a CLEAN env: env -i HOME USER PATH /usr/bin/open -a cmux",
+        "  3. wait for the socket to be healthy and the app to reopen its own workspaces",
+        "  4. type each pane's command + Enter into the reopened surfaces (order-matched, title-checked)",
+        "  5. report panes stopped at interactive prompts — rescue never answers them",
+    ];
+    p.note(steps.join("\n"), "Plan");
+
+    if (flags.dryRun) {
+        p.outro(pc.dim("Dry run — nothing changed."));
+        return;
+    }
+
+    if (!flags.yes) {
+        if (!isInteractive()) {
+            out.error(
+                `Pass --yes to confirm the kill in non-interactive mode. ${suggestCommand(`tools cmux rescue ${name} --yes`)}`
+            );
+            process.exitCode = 1;
+            return;
+        }
+        const proceed = await withCancel(
+            p.confirm({ message: "Kill cmux and run the rescue now?", initialValue: false })
+        );
+        if (!proceed) {
+            p.cancel("Aborted — the offline profile stays saved.");
+            return;
+        }
+    }
+
+    if (health.appPid) {
+        await killApp(health.appPid);
+    } else {
+        p.log.warn("No running cmux app found — skipping the kill step.");
+    }
+
+    p.log.step("Relaunching cmux with a clean environment…");
+    await cleanRelaunch();
+
+    const ready = await waitForHealthy(60_000);
+    if (!ready) {
+        throw new Error("cmux did not become healthy within 60 s after relaunch — check the app manually.");
+    }
+
+    // Give the app a moment to finish reopening its autosaved workspaces.
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    const entries = collectReplayEntries(profile);
+    const workspaceRefs = await replayIntoReopenedSurfaces(profile, entries);
+
+    await new Promise((resolve) => setTimeout(resolve, 4000));
+    const waiting = await scanForInteractivePrompts(workspaceRefs).catch(() => []);
+    if (waiting.length > 0) {
+        const lines = waiting.map((w) => `  ${pc.yellow("⚠")} ${w.workspaceRef} ${w.surfaceRef} — ${w.prompt}`);
+        lines.push(pc.dim("  Rescue does not auto-confirm these; answer each pane yourself."));
+        p.note(lines.join("\n"), "Panes waiting for you");
+    } else {
+        p.log.info("No panes are waiting at an interactive prompt.");
+    }
+
+    p.outro(pc.green("Rescue complete."));
+}
+
+async function killApp(pid: number): Promise<void> {
+    p.log.step(`Sending SIGTERM to cmux (pid ${pid})…`);
+    try {
+        process.kill(pid, "SIGTERM");
+    } catch (error) {
+        logger.warn({ error, pid }, "[rescue] SIGTERM failed");
+    }
+
+    for (let i = 0; i < 10; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        if (!isAlive(pid)) {
+            p.log.info("cmux terminated on SIGTERM.");
+            return;
+        }
+    }
+
+    p.log.warn("Still alive after 5 s — sending SIGKILL.");
+    try {
+        process.kill(pid, "SIGKILL");
+    } catch (error) {
+        logger.warn({ error, pid }, "[rescue] SIGKILL failed");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+}
+
+function isAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * `open` forwards its ENTIRE environment to the launched app, and every pane's
+ * login shell inherits it. Launched from an agent session that would propagate
+ * CLAUDECODE/CLAUDE_CODE_* markers and silently disable transcript saving in
+ * every resumed claude — so the relaunch runs with a minimal clean environment.
+ */
+async function cleanRelaunch(): Promise<void> {
+    const env: Record<string, string> = {
+        HOME: process.env.HOME ?? "",
+        USER: process.env.USER ?? "",
+        LOGNAME: process.env.LOGNAME ?? process.env.USER ?? "",
+        PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+    };
+    const proc = Bun.spawn(["/usr/bin/open", "-a", "cmux"], { env, stdin: "ignore", stdout: "ignore", stderr: "pipe" });
+    const code = await proc.exited;
+    if (code !== 0) {
+        const stderr = await new Response(proc.stderr).text();
+        throw new Error(`Relaunch failed (open exit ${code}): ${stderr.trim()}`);
+    }
+}
+
+async function waitForHealthy(timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        const health = await probeCmuxHealth({ pingTimeoutMs: 1000, identifyTimeoutMs: 2500 });
+        if (health.state === "healthy") {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+interface LiveSurfaceEntry {
+    ref: string;
+    title?: string;
+    index: number;
+}
+
+interface ListPaneSurfacesResponse {
+    surfaces: LiveSurfaceEntry[];
+}
+
+/**
+ * Type each captured command into the matching reopened surface. Surfaces are
+ * matched positionally per workspace (the reopen recreates the autosave order —
+ * the same order the offline profile was built from) and cross-checked by title;
+ * a count mismatch aborts instead of typing into the wrong pane.
+ */
+async function replayIntoReopenedSurfaces(profile: Profile, entries: ReplayEntry[]): Promise<string[]> {
+    const live = await workspaceList();
+    const workspaceRefs: string[] = [];
+    const profileWorkspaces = profile.windows.flatMap((w) => w.workspaces);
+
+    for (let wsIndex = 0; wsIndex < profileWorkspaces.length; wsIndex += 1) {
+        const saved = profileWorkspaces[wsIndex];
+        const liveWs = live.workspaces.find((ws) => ws.title === saved.title) ?? live.workspaces[wsIndex];
+        if (!liveWs) {
+            p.log.warn(`No reopened workspace matches "${saved.title}" — skipped.`);
+            continue;
+        }
+
+        workspaceRefs.push(liveWs.ref);
+        const wsEntries = entries.filter((e) => e.workspaceIndex === wsIndex);
+
+        const liveSurfaces: LiveSurfaceEntry[] = [];
+        const layout = await paneList(liveWs.ref);
+        for (const pane of layout.panes) {
+            const response = await runCmuxJSON<ListPaneSurfacesResponse>([
+                "list-pane-surfaces",
+                "--workspace",
+                liveWs.ref,
+                "--pane",
+                pane.ref,
+            ]);
+            liveSurfaces.push(...[...response.surfaces].sort((a, b) => a.index - b.index));
+        }
+
+        if (liveSurfaces.length !== wsEntries.length) {
+            p.log.error(
+                `Workspace "${saved.title}": ${liveSurfaces.length} reopened surface(s) vs ${wsEntries.length} saved — refusing to type into a mismatched layout.`
+            );
+            continue;
+        }
+
+        let sent = 0;
+        for (let i = 0; i < wsEntries.length; i += 1) {
+            const entry = wsEntries[i];
+            const target = liveSurfaces[i];
+            if (!entry.command) {
+                continue;
+            }
+
+            const titleMatches = !target.title || !entry.title || target.title === entry.title;
+            if (!titleMatches) {
+                logger.debug(
+                    { saved: entry.title, live: target.title, surface: target.ref },
+                    "[rescue] title mismatch — replaying by position anyway"
+                );
+            }
+
+            await runCmuxOk(["send", "--workspace", liveWs.ref, "--surface", target.ref, `${entry.command}\n`]);
+            sent += 1;
+            await new Promise((resolve) => setTimeout(resolve, 300));
+        }
+
+        p.log.info(`Workspace "${saved.title}": replayed ${sent} command(s) into ${wsEntries.length} surface(s).`);
+    }
+
+    return workspaceRefs;
+}

--- a/src/cmux/commands/rescue.ts
+++ b/src/cmux/commands/rescue.ts
@@ -39,9 +39,11 @@ interface RescueFlags {
 export interface RescueDeps {
     /** Injected so a test can spy on the irreversible call and make it throw. */
     killApp: typeof killApp;
+    /** Same reason: `open -a cmux` must never fire from a test run. */
+    relaunch: () => Promise<void>;
 }
 
-const defaultDeps: RescueDeps = { killApp };
+const defaultDeps: RescueDeps = { killApp, relaunch: cleanRelaunch };
 
 export function registerRescueCommand(parent: Command): void {
     parent
@@ -132,12 +134,22 @@ export async function runRescue(name: string, flags: RescueFlags, deps: RescueDe
         p.log.info(
             `Sent ${outcome.signals.join(" then ") || "no signal"}; cmux ${outcome.exited ? "exited" : "may still be alive"}.`
         );
+
+        // Relaunching now would `open -a cmux` onto the STILL-RUNNING app, the
+        // health wait below would pass against that old instance, and replay
+        // would type every captured command into the livelocked surfaces. The
+        // profile is already on disk, so stopping here costs nothing.
+        if (!outcome.exited) {
+            throw new Error(
+                `cmux (pid ${health.appPid}) did not terminate — refusing to relaunch or replay into it. Quit the app yourself, then re-run the rescue. The profile is saved at ${profilePath}.`
+            );
+        }
     } else {
         p.log.warn("No running cmux app found — skipping the kill step.");
     }
 
     p.log.step("Relaunching cmux with a clean environment…");
-    await cleanRelaunch();
+    await deps.relaunch();
 
     const ready = await waitForHealthy(60_000);
     if (!ready) {

--- a/src/cmux/index.ts
+++ b/src/cmux/index.ts
@@ -14,7 +14,9 @@
  *   tools cmux send-self <text> [--no-enter]
  */
 
+import { registerDoctorCommand } from "@app/cmux/commands/doctor";
 import { registerProfilesCommand } from "@app/cmux/commands/profiles";
+import { registerRescueCommand } from "@app/cmux/commands/rescue";
 import { registerSendSelfCommand } from "@app/cmux/commands/send-self";
 import { enhanceHelp, runTool } from "@genesiscz/utils/cli";
 import { out } from "@genesiscz/utils/logger";
@@ -34,6 +36,8 @@ program
 
 registerProfilesCommand(program);
 registerSendSelfCommand(program);
+registerDoctorCommand(program);
+registerRescueCommand(program);
 
 enhanceHelp(program);
 

--- a/src/cmux/lib/autosave.ts
+++ b/src/cmux/lib/autosave.ts
@@ -1,0 +1,141 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+/**
+ * Reader for cmux's own autosave file (`~/Library/Application Support/cmux/
+ * session-<bundle>.json`). It is written by the app continuously and survives a
+ * UI-thread livelock, which makes it the layout source of truth for offline
+ * profile capture when the socket cannot answer.
+ */
+
+export interface AutosavePanel {
+    id: string;
+    stableSurfaceId?: string;
+    type: string;
+    title?: string;
+    directory?: string;
+    ttyName?: string;
+    listeningPorts?: number[];
+}
+
+export interface AutosaveLayoutPaneNode {
+    type: "pane";
+    pane: { panelIds: string[]; selectedPanelId?: string };
+}
+
+export interface AutosaveLayoutSplitNode {
+    type: "split";
+    split: {
+        orientation: "horizontal" | "vertical";
+        /** Fraction (0..1) of the container given to `first`. */
+        dividerPosition: number;
+        first: AutosaveLayoutNode;
+        second: AutosaveLayoutNode;
+    };
+}
+
+export type AutosaveLayoutNode = AutosaveLayoutPaneNode | AutosaveLayoutSplitNode;
+
+export interface AutosaveWorkspace {
+    workspaceId?: string;
+    stableId?: string;
+    customTitle?: string;
+    processTitle?: string;
+    currentDirectory?: string;
+    focusedPanelId?: string;
+    layout: AutosaveLayoutNode;
+    panels: AutosavePanel[];
+}
+
+export interface AutosaveWindow {
+    frame?: { x: number; y: number; width: number; height: number };
+    tabManager: { selectedWorkspaceIndex?: number; workspaces: AutosaveWorkspace[] };
+}
+
+export interface AutosaveSession {
+    path: string;
+    savedAtMs: number;
+    windows: AutosaveWindow[];
+}
+
+export function autosaveDir(): string {
+    return join(homedir(), "Library", "Application Support", "cmux");
+}
+
+/** Newest `session-*.json` in the autosave dir, parsed. Throws when none exists. */
+export function readAutosaveSession(dir: string = autosaveDir()): AutosaveSession {
+    const candidates = readdirSync(dir)
+        .filter((name) => name.startsWith("session-") && name.endsWith(".json") && !name.includes("-previous"))
+        .map((name) => {
+            const path = join(dir, name);
+            return { path, mtimeMs: statSync(path).mtimeMs };
+        })
+        .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+    const newest = candidates[0];
+    if (!newest) {
+        throw new Error(`No cmux autosave session file found in ${dir}`);
+    }
+
+    const raw = SafeJSON.parse(readFileSync(newest.path, "utf8"), { strict: true }) as { windows?: AutosaveWindow[] };
+    const windows = raw.windows ?? [];
+    logger.debug({ path: newest.path, windows: windows.length }, "[cmux-autosave] loaded");
+    return { path: newest.path, savedAtMs: newest.mtimeMs, windows };
+}
+
+/** panel id (== live surface uuid == CMUX_SURFACE_ID) → panel, across all windows/workspaces. */
+export function panelsById(session: AutosaveSession): Map<string, AutosavePanel> {
+    const map = new Map<string, AutosavePanel>();
+    for (const window of session.windows) {
+        for (const ws of window.tabManager.workspaces) {
+            for (const panel of ws.panels) {
+                map.set(panel.id, panel);
+                if (panel.stableSurfaceId) {
+                    map.set(panel.stableSurfaceId, panel);
+                }
+            }
+        }
+    }
+
+    return map;
+}
+
+export interface FlattenedPane {
+    panelIds: string[];
+    selectedPanelId?: string;
+    frame: { x: number; y: number; width: number; height: number };
+}
+
+/**
+ * Walk the autosave's binary split tree and assign each leaf pane a pixel frame
+ * within the given container. `dividerPosition` is the fraction handed to the
+ * `first` child; horizontal splits divide left/right, vertical top/bottom.
+ */
+export function flattenLayout(
+    node: AutosaveLayoutNode,
+    frame: { x: number; y: number; width: number; height: number }
+): FlattenedPane[] {
+    if (node.type === "pane") {
+        return [{ panelIds: node.pane.panelIds, selectedPanelId: node.pane.selectedPanelId, frame }];
+    }
+
+    const { orientation, dividerPosition, first, second } = node.split;
+    const fraction = Math.min(Math.max(dividerPosition, 0.05), 0.95);
+
+    if (orientation === "horizontal") {
+        const firstWidth = frame.width * fraction;
+        return [
+            ...flattenLayout(first, { ...frame, width: firstWidth }),
+            ...flattenLayout(second, { ...frame, x: frame.x + firstWidth, width: frame.width - firstWidth }),
+        ];
+    }
+
+    const firstHeight = frame.height * fraction;
+    return [
+        ...flattenLayout(first, { ...frame, height: firstHeight }),
+        ...flattenLayout(second, { ...frame, y: frame.y + firstHeight, height: frame.height - firstHeight }),
+    ];
+}

--- a/src/cmux/lib/command-capture.test.ts
+++ b/src/cmux/lib/command-capture.test.ts
@@ -50,6 +50,19 @@ describe("deriveReplayCommand", () => {
         expect(result.drift.some((d) => d.includes("account"))).toBe(false);
     });
 
+    test("`tools claude run` keeps its explicit account, same as `tools cc run`", () => {
+        // The launcher test accepted both spellings while the account parser only
+        // matched `tools cc run`, so `tools claude run personal` silently replayed
+        // under the journal account and the drift line claimed there had been none.
+        const result = deriveReplayCommand({
+            original: "tools claude run personal --resume burn",
+            sessionId,
+            account: "work",
+        });
+        expect(result.command).toBe(`tools cc run personal -- --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes("account"))).toBe(false);
+    });
+
     test("flags a bare --resume picker being replaced", () => {
         const result = deriveReplayCommand({ original: "tools cc run work --resume", sessionId, account: "work" });
         expect(result.command).toBe(`tools cc run work -- --resume ${sessionId}`);

--- a/src/cmux/lib/command-capture.test.ts
+++ b/src/cmux/lib/command-capture.test.ts
@@ -56,6 +56,28 @@ describe("deriveReplayCommand", () => {
         expect(result.drift.some((d) => d.includes("bare --resume"))).toBe(true);
     });
 
+    test("bare claude launchers keep the launcher and other flags, only pinning the resume target", () => {
+        const result = deriveReplayCommand({
+            original: "claude --model opus --resume burn",
+            sessionId,
+            account: "work",
+        });
+        expect(result.command).toBe(`claude --model opus --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes('resume target "burn" replaced'))).toBe(true);
+    });
+
+    test("bare claude without --resume gets one appended", () => {
+        const result = deriveReplayCommand({ original: "claude --model opus", sessionId });
+        expect(result.command).toBe(`claude --model opus --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes("added"))).toBe(true);
+    });
+
+    test("bare claude already resuming the right session passes through with no drift", () => {
+        const result = deriveReplayCommand({ original: `claude --resume ${sessionId}`, sessionId });
+        expect(result.command).toBe(`claude --resume ${sessionId}`);
+        expect(result.drift).toEqual([]);
+    });
+
     test("without any account the command defers to cc run's own prompt and says so", () => {
         const result = deriveReplayCommand({ original: "tools cc run", sessionId });
         expect(result.command).toBe(`tools cc run -- --resume ${sessionId}`);

--- a/src/cmux/lib/command-capture.test.ts
+++ b/src/cmux/lib/command-capture.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { cleanLaunchCommand, deriveReplayCommand } from "@app/cmux/lib/command-capture";
+
+describe("cleanLaunchCommand", () => {
+    test("strips the bun wrapper down to `tools`", () => {
+        expect(cleanLaunchCommand("bun /Users/x/Projects/GenesisTools/tools cc run foltyn --resume burn")).toBe(
+            "tools cc run foltyn --resume burn"
+        );
+        expect(cleanLaunchCommand("/Users/x/.bun/bin/bun run /repo/tools cc run a")).toBe("tools cc run a");
+    });
+
+    test("normalizes an absolute grok path", () => {
+        expect(cleanLaunchCommand("/Users/x/.local/bin/grok --resume")).toBe("grok --resume");
+    });
+
+    test("leaves ordinary commands alone", () => {
+        expect(cleanLaunchCommand("vim notes.md")).toBe("vim notes.md");
+    });
+});
+
+describe("deriveReplayCommand", () => {
+    const sessionId = "aa45fee8-9a3b-4745-83d2-89a4445092b7";
+
+    test("non-claude commands pass through with no drift", () => {
+        const result = deriveReplayCommand({ original: "grok --resume", sessionId, account: "work" });
+        expect(result.command).toBe("grok --resume");
+        expect(result.drift).toEqual([]);
+    });
+
+    test("without a session id the original is kept verbatim", () => {
+        const result = deriveReplayCommand({ original: "tools cc run work --resume burn" });
+        expect(result.command).toBe("tools cc run work --resume burn");
+        expect(result.drift).toEqual([]);
+    });
+
+    test("adds the pinned account and flags the drift when the original had none", () => {
+        const result = deriveReplayCommand({ original: "tools cc run", sessionId, account: "work" });
+        expect(result.command).toBe(`tools cc run work -- --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes('account "work" added'))).toBe(true);
+    });
+
+    test("keeps the original explicit account over the pinned one", () => {
+        const result = deriveReplayCommand({
+            original: "tools cc run personal --resume burn",
+            sessionId,
+            account: "work",
+        });
+        expect(result.command).toBe(`tools cc run personal -- --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes('resume target "burn" replaced'))).toBe(true);
+        expect(result.drift.some((d) => d.includes("account"))).toBe(false);
+    });
+
+    test("flags a bare --resume picker being replaced", () => {
+        const result = deriveReplayCommand({ original: "tools cc run work --resume", sessionId, account: "work" });
+        expect(result.command).toBe(`tools cc run work -- --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes("bare --resume"))).toBe(true);
+    });
+
+    test("without any account the command defers to cc run's own prompt and says so", () => {
+        const result = deriveReplayCommand({ original: "tools cc run", sessionId });
+        expect(result.command).toBe(`tools cc run -- --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes("no account recorded"))).toBe(true);
+    });
+});
+
+describe("etimeToSeconds", () => {
+    test("parses mm:ss, hh:mm:ss and dd-hh:mm:ss", async () => {
+        const { etimeToSeconds } = await import("@app/cmux/lib/command-capture");
+        expect(etimeToSeconds("00:05")).toBe(5);
+        expect(etimeToSeconds("01:02:03")).toBe(3723);
+        expect(etimeToSeconds("2-01:00:00")).toBe(176400);
+        expect(etimeToSeconds("garbage")).toBe(0);
+    });
+});

--- a/src/cmux/lib/command-capture.ts
+++ b/src/cmux/lib/command-capture.ts
@@ -131,8 +131,13 @@ export interface ReplayDerivation {
     drift: string[];
 }
 
-const CLAUDE_LAUNCHER = /(^|\s)(tools cc run|tools claude run|claude)\b/;
-const CC_RUN_LAUNCHER = /(^|\s)tools (?:cc|claude) run\b/;
+// Anchored at the START of the command on purpose. `(^|\s)` matched a launcher
+// ANYWHERE, so `echo tools cc run` was rewritten wholesale to
+// `tools cc run -- --resume <id>` and the original command was lost. The policy
+// is that a non-Claude command replays verbatim, so an embedded mention is not
+// a launcher.
+const CLAUDE_LAUNCHER = /^(tools cc run|tools claude run|claude)\b/;
+const CC_RUN_LAUNCHER = /^tools (?:cc|claude) run\b/;
 
 /**
  * Pin the resume target inside the original command without touching anything

--- a/src/cmux/lib/command-capture.ts
+++ b/src/cmux/lib/command-capture.ts
@@ -186,7 +186,10 @@ export function deriveReplayCommand(input: {
     }
 
     const drift: string[] = [];
-    const accountInOriginal = original.match(/^tools cc run\s+(?!-)(\S+)/)?.[1];
+    // Both launcher spellings, or `tools claude run personal` would lose the
+    // explicit account and replay under the journal's one (or none) while the
+    // drift line claimed the original had no account.
+    const accountInOriginal = original.match(/^tools (?:cc|claude) run\s+(?!-)(\S+)/)?.[1];
     const account = accountInOriginal ?? input.account;
 
     if (!accountInOriginal && input.account) {

--- a/src/cmux/lib/command-capture.ts
+++ b/src/cmux/lib/command-capture.ts
@@ -1,0 +1,182 @@
+import { homedir } from "node:os";
+import { loadPins } from "@app/claude/lib/cmux/pins";
+import { loadAllSessionCmuxRefs } from "@app/claude/lib/cmux/session-refs";
+import { logger } from "@genesiscz/utils/logger";
+
+/**
+ * Foreground-command capture and replay-command derivation for profile save.
+ *
+ * Scrollback parsing cannot see the launch command once a fullscreen TUI (claude,
+ * grok, vim) owns the pane, so the reliable source is the process table: the
+ * oldest non-shell process on the pane's tty IS the command the user typed.
+ *
+ * Replay commands follow Martin's 2026-08-27 policy: start from the original
+ * verbatim; the only allowed enrichments are the account (from the session pin
+ * journal) and `-- --resume <sessionId>` (pass-through — `--resume <query>`
+ * opens a fuzzy picker whose top match can be a different session). Every
+ * change is recorded as a drift note that restore must display.
+ */
+
+const SHELL_NAMES = new Set(["zsh", "-zsh", "bash", "-bash", "sh", "-sh", "fish", "-fish"]);
+
+function isShellOrLogin(command: string): boolean {
+    const first = command.split(/\s+/, 1)[0] ?? "";
+    const base = first.split("/").pop() ?? first;
+    if (SHELL_NAMES.has(base)) {
+        return true;
+    }
+
+    return first === "/usr/bin/login" || base === "login";
+}
+
+/** Normalize an absolute launcher path back to what the user actually types. */
+export function cleanLaunchCommand(command: string): string {
+    return command
+        .replace(/^\S*\bbun (?:run )?\S*\/tools\s+/, "tools ")
+        .replace(new RegExp(`^${homedir()}/\\.local/bin/grok\\b`), "grok")
+        .replace(/^\S*\/grok\b/, "grok")
+        .trim();
+}
+
+/** `[[dd-]hh:]mm:ss` → seconds. Returns 0 for unparseable values. */
+export function etimeToSeconds(etime: string): number {
+    const match = etime.trim().match(/^(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/);
+    if (!match) {
+        return 0;
+    }
+    const [, days, hours, minutes, seconds] = match;
+    return Number(days ?? 0) * 86400 + Number(hours ?? 0) * 3600 + Number(minutes) * 60 + Number(seconds);
+}
+
+/**
+ * tty name (e.g. `ttys012`) → the cleaned launch command running on it.
+ * The launch command is the OLDEST non-shell process on the tty (largest etime):
+ * the shell comes first, the typed command next, and everything after is its
+ * children. Pid ordering is NOT usable here — pids wrap, so a transient
+ * `sleep 1` background job can carry a lower pid than the hours-old wrapper.
+ */
+export async function collectTtyLaunchCommands(): Promise<Map<string, string>> {
+    const map = new Map<string, { ageSeconds: number; command: string }>();
+    try {
+        const proc = Bun.spawn(["ps", "-axo", "tty=,etime=,command="], {
+            stdin: "ignore",
+            stdout: "pipe",
+            stderr: "ignore",
+        });
+        const text = await new Response(proc.stdout).text();
+        await proc.exited;
+
+        for (const line of text.split("\n")) {
+            const match = line.match(/^\s*(ttys\d+)\s+([\d:-]+)\s+(.+)$/);
+            if (!match) {
+                continue;
+            }
+            const [, tty, etime, command] = match;
+            if (isShellOrLogin(command)) {
+                continue;
+            }
+            const ageSeconds = etimeToSeconds(etime);
+            const existing = map.get(tty);
+            if (!existing || ageSeconds > existing.ageSeconds) {
+                map.set(tty, { ageSeconds, command });
+            }
+        }
+    } catch (error) {
+        logger.warn({ error }, "[command-capture] ps tty scan failed");
+    }
+
+    const out = new Map<string, string>();
+    for (const [tty, entry] of map) {
+        out.set(tty, cleanLaunchCommand(entry.command));
+    }
+
+    return out;
+}
+
+export interface SurfaceSessionInfo {
+    sessionId: string;
+    account?: string;
+}
+
+/** surface uuid (CMUX_SURFACE_ID) → newest known claude session + account. */
+export async function loadSurfaceSessions(): Promise<Map<string, SurfaceSessionInfo>> {
+    const out = new Map<string, { sessionId: string; account?: string; at: number }>();
+    try {
+        const refs = loadAllSessionCmuxRefs();
+        const pins = await loadPins({ readOnly: true });
+
+        for (const entry of refs.values()) {
+            if (!entry.surfaceId) {
+                continue;
+            }
+            const existing = out.get(entry.surfaceId);
+            if (existing && existing.at >= (entry.at ?? 0)) {
+                continue;
+            }
+            out.set(entry.surfaceId, {
+                sessionId: entry.sessionId,
+                account: pins.get(entry.sessionId)?.account ?? undefined,
+                at: entry.at ?? 0,
+            });
+        }
+    } catch (error) {
+        logger.warn({ error }, "[command-capture] session refs/pins unavailable");
+    }
+
+    return new Map([...out].map(([k, v]) => [k, { sessionId: v.sessionId, account: v.account }]));
+}
+
+export interface ReplayDerivation {
+    command: string;
+    drift: string[];
+}
+
+const CLAUDE_LAUNCHER = /(^|\s)(tools cc run|tools claude run|claude)\b/;
+
+/**
+ * Derive the replay command from the captured original plus what we know about
+ * the session that ran in the pane. Non-claude commands pass through untouched.
+ */
+export function deriveReplayCommand(input: {
+    original: string;
+    sessionId?: string;
+    account?: string;
+}): ReplayDerivation {
+    const original = input.original.trim();
+    if (!input.sessionId || !CLAUDE_LAUNCHER.test(original)) {
+        return { command: original, drift: [] };
+    }
+
+    const drift: string[] = [];
+    const accountInOriginal = original.match(/^tools cc run\s+(?!-)(\S+)/)?.[1];
+    const account = accountInOriginal ?? input.account;
+
+    if (!accountInOriginal && input.account) {
+        drift.push(
+            `account "${input.account}" added from the session pin journal — the original had none (it may have been picked interactively)`
+        );
+    }
+
+    const originalResume = original.match(/--resume(?:[= ]("[^"]*"|\S+))?/);
+    if (originalResume?.[1] && originalResume[1].replace(/"/g, "") !== input.sessionId) {
+        drift.push(`resume target "${originalResume[1]}" replaced with the session that was active here`);
+    } else if (!originalResume) {
+        drift.push(`-- --resume ${input.sessionId} added (session that was active in this pane)`);
+    } else if (originalResume && !originalResume[1]) {
+        drift.push(`bare --resume (interactive picker) replaced with the concrete session id`);
+    }
+
+    const command = account
+        ? `tools cc run ${account} -- --resume ${input.sessionId}`
+        : `tools cc run -- --resume ${input.sessionId}`;
+
+    if (!account) {
+        drift.push("no account recorded for this session — cc run will ask for one");
+    }
+
+    if (command !== original && drift.length === 0) {
+        drift.push("command rewritten to the deterministic pass-through resume form");
+    }
+
+    return { command, drift };
+}

--- a/src/cmux/lib/command-capture.ts
+++ b/src/cmux/lib/command-capture.ts
@@ -132,6 +132,33 @@ export interface ReplayDerivation {
 }
 
 const CLAUDE_LAUNCHER = /(^|\s)(tools cc run|tools claude run|claude)\b/;
+const CC_RUN_LAUNCHER = /(^|\s)tools (?:cc|claude) run\b/;
+
+/**
+ * Pin the resume target inside the original command without touching anything
+ * else — the launcher and every other flag (e.g. `--model`) stay as typed.
+ */
+function replaceResumeInPlace(original: string, sessionId: string): ReplayDerivation {
+    const drift: string[] = [];
+    const match = original.match(/--resume(?:[= ]("[^"]*"|\S+))?/);
+
+    if (!match) {
+        drift.push(`--resume ${sessionId} added (session that was active in this pane)`);
+        return { command: `${original} --resume ${sessionId}`, drift };
+    }
+
+    if (match[1]) {
+        if (match[1].replace(/"/g, "") === sessionId) {
+            return { command: original, drift };
+        }
+
+        drift.push(`resume target "${match[1]}" replaced with the session that was active here`);
+    } else {
+        drift.push(`bare --resume (interactive picker) replaced with the concrete session id`);
+    }
+
+    return { command: original.replace(match[0], `--resume ${sessionId}`), drift };
+}
 
 /**
  * Derive the replay command from the captured original plus what we know about
@@ -145,6 +172,12 @@ export function deriveReplayCommand(input: {
     const original = input.original.trim();
     if (!input.sessionId || !CLAUDE_LAUNCHER.test(original)) {
         return { command: original, drift: [] };
+    }
+
+    if (!CC_RUN_LAUNCHER.test(original)) {
+        // Bare `claude …` launchers keep their command verbatim (rebuilding as
+        // `tools cc run` would drop options and change the launcher the user ran).
+        return replaceResumeInPlace(original, input.sessionId);
     }
 
     const drift: string[] = [];

--- a/src/cmux/lib/command-capture.ts
+++ b/src/cmux/lib/command-capture.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { loadPins } from "@app/claude/lib/cmux/pins";
 import { loadAllSessionCmuxRefs } from "@app/claude/lib/cmux/session-refs";
+import { parseEtime } from "@app/macos/lib/swap/scanner";
 import { logger } from "@genesiscz/utils/logger";
 
 /**
@@ -29,23 +30,24 @@ function isShellOrLogin(command: string): boolean {
     return first === "/usr/bin/login" || base === "login";
 }
 
+// Interpolating homedir() into a fresh RegExp on every call recompiled it 10-60
+// times per capture. The home directory does not change while the process runs.
+const GROK_LOCAL_BIN_RE = new RegExp(`^${homedir()}/\\.local/bin/grok\\b`);
+
 /** Normalize an absolute launcher path back to what the user actually types. */
 export function cleanLaunchCommand(command: string): string {
     return command
         .replace(/^\S*\bbun (?:run )?\S*\/tools\s+/, "tools ")
-        .replace(new RegExp(`^${homedir()}/\\.local/bin/grok\\b`), "grok")
+        .replace(GROK_LOCAL_BIN_RE, "grok")
         .replace(/^\S*\/grok\b/, "grok")
         .trim();
 }
 
 /** `[[dd-]hh:]mm:ss` → seconds. Returns 0 for unparseable values. */
 export function etimeToSeconds(etime: string): number {
-    const match = etime.trim().match(/^(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)$/);
-    if (!match) {
-        return 0;
-    }
-    const [, days, hours, minutes, seconds] = match;
-    return Number(days ?? 0) * 86400 + Number(hours ?? 0) * 3600 + Number(minutes) * 60 + Number(seconds);
+    // parseEtime owns this format (same `ps -o etime=` output, same regex); it
+    // answers in milliseconds, and the tty scan compares ages in seconds.
+    return parseEtime(etime) / 1000;
 }
 
 /**

--- a/src/cmux/lib/format.ts
+++ b/src/cmux/lib/format.ts
@@ -152,3 +152,55 @@ function renderTable(rows: string[][]): string {
         )
         .join("\n");
 }
+
+/**
+ * Per-pane detail for restore/rescue plans: title, cwd, the command that will be
+ * replayed, and — when the command was enriched at save time — a diff against the
+ * captured original plus every drift note. Drifts are never hidden: the user must
+ * see what will be typed before it happens.
+ */
+export function renderProfileCommandDetail(profile: Profile): string[] {
+    const lines: string[] = [];
+
+    for (const window of profile.windows) {
+        for (const ws of window.workspaces) {
+            if (profile.windows.length > 1 || window.workspaces.length > 1) {
+                lines.push(pc.bold(`${ws.title}`));
+            }
+
+            for (const pane of ws.panes) {
+                pane.surfaces.forEach((surface, tabIndex) => {
+                    const tab = pane.surfaces.length > 1 ? ` tab ${tabIndex}` : "";
+                    lines.push(`  ${pc.cyan(`${pane.ref}${tab}`)}  ${surface.title || pc.dim("(untitled)")}`);
+
+                    if (surface.type === "browser") {
+                        lines.push(`      ${pc.dim(surface.url ?? "(browser)")}`);
+                        return;
+                    }
+
+                    if (surface.cwd) {
+                        lines.push(`      ${pc.dim(`cwd ${surface.cwd}`)}`);
+                    }
+
+                    if (!surface.command) {
+                        lines.push(`      ${pc.dim("(no command)")}`);
+                        return;
+                    }
+
+                    if (surface.command_original && surface.command_original !== surface.command) {
+                        lines.push(`      ${pc.red(`- ${surface.command_original}`)}`);
+                        lines.push(`      ${pc.green(`+ ${surface.command}`)}`);
+                    } else {
+                        lines.push(`      ${surface.command} ${pc.dim(`(${surface.command_source ?? "?"})`)}`);
+                    }
+
+                    for (const note of surface.drift ?? []) {
+                        lines.push(`      ${pc.yellow(`⚠ drift: ${note}`)}`);
+                    }
+                });
+            }
+        }
+    }
+
+    return lines;
+}

--- a/src/cmux/lib/offline-snapshot.test.ts
+++ b/src/cmux/lib/offline-snapshot.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import type { AutosaveWorkspace } from "@app/cmux/lib/autosave";
+import { flattenLayout } from "@app/cmux/lib/autosave";
+import { buildOfflinePanes } from "@app/cmux/lib/offline-snapshot";
+
+const FRAME = { x: 0, y: 0, width: 1000, height: 800 };
+
+function workspaceFixture(): AutosaveWorkspace {
+    return {
+        layout: {
+            type: "split",
+            split: {
+                orientation: "horizontal",
+                dividerPosition: 0.5,
+                first: { type: "pane", pane: { panelIds: ["a", "b", "c"], selectedPanelId: "b" } },
+                second: {
+                    type: "split",
+                    split: {
+                        orientation: "vertical",
+                        dividerPosition: 0.25,
+                        first: { type: "pane", pane: { panelIds: ["d"] } },
+                        second: { type: "pane", pane: { panelIds: ["e"], selectedPanelId: "e" } },
+                    },
+                },
+            },
+        },
+        panels: [
+            { id: "a", type: "terminal", title: "one", directory: "/tmp/one", ttyName: "ttys001" },
+            { id: "b", type: "terminal", title: "two", directory: "/tmp/two", ttyName: "ttys002" },
+            { id: "c", type: "browser", title: "docs" },
+            { id: "d", type: "terminal", title: "three", directory: "/tmp/three", ttyName: "ttys003" },
+            { id: "e", type: "terminal", title: "four", directory: "/tmp/four" },
+        ],
+    };
+}
+
+describe("flattenLayout", () => {
+    test("splits recursively into frames that tile the container", () => {
+        const ws = workspaceFixture();
+        const leaves = flattenLayout(ws.layout, FRAME);
+        expect(leaves.map((l) => l.panelIds)).toEqual([["a", "b", "c"], ["d"], ["e"]]);
+        expect(leaves[0].frame).toEqual({ x: 0, y: 0, width: 500, height: 800 });
+        expect(leaves[1].frame).toEqual({ x: 500, y: 0, width: 500, height: 200 });
+        expect(leaves[2].frame).toEqual({ x: 500, y: 200, width: 500, height: 600 });
+        const area = leaves.reduce((sum, l) => sum + l.frame.width * l.frame.height, 0);
+        expect(area).toBe(FRAME.width * FRAME.height);
+    });
+});
+
+describe("buildOfflinePanes", () => {
+    test("groups tabs per pane, keeps selection, joins commands via tty and enriches claude launchers", () => {
+        const ws = workspaceFixture();
+        const panes = buildOfflinePanes(ws, FRAME, {
+            ttyCommands: new Map([
+                ["ttys001", "tools cc run"],
+                ["ttys002", "vim notes.md"],
+                ["ttys003", "tools cc run work --resume old-name"],
+            ]),
+            surfaceSessions: new Map([
+                ["a", { sessionId: "11111111-aaaa-bbbb-cccc-222222222222", account: "work" }],
+                ["d", { sessionId: "33333333-aaaa-bbbb-cccc-444444444444", account: "work" }],
+            ]),
+        });
+
+        expect(panes).toHaveLength(3);
+        expect(panes[0].surfaces.map((s) => s.title)).toEqual(["one", "two", "docs"]);
+        expect(panes[0].selected_surface_index).toBe(1);
+        expect(panes[0].surfaces[2].type).toBe("browser");
+
+        const first = panes[0].surfaces[0];
+        expect(first.type).toBe("terminal");
+        if (first.type === "terminal") {
+            expect(first.command).toBe("tools cc run work -- --resume 11111111-aaaa-bbbb-cccc-222222222222");
+            expect(first.command_original).toBe("tools cc run");
+            expect(first.drift?.some((d) => d.includes("account"))).toBe(true);
+            expect(first.command_source).toBe("offline");
+        }
+
+        const second = panes[0].surfaces[1];
+        if (second.type === "terminal") {
+            expect(second.command).toBe("vim notes.md");
+            expect(second.command_original).toBeUndefined();
+            expect(second.drift).toBeUndefined();
+        }
+
+        const third = panes[1].surfaces[0];
+        if (third.type === "terminal") {
+            expect(third.command).toBe("tools cc run work -- --resume 33333333-aaaa-bbbb-cccc-444444444444");
+            expect(third.drift?.some((d) => d.includes("replaced"))).toBe(true);
+        }
+
+        const fourth = panes[2].surfaces[0];
+        if (fourth.type === "terminal") {
+            expect(fourth.command).toBeUndefined();
+            expect(fourth.cwd).toBe("/tmp/four");
+        }
+    });
+});

--- a/src/cmux/lib/offline-snapshot.ts
+++ b/src/cmux/lib/offline-snapshot.ts
@@ -1,0 +1,137 @@
+import {
+    type AutosaveSession,
+    type AutosaveWorkspace,
+    flattenLayout,
+    readAutosaveSession,
+} from "@app/cmux/lib/autosave";
+import {
+    collectTtyLaunchCommands,
+    deriveReplayCommand,
+    loadSurfaceSessions,
+    type SurfaceSessionInfo,
+} from "@app/cmux/lib/command-capture";
+import type { Pane, Profile, Surface, Window, Workspace } from "@app/cmux/lib/types";
+import { PROFILE_VERSION } from "@app/cmux/lib/types";
+import { logger } from "@genesiscz/utils/logger";
+
+/**
+ * Offline profile capture: builds a restorable profile WITHOUT the cmux socket,
+ * from the app's autosave file (layout tree, panels with cwd/title/tty) joined
+ * with the process table and the claude session journals. This is the rescue
+ * path for a UI-thread livelock, where every socket state command starves.
+ *
+ * Not captured offline: visible screen contents (needs `capture-pane`) and
+ * browser URLs. Both degrade gracefully on restore.
+ */
+
+const DEFAULT_CELL_WIDTH_PX = 8;
+const DEFAULT_CELL_HEIGHT_PX = 17;
+
+export interface OfflineCaptureDeps {
+    ttyCommands: Map<string, string>;
+    surfaceSessions: Map<string, SurfaceSessionInfo>;
+}
+
+export interface OfflineCaptureOptions {
+    name: string;
+    note?: string;
+}
+
+export async function captureOfflineProfile(options: OfflineCaptureOptions): Promise<Profile> {
+    const session = readAutosaveSession();
+    const [ttyCommands, surfaceSessions] = await Promise.all([collectTtyLaunchCommands(), loadSurfaceSessions()]);
+    return buildOfflineProfile(session, { ttyCommands, surfaceSessions }, options);
+}
+
+export function buildOfflineProfile(
+    session: AutosaveSession,
+    deps: OfflineCaptureDeps,
+    options: OfflineCaptureOptions
+): Profile {
+    const windows: Window[] = session.windows.map((window, windowIndex) => {
+        const frame = window.frame ?? { x: 0, y: 0, width: 1920, height: 1080 };
+        const selectedIndex = window.tabManager.selectedWorkspaceIndex ?? 0;
+
+        const workspaces: Workspace[] = window.tabManager.workspaces.map((ws, wsIndex) => ({
+            ref: `workspace:${wsIndex + 1}`,
+            title: ws.customTitle || ws.processTitle || `workspace ${wsIndex + 1}`,
+            selected: wsIndex === selectedIndex,
+            current_directory: ws.currentDirectory,
+            panes: buildOfflinePanes(ws, { x: 0, y: 0, width: frame.width, height: frame.height }, deps),
+        }));
+
+        return {
+            ref: `window:${windowIndex + 1}`,
+            title: `Window ${windowIndex + 1}`,
+            container_frame: { width: frame.width, height: frame.height },
+            workspaces,
+        };
+    });
+
+    return {
+        version: PROFILE_VERSION,
+        name: options.name,
+        scope: "all",
+        captured_at: new Date().toISOString(),
+        cmux_version: `offline (autosave ${new Date(session.savedAtMs).toISOString()})`,
+        note: options.note,
+        windows,
+    };
+}
+
+export function buildOfflinePanes(
+    workspace: AutosaveWorkspace,
+    frame: { x: number; y: number; width: number; height: number },
+    deps: OfflineCaptureDeps
+): Pane[] {
+    const panelMap = new Map(workspace.panels.map((panel) => [panel.id, panel]));
+    const leaves = flattenLayout(workspace.layout, frame);
+
+    return leaves.map((leaf, paneIndex) => {
+        const surfaces: Surface[] = [];
+        let selectedSurfaceIndex = 0;
+
+        for (const panelId of leaf.panelIds) {
+            const panel = panelMap.get(panelId);
+            if (!panel) {
+                logger.warn({ panelId }, "[offline-snapshot] layout references an unknown panel — skipped");
+                continue;
+            }
+
+            if (panelId === leaf.selectedPanelId) {
+                selectedSurfaceIndex = surfaces.length;
+            }
+
+            if (panel.type === "browser") {
+                surfaces.push({ type: "browser", title: panel.title ?? "" });
+                continue;
+            }
+
+            const original = panel.ttyName ? deps.ttyCommands.get(panel.ttyName) : undefined;
+            const session = deps.surfaceSessions.get(panel.id);
+            const derived = original
+                ? deriveReplayCommand({ original, sessionId: session?.sessionId, account: session?.account })
+                : undefined;
+
+            surfaces.push({
+                type: "terminal",
+                title: panel.title ?? "",
+                cwd: panel.directory,
+                command: derived?.command,
+                command_source: derived ? "offline" : undefined,
+                command_original: derived && derived.command !== original ? original : undefined,
+                drift: derived && derived.drift.length > 0 ? derived.drift : undefined,
+            });
+        }
+
+        return {
+            ref: `pane:${paneIndex + 1}`,
+            index: paneIndex,
+            columns: Math.max(20, Math.round(leaf.frame.width / DEFAULT_CELL_WIDTH_PX)),
+            rows: Math.max(5, Math.round(leaf.frame.height / DEFAULT_CELL_HEIGHT_PX)),
+            pixel_frame: leaf.frame,
+            selected_surface_index: selectedSurfaceIndex,
+            surfaces,
+        };
+    });
+}

--- a/src/cmux/lib/rescue.test.ts
+++ b/src/cmux/lib/rescue.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import { PROFILE_VERSION, type Profile } from "@app/cmux/lib/types";
+import { START_MS_TOLERANCE } from "@genesiscz/utils/process-identity";
 import { collectReplayEntries, isAlive, killApp, mayReplayIntoSurface, type RescueSystem } from "./rescue";
 
-/** Records every signal AND stays controllable, so escalation is observable without a real pid. */
-function fakeSystem(opts: { diesAfterSignals?: number } = {}) {
+/**
+ * Records every signal, every simulated sleep AND stays controllable, so the
+ * escalation and the grace window it waits through are both observable without
+ * a real pid.
+ */
+function fakeSystem(opts: { diesAfterSignals?: number; isCmux?: () => boolean; startMs?: () => number | null } = {}) {
     const signals: Array<number | string> = [];
+    const sleeps: number[] = [];
+    /** Sleeps that had already elapsed when the first SIGKILL was delivered. */
+    let sleepsBeforeKill = -1;
     let alive = true;
     let delivered = 0;
 
@@ -18,6 +26,10 @@ function fakeSystem(opts: { diesAfterSignals?: number } = {}) {
                 return;
             }
 
+            if (signal === "SIGKILL" && sleepsBeforeKill === -1) {
+                sleepsBeforeKill = sleeps.length;
+            }
+
             signals.push(signal);
             delivered += 1;
 
@@ -25,10 +37,14 @@ function fakeSystem(opts: { diesAfterSignals?: number } = {}) {
                 alive = false;
             }
         },
-        sleep: async () => {},
+        sleep: async (ms) => {
+            sleeps.push(ms);
+        },
+        isCmux: opts.isCmux ?? (() => true),
+        startMs: opts.startMs ?? (() => 1_000_000),
     };
 
-    return { sys, signals, isAlive: () => alive };
+    return { sys, signals, sleeps, isAlive: () => alive, sleepsBeforeKill: () => sleepsBeforeKill };
 }
 
 describe("killApp", () => {
@@ -42,13 +58,18 @@ describe("killApp", () => {
         expect(fake.signals).not.toContain("SIGKILL");
     });
 
-    test("escalates to SIGKILL only after the grace window", async () => {
+    test("escalates to SIGKILL only after the whole grace window has elapsed", async () => {
         const fake = fakeSystem({ diesAfterSignals: 2 });
 
         const outcome = await killApp(4242, { sys: fake.sys, graceMs: 5000 });
 
         expect(outcome.signals).toEqual(["SIGTERM", "SIGKILL"]);
         expect(outcome.exited).toBe(true);
+        // Asserting the signal ORDER alone would also pass for an implementation
+        // that sent SIGKILL immediately, which is the 5 s safety the docstring
+        // promises. So: ten 500 ms slices waited through before SIGKILL landed.
+        expect(fake.sleepsBeforeKill()).toBe(10);
+        expect(fake.sleeps.slice(0, 10)).toEqual(Array(10).fill(500));
     });
 
     test("a refused SIGTERM is reported, not thrown", async () => {
@@ -59,25 +80,155 @@ describe("killApp", () => {
                 }
             },
             sleep: async () => {},
+            isCmux: () => true,
+            startMs: () => 1_000_000,
         };
 
         const outcome = await killApp(4242, { sys, graceMs: 500 });
 
         expect(outcome.signals).toEqual(["SIGKILL"]);
     });
+
+    test("a pid that no longer identifies as cmux is never signalled", async () => {
+        const fake = fakeSystem({ isCmux: () => false });
+
+        const outcome = await killApp(4242, { sys: fake.sys, graceMs: 5000 });
+
+        expect(outcome.signals).toEqual([]);
+        expect(fake.signals).toEqual([]);
+        expect(outcome.exited).toBe(true);
+    });
+
+    test("a pid recycled DURING the grace window is not escalated to SIGKILL", async () => {
+        // The window that matters: SIGTERM lands on cmux, cmux dies, the kernel
+        // reissues the number, and the liveness probe now answers about a
+        // stranger. Without the identity re-check that stranger gets SIGKILLed.
+        let cmux = true;
+        const fake = fakeSystem({ isCmux: () => cmux });
+        const outcome = await killApp(4242, {
+            sys: fake.sys,
+            graceMs: 5000,
+            onStep: (message) => {
+                if (message.startsWith("Sending SIGTERM")) {
+                    cmux = false;
+                }
+            },
+        });
+
+        expect(outcome.signals).toEqual(["SIGTERM"]);
+        expect(fake.signals).not.toContain("SIGKILL");
+    });
+
+    test("a SECOND cmux on the reissued pid is not escalated to SIGKILL", async () => {
+        // The case the command-line check cannot see: the user relaunches cmux
+        // during the grace window and the kernel hands the new app the old pid.
+        // Both processes match the binary suffix, so only the start time differs.
+        let startMs = 1_000_000;
+        const fake = fakeSystem({ startMs: () => startMs });
+        const outcome = await killApp(4242, {
+            sys: fake.sys,
+            graceMs: 5000,
+            onStep: (message) => {
+                if (message.startsWith("Sending SIGTERM")) {
+                    startMs = 1_000_000 + START_MS_TOLERANCE + 1;
+                }
+            },
+        });
+
+        expect(outcome.signals).toEqual(["SIGTERM"]);
+        expect(fake.signals).not.toContain("SIGKILL");
+    });
+
+    test("a start time that drifts inside the ps rounding tolerance is still the same app", async () => {
+        // `ps -o etime=` has one-second granularity, so two readings of one live
+        // process differ. Treating that jitter as a recycled pid would refuse
+        // every real rescue.
+        let startMs = 1_000_000;
+        const fake = fakeSystem({ diesAfterSignals: 2, startMs: () => startMs });
+        const outcome = await killApp(4242, {
+            sys: fake.sys,
+            graceMs: 5000,
+            onStep: (message) => {
+                if (message.startsWith("Sending SIGTERM")) {
+                    startMs = 1_000_000 + START_MS_TOLERANCE - 1;
+                }
+            },
+        });
+
+        expect(outcome.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    });
+
+    test("a pid unreadable at baseline falls back to the command match alone", async () => {
+        // Without a baseline there is nothing to compare against, and refusing
+        // there would break the rescue on exactly the machines that need it.
+        const fake = fakeSystem({ diesAfterSignals: 2, startMs: () => null });
+
+        const outcome = await killApp(4242, { sys: fake.sys, graceMs: 5000 });
+
+        expect(outcome.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    });
+
+    test("a pid recycled after SIGKILL reports exited, not a surviving cmux", async () => {
+        // rescue.ts treats `exited: false` as fatal and refuses to relaunch. A
+        // stranger answering the final liveness probe would abort a rescue that
+        // actually killed cmux.
+        let cmux = true;
+        const fake = fakeSystem({ isCmux: () => cmux });
+        const outcome = await killApp(4242, {
+            sys: fake.sys,
+            graceMs: 500,
+            onStep: (message) => {
+                if (message.startsWith("Still alive")) {
+                    cmux = false;
+                }
+            },
+        });
+
+        // The fake never dies, so isAlive() still says "something is there".
+        expect(fake.isAlive()).toBe(true);
+        expect(outcome.signals).toEqual(["SIGTERM", "SIGKILL"]);
+        expect(outcome.exited).toBe(true);
+    });
 });
 
 describe("isAlive", () => {
+    const base = { sleep: async () => {}, isCmux: () => true, startMs: () => 1_000_000 };
+
     test("signal 0 succeeding means alive; ESRCH means gone", () => {
-        expect(isAlive(1, { kill: () => {}, sleep: async () => {} })).toBe(true);
+        expect(isAlive(1, { ...base, kill: () => {} })).toBe(true);
         expect(
             isAlive(1, {
+                ...base,
                 kill: () => {
-                    throw new Error("ESRCH");
+                    throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
                 },
-                sleep: async () => {},
             })
         ).toBe(false);
+    });
+
+    test("EPERM means the process EXISTS but is not ours to signal — alive", () => {
+        // Collapsing EPERM into "dead" made killApp report exited: true while
+        // cmux was still running, and rescue then relaunched and replayed into
+        // the live app.
+        expect(
+            isAlive(1, {
+                ...base,
+                kill: () => {
+                    throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+                },
+            })
+        ).toBe(true);
+    });
+
+    test("an unexpected probe failure is treated as alive, not as gone", () => {
+        expect(
+            isAlive(1, {
+                ...base,
+                kill: () => {
+                    throw new Error("something else entirely");
+                },
+            })
+        ).toBe(true);
     });
 });
 

--- a/src/cmux/lib/rescue.test.ts
+++ b/src/cmux/lib/rescue.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { PROFILE_VERSION, type Profile } from "@app/cmux/lib/types";
+import { collectReplayEntries, isAlive, killApp, mayReplayIntoSurface, type RescueSystem } from "./rescue";
+
+/** Records every signal AND stays controllable, so escalation is observable without a real pid. */
+function fakeSystem(opts: { diesAfterSignals?: number } = {}) {
+    const signals: Array<number | string> = [];
+    let alive = true;
+    let delivered = 0;
+
+    const sys: RescueSystem = {
+        kill: (_pid, signal) => {
+            if (signal === 0) {
+                if (!alive) {
+                    throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+                }
+
+                return;
+            }
+
+            signals.push(signal);
+            delivered += 1;
+
+            if (opts.diesAfterSignals !== undefined && delivered >= opts.diesAfterSignals) {
+                alive = false;
+            }
+        },
+        sleep: async () => {},
+    };
+
+    return { sys, signals, isAlive: () => alive };
+}
+
+describe("killApp", () => {
+    test("SIGTERM alone when the app exits during the grace window", async () => {
+        const fake = fakeSystem({ diesAfterSignals: 1 });
+
+        const outcome = await killApp(4242, { sys: fake.sys, graceMs: 5000 });
+
+        expect(outcome.signals).toEqual(["SIGTERM"]);
+        expect(outcome.exited).toBe(true);
+        expect(fake.signals).not.toContain("SIGKILL");
+    });
+
+    test("escalates to SIGKILL only after the grace window", async () => {
+        const fake = fakeSystem({ diesAfterSignals: 2 });
+
+        const outcome = await killApp(4242, { sys: fake.sys, graceMs: 5000 });
+
+        expect(outcome.signals).toEqual(["SIGTERM", "SIGKILL"]);
+        expect(outcome.exited).toBe(true);
+    });
+
+    test("a refused SIGTERM is reported, not thrown", async () => {
+        const sys: RescueSystem = {
+            kill: (_pid, signal) => {
+                if (signal === "SIGTERM") {
+                    throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+                }
+            },
+            sleep: async () => {},
+        };
+
+        const outcome = await killApp(4242, { sys, graceMs: 500 });
+
+        expect(outcome.signals).toEqual(["SIGKILL"]);
+    });
+});
+
+describe("isAlive", () => {
+    test("signal 0 succeeding means alive; ESRCH means gone", () => {
+        expect(isAlive(1, { kill: () => {}, sleep: async () => {} })).toBe(true);
+        expect(
+            isAlive(1, {
+                kill: () => {
+                    throw new Error("ESRCH");
+                },
+                sleep: async () => {},
+            })
+        ).toBe(false);
+    });
+});
+
+describe("mayReplayIntoSurface", () => {
+    test("a real title mismatch refuses the surface", () => {
+        // Positional replay into a renamed surface types a captured command into
+        // a different terminal than the reviewed plan showed.
+        expect(mayReplayIntoSurface({ title: "bun test" }, { title: "vim" })).toBe(false);
+        expect(mayReplayIntoSurface({ title: "bun test" }, { title: "bun test" })).toBe(true);
+    });
+
+    test("an unknown title on either side is not treated as a mismatch", () => {
+        expect(mayReplayIntoSurface({ title: undefined }, { title: "vim" })).toBe(true);
+        expect(mayReplayIntoSurface({ title: "bun test" }, { title: undefined })).toBe(true);
+    });
+});
+
+describe("collectReplayEntries", () => {
+    test("flattens windows → workspaces → panes → surfaces, keeping terminal commands only", () => {
+        // Typed, not `as never`: the cast would hide a Profile field rename.
+        const pane = {
+            ref: "pane:1",
+            index: 0,
+            columns: 80,
+            rows: 24,
+            pixel_frame: { x: 0, y: 0, width: 800, height: 600 },
+            selected_surface_index: 0,
+            surfaces: [
+                { title: "zsh", type: "terminal" as const, command: "bun run test" },
+                { title: "docs", type: "browser" as const },
+            ],
+        };
+        const profile: Profile = {
+            version: PROFILE_VERSION,
+            name: "rescue",
+            scope: "all",
+            captured_at: "2026-08-27T12:00:00.000Z",
+            cmux_version: "test",
+            windows: [
+                {
+                    ref: "window:1",
+                    title: "main",
+                    container_frame: { width: 1920, height: 1080 },
+                    workspaces: [{ ref: "workspace:1", title: "GenesisTools", selected: true, panes: [pane] }],
+                },
+            ],
+        };
+
+        const entries = collectReplayEntries(profile);
+
+        expect(entries).toHaveLength(2);
+        expect(entries[0]).toMatchObject({ workspaceIndex: 0, tabIndex: 0, command: "bun run test" });
+        expect(entries[1].command).toBeUndefined();
+    });
+});

--- a/src/cmux/lib/rescue.ts
+++ b/src/cmux/lib/rescue.ts
@@ -1,6 +1,8 @@
 import type { Profile } from "@app/cmux/lib/types";
+import { APP_BINARY_SUFFIX } from "@genesiscz/utils/cmux/lib/health";
 import { env } from "@genesiscz/utils/env";
 import { logger } from "@genesiscz/utils/logger";
+import { classifyPid, processStartMs, START_MS_TOLERANCE } from "@genesiscz/utils/process-identity";
 
 /**
  * Rescue workflow primitives, kept out of the command layer so the irreversible
@@ -12,14 +14,43 @@ import { logger } from "@genesiscz/utils/logger";
 export interface RescueSystem {
     kill(pid: number, signal: NodeJS.Signals | 0): void;
     sleep(ms: number): Promise<void>;
+    /**
+     * Does `pid` still name the cmux app? Re-asked immediately before every
+     * signal, because the pid arrives from a health probe that ran before the
+     * offline capture and the confirmation prompt, and the SIGKILL escalation
+     * fires a further 5 s after SIGTERM. Both are unbounded windows in which
+     * cmux can exit and the kernel can reissue the number to something else.
+     */
+    isCmux(pid: number): boolean;
+    /**
+     * When the process at `pid` started, in epoch ms, or null when the OS will
+     * not say. `isCmux` alone cannot separate the livelocked cmux from a SECOND
+     * cmux launched into the same reissued number: both match the binary
+     * suffix. The start time is the signal that does.
+     */
+    startMs(pid: number): number | null;
 }
 
 export const defaultRescueSystem: RescueSystem = {
-    // The caller passes probeCmuxHealth().appPid, which findCmuxApp() obtained by
-    // matching the process's own `comm` against cmux.app/Contents/MacOS/cmux.
-    // pid-verified: identity established by a live command match, not a file read.
+    // The marker has to sit on the line immediately above the signal, so keep the
+    // explanation short: killApp asks isCmux() right before each signal, and a pid
+    // that no longer matches the cmux binary is never signalled at all.
+    // pid-verified: isCmux() re-matched this pid's live `ps` command line first.
     kill: (pid, signal) => process.kill(pid, signal),
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    isCmux: (pid) => {
+        // "unverified" means the OS would not tell us the command line, not that
+        // the pid is wrong; refusing there would break the rescue on the machines
+        // that need it. Only a positive mismatch ("foreign") vetoes the signal.
+        const identity = classifyPid(pid, (command) => command.endsWith(APP_BINARY_SUFFIX));
+
+        if (identity.status === "foreign") {
+            logger.warn({ pid, command: identity.command }, "[rescue] pid was recycled onto another process");
+        }
+
+        return identity.status === "live" || identity.status === "unverified";
+    },
+    startMs: (pid) => processStartMs(pid),
 };
 
 export function isAlive(pid: number, sys: RescueSystem = defaultRescueSystem): boolean {
@@ -27,10 +58,20 @@ export function isAlive(pid: number, sys: RescueSystem = defaultRescueSystem): b
         sys.kill(pid, 0);
         return true;
     } catch (err) {
-        // ESRCH is the answer we asked for; anything else (EPERM) still means
-        // "not ours to signal", but is worth a trace rather than silence.
-        logger.debug({ err, pid }, "[rescue] liveness probe says gone");
-        return false;
+        const code = (err as { code?: string }).code;
+
+        // ESRCH is the ONLY answer that means gone. EPERM means the process
+        // exists but is not ours to signal, and an unexpected probe failure says
+        // nothing about liveness. Reporting either as dead would make killApp
+        // claim `exited: true` while cmux is still up, and rescue would then
+        // relaunch and replay into the live app.
+        if (code === "ESRCH") {
+            return false;
+        }
+
+        logger.debug({ err, pid, code }, "[rescue] liveness probe could not signal; treating the pid as alive");
+
+        return true;
     }
 }
 
@@ -53,6 +94,54 @@ export async function killApp(
     const step = opts.onStep ?? (() => {});
     const signals: NodeJS.Signals[] = [];
 
+    // Baseline taken once, before the first signal. A pid reissued to a SECOND
+    // cmux — the user relaunching the app while the confirmation prompt is up —
+    // matches the binary suffix just as well as the livelocked one, so the
+    // command line cannot tell them apart. The start time can.
+    const baselineStartMs = sys.startMs(pid);
+
+    /** Is this still the same process the health probe found? */
+    const isSameApp = (): boolean => {
+        if (!sys.isCmux(pid)) {
+            return false;
+        }
+
+        // Nothing readable at baseline means this machine never offers the
+        // signal (ps refused, or a platform without it), so the command match
+        // stands alone exactly as it did before.
+        if (baselineStartMs === null) {
+            return true;
+        }
+
+        const current = sys.startMs(pid);
+
+        // Readable then, unreadable now: something changed under us, and SIGKILL
+        // is unrecoverable. Fail closed — the caller tells the user to quit the
+        // app by hand, which costs a manual step and never the wrong process.
+        if (current === null) {
+            logger.warn({ pid }, "[rescue] pid start time became unreadable — refusing to signal");
+
+            return false;
+        }
+
+        if (Math.abs(current - baselineStartMs) > START_MS_TOLERANCE) {
+            logger.warn(
+                { pid, baselineStartMs, current },
+                "[rescue] pid was reissued to a different process with the same command"
+            );
+
+            return false;
+        }
+
+        return true;
+    };
+
+    if (!isSameApp()) {
+        step(`pid ${pid} is no longer the cmux the health probe found — sending nothing.`);
+
+        return { signals, exited: true };
+    }
+
     step(`Sending SIGTERM to cmux (pid ${pid})…`);
 
     try {
@@ -73,6 +162,16 @@ export async function killApp(
         }
     }
 
+    if (!isSameApp()) {
+        // Something at this pid is alive, but it is no longer the app we started
+        // on: it died during the grace window and the number was reissued —
+        // possibly to a fresh cmux. SIGKILL is unrecoverable, so the escalation
+        // stops rather than guessing.
+        step(`pid ${pid} was recycled onto another process — not escalating to SIGKILL.`);
+
+        return { signals, exited: true };
+    }
+
     step(`Still alive after ${graceMs / 1000} s — sending SIGKILL.`);
 
     try {
@@ -84,7 +183,11 @@ export async function killApp(
 
     await sys.sleep(1000);
 
-    return { signals, exited: !isAlive(pid, sys) };
+    // A pid reissued during that last second answers the liveness probe about a
+    // stranger. The caller treats `exited: false` as fatal and refuses to
+    // relaunch, so reading a stranger as "cmux survived" aborts a rescue that
+    // actually worked. Our app is gone either way.
+    return { signals, exited: !isAlive(pid, sys) || !isSameApp() };
 }
 
 /**

--- a/src/cmux/lib/rescue.ts
+++ b/src/cmux/lib/rescue.ts
@@ -1,0 +1,149 @@
+import type { Profile } from "@app/cmux/lib/types";
+import { env } from "@genesiscz/utils/env";
+import { logger } from "@genesiscz/utils/logger";
+
+/**
+ * Rescue workflow primitives, kept out of the command layer so the irreversible
+ * ones can be spied on. `killApp` reaches process.kill with SIGTERM and then
+ * SIGKILL, which is exactly the shape the repo's side-effects rule says must be
+ * testable independently of a Commander action.
+ */
+
+export interface RescueSystem {
+    kill(pid: number, signal: NodeJS.Signals | 0): void;
+    sleep(ms: number): Promise<void>;
+}
+
+export const defaultRescueSystem: RescueSystem = {
+    // The caller passes probeCmuxHealth().appPid, which findCmuxApp() obtained by
+    // matching the process's own `comm` against cmux.app/Contents/MacOS/cmux.
+    // pid-verified: identity established by a live command match, not a file read.
+    kill: (pid, signal) => process.kill(pid, signal),
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+export function isAlive(pid: number, sys: RescueSystem = defaultRescueSystem): boolean {
+    try {
+        sys.kill(pid, 0);
+        return true;
+    } catch (err) {
+        // ESRCH is the answer we asked for; anything else (EPERM) still means
+        // "not ours to signal", but is worth a trace rather than silence.
+        logger.debug({ err, pid }, "[rescue] liveness probe says gone");
+        return false;
+    }
+}
+
+export interface KillOutcome {
+    /** Signals actually delivered, in order. Empty when the process was already gone. */
+    signals: NodeJS.Signals[];
+    exited: boolean;
+}
+
+/**
+ * SIGTERM, wait up to 5 s, then SIGKILL. Returns what was actually sent so the
+ * caller can report it and a test can assert the escalation without a real pid.
+ */
+export async function killApp(
+    pid: number,
+    opts: { sys?: RescueSystem; graceMs?: number; onStep?: (message: string) => void } = {}
+): Promise<KillOutcome> {
+    const sys = opts.sys ?? defaultRescueSystem;
+    const graceMs = opts.graceMs ?? 5000;
+    const step = opts.onStep ?? (() => {});
+    const signals: NodeJS.Signals[] = [];
+
+    step(`Sending SIGTERM to cmux (pid ${pid})…`);
+
+    try {
+        sys.kill(pid, "SIGTERM");
+        signals.push("SIGTERM");
+    } catch (error) {
+        logger.warn({ error, pid }, "[rescue] SIGTERM failed");
+    }
+
+    const slices = Math.max(1, Math.round(graceMs / 500));
+
+    for (let i = 0; i < slices; i += 1) {
+        await sys.sleep(500);
+
+        if (!isAlive(pid, sys)) {
+            step("cmux terminated on SIGTERM.");
+            return { signals, exited: true };
+        }
+    }
+
+    step(`Still alive after ${graceMs / 1000} s — sending SIGKILL.`);
+
+    try {
+        sys.kill(pid, "SIGKILL");
+        signals.push("SIGKILL");
+    } catch (error) {
+        logger.warn({ error, pid }, "[rescue] SIGKILL failed");
+    }
+
+    await sys.sleep(1000);
+
+    return { signals, exited: !isAlive(pid, sys) };
+}
+
+/**
+ * `open` forwards its ENTIRE environment to the launched app, and every pane's
+ * login shell inherits it. Launched from an agent session that would propagate
+ * CLAUDECODE/CLAUDE_CODE_* markers and silently disable transcript saving in
+ * every resumed claude — so the relaunch runs with a minimal clean environment.
+ */
+export function cleanRelaunchEnv(): Record<string, string> {
+    const user = env.device.getUser() ?? "";
+
+    return {
+        HOME: env.paths.getHome(),
+        USER: user,
+        LOGNAME: env.device.getLogname() ?? user,
+        PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+    };
+}
+
+export interface ReplayEntry {
+    workspaceIndex: number;
+    workspaceTitle: string;
+    paneRef: string;
+    tabIndex: number;
+    title: string;
+    command?: string;
+}
+
+export function collectReplayEntries(profile: Profile): ReplayEntry[] {
+    const entries: ReplayEntry[] = [];
+    let workspaceIndex = 0;
+
+    for (const window of profile.windows) {
+        for (const ws of window.workspaces) {
+            for (const pane of ws.panes) {
+                pane.surfaces.forEach((surface, tabIndex) => {
+                    entries.push({
+                        workspaceIndex,
+                        workspaceTitle: ws.title,
+                        paneRef: pane.ref,
+                        tabIndex,
+                        title: surface.title,
+                        command: surface.type === "terminal" ? surface.command : undefined,
+                    });
+                });
+            }
+
+            workspaceIndex += 1;
+        }
+    }
+
+    return entries;
+}
+
+/**
+ * A saved surface may only be typed into when the reopened one is the same
+ * surface. Titles derive from the running command, so a mismatch means the
+ * layout moved and positional replay would type into a different terminal.
+ */
+export function mayReplayIntoSurface(saved: { title?: string }, live: { title?: string }): boolean {
+    return !live.title || !saved.title || live.title === saved.title;
+}

--- a/src/cmux/lib/restore.prompts.test.ts
+++ b/src/cmux/lib/restore.prompts.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { detectInteractivePrompt } from "@app/cmux/lib/restore";
+
+describe("detectInteractivePrompt", () => {
+    test("recognizes the cc-run account headroom gate", () => {
+        const screen = "⚠ Fable weekly on \"work\" is spent.\n◆ Launch anyway? (No cancels so you can pick another account)\n● Yes / ○ No";
+        expect(detectInteractivePrompt(screen)).toContain("account-headroom");
+    });
+
+    test("recognizes claude's resume-mode dialog", () => {
+        const screen = "1. Resume from summary (recommended)\n2. Resume full session as-is\n3. Don't ask me again";
+        expect(detectInteractivePrompt(screen)).toContain("resume-mode");
+    });
+
+    test("recognizes the session picker and warns about verification", () => {
+        const screen = "Select session to resume: matching \"burn\"\n  NAME    BRANCH   AGE\n❯ one     develop  22m";
+        expect(detectInteractivePrompt(screen)).toContain("verify the highlighted session");
+    });
+
+    test("returns undefined for a busy claude pane", () => {
+        const screen = "✳ Cooking… (2m 3s · ↓ 1.2k tokens)\n  ⏵⏵ bypass permissions on";
+        expect(detectInteractivePrompt(screen)).toBeUndefined();
+    });
+});

--- a/src/cmux/lib/restore.prompts.test.ts
+++ b/src/cmux/lib/restore.prompts.test.ts
@@ -3,7 +3,8 @@ import { detectInteractivePrompt } from "@app/cmux/lib/restore";
 
 describe("detectInteractivePrompt", () => {
     test("recognizes the cc-run account headroom gate", () => {
-        const screen = "⚠ Fable weekly on \"work\" is spent.\n◆ Launch anyway? (No cancels so you can pick another account)\n● Yes / ○ No";
+        const screen =
+            '⚠ Fable weekly on "work" is spent.\n◆ Launch anyway? (No cancels so you can pick another account)\n● Yes / ○ No';
         expect(detectInteractivePrompt(screen)).toContain("account-headroom");
     });
 
@@ -13,7 +14,7 @@ describe("detectInteractivePrompt", () => {
     });
 
     test("recognizes the session picker and warns about verification", () => {
-        const screen = "Select session to resume: matching \"burn\"\n  NAME    BRANCH   AGE\n❯ one     develop  22m";
+        const screen = 'Select session to resume: matching "burn"\n  NAME    BRANCH   AGE\n❯ one     develop  22m';
         expect(detectInteractivePrompt(screen)).toContain("verify the highlighted session");
     });
 

--- a/src/cmux/lib/restore.prompts.test.ts
+++ b/src/cmux/lib/restore.prompts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { detectInteractivePrompt } from "@app/cmux/lib/restore";
+import { detectInteractivePrompt, formatWaitingPanes } from "@app/cmux/lib/restore";
+import { stripAnsi } from "@genesiscz/utils/string";
 
 describe("detectInteractivePrompt", () => {
     test("recognizes the cc-run account headroom gate", () => {
@@ -21,5 +22,32 @@ describe("detectInteractivePrompt", () => {
     test("returns undefined for a busy claude pane", () => {
         const screen = "✳ Cooking… (2m 3s · ↓ 1.2k tokens)\n  ⏵⏵ bypass permissions on";
         expect(detectInteractivePrompt(screen)).toBeUndefined();
+    });
+});
+
+describe("formatWaitingPanes", () => {
+    const waiting = [
+        { workspaceRef: "ws-1", surfaceRef: "surf-1", prompt: "account-headroom gate" },
+        { workspaceRef: "ws-2", surfaceRef: "surf-2", prompt: "resume-mode dialog" },
+    ];
+
+    test("one line per waiting pane, then the advice line", () => {
+        const lines = formatWaitingPanes(waiting, "Rescue").map(stripAnsi);
+
+        expect(lines).toEqual([
+            "  ⚠ ws-1 surf-1 — account-headroom gate",
+            "  ⚠ ws-2 surf-2 — resume-mode dialog",
+            "  Rescue does not auto-confirm these; answer each pane yourself.",
+        ]);
+    });
+
+    test("the actor is the ONLY difference between the two callers", () => {
+        // Rescue and restore each kept their own copy of this block, one word
+        // apart, so a fix to either never reached the other.
+        const rescue = formatWaitingPanes(waiting, "Rescue").map(stripAnsi);
+        const restore = formatWaitingPanes(waiting, "Restore").map(stripAnsi);
+
+        expect(restore.slice(0, -1)).toEqual(rescue.slice(0, -1));
+        expect(restore.at(-1)).toBe("  Restore does not auto-confirm these; answer each pane yourself.");
     });
 });

--- a/src/cmux/lib/restore.ts
+++ b/src/cmux/lib/restore.ts
@@ -1,3 +1,4 @@
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Pane, Profile, Surface, Workspace } from "@app/cmux/lib/types";
@@ -411,14 +412,18 @@ async function replayTerminal(
     if (surface.cwd) {
         parts.push(`cd -- ${shellQuote(surface.cwd)} 2>/dev/null`);
     }
+    // The screen text can hold tokens and private output, so it goes into a fresh
+    // 0700 mkdtemp dir (unpredictable path, unreadable by other local users). The
+    // replayed pipeline itself deletes the dir right after the cat — the pane's
+    // shell is the only consumer, so that is the earliest race-free moment.
+    let screenDir: string | undefined;
     if (surface.screen?.text) {
-        const screenFile = join(
-            tmpdir(),
-            `cmux-restore-screen-${process.pid}-${surfaceRef.replace(/[^A-Za-z0-9]/g, "-")}.txt`
-        );
+        screenDir = await mkdtemp(join(tmpdir(), "cmux-restore-screen-"));
+        const screenFile = join(screenDir, `${surfaceRef.replace(/[^A-Za-z0-9]/g, "-")}.txt`);
         await Bun.write(screenFile, surface.screen.text);
         parts.push("printf '\\033[2J\\033[3J\\033[H'");
         parts.push(`cat -- ${shellQuote(screenFile)}`);
+        parts.push(`rm -rf -- ${shellQuote(screenDir)}`);
     }
     let payload = parts.length > 0 ? `${parts.join("; ")}\n` : "";
     if (surface.command && surface.command_source && surface.command_source !== "none") {
@@ -427,5 +432,17 @@ async function replayTerminal(
     if (!payload) {
         return;
     }
-    await runCmuxOk(["send", "--workspace", workspaceRef, "--surface", surfaceRef, payload]);
+
+    try {
+        await runCmuxOk(["send", "--workspace", workspaceRef, "--surface", surfaceRef, payload]);
+    } catch (error) {
+        if (screenDir) {
+            // The pipeline never reached the pane, so nothing will consume the file.
+            await rm(screenDir, { recursive: true, force: true }).catch((cleanupError) => {
+                logger.debug({ error: cleanupError, dir: screenDir }, "[restore] screen temp cleanup failed");
+            });
+        }
+
+        throw error;
+    }
 }

--- a/src/cmux/lib/restore.ts
+++ b/src/cmux/lib/restore.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Pane, Profile, Surface, Workspace } from "@app/cmux/lib/types";
 import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
 import { withFocusedWorkspace } from "@genesiscz/utils/cmux/lib/focus-guard";
@@ -12,6 +14,8 @@ const EDGE_TOLERANCE_PX = 2;
 export interface RestoreOptions {
     prefix: string;
     replay: boolean;
+    /** Also press Enter after typing the replayed command, so it executes immediately. */
+    enter: boolean;
     yes: boolean;
     dryRun: boolean;
 }
@@ -246,6 +250,46 @@ async function populatePane(
         surfaceRefs.push(created.surface_ref);
     }
 
+    // cmux inserts each new tab immediately after the anchor, which reverses the tail
+    // order for multi-tab panes. Put every surface back at its saved index, then land
+    // the pane's selection on the saved active tab.
+    if (expectedCount > 1) {
+        for (let i = 0; i < surfaceRefs.length; i += 1) {
+            await runCmuxOk([
+                "reorder-surface",
+                "--workspace",
+                workspaceRef,
+                "--surface",
+                surfaceRefs[i],
+                "--index",
+                String(i),
+                "--focus",
+                "false",
+            ]).catch((error) => {
+                logger.debug({ error, surfaceRef: surfaceRefs[i] }, "[restore] reorder-surface failed");
+            });
+        }
+    }
+
+    // cmux leaves the last-created tab selected, so the saved selection must be
+    // restored explicitly even when it is the first tab.
+    const selectedIndex = savedPane.selected_surface_index;
+    if (surfaceRefs.length > 1 && selectedIndex >= 0 && selectedIndex < surfaceRefs.length) {
+        await runCmuxOk([
+            "reorder-surface",
+            "--workspace",
+            workspaceRef,
+            "--surface",
+            surfaceRefs[selectedIndex],
+            "--index",
+            String(selectedIndex),
+            "--focus",
+            "true",
+        ]).catch((error) => {
+            logger.debug({ error, selectedIndex }, "[restore] selecting saved tab failed");
+        });
+    }
+
     // Rename + replay
     for (let i = 0; i < expectedCount; i += 1) {
         const savedSurface = savedPane.surfaces[i];
@@ -272,6 +316,65 @@ function shellQuote(path: string): string {
     return `'${path.replace(/'/g, "'\\''")}'`;
 }
 
+/**
+ * Interactive prompts a replayed command can stop at. Restore NEVER answers these
+ * (Martin's rule: type the command + Enter, nothing more) — it only reports which
+ * panes are waiting so the user confirms each one deliberately.
+ */
+const INTERACTIVE_PROMPT_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+    { pattern: /Launch anyway\?/, label: "account-headroom gate (weekly limit spent — Launch anyway?)" },
+    { pattern: /Resume full session as-is/, label: "resume-mode dialog (summary vs full session)" },
+    { pattern: /NAME\s+BRANCH\s+AGE/, label: "session picker (verify the highlighted session before Enter!)" },
+    { pattern: /Select session to resume/, label: "session picker (verify the highlighted session before Enter!)" },
+];
+
+export function detectInteractivePrompt(screenText: string): string | undefined {
+    for (const { pattern, label } of INTERACTIVE_PROMPT_PATTERNS) {
+        if (pattern.test(screenText)) {
+            return label;
+        }
+    }
+
+    return undefined;
+}
+
+export interface WaitingPane {
+    workspaceRef: string;
+    surfaceRef: string;
+    title: string;
+    prompt: string;
+}
+
+/** Scan the restored workspaces for panes stopped at an interactive prompt. Read-only. */
+export async function scanForInteractivePrompts(workspaceRefs: string[]): Promise<WaitingPane[]> {
+    const waiting: WaitingPane[] = [];
+
+    for (const workspaceRef of workspaceRefs) {
+        const layout = await paneList(workspaceRef);
+        for (const pane of layout.panes) {
+            for (const surfaceRef of pane.surface_refs) {
+                const result = await runCmuxOk([
+                    "read-screen",
+                    "--workspace",
+                    workspaceRef,
+                    "--surface",
+                    surfaceRef,
+                ]).catch(() => undefined);
+                if (!result) {
+                    continue;
+                }
+
+                const prompt = detectInteractivePrompt(result.stdout);
+                if (prompt) {
+                    waiting.push({ workspaceRef, surfaceRef, title: "", prompt });
+                }
+            }
+        }
+    }
+
+    return waiting;
+}
+
 async function replayTerminal(
     surface: Surface & { type: "terminal" },
     workspaceRef: string,
@@ -296,8 +399,11 @@ async function replayTerminal(
     //   1. cd's to the saved cwd (silently — failures don't abort)
     //   2. clears the screen AND scrollback (\033[2J\033[3J\033[H), erasing both the
     //      shell's startup banner and the typed-input echo of this very command
-    //   3. base64-decodes the saved screen contents to stdout, faithfully reproducing
-    //      what the pane looked like when the profile was saved
+    //   3. cats the saved screen contents from a temp file, faithfully reproducing
+    //      what the pane looked like when the profile was saved. The content goes
+    //      through a file, NOT inline base64 — a full pane screen inlined into one
+    //      typed line exceeds the pty input limit and the shell echoes the mangled
+    //      command as garbage instead of executing it.
     // Then, after the trailing newline, the saved last-typed command is sent (without
     // a newline) so it sits queued at the fresh prompt for the user to confirm — this
     // is what re-launches `claude --resume <id>`, `vim file`, etc.
@@ -306,13 +412,17 @@ async function replayTerminal(
         parts.push(`cd -- ${shellQuote(surface.cwd)} 2>/dev/null`);
     }
     if (surface.screen?.text) {
-        const b64 = Buffer.from(surface.screen.text, "utf8").toString("base64");
+        const screenFile = join(
+            tmpdir(),
+            `cmux-restore-screen-${process.pid}-${surfaceRef.replace(/[^A-Za-z0-9]/g, "-")}.txt`
+        );
+        await Bun.write(screenFile, surface.screen.text);
         parts.push("printf '\\033[2J\\033[3J\\033[H'");
-        parts.push(`printf %s '${b64}' | base64 -d`);
+        parts.push(`cat -- ${shellQuote(screenFile)}`);
     }
     let payload = parts.length > 0 ? `${parts.join("; ")}\n` : "";
     if (surface.command && surface.command_source && surface.command_source !== "none") {
-        payload += surface.command;
+        payload += opts.enter ? `${surface.command}\n` : surface.command;
     }
     if (!payload) {
         return;

--- a/src/cmux/lib/restore.ts
+++ b/src/cmux/lib/restore.ts
@@ -2,11 +2,13 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Pane, Profile, Surface, Workspace } from "@app/cmux/lib/types";
+import * as p from "@clack/prompts";
 import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
 import { withFocusedWorkspace } from "@genesiscz/utils/cmux/lib/focus-guard";
 import { paneList, workspaceCreate } from "@genesiscz/utils/cmux/lib/socket";
 import { applySplitTree, measureCellDelta, type SplitTree } from "@genesiscz/utils/cmux/split-tree";
 import { logger } from "@genesiscz/utils/logger";
+import pc from "picocolors";
 
 export type { SplitTree };
 
@@ -254,41 +256,34 @@ async function populatePane(
     // cmux inserts each new tab immediately after the anchor, which reverses the tail
     // order for multi-tab panes. Put every surface back at its saved index, then land
     // the pane's selection on the saved active tab.
+    const reorder = async (surfaceRef: string, index: number, focus: boolean): Promise<void> => {
+        await runCmuxOk([
+            "reorder-surface",
+            "--workspace",
+            workspaceRef,
+            "--surface",
+            surfaceRef,
+            "--index",
+            String(index),
+            "--focus",
+            String(focus),
+        ]).catch((error) => {
+            logger.debug({ error, surfaceRef, index, focus }, "[restore] reorder-surface failed");
+        });
+    };
+
     if (expectedCount > 1) {
         for (let i = 0; i < surfaceRefs.length; i += 1) {
-            await runCmuxOk([
-                "reorder-surface",
-                "--workspace",
-                workspaceRef,
-                "--surface",
-                surfaceRefs[i],
-                "--index",
-                String(i),
-                "--focus",
-                "false",
-            ]).catch((error) => {
-                logger.debug({ error, surfaceRef: surfaceRefs[i] }, "[restore] reorder-surface failed");
-            });
+            await reorder(surfaceRefs[i], i, false);
         }
     }
 
     // cmux leaves the last-created tab selected, so the saved selection must be
     // restored explicitly even when it is the first tab.
     const selectedIndex = savedPane.selected_surface_index;
+
     if (surfaceRefs.length > 1 && selectedIndex >= 0 && selectedIndex < surfaceRefs.length) {
-        await runCmuxOk([
-            "reorder-surface",
-            "--workspace",
-            workspaceRef,
-            "--surface",
-            surfaceRefs[selectedIndex],
-            "--index",
-            String(selectedIndex),
-            "--focus",
-            "true",
-        ]).catch((error) => {
-            logger.debug({ error, selectedIndex }, "[restore] selecting saved tab failed");
-        });
+        await reorder(surfaceRefs[selectedIndex], selectedIndex, true);
     }
 
     // Rename + replay
@@ -342,7 +337,6 @@ export function detectInteractivePrompt(screenText: string): string | undefined 
 export interface WaitingPane {
     workspaceRef: string;
     surfaceRef: string;
-    title: string;
     prompt: string;
 }
 
@@ -367,13 +361,52 @@ export async function scanForInteractivePrompts(workspaceRefs: string[]): Promis
 
                 const prompt = detectInteractivePrompt(result.stdout);
                 if (prompt) {
-                    waiting.push({ workspaceRef, surfaceRef, title: "", prompt });
+                    waiting.push({ workspaceRef, surfaceRef, prompt });
                 }
             }
         }
     }
 
     return waiting;
+}
+
+/**
+ * Report the panes a run left sitting at an interactive prompt. Neither rescue
+ * nor restore ever answers one: confirming an account-headroom gate or a session
+ * picker on the user's behalf is exactly the automation this tool refuses.
+ *
+ * `actor` only names the caller in the advice line — the scan is identical, and
+ * having two copies of it meant a fix to one never reached the other.
+ */
+export async function reportWaitingPrompts(workspaceRefs: string[], actor: "Rescue" | "Restore"): Promise<void> {
+    // The replayed commands need a moment to draw whatever they are going to ask.
+    await new Promise((resolve) => setTimeout(resolve, 4000));
+
+    let waiting: WaitingPane[];
+    try {
+        waiting = await scanForInteractivePrompts(workspaceRefs);
+    } catch (error) {
+        // Reporting "nothing is waiting" here would be a lie: the scan never ran.
+        logger.debug({ error, actor }, "[cmux] waiting-prompt scan failed");
+
+        return;
+    }
+
+    if (waiting.length === 0) {
+        p.log.info("No panes are waiting at an interactive prompt.");
+
+        return;
+    }
+
+    p.note(formatWaitingPanes(waiting, actor).join("\n"), "Panes waiting for you");
+}
+
+/** The note body: one line per waiting pane, then the advice line. Pure, so it is testable. */
+export function formatWaitingPanes(waiting: WaitingPane[], actor: "Rescue" | "Restore"): string[] {
+    const lines = waiting.map((w) => `  ${pc.yellow("⚠")} ${w.workspaceRef} ${w.surfaceRef} — ${w.prompt}`);
+    lines.push(pc.dim(`  ${actor} does not auto-confirm these; answer each pane yourself.`));
+
+    return lines;
 }
 
 async function replayTerminal(

--- a/src/cmux/lib/snapshot.ts
+++ b/src/cmux/lib/snapshot.ts
@@ -1,3 +1,10 @@
+import { panelsById, readAutosaveSession } from "@app/cmux/lib/autosave";
+import {
+    collectTtyLaunchCommands,
+    deriveReplayCommand,
+    loadSurfaceSessions,
+    type SurfaceSessionInfo,
+} from "@app/cmux/lib/command-capture";
 import { captureSurfaceState, cwdFromTitle } from "@app/cmux/lib/shell-probe";
 import type { Pane, Profile, ProfileScope, Surface, Window, Workspace } from "@app/cmux/lib/types";
 import { PROFILE_VERSION } from "@app/cmux/lib/types";
@@ -16,12 +23,43 @@ import { logger } from "@genesiscz/utils/logger";
 
 interface SurfaceListEntry {
     ref: string;
+    /** Surface UUID (== CMUX_SURFACE_ID == autosave panel id); present with --id-format both. */
+    id?: string;
     type: "terminal" | "browser";
     title?: string;
     /** Position within the parent pane (0..N-1). Field name is `index` in the CLI's list-pane-surfaces output. */
     index: number;
     /** True when this surface is the active tab of its pane. CLI calls this `selected`. */
     selected?: boolean;
+}
+
+/**
+ * Joined side-channels for command capture: the process table (foreground command
+ * per tty), cmux's autosave (surface uuid → tty), and the claude session journals
+ * (surface uuid → session id + account). All readable without the cmux socket.
+ */
+interface CommandCaptureContext {
+    ttyCommands: Map<string, string>;
+    panelTty: Map<string, string>;
+    surfaceSessions: Map<string, SurfaceSessionInfo>;
+}
+
+export async function buildCommandCaptureContext(): Promise<CommandCaptureContext> {
+    const [ttyCommands, surfaceSessions] = await Promise.all([collectTtyLaunchCommands(), loadSurfaceSessions()]);
+
+    const panelTty = new Map<string, string>();
+    try {
+        const session = readAutosaveSession();
+        for (const [id, panel] of panelsById(session)) {
+            if (panel.ttyName) {
+                panelTty.set(id, panel.ttyName);
+            }
+        }
+    } catch (error) {
+        logger.debug({ error }, "[snapshot] autosave unavailable — foreground command capture degraded");
+    }
+
+    return { ttyCommands, panelTty, surfaceSessions };
 }
 
 interface ListPaneSurfacesResponse {
@@ -57,6 +95,7 @@ export async function captureProfile(options: SnapshotOptions, progress: Snapsho
     const allWorkspaces = await collectAllWorkspaces(allWindows);
 
     const ctx = await getIdentifyContext();
+    const capture = options.captureHistory ? await buildCommandCaptureContext() : undefined;
     const targetWorkspaces = filterWorkspaces(allWorkspaces, options, ctx.focusedWorkspaceRef);
     const targetWindowRefs = new Set(targetWorkspaces.map((ws) => ws.window_ref));
     const targetWindows = allWindows.filter((w) => targetWindowRefs.has(w.ref));
@@ -82,7 +121,7 @@ export async function captureProfile(options: SnapshotOptions, progress: Snapsho
             });
 
             const captured = await withFocusedWorkspace(ws.ref, async () => {
-                const panes = await capturePanes(ws.ref, options, ctx.callerSurfaceRef);
+                const panes = await capturePanes(ws.ref, options, ctx.callerSurfaceRef, capture);
                 const fresh = await paneList(ws.ref);
                 return { panes, container: fresh.container_frame };
             });
@@ -199,13 +238,16 @@ function cellSizeOf(panes: PaneListPane[], field: "cell_width_px" | "cell_height
 async function capturePanes(
     workspaceRef: string,
     options: SnapshotOptions,
-    callerSurfaceRef: string | undefined
+    callerSurfaceRef: string | undefined,
+    capture: CommandCaptureContext | undefined
 ): Promise<Pane[]> {
     const layout = await paneList(workspaceRef);
     const panes: Pane[] = [];
 
     for (const paneInfo of layout.panes) {
         const surfacesInfo = await runCmuxJSON<ListPaneSurfacesResponse>([
+            "--id-format",
+            "both",
             "list-pane-surfaces",
             "--workspace",
             workspaceRef,
@@ -220,7 +262,7 @@ async function capturePanes(
             if (surfaceEntry.selected) {
                 selectedIndex = surfaces.length;
             }
-            surfaces.push(await captureSurface(surfaceEntry, workspaceRef, options, callerSurfaceRef));
+            surfaces.push(await captureSurface(surfaceEntry, workspaceRef, options, callerSurfaceRef, capture));
         }
 
         // A pane cmux has not rendered reports no cell geometry, only pixels. The saved
@@ -262,7 +304,8 @@ async function captureSurface(
     entry: SurfaceListEntry,
     workspaceRef: string,
     options: SnapshotOptions,
-    callerSurfaceRef: string | undefined
+    callerSurfaceRef: string | undefined,
+    capture: CommandCaptureContext | undefined
 ): Promise<Surface> {
     const title = entry.title ?? "";
     if (entry.type === "browser") {
@@ -284,13 +327,28 @@ async function captureSurface(
         history: options.captureHistory,
     });
 
+    // The foreground process on the pane's tty beats scrollback parsing: a pane
+    // running a fullscreen TUI (claude, grok, vim) shows no shell prompt to parse,
+    // but its launch command is right there in the process table.
+    const tty = capture && entry.id ? capture.panelTty.get(entry.id) : undefined;
+    const foreground = tty ? capture?.ttyCommands.get(tty) : undefined;
+    const original = foreground ?? captured.command.value;
+    const session = capture && entry.id ? capture.surfaceSessions.get(entry.id) : undefined;
+
+    if (!original) {
+        return { type: "terminal", title, cwd, screen: captured.screen };
+    }
+
+    const derived = deriveReplayCommand({ original, sessionId: session?.sessionId, account: session?.account });
     return {
         type: "terminal",
         title,
         cwd,
         screen: captured.screen,
-        command: captured.command.value,
-        command_source: captured.command.value ? captured.command.source : undefined,
+        command: derived.command,
+        command_source: foreground ? "foreground" : captured.command.source,
+        command_original: derived.command !== original ? original : undefined,
+        drift: derived.drift.length > 0 ? derived.drift : undefined,
     };
 }
 

--- a/src/cmux/lib/types.ts
+++ b/src/cmux/lib/types.ts
@@ -2,7 +2,7 @@ export const PROFILE_VERSION = 1;
 
 export type ProfileScope = "all" | "window" | "workspace";
 
-export type CommandSource = "scrollback" | "manual" | "none";
+export type CommandSource = "scrollback" | "foreground" | "offline" | "manual" | "none";
 
 export interface ScreenSnapshot {
     /** Raw rendered text returned by `cmux capture-pane` at save time. ANSI-stripped. */
@@ -41,6 +41,16 @@ export interface TerminalSurface {
      */
     command?: string;
     command_source?: CommandSource;
+    /**
+     * The command as originally captured, before any enrichment (account added,
+     * `-- --resume <sessionId>` appended). Present only when `command` differs.
+     */
+    command_original?: string;
+    /**
+     * Human-readable notes for every difference between command_original and command.
+     * Restore prints these as a per-pane drift diff and never hides them.
+     */
+    drift?: string[];
 }
 
 export interface BrowserSurface {

--- a/src/utils/cmux/lib/cli.timeout.test.ts
+++ b/src/utils/cmux/lib/cli.timeout.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CMUX_TIMEOUT_MS, runCmux, runCmuxJSON, runCmuxOk } from "./cli";
+
+/**
+ * Regression test: `runCmux` gained a kill + SIGKILL escalation behind an opt-in
+ * `timeoutMs`, but the two wrappers every consumer actually uses — runCmuxJSON
+ * and runCmuxOk — neither accepted nor forwarded it. 37 awaited calls across 15
+ * files could not pass one, so a wedged cmux hung them forever. On a branch
+ * whose whole subject is cmux livelock, the safety belonged in the default.
+ */
+function fakeCmuxOnPath(script: string): void {
+    const dir = mkdtempSync(join(tmpdir(), "fake-cmux-"));
+    const bin = join(dir, "cmux");
+    writeFileSync(bin, script);
+    chmodSync(bin, 0o755);
+    process.env.PATH = `${dir}:${process.env.PATH}`;
+}
+
+describe("runCmux timeout", () => {
+    test("a hung invocation is killed rather than awaited forever", async () => {
+        fakeCmuxOnPath("#!/bin/sh\nsleep 30\n");
+
+        const started = Date.now();
+        const result = await runCmux(["anything"], { timeoutMs: 300 });
+        const elapsed = Date.now() - started;
+
+        expect(result.timedOut).toBe(true);
+        // Generous bound: the point is that it returns at all, not that it is fast.
+        expect(elapsed).toBeLessThan(10_000);
+    });
+
+    test("the wrappers forward the option, so every caller can bound its own call", async () => {
+        fakeCmuxOnPath("#!/bin/sh\nsleep 30\n");
+
+        await expect(runCmuxOk(["anything"], { timeoutMs: 300 })).rejects.toThrow();
+        await expect(runCmuxJSON(["anything"], { timeoutMs: 300 })).rejects.toThrow();
+    });
+
+    test("there is a default, so a caller that passes nothing is still bounded", () => {
+        expect(DEFAULT_CMUX_TIMEOUT_MS).toBeGreaterThan(0);
+        expect(Number.isFinite(DEFAULT_CMUX_TIMEOUT_MS)).toBe(true);
+    });
+});

--- a/src/utils/cmux/lib/cli.ts
+++ b/src/utils/cmux/lib/cli.ts
@@ -8,6 +8,8 @@ export interface CmuxRunResult {
     code: number;
     stdout: string;
     stderr: string;
+    /** True when the process was killed by the caller-supplied timeoutMs. */
+    timedOut?: boolean;
 }
 
 const CMUX_FALLBACK_DIRS = [".local/bin", ".bun/bin", ".cargo/bin"];
@@ -44,19 +46,44 @@ function resolveCmuxPath(): string {
     throw new Error(`cmux is not installed (or not found in ${searched})`);
 }
 
-export async function runCmux(args: string[], opts: { json?: boolean } = {}): Promise<CmuxRunResult> {
+export async function runCmux(args: string[], opts: { json?: boolean; timeoutMs?: number } = {}): Promise<CmuxRunResult> {
     const finalArgs = opts.json ? ["--json", ...args] : args;
     const cmuxPath = resolveCmuxPath();
     logger.debug({ args: finalArgs, cmuxPath }, "[cmux] spawn");
     const proc = Bun.spawn([cmuxPath, ...finalArgs], { stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (opts.timeoutMs) {
+        timer = setTimeout(() => {
+            timedOut = true;
+            proc.kill();
+        }, opts.timeoutMs);
+    }
+
     const [stdout, stderr, exitCode] = await Promise.all([
         new Response(proc.stdout).text(),
         new Response(proc.stderr).text(),
         proc.exited,
     ]);
+
+    if (timer) {
+        clearTimeout(timer);
+    }
+
+    if (timedOut) {
+        return {
+            code: exitCode ?? -1,
+            stdout,
+            stderr: stderr || `cmux ${args[0]} timed out after ${opts.timeoutMs} ms`,
+            timedOut: true,
+        };
+    }
+
     if (exitCode === null) {
         throw new Error(`cmux terminated by signal before exiting`);
     }
+
     return { code: exitCode, stdout, stderr };
 }
 

--- a/src/utils/cmux/lib/cli.ts
+++ b/src/utils/cmux/lib/cli.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 
@@ -22,7 +23,11 @@ function resolveCmuxPath(): string {
         return cachedCmuxPath;
     }
 
-    const fromPath = Bun.which("cmux");
+    // Explicit PATH, not the implicit one: Bun.which reads the PATH captured at
+    // process start and ignores later mutations of process.env.PATH (verified).
+    // So a PATH set by the caller — or by a test installing a stand-in — was
+    // silently ignored.
+    const fromPath = Bun.which("cmux", { PATH: env.getProcessEnv().PATH ?? "" });
     if (fromPath) {
         cachedCmuxPath = fromPath;
         return fromPath;
@@ -46,10 +51,24 @@ function resolveCmuxPath(): string {
     throw new Error(`cmux is not installed (or not found in ${searched})`);
 }
 
-export async function runCmux(
-    args: string[],
-    opts: { json?: boolean; timeoutMs?: number } = {}
-): Promise<CmuxRunResult> {
+/**
+ * Upper bound on every cmux call that does not name its own.
+ *
+ * The escalation used to be opt-in, and only one of 38 call sites opted in — so
+ * a wedged cmux hung the other 37 forever, on the branch whose entire subject is
+ * cmux livelock. CLAUDE.md: "A new safety parameter leaves every existing caller
+ * unsafe. Prefer inverting the default so the DANGEROUS behavior is the opt-in."
+ * Generous on purpose: no healthy local socket call comes close.
+ */
+export const DEFAULT_CMUX_TIMEOUT_MS = 30_000;
+
+/** Bounded unless the caller explicitly passes `timeoutMs: null`. */
+export type CmuxTimeoutOpt = { timeoutMs?: number | null };
+
+export async function runCmux(args: string[], opts: { json?: boolean } & CmuxTimeoutOpt = {}): Promise<CmuxRunResult> {
+    // null is the explicit opt-out; undefined means "nobody thought about it",
+    // which is exactly the case that must be bounded.
+    const timeoutMs = opts.timeoutMs === null ? undefined : (opts.timeoutMs ?? DEFAULT_CMUX_TIMEOUT_MS);
     const finalArgs = opts.json ? ["--json", ...args] : args;
     const cmuxPath = resolveCmuxPath();
     logger.debug({ args: finalArgs, cmuxPath }, "[cmux] spawn");
@@ -58,14 +77,23 @@ export async function runCmux(
     let timedOut = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let killTimer: ReturnType<typeof setTimeout> | undefined;
-    if (opts.timeoutMs) {
+    // Resolves once the child has been SIGKILLed, so the reads can be abandoned.
+    let abandon: Promise<void> | undefined;
+    if (timeoutMs) {
+        let giveUp: () => void = () => {};
+        abandon = new Promise<void>((resolve) => {
+            giveUp = resolve;
+        });
         timer = setTimeout(() => {
             timedOut = true;
             proc.kill();
             // SIGTERM can be ignored, and proc.exited only settles on a real exit —
             // escalate so the timeout is an upper bound, not a suggestion.
-            killTimer = setTimeout(() => proc.kill("SIGKILL"), 2000);
-        }, opts.timeoutMs);
+            killTimer = setTimeout(() => {
+                proc.kill("SIGKILL");
+                giveUp();
+            }, 2000);
+        }, timeoutMs);
     }
 
     let stdout: string;
@@ -73,11 +101,24 @@ export async function runCmux(
     let exitCode: number | null;
 
     try {
-        [stdout, stderr, exitCode] = await Promise.all([
+        const collected = Promise.all([
             new Response(proc.stdout).text(),
             new Response(proc.stderr).text(),
             proc.exited,
-        ]);
+        ]).then(([o, e, c]) => ({ abandoned: false, o, e, c }) as const);
+
+        // Killing the child is not enough to unblock these reads: a grandchild
+        // inherits the pipe, so `sh -c "sleep 30"` keeps the write end open long
+        // after the shell is gone and the Response never settles. Without this
+        // race the timeout killed the process and then waited for it anyway —
+        // measured at 30.2 s against a 300 ms timeout.
+        const outcome = await (abandon
+            ? Promise.race([collected, abandon.then(() => ({ abandoned: true, o: "", e: "", c: null }) as const)])
+            : collected);
+
+        stdout = outcome.o;
+        stderr = outcome.e;
+        exitCode = outcome.c;
     } finally {
         clearTimeout(timer);
         clearTimeout(killTimer);
@@ -87,7 +128,7 @@ export async function runCmux(
         return {
             code: exitCode ?? -1,
             stdout,
-            stderr: stderr || `cmux ${args[0]} timed out after ${opts.timeoutMs} ms`,
+            stderr: stderr || `cmux ${args[0]} timed out after ${timeoutMs} ms`,
             timedOut: true,
         };
     }
@@ -99,8 +140,8 @@ export async function runCmux(
     return { code: exitCode, stdout, stderr };
 }
 
-export async function runCmuxJSON<T = unknown>(args: string[]): Promise<T> {
-    const result = await runCmux(args, { json: true });
+export async function runCmuxJSON<T = unknown>(args: string[], opts: CmuxTimeoutOpt = {}): Promise<T> {
+    const result = await runCmux(args, { json: true, ...opts });
     if (result.code !== 0) {
         const message = `cmux ${args.join(" ")} failed (${result.code}): ${result.stderr.trim()}`;
         logger.error({ args, code: result.code, stderr: result.stderr }, "[cmux] command failed");
@@ -114,8 +155,8 @@ export async function runCmuxJSON<T = unknown>(args: string[]): Promise<T> {
     }
 }
 
-export async function runCmuxOk(args: string[]): Promise<CmuxRunResult> {
-    const result = await runCmux(args);
+export async function runCmuxOk(args: string[], opts: CmuxTimeoutOpt = {}): Promise<CmuxRunResult> {
+    const result = await runCmux(args, opts);
     if (result.code !== 0) {
         logger.error({ args, code: result.code, stderr: result.stderr }, "[cmux] command failed");
         throw new Error(`cmux ${args.join(" ")} failed (${result.code}): ${result.stderr.trim()}`);

--- a/src/utils/cmux/lib/cli.ts
+++ b/src/utils/cmux/lib/cli.ts
@@ -46,7 +46,10 @@ function resolveCmuxPath(): string {
     throw new Error(`cmux is not installed (or not found in ${searched})`);
 }
 
-export async function runCmux(args: string[], opts: { json?: boolean; timeoutMs?: number } = {}): Promise<CmuxRunResult> {
+export async function runCmux(
+    args: string[],
+    opts: { json?: boolean; timeoutMs?: number } = {}
+): Promise<CmuxRunResult> {
     const finalArgs = opts.json ? ["--json", ...args] : args;
     const cmuxPath = resolveCmuxPath();
     logger.debug({ args: finalArgs, cmuxPath }, "[cmux] spawn");
@@ -54,21 +57,30 @@ export async function runCmux(args: string[], opts: { json?: boolean; timeoutMs?
 
     let timedOut = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
     if (opts.timeoutMs) {
         timer = setTimeout(() => {
             timedOut = true;
             proc.kill();
+            // SIGTERM can be ignored, and proc.exited only settles on a real exit —
+            // escalate so the timeout is an upper bound, not a suggestion.
+            killTimer = setTimeout(() => proc.kill("SIGKILL"), 2000);
         }, opts.timeoutMs);
     }
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-        proc.exited,
-    ]);
+    let stdout: string;
+    let stderr: string;
+    let exitCode: number | null;
 
-    if (timer) {
+    try {
+        [stdout, stderr, exitCode] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+        ]);
+    } finally {
         clearTimeout(timer);
+        clearTimeout(killTimer);
     }
 
     if (timedOut) {

--- a/src/utils/cmux/lib/health.test.ts
+++ b/src/utils/cmux/lib/health.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { classifyCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
+
+describe("classifyCmuxHealth", () => {
+    test("ping + identify ok is healthy regardless of app detection", () => {
+        expect(classifyCmuxHealth({ appRunning: true, pingOk: true, identifyOk: true })).toBe("healthy");
+        expect(classifyCmuxHealth({ appRunning: false, pingOk: true, identifyOk: true })).toBe("healthy");
+    });
+
+    test("ping ok but identify starved is the UI livelock signature", () => {
+        expect(classifyCmuxHealth({ appRunning: true, pingOk: true, identifyOk: false })).toBe("ui-starved");
+    });
+
+    test("dead socket with a running app is socket-dead", () => {
+        expect(classifyCmuxHealth({ appRunning: true, pingOk: false, identifyOk: false })).toBe("socket-dead");
+    });
+
+    test("dead socket without an app process is not-running", () => {
+        expect(classifyCmuxHealth({ appRunning: false, pingOk: false, identifyOk: false })).toBe("not-running");
+    });
+});

--- a/src/utils/cmux/lib/health.ts
+++ b/src/utils/cmux/lib/health.ts
@@ -1,0 +1,150 @@
+import { runCmux } from "@genesiscz/utils/cmux/lib/cli";
+import { logger } from "@genesiscz/utils/logger";
+
+/**
+ * cmux health triage. The socket layer answers `ping`/`capabilities` off the app's
+ * UI thread, while state commands (`identify`, `list-panes`, …) require it — so a
+ * livelocked UI thread (2026-08-27 Task Manager incident) leaves ping healthy and
+ * every state command starving forever. Probing both sides tells the states apart.
+ */
+export type CmuxHealthState = "healthy" | "not-running" | "socket-dead" | "ui-starved";
+
+export interface CmuxProbeResult {
+    ok: boolean;
+    ms: number;
+    detail?: string;
+}
+
+export interface CmuxHealth {
+    state: CmuxHealthState;
+    appPid?: number;
+    appCpu?: number;
+    probes: {
+        ping: CmuxProbeResult;
+        capabilities?: CmuxProbeResult;
+        identify: CmuxProbeResult;
+    };
+}
+
+export interface ProbeCmuxHealthOptions {
+    pingTimeoutMs?: number;
+    identifyTimeoutMs?: number;
+    /** Also time the `capabilities` probe (doctor display; not needed for classification). */
+    full?: boolean;
+}
+
+export function classifyCmuxHealth(input: { appRunning: boolean; pingOk: boolean; identifyOk: boolean }): CmuxHealthState {
+    if (input.pingOk && input.identifyOk) {
+        return "healthy";
+    }
+
+    if (input.pingOk) {
+        return "ui-starved";
+    }
+
+    return input.appRunning ? "socket-dead" : "not-running";
+}
+
+const APP_BINARY_SUFFIX = "cmux.app/Contents/MacOS/cmux";
+
+async function findCmuxApp(): Promise<{ pid: number; cpu: number } | undefined> {
+    try {
+        const proc = Bun.spawn(["ps", "-axo", "pid=,%cpu=,comm="], { stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+        const text = await new Response(proc.stdout).text();
+        await proc.exited;
+
+        for (const line of text.split("\n")) {
+            const match = line.trim().match(/^(\d+)\s+([\d.]+)\s+(.+)$/);
+            if (match?.[3]?.endsWith(APP_BINARY_SUFFIX)) {
+                return { pid: Number(match[1]), cpu: Number(match[2]) };
+            }
+        }
+    } catch (error) {
+        logger.debug({ error }, "[cmux-health] ps scan failed");
+    }
+
+    return undefined;
+}
+
+async function timedProbe(args: string[], timeoutMs: number, expect?: string): Promise<CmuxProbeResult> {
+    const startedAt = Date.now();
+    try {
+        const result = await runCmux(args, { timeoutMs });
+        const ms = Date.now() - startedAt;
+        if (result.timedOut) {
+            return { ok: false, ms, detail: `timed out after ${timeoutMs} ms` };
+        }
+
+        if (result.code !== 0) {
+            return { ok: false, ms, detail: result.stderr.trim().slice(0, 200) || `exit ${result.code}` };
+        }
+
+        if (expect && !result.stdout.includes(expect)) {
+            return { ok: false, ms, detail: `unexpected output: ${result.stdout.slice(0, 80)}` };
+        }
+
+        return { ok: true, ms };
+    } catch (error) {
+        return { ok: false, ms: Date.now() - startedAt, detail: error instanceof Error ? error.message : String(error) };
+    }
+}
+
+export async function probeCmuxHealth(opts: ProbeCmuxHealthOptions = {}): Promise<CmuxHealth> {
+    const pingTimeoutMs = opts.pingTimeoutMs ?? 1500;
+    const identifyTimeoutMs = opts.identifyTimeoutMs ?? 4000;
+
+    const [app, ping] = await Promise.all([findCmuxApp(), timedProbe(["ping"], pingTimeoutMs, "PONG")]);
+    const capabilities = opts.full ? await timedProbe(["capabilities"], pingTimeoutMs) : undefined;
+    // Skip the slow probe when the socket is already dead — identify cannot succeed.
+    const identify = ping.ok
+        ? await timedProbe(["identify"], identifyTimeoutMs)
+        : { ok: false, ms: 0, detail: "skipped (ping failed)" };
+
+    return {
+        state: classifyCmuxHealth({ appRunning: app !== undefined, pingOk: ping.ok, identifyOk: identify.ok }),
+        appPid: app?.pid,
+        appCpu: app?.cpu,
+        probes: { ping, capabilities, identify },
+    };
+}
+
+export class CmuxUnresponsiveError extends Error {
+    readonly health: CmuxHealth;
+
+    constructor(context: string, health: CmuxHealth) {
+        super(describeUnresponsive(context, health));
+        this.name = "CmuxUnresponsiveError";
+        this.health = health;
+    }
+}
+
+function describeUnresponsive(context: string, health: CmuxHealth): string {
+    switch (health.state) {
+        case "not-running":
+            return `${context}: cmux is not running.`;
+        case "socket-dead":
+            return `${context}: the cmux app is running (pid ${health.appPid}) but its socket does not answer — run \`tools cmux doctor\`.`;
+        case "ui-starved":
+            return (
+                `${context}: cmux's UI thread is not responding (ping answers in ${health.probes.ping.ms} ms but ` +
+                `identify starved${health.appCpu !== undefined ? `, app CPU ${health.appCpu}%` : ""}) — likely a UI livelock. ` +
+                "Run `tools cmux doctor` for triage and the rescue recipe."
+            );
+        default:
+            return `${context}: cmux unhealthy`;
+    }
+}
+
+/**
+ * Cheap fail-fast preflight for anything about to issue cmux state commands.
+ * Throws CmuxUnresponsiveError within ~4 s instead of letting every downstream
+ * request hang for its full per-request timeout.
+ */
+export async function ensureCmuxResponsive(context: string, opts: ProbeCmuxHealthOptions = {}): Promise<CmuxHealth> {
+    const health = await probeCmuxHealth({ identifyTimeoutMs: 3500, ...opts });
+    if (health.state !== "healthy") {
+        throw new CmuxUnresponsiveError(context, health);
+    }
+
+    return health;
+}

--- a/src/utils/cmux/lib/health.ts
+++ b/src/utils/cmux/lib/health.ts
@@ -49,7 +49,9 @@ export function classifyCmuxHealth(input: {
     return input.appRunning ? "socket-dead" : "not-running";
 }
 
-const APP_BINARY_SUFFIX = "cmux.app/Contents/MacOS/cmux";
+/** The app binary `ps` reports for a running cmux. Exported: the rescue kill path
+ * re-checks a pid against this before signalling it. */
+export const APP_BINARY_SUFFIX = "cmux.app/Contents/MacOS/cmux";
 
 async function findCmuxApp(): Promise<{ pid: number; cpu: number } | undefined> {
     try {

--- a/src/utils/cmux/lib/health.ts
+++ b/src/utils/cmux/lib/health.ts
@@ -33,7 +33,11 @@ export interface ProbeCmuxHealthOptions {
     full?: boolean;
 }
 
-export function classifyCmuxHealth(input: { appRunning: boolean; pingOk: boolean; identifyOk: boolean }): CmuxHealthState {
+export function classifyCmuxHealth(input: {
+    appRunning: boolean;
+    pingOk: boolean;
+    identifyOk: boolean;
+}): CmuxHealthState {
     if (input.pingOk && input.identifyOk) {
         return "healthy";
     }
@@ -49,7 +53,11 @@ const APP_BINARY_SUFFIX = "cmux.app/Contents/MacOS/cmux";
 
 async function findCmuxApp(): Promise<{ pid: number; cpu: number } | undefined> {
     try {
-        const proc = Bun.spawn(["ps", "-axo", "pid=,%cpu=,comm="], { stdin: "ignore", stdout: "pipe", stderr: "ignore" });
+        const proc = Bun.spawn(["ps", "-axo", "pid=,%cpu=,comm="], {
+            stdin: "ignore",
+            stdout: "pipe",
+            stderr: "ignore",
+        });
         const text = await new Response(proc.stdout).text();
         await proc.exited;
 
@@ -85,7 +93,11 @@ async function timedProbe(args: string[], timeoutMs: number, expect?: string): P
 
         return { ok: true, ms };
     } catch (error) {
-        return { ok: false, ms: Date.now() - startedAt, detail: error instanceof Error ? error.message : String(error) };
+        return {
+            ok: false,
+            ms: Date.now() - startedAt,
+            detail: error instanceof Error ? error.message : String(error),
+        };
     }
 }
 

--- a/src/utils/cmux/lib/live-snapshot.ts
+++ b/src/utils/cmux/lib/live-snapshot.ts
@@ -1,4 +1,5 @@
 import { type CmuxRunResult, runCmux, runCmuxJSON } from "@genesiscz/utils/cmux/lib/cli";
+import { ensureCmuxResponsive } from "@genesiscz/utils/cmux/lib/health";
 import { logger } from "@genesiscz/utils/logger";
 import { profiler } from "@genesiscz/utils/profile";
 
@@ -319,6 +320,13 @@ export async function fetchCmuxLiveSnapshot(deps: SnapshotDeps = {}): Promise<Cm
 
     const prof = profiler.scope("cmux");
     try {
+        // Fail fast on a starved UI thread: with a livelocked cmux every state command
+        // below would hang for its full per-request timeout. Injected runners (tests)
+        // skip the probe.
+        if (!deps.runJson) {
+            await prof.measureAsync("preflight", () => ensureCmuxResponsive("cmux live snapshot"));
+        }
+
         let windows: CmuxLiveWindow[] | undefined;
         let workspaceLists: WorkspaceListRpc[];
 

--- a/src/utils/env/envVariables.ts
+++ b/src/utils/env/envVariables.ts
@@ -220,6 +220,7 @@ export const env = {
 
     device: {
         getUser: () => getTrimmed("USER"),
+        getLogname: () => getTrimmed("LOGNAME"),
         isRoot: () => getRaw("USER") === "root",
         getTermProgram: () => getTrimmed("TERM_PROGRAM"),
         getCmuxBundleId: () => getTrimmed("CMUX_BUNDLE_ID"),


### PR DESCRIPTION
## Why

On 2026-08-27 cmux's Task Manager window livelocked the app's SwiftUI main thread (100% CPU pinned in one `LazySubviewPlacements` relayout cycle for 40+ minutes). The socket layer split in two — `ping`/`capabilities` answered in ~30 ms while every state command (`identify`, `list-panes`, `capture-pane`) starved forever — so `tools claude cmux tree` hung, `profiles save` died on its first call, and recovery had to be hand-rolled from the app's autosave file plus the process table. This PR turns that hand-rolled rescue into tooling and fixes every restore bug the incident exposed. Tracking: handoff `h_fhg65pu3`.

## What

- **`tools cmux doctor`** (+ shared `src/utils/cmux/lib/health.ts`): probes off-UI-thread (`ping`, `capabilities`) vs UI-thread (`identify`) responsiveness with per-probe timings and app CPU, classifies `healthy / not-running / socket-dead / ui-starved`, and prints the rescue recipe on livelock. Read-only.
- **Fail-fast preflights**: `runCmux` gained `timeoutMs`; `ensureCmuxResponsive()` guards `fetchCmuxLiveSnapshot` (live snapshot / claude cmux tree), `profiles restore`, and `profiles save` — a starved cmux now fails with a diagnosis in ~4 s instead of hanging per request.
- **Foreground command capture** (`profiles save`): joins surface uuid → autosave `ttyName` → the OLDEST non-shell process on that tty. Scrollback parsing sees nothing under a fullscreen TUI (live acceptance: 0/14 commands before, 14/14 after). Oldest-by-etime, not lowest-pid — pids wrap.
- **Session enrichment with drift notes**: claude launchers are rewritten to the deterministic `tools cc run <acct> -- --resume <uuid>` pass-through form using the session-refs/pins journals; `--resume <query>` opens a fuzzy picker whose top match can be a different session. Every change vs. the captured original is recorded as a drift note; unknown session ⇒ original kept verbatim.
- **`profiles save --offline`** (+ automatic fallback when unhealthy): builds a restorable profile without the socket — layout from the autosave's binary `layout.split` tree (tab grouping and selection preserved), commands from the process table.
- **Restore fixes**: multi-tab pane order no longer reverses (explicit reorder to saved index), the saved active tab is re-selected, and screen replay goes through a temp file (inline base64 exceeded the pty input limit and echoed garbage).
- **`profiles restore --enter`**: executes the replayed command instead of only pre-typing it.
- **Rich plan + drift diff**: dry-run and real runs print per-pane title/cwd/command with `- original` / `+ enriched` diffs and ⚠ drift notes. After an `--enter` run, restore lists panes stopped at interactive prompts (account-headroom gate, resume-mode dialog, session picker) and never answers them — the only automation allowed is type + Enter.
- **`tools cmux rescue`**: the guided chain — offline capture → plan + drift detail → explicit confirm → SIGTERM/SIGKILL → clean-env relaunch (`open` forwards its entire environment; launched from an agent shell every pane inherits `CLAUDE_CODE_*` markers and resumed claudes silently disable transcript saving) → wait healthy → replay into the app-reopened surfaces (position-matched, title-checked, count mismatch refuses) → waiting-prompt report. `--dry-run` supported.
- `src/claude/lib/cmux/session-refs.ts` is extracted from the in-flight `feat/2026-08-24-enhancements` branch (identical content) because the capture enrichment reads it.

## Verification

- `bun run test src/cmux src/utils/cmux src/claude/lib/cmux` — 193 tests, 0 fail (includes new suites for health classification, command derivation, layout flattening, prompt detection).
- `tsgo --noEmit` clean.
- Live acceptance during the incident recovery: offline save reproduced the real workspace (7 panes, 4+2+1+1+3+1+2 tabs, 14/14 commands); save→restore→save round-trip structurally identical (tab order, frames ≤0.6 px, cells, selection, cwds); `rescue --dry-run` prints the full plan without touching anything. The rescue kill-path is reviewed but was not live-run against a healthy cmux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `cmux doctor` for connectivity and UI health diagnostics.
  - Added `cmux rescue` to capture, relaunch, and restore workspaces.
  - Added offline profile capture with automatic fallback when live capture is unavailable.
  - Profile restore supports `--enter`, preserves pane and tab placement, and reports interactive prompts.
  - Restore and rescue output includes command details, differences, and replay warnings.
- **Bug Fixes**
  - Added health checks and timeouts to prevent stalled operations.
  - Improved recovery and replay safety when cmux is unresponsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->