### PR TITLE
feat(ai-spend): monitor reads Codex and Grok through a driver layer

### DIFF
--- a/src/ai-spend/README.md
+++ b/src/ai-spend/README.md
@@ -1,8 +1,10 @@
 # tools ai-spend
 
-> **Claude Code token and cost analytics across all local sessions.**
+> **Coding-agent token and cost analytics across all local sessions.**
 
-Reads the session records Claude Code leaves on disk and turns them into a spend report: what the window cost, which sessions were expensive, and what today looks like so far.
+Reads the session records your coding agents leave on disk and turns them into a spend report: what the window cost, which sessions were expensive, and what today looks like so far.
+
+`summary`, `sessions` and `today` read Claude Code only. `monitor` reads Claude Code, Codex and Grok, and reports each one separately.
 
 Also reachable as `tools claude spending`, which is an alias for this tool.
 
@@ -15,7 +17,7 @@ Also reachable as `tools claude spending`, which is an alias for this tool.
 | `summary` | Spend summary for the window (default) |
 | `sessions` | Most expensive sessions leaderboard |
 | `today` | Today's spend, by UTC day |
-| `monitor` | Today + current week (LOCAL timezone, Monday week start) in well under 1s — for status bars. `--json` emits `{today, week, todayDate, weekStart, timezone}` |
+| `monitor` | Today + current week (LOCAL timezone, Monday week start) across Claude Code, Codex and Grok in well under 1s — for status bars. `--json` emits `{today, week, todayDate, weekStart, timezone, agents}` |
 
 ## Quick start
 
@@ -52,12 +54,51 @@ Every option applies to every subcommand.
 
 `today` uses the **UTC day**, not your local one. That matters near midnight in a non-UTC timezone: a session that feels like tonight may land in tomorrow's bucket. Use `--since` with an explicit date when the boundary matters.
 
-`monitor` is the exception: it uses **local midnight** and a **Monday-start local week**, and it is built for sub-second polling. It prunes transcripts by mtime (a file untouched since the week start is never opened), keeps an incremental per-file cache (unchanged files are never re-read; grown files parse only the appended tail), and does a full tree re-walk at most every 10 minutes — between sweeps, a brand-new transcript in a previously-quiet deep directory shows up on the next sweep. Pricing is the same static Anthropic catalog as the rest of this tool — **no LiteLLM, no ccusage, no network** — so a model missing from the catalog costs $0 rather than a guessed rate.
+`monitor` is the exception: it uses **local midnight** and a **Monday-start local week**, and it is built for sub-second polling. It prunes transcripts by mtime (a file untouched since the week start is never opened), keeps an incremental per-file cache (unchanged files are never re-read; grown files parse only the appended tail), and does a full tree re-walk at most every 10 minutes — between sweeps, a brand-new transcript in a previously-quiet deep directory shows up on the next sweep. Pricing is the same static catalog as the rest of this tool — **no LiteLLM, no ccusage, no network** — so a model missing from the catalog costs $0 rather than a guessed rate.
 
 `--json` is the stable interface for dashboards and scripts. The table layout is for humans.
 
+---
+
+## `monitor` drivers
+
+Each agent contributes a driver under `lib/drivers/`. A driver declares only three things: which directories to walk, which file names are transcripts, and how one JSONL line becomes a usage event. The walker, the mtime pruning, the incremental tail cache and the 10-minute sweep are shared, so an agent is added by adding a folder, not by forking the scanner.
+
+| Agent | Files | Usage line | Cost |
+|---|---|---|---|
+| `claude` | `~/.claude/projects/**/*.jsonl`, `~/.config/claude/projects/**`, `$CLAUDE_CONFIG_DIR/projects/**` | `type: "assistant"` with `message.usage` | catalog rates for `anthropic` |
+| `codex` | `~/.codex/{sessions,archived_sessions}/**/*.jsonl`, or every `$CODEX_HOME` in the comma-separated list | `type: "event_msg"` with `payload.type: "token_count"`; the model comes from the preceding `turn_context` line | catalog rates for `openai` |
+| `grok` | `~/.grok/sessions/**/updates.jsonl`, or under `$GROK_HOME` | `params.update.sessionUpdate: "turn_completed"`, one event per entry in `usage.modelUsage` | the `costUsdTicks` Grok recorded (1 tick = 1e-10 USD) |
+
+Line shapes and token arithmetic mirror ccusage's Rust adapters, so the numbers line up with what ccusage reports for the same files:
+
+- **Codex.** `last_token_usage` is the per-turn figure, but it is only counted when `total_token_usage` ADVANCED since the previous line — Codex re-emits an unchanged total on some events, and counting `last` again would double-bill the turn. With no `last_token_usage` at all, the difference of the cumulative totals is used instead. `cached_input_tokens` is a subset of `input_tokens`, so billable input is `input − cached`. `reasoning_output_tokens` sits inside `output_tokens` and is never billed on top.
+- **Grok.** `cachedReadTokens` and `cacheCreationTokens` are subsets of `inputTokens`, so the three parts sum back to `inputTokens`. `reasoningTokens` sits inside `outputTokens`. The recorded `costUsdTicks` is authoritative: Grok prices each API request separately and a `turn_completed` row carries only the per-turn sum, so recomputing from those totals cannot reproduce the figure Grok actually billed.
+- **Claude.** Anthropic reports `input_tokens` already net of cache, so its four token fields are disjoint and nothing is subtracted.
+
+**Unpriced models cost $0.** The catalog carries rates for `anthropic` and `openai` only. Codex's plan and task variants are peeled down to a catalog id one suffix at a time (`gpt-5.3-codex-spark` → `gpt-5.3-codex` → `gpt-5.3`, `gpt-5.6-sol` → `gpt-5.6`), and `grok-4.6-build` peels to `grok-4.6`. An id that still matches nothing — `codex-auto-review`, every `xai` id — contributes $0 rather than a guessed family rate. Grok is unaffected in practice because it reports its own cost.
+
+`--json` gains an `agents` object and keeps the existing top level, which is the sum across agents:
+
+```json
+{
+  "today": { "cost": 404.96, "tokens": 358954522 },
+  "week": { "cost": 2612.44, "tokens": 3254443009 },
+  "todayDate": "2026-08-27",
+  "weekStart": "2026-08-24",
+  "timezone": "Europe/Prague",
+  "agents": {
+    "claude": { "today": { "cost": 404.36, "tokens": 355450116 }, "week": { "cost": 2550.61, "tokens": 2872579230 } },
+    "codex":  { "today": { "cost": 0, "tokens": 0 },              "week": { "cost": 0.50, "tokens": 429041 } },
+    "grok":   { "today": { "cost": 0.61, "tokens": 3504406 },     "week": { "cost": 61.34, "tokens": 381434738 } }
+  }
+}
+```
+
+Measured on this machine (11.5k Claude transcripts, 207 Codex rollouts, 2.9k Grok sessions): a warm run is **0.08–0.11s** wall clock, and the 10-minute full sweep costs about **200–270ms** on top.
+
 ## Notes
 
-- This reports on Claude Code sessions specifically. For token and cost analytics of the `ask` tool, use [`tools usage`](../usage/README.md).
+- `summary`, `sessions` and `today` report on Claude Code sessions specifically; only `monitor` reads Codex and Grok as well. For token and cost analytics of the `ask` tool, use [`tools usage`](../usage/README.md).
 - Costs are derived from recorded token counts and model rates. A number here is an estimate of what was consumed, not an invoice fetched from a billing API.
 - `tools claude usage` is a different thing: an interactive TUI showing API usage and account limits. This tool is the historical spend view.

--- a/src/ai-spend/README.md
+++ b/src/ai-spend/README.md
@@ -15,6 +15,7 @@ Also reachable as `tools claude spending`, which is an alias for this tool.
 | `summary` | Spend summary for the window (default) |
 | `sessions` | Most expensive sessions leaderboard |
 | `today` | Today's spend, by UTC day |
+| `monitor` | Today + current week (LOCAL timezone, Monday week start) in well under 1s — for status bars. `--json` emits `{today, week, todayDate, weekStart, timezone}` |
 
 ## Quick start
 
@@ -50,6 +51,8 @@ Every option applies to every subcommand.
 `--project` matches on the session's working directory, which is how per-repo attribution works without any tagging on your part. `--model` is a substring match, so `--model opus` covers every Opus variant in the window.
 
 `today` uses the **UTC day**, not your local one. That matters near midnight in a non-UTC timezone: a session that feels like tonight may land in tomorrow's bucket. Use `--since` with an explicit date when the boundary matters.
+
+`monitor` is the exception: it uses **local midnight** and a **Monday-start local week**, and it is built for sub-second polling. It prunes transcripts by mtime (a file untouched since the week start is never opened), keeps an incremental per-file cache (unchanged files are never re-read; grown files parse only the appended tail), and does a full tree re-walk at most every 10 minutes — between sweeps, a brand-new transcript in a previously-quiet deep directory shows up on the next sweep. Pricing is the same static Anthropic catalog as the rest of this tool — **no LiteLLM, no ccusage, no network** — so a model missing from the catalog costs $0 rather than a guessed rate.
 
 `--json` is the stable interface for dashboards and scripts. The table layout is for humans.
 

--- a/src/ai-spend/ai-spend.test.ts
+++ b/src/ai-spend/ai-spend.test.ts
@@ -8,7 +8,7 @@ import { aggregate } from "./lib/aggregate";
 import { loadPricing } from "./lib/config";
 import { findTranscriptFiles, readEvents } from "./lib/discover";
 import { parseTranscriptLine } from "./lib/parse";
-import { costOf, DEFAULT_PRICING, priceFor } from "./lib/pricing";
+import { costOf, DEFAULT_PRICING, priceFor, resolvePrice } from "./lib/pricing";
 import { renderSummary } from "./lib/render";
 import { resolveSince } from "./lib/since";
 import type { UsageEvent } from "./lib/types";
@@ -88,6 +88,36 @@ describe("pricing", () => {
 
     it("returns null for genuinely unknown models", () => {
         expect(priceFor("glm-4.6", DEFAULT_PRICING)).toBeNull();
+    });
+
+    it("carries the catalog's dated rules through instead of flattening them away", () => {
+        // claude-sonnet-5 has a promotion through 2026-08-31 ($2/$10 vs the list rate).
+        const entry = priceFor("claude-sonnet-5", DEFAULT_PRICING);
+        expect(entry?.rules?.length).toBeGreaterThan(0);
+
+        const inWindow = resolvePrice(entry!, { at: new Date("2026-08-01T00:00:00.000Z") });
+        const afterWindow = resolvePrice(entry!, { at: new Date("2026-09-01T00:00:00.000Z") });
+
+        expect(inWindow.input).toBe(2);
+        expect(inWindow.output).toBe(10);
+        expect(afterWindow.input).not.toBe(2);
+    });
+
+    it("applies a long-context band to the request that is actually large", () => {
+        const entry = priceFor("claude-sonnet-4-5-20250929", DEFAULT_PRICING);
+        expect(entry?.rules?.length).toBeGreaterThan(0);
+
+        const small = resolvePrice(entry!, { contextTokens: 1000 });
+        const large = resolvePrice(entry!, { contextTokens: 250_000 });
+
+        expect(large.input).toBeGreaterThan(small.input);
+        expect(large.input).toBe(6);
+    });
+
+    it("a model with no rules resolves to its flat rates unchanged", () => {
+        const entry = priceFor("claude-opus-4-8", DEFAULT_PRICING);
+
+        expect(resolvePrice(entry!, { at: new Date() })).toEqual(entry!);
     });
 });
 

--- a/src/ai-spend/lib/aggregate.ts
+++ b/src/ai-spend/lib/aggregate.ts
@@ -1,4 +1,4 @@
-import { priceFor } from "./pricing";
+import { priceFor, resolvePrice } from "./pricing";
 import type {
     DayBreakdown,
     Filters,
@@ -54,10 +54,18 @@ function passesFilters(ev: UsageEvent, f: Filters): boolean {
 }
 
 function eventCost(ev: UsageEvent, pricing: PricingTable): number {
-    const price = priceFor(ev.model, pricing);
-    if (!price) {
+    const entry = priceFor(ev.model, pricing);
+    if (!entry) {
         return 0;
     }
+
+    // Per event, not per table: a dated promotion or a long-context band only
+    // resolves against THIS event's timestamp and request size.
+    const at = new Date(ev.timestamp);
+    const price = resolvePrice(entry, {
+        at: Number.isNaN(at.getTime()) ? undefined : at,
+        contextTokens: ev.inputTokens + ev.cacheReadTokens + ev.cacheCreationTokens,
+    });
 
     return (
         (ev.inputTokens * price.input +

--- a/src/ai-spend/lib/drivers/claude.test.ts
+++ b/src/ai-spend/lib/drivers/claude.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { claudeDriver } from "./claude";
 import { billedCost, collectEvents } from "./driver-test-helpers";
+import { isolateAgentHomeEnv } from "./test-env";
+
+// An ambient CLAUDE_CONFIG_DIR adds a third root and would break the exact list below.
+isolateAgentHomeEnv();
 
 function line(id: string, usage: Record<string, number>): string {
     return SafeJSON.stringify({
@@ -47,6 +51,23 @@ describe("claude driver", () => {
         ]);
 
         expect(events).toEqual([]);
+    });
+
+    test("a line with no timestamp still emits, and the monitor drops it without burning the id", () => {
+        // `parseTranscriptLine` defaults a missing timestamp to "". The driver passes
+        // that through; rejecting it is `parseChunk`'s job, and it must reject BEFORE
+        // recording the id — see monitor.test.ts for the end-to-end assertion.
+        const events = collectEvents(claudeDriver, [
+            SafeJSON.stringify({
+                type: "assistant",
+                cwd: "/tmp/p",
+                message: { id: "msg-x", usage: { input_tokens: 5 } },
+            }),
+        ]);
+
+        expect(events).toHaveLength(1);
+        expect(events[0].timestamp).toBe("");
+        expect(Number.isNaN(new Date(events[0].timestamp).getTime())).toBe(true);
     });
 
     test("roots cover both fixed trees, and every .jsonl counts", () => {

--- a/src/ai-spend/lib/drivers/claude.test.ts
+++ b/src/ai-spend/lib/drivers/claude.test.ts
@@ -70,6 +70,28 @@ describe("claude driver", () => {
         expect(events[0]).toMatchObject({ id: "msg-p", inputTokens: 7, outputTokens: 3 });
     });
 
+    test("a whitespace-formatted assistant record survives the prefilter", () => {
+        // Claude Code writes minified JSONL, but the prefilter must not be the
+        // thing that decides that. A needle of `"type":"assistant"` would drop
+        // this line unparsed and silently undercount the day.
+        const formatted = SafeJSON.stringify(
+            {
+                type: "assistant",
+                timestamp: "2026-08-27T09:00:00.000Z",
+                message: { id: "msg-fmt", model: "claude-3-5-haiku", usage: { input_tokens: 11 } },
+            },
+            null,
+            4
+        ).replace(/\n\s*/g, " ");
+
+        expect(formatted).toContain('"type": "assistant"');
+
+        const events = collectEvents(claudeDriver, [formatted]);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({ id: "msg-fmt", inputTokens: 11 });
+    });
+
     test("a line with no timestamp still emits, and the monitor drops it without burning the id", () => {
         // `parseTranscriptLine` defaults a missing timestamp to "". The driver passes
         // that through; rejecting it is `parseChunk`'s job, and it must reject BEFORE

--- a/src/ai-spend/lib/drivers/claude.test.ts
+++ b/src/ai-spend/lib/drivers/claude.test.ts
@@ -53,6 +53,23 @@ describe("claude driver", () => {
         expect(events).toEqual([]);
     });
 
+    test("the cheap prefilter keeps every assistant line and drops the rest", () => {
+        // The prefilter runs on the raw line before the JSON parse, so it must not
+        // change what the driver emits: a non-assistant line stays skipped, and an
+        // assistant line still parses into a full event.
+        const events = collectEvents(claudeDriver, [
+            SafeJSON.stringify({
+                type: "user",
+                timestamp: "2026-08-27T09:00:00.000Z",
+                message: { id: "u1", model: "claude-3-5-haiku", usage: { input_tokens: 9 } },
+            }),
+            line("msg-p", { input_tokens: 7, output_tokens: 3 }),
+        ]);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({ id: "msg-p", inputTokens: 7, outputTokens: 3 });
+    });
+
     test("a line with no timestamp still emits, and the monitor drops it without burning the id", () => {
         // `parseTranscriptLine` defaults a missing timestamp to "". The driver passes
         // that through; rejecting it is `parseChunk`'s job, and it must reject BEFORE

--- a/src/ai-spend/lib/drivers/claude.test.ts
+++ b/src/ai-spend/lib/drivers/claude.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { claudeDriver } from "./claude";
+import { billedCost, collectEvents } from "./driver-test-helpers";
+
+function line(id: string, usage: Record<string, number>): string {
+    return SafeJSON.stringify({
+        type: "assistant",
+        timestamp: "2026-08-27T09:00:00.000Z",
+        cwd: "/tmp/proj",
+        sessionId: "sess-1",
+        message: { id, model: "claude-3-5-haiku", usage },
+    });
+}
+
+describe("claude driver", () => {
+    test("reads the four disjoint token fields off an assistant line", () => {
+        const events = collectEvents(claudeDriver, [
+            line("msg-a", {
+                input_tokens: 1_000_000,
+                output_tokens: 500_000,
+                cache_creation_input_tokens: 200_000,
+                cache_read_input_tokens: 4_000_000,
+            }),
+        ]);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            id: "msg-a",
+            model: "claude-3-5-haiku",
+            inputTokens: 1_000_000,
+            outputTokens: 500_000,
+            cacheCreationTokens: 200_000,
+            cacheReadTokens: 4_000_000,
+        });
+        // claude-3-5-haiku: $0.8 in · $4 out · $1.0 cacheWrite · $0.08 cacheRead per Mtok.
+        // 0.80 + 2.00 + 0.20 + 0.32 = $3.32
+        expect(billedCost(claudeDriver, events[0])).toBeCloseTo(3.32, 10);
+    });
+
+    test("ignores non-assistant lines and lines without usage", () => {
+        const events = collectEvents(claudeDriver, [
+            SafeJSON.stringify({ type: "user", timestamp: "2026-08-27T09:00:00.000Z", message: { id: "u1" } }),
+            SafeJSON.stringify({ type: "assistant", timestamp: "2026-08-27T09:00:00.000Z", message: { id: "m1" } }),
+            "",
+            "{ not json",
+        ]);
+
+        expect(events).toEqual([]);
+    });
+
+    test("roots cover both fixed trees, and every .jsonl counts", () => {
+        expect(claudeDriver.roots("/home/u")).toEqual(["/home/u/.claude/projects", "/home/u/.config/claude/projects"]);
+        expect(claudeDriver.isTranscript("s1.jsonl")).toBe(true);
+        expect(claudeDriver.isTranscript("notes.txt")).toBe(false);
+    });
+
+    test("price candidates strip a dated variant suffix", () => {
+        expect(claudeDriver.priceCandidates("claude-opus-4-5-20251101")).toEqual([
+            "claude-opus-4-5-20251101",
+            "claude-opus-4-5",
+        ]);
+        expect(claudeDriver.priceCandidates("claude-3-5-haiku")).toEqual(["claude-3-5-haiku"]);
+    });
+});

--- a/src/ai-spend/lib/drivers/claude.ts
+++ b/src/ai-spend/lib/drivers/claude.ts
@@ -44,10 +44,17 @@ export const claudeDriver: MonitorDriver = {
                 // Cheap prefilter before the JSON parse. About 72% of transcript lines
                 // are user, tool-result and system records that `parseTranscriptLine`
                 // discards on `type !== "assistant"` anyway, after paying for a full
-                // parse. Measured on a 94.5 MB / 35,170-line transcript: 106 ms
-                // parse-all vs 46 ms prefiltered, identical hit counts. The grok
-                // driver and ccusage (`LinePrefilter`) do the same.
-                if (!line.includes('"type":"assistant"')) {
+                // parse. The grok driver and ccusage (`LinePrefilter`) do the same.
+                //
+                // The needle is the bare token, NOT `"type":"assistant"`: whitespace
+                // may sit around the colon, and no serializer puts any inside the
+                // string literal. So this is a strict superset of what the parser
+                // accepts — it can let an extra line through to be rejected there,
+                // and can never drop a billable one. Measured over 22,465 lines of a
+                // 132 MB transcript, five passes: 7.9 ms for this, 21.3 ms for the
+                // `/"type"\s*:\s*"assistant"/` regex, against ~106 ms to parse
+                // every line. All three agree on 6,503 hits.
+                if (!line.includes('"assistant"')) {
                     return;
                 }
 

--- a/src/ai-spend/lib/drivers/claude.ts
+++ b/src/ai-spend/lib/drivers/claude.ts
@@ -1,0 +1,71 @@
+import { join } from "node:path";
+import { stripModelVariantSuffix } from "@genesiscz/utils/ai/catalog";
+import { env } from "@genesiscz/utils/env";
+import { parseTranscriptLine } from "../parse";
+import type { DriverUsageEvent, MonitorDriver } from "./types";
+
+/**
+ * Claude Code transcripts: `~/.claude/projects/**\/*.jsonl`, one JSON object per
+ * line, usage on `message.usage` of `type: "assistant"` lines. Mirrors
+ * ccusage's claude adapter (`rust/adapters/claude/src/lib.rs`), which reads the
+ * same four token fields and dedups on the message id.
+ *
+ * Anthropic reports `input_tokens` already NET of cache, so the four fields are
+ * disjoint and no subtraction is needed here (unlike codex and grok).
+ */
+export const claudeDriver: MonitorDriver = {
+    id: "claude",
+
+    roots(home: string): string[] {
+        const roots = [join(home, ".claude", "projects"), join(home, ".config", "claude", "projects")];
+        const configDir = env.paths.getClaudeConfigDir();
+
+        if (configDir) {
+            const extra = join(configDir, "projects");
+
+            if (!roots.includes(extra)) {
+                roots.push(extra);
+            }
+        }
+
+        return roots;
+    },
+
+    isTranscript(name: string): boolean {
+        return name.endsWith(".jsonl");
+    },
+
+    // Subagent transcripts nest below the project directory.
+    maxDepth: 6,
+
+    createParser() {
+        return {
+            parseLine(line: string, emit: (event: DriverUsageEvent) => void): void {
+                const event = parseTranscriptLine(line);
+
+                if (!event) {
+                    return;
+                }
+
+                emit({
+                    id: event.messageId,
+                    model: event.model,
+                    timestamp: event.timestamp,
+                    inputTokens: event.inputTokens,
+                    outputTokens: event.outputTokens,
+                    cacheCreationTokens: event.cacheCreationTokens,
+                    cacheReadTokens: event.cacheReadTokens,
+                });
+            },
+            snapshot(): unknown {
+                return undefined;
+            },
+        };
+    },
+
+    priceCandidates(model: string): string[] {
+        const base = stripModelVariantSuffix(model);
+
+        return base ? [model, base] : [model];
+    },
+};

--- a/src/ai-spend/lib/drivers/claude.ts
+++ b/src/ai-spend/lib/drivers/claude.ts
@@ -41,6 +41,16 @@ export const claudeDriver: MonitorDriver = {
     createParser() {
         return {
             parseLine(line: string, emit: (event: DriverUsageEvent) => void): void {
+                // Cheap prefilter before the JSON parse. About 72% of transcript lines
+                // are user, tool-result and system records that `parseTranscriptLine`
+                // discards on `type !== "assistant"` anyway, after paying for a full
+                // parse. Measured on a 94.5 MB / 35,170-line transcript: 106 ms
+                // parse-all vs 46 ms prefiltered, identical hit counts. The grok
+                // driver and ccusage (`LinePrefilter`) do the same.
+                if (!line.includes('"type":"assistant"')) {
+                    return;
+                }
+
                 const event = parseTranscriptLine(line);
 
                 if (!event) {

--- a/src/ai-spend/lib/drivers/codex.test.ts
+++ b/src/ai-spend/lib/drivers/codex.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { DEFAULT_PRICING } from "../pricing";
+import { codexDriver } from "./codex";
+import { billedCost, collectEvents } from "./driver-test-helpers";
+import type { DriverUsageEvent } from "./types";
+
+const turnContext = (model: string): string =>
+    SafeJSON.stringify({
+        timestamp: "2026-08-27T09:00:00.000Z",
+        type: "turn_context",
+        payload: { turn_id: "turn-1", cwd: "/tmp/proj", model, effort: "medium" },
+    });
+
+const tokenCount = (timestamp: string, total: Record<string, number>, last: Record<string, number>): string =>
+    SafeJSON.stringify({
+        timestamp,
+        type: "event_msg",
+        payload: {
+            type: "token_count",
+            info: { total_token_usage: total, last_token_usage: last, model_context_window: 258_400 },
+        },
+    });
+
+describe("codex driver", () => {
+    test("bills last_token_usage with cached input subtracted, model from turn_context", () => {
+        const events = collectEvents(codexDriver, [
+            turnContext("gpt-5.6-sol"),
+            tokenCount(
+                "2026-08-27T09:00:10.000Z",
+                {
+                    input_tokens: 208_890,
+                    cached_input_tokens: 185_344,
+                    output_tokens: 1_454,
+                    reasoning_output_tokens: 362,
+                    total_tokens: 210_344,
+                },
+                {
+                    input_tokens: 27_003,
+                    cached_input_tokens: 26_368,
+                    output_tokens: 139,
+                    reasoning_output_tokens: 32,
+                    total_tokens: 27_142,
+                }
+            ),
+        ]);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            model: "gpt-5.6-sol",
+            // 27003 − 26368 uncached
+            inputTokens: 635,
+            outputTokens: 139,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 26_368,
+        });
+        // gpt-5.6: $5 in · $30 out · $0.5 cacheRead per Mtok. Reasoning is inside output.
+        // 635×5e-6 + 139×30e-6 + 26368×0.5e-6 = 0.003175 + 0.00417 + 0.013184
+        expect(billedCost(codexDriver, events[0])).toBeCloseTo(0.020529, 10);
+    });
+
+    test("a repeated cumulative total is not billed twice", () => {
+        const total = {
+            input_tokens: 27_003,
+            cached_input_tokens: 26_368,
+            output_tokens: 139,
+            reasoning_output_tokens: 32,
+            total_tokens: 27_142,
+        };
+        const last = { ...total };
+        const events = collectEvents(codexDriver, [
+            turnContext("gpt-5-codex"),
+            tokenCount("2026-08-27T09:00:10.000Z", total, last),
+            // Codex re-emits the same total; `last` must NOT be counted again.
+            tokenCount("2026-08-27T09:00:11.000Z", total, last),
+        ]);
+
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(635);
+    });
+
+    test("falls back to the cumulative difference when last_token_usage is absent", () => {
+        const events = collectEvents(codexDriver, [
+            turnContext("gpt-5"),
+            SafeJSON.stringify({
+                timestamp: "2026-08-27T09:00:10.000Z",
+                type: "event_msg",
+                payload: {
+                    type: "token_count",
+                    info: { total_token_usage: { input_tokens: 1_000, cached_input_tokens: 400, output_tokens: 50 } },
+                },
+            }),
+            SafeJSON.stringify({
+                timestamp: "2026-08-27T09:00:20.000Z",
+                type: "event_msg",
+                payload: {
+                    type: "token_count",
+                    info: { total_token_usage: { input_tokens: 2_500, cached_input_tokens: 900, output_tokens: 130 } },
+                },
+            }),
+        ]);
+
+        expect(events).toHaveLength(2);
+        expect(events[0]).toMatchObject({ inputTokens: 600, cacheReadTokens: 400, outputTokens: 50 });
+        // Second event is the delta: 1500 input, 500 cached, 80 output.
+        expect(events[1]).toMatchObject({ inputTokens: 1_000, cacheReadTokens: 500, outputTokens: 80 });
+    });
+
+    test("an all-zero usage event is dropped", () => {
+        const zero = { input_tokens: 0, cached_input_tokens: 0, output_tokens: 0, reasoning_output_tokens: 0 };
+
+        expect(
+            collectEvents(codexDriver, [turnContext("gpt-5"), tokenCount("2026-08-27T09:00:10.000Z", zero, zero)])
+        ).toEqual([]);
+    });
+
+    test("the sticky model survives a resume from a persisted snapshot", () => {
+        const first = codexDriver.createParser({ file: "/tmp/rollout.jsonl", state: undefined });
+        first.parseLine(turnContext("gpt-5.6-sol"), () => undefined);
+
+        const resumed = codexDriver.createParser({ file: "/tmp/rollout.jsonl", state: first.snapshot() });
+        const events: DriverUsageEvent[] = [];
+        resumed.parseLine(
+            tokenCount(
+                "2026-08-27T09:05:00.000Z",
+                { input_tokens: 100, output_tokens: 10 },
+                { input_tokens: 100, output_tokens: 10 }
+            ),
+            (event) => events.push(event)
+        );
+
+        expect(events).toHaveLength(1);
+        expect(events[0].model).toBe("gpt-5.6-sol");
+    });
+
+    test("price candidates peel codex and plan suffixes down to a catalog id", () => {
+        expect(codexDriver.priceCandidates("gpt-5.3-codex-spark")).toEqual([
+            "gpt-5.3-codex-spark",
+            "gpt-5.3-codex",
+            "gpt-5.3",
+        ]);
+        expect(codexDriver.priceCandidates("gpt-5-codex")).toEqual(["gpt-5-codex", "gpt-5"]);
+        expect(codexDriver.priceCandidates("gpt-5.6-sol")).toEqual(["gpt-5.6-sol", "gpt-5.6"]);
+        // Nothing to peel and nothing in the catalog: unpriced, so $0.
+        expect(codexDriver.priceCandidates("codex-auto-review")).toEqual(["codex-auto-review"]);
+        expect(DEFAULT_PRICING["codex-auto-review"]).toBeUndefined();
+    });
+
+    test("roots follow CODEX_HOME, comma-separated, sessions + archived_sessions", async () => {
+        expect(codexDriver.roots("/home/u")).toEqual(["/home/u/.codex/sessions", "/home/u/.codex/archived_sessions"]);
+
+        await env.testing.withOverrides({ CODEX_HOME: "/a/codex, /b/codex" }, () => {
+            expect(codexDriver.roots("/home/u")).toEqual([
+                "/a/codex/sessions",
+                "/a/codex/archived_sessions",
+                "/b/codex/sessions",
+                "/b/codex/archived_sessions",
+            ]);
+        });
+    });
+});

--- a/src/ai-spend/lib/drivers/codex.test.ts
+++ b/src/ai-spend/lib/drivers/codex.test.ts
@@ -4,7 +4,11 @@ import { SafeJSON } from "@genesiscz/utils/json";
 import { DEFAULT_PRICING } from "../pricing";
 import { codexDriver } from "./codex";
 import { billedCost, collectEvents } from "./driver-test-helpers";
+import { isolateAgentHomeEnv } from "./test-env";
 import type { DriverUsageEvent } from "./types";
+
+// An ambient CODEX_HOME would relocate the roots asserted below.
+isolateAgentHomeEnv();
 
 const turnContext = (model: string): string =>
     SafeJSON.stringify({
@@ -145,6 +149,21 @@ describe("codex driver", () => {
         // Nothing to peel and nothing in the catalog: unpriced, so $0.
         expect(codexDriver.priceCandidates("codex-auto-review")).toEqual(["codex-auto-review"]);
         expect(DEFAULT_PRICING["codex-auto-review"]).toBeUndefined();
+    });
+
+    test("a non-string model on a corrupt line never reaches the event", () => {
+        // These files are a system boundary; the CodexLine cast validates nothing.
+        // A number here used to flow into priceCandidates() and throw on .endsWith.
+        const events = collectEvents(codexDriver, [
+            turnContext("gpt-5"),
+            '{"timestamp":"2026-08-27T09:00:10.000Z","type":"event_msg","payload":{"type":"token_count","model":404,"info":{"last_token_usage":{"input_tokens":100,"output_tokens":10}}}}',
+        ]);
+
+        expect(events).toHaveLength(1);
+        // Falls through the invalid value to the sticky turn_context model.
+        expect(events[0].model).toBe("gpt-5");
+        expect(() => codexDriver.priceCandidates(events[0].model)).not.toThrow();
+        expect(billedCost(codexDriver, events[0])).toBeCloseTo(100 * 1.25e-6 + 10 * 10e-6, 12);
     });
 
     test("roots follow CODEX_HOME, comma-separated, sessions + archived_sessions", async () => {

--- a/src/ai-spend/lib/drivers/codex.ts
+++ b/src/ai-spend/lib/drivers/codex.ts
@@ -3,6 +3,7 @@ import { stripModelVariantSuffix } from "@genesiscz/utils/ai/catalog";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
+import { isRecord, num } from "./parse-helpers";
 import type { CreateParserOptions, DriverLineParser, DriverUsageEvent, MonitorDriver } from "./types";
 
 /**
@@ -64,12 +65,15 @@ interface CodexState {
     totals?: CodexRawUsage;
 }
 
-function num(value: number | undefined): number {
-    return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
+/** First candidate that is genuinely a non-empty string. */
+function firstString(...candidates: (string | undefined)[]): string | undefined {
+    for (const candidate of candidates) {
+        if (typeof candidate === "string" && candidate.length > 0) {
+            return candidate;
+        }
+    }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
+    return undefined;
 }
 
 function readState(state: unknown): CodexState {
@@ -255,7 +259,10 @@ export const codexDriver: MonitorDriver = {
                 }
 
                 const timestamp = typeof raw.timestamp === "string" ? raw.timestamp : "";
-                const model = raw.payload.model ?? info?.model ?? state.model ?? "unknown";
+                // The cast to CodexLine is a shape hint, not a validation: these files
+                // are a system boundary. A non-string `model` would reach
+                // `priceCandidates()` and throw on `.endsWith`, aborting the chunk.
+                const model = firstString(raw.payload.model, info?.model, state.model) ?? "unknown";
                 const inputTokens = inputTotal - cached;
 
                 emit({

--- a/src/ai-spend/lib/drivers/codex.ts
+++ b/src/ai-spend/lib/drivers/codex.ts
@@ -1,0 +1,278 @@
+import { join } from "node:path";
+import { stripModelVariantSuffix } from "@genesiscz/utils/ai/catalog";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import type { CreateParserOptions, DriverLineParser, DriverUsageEvent, MonitorDriver } from "./types";
+
+/**
+ * Codex CLI rollouts: `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`, plus
+ * `archived_sessions` next to it. `CODEX_HOME` overrides the root and accepts a
+ * comma-separated list, exactly as ccusage does
+ * (`rust/adapters/codex/src/paths.rs:104` `codex_home_paths`).
+ *
+ * Two line types matter:
+ *   - `{"type":"turn_context","payload":{"model":"gpt-5.6-sol",…}}` — sets the
+ *     model for every later usage line in the file.
+ *   - `{"type":"event_msg","payload":{"type":"token_count","info":{…}}}` — the
+ *     usage itself, with a per-turn `last_token_usage` and a cumulative
+ *     `total_token_usage`.
+ *
+ * Token semantics mirror `visit_codex_session_entry`
+ * (`rust/adapters/codex/src/parser.rs:317-367`):
+ *   - prefer `last_token_usage`, but only when `total_token_usage` ADVANCED
+ *     since the previous line; Codex re-emits an unchanged total on some
+ *     events, and counting `last` again would double-bill the turn.
+ *   - otherwise fall back to the difference of the cumulative totals.
+ *   - `cached_input_tokens` is a SUBSET of `input_tokens`, so billable input is
+ *     `input - cached` (`rust/adapters/codex/src/report.rs:85`
+ *     `non_cached_input_tokens`).
+ *   - `reasoning_output_tokens` is a subset of `output_tokens` and is never
+ *     billed on top of it.
+ */
+
+interface CodexRawUsage {
+    input_tokens?: number;
+    cached_input_tokens?: number;
+    output_tokens?: number;
+    reasoning_output_tokens?: number;
+    total_tokens?: number;
+}
+
+interface CodexInfo {
+    model?: string;
+    last_token_usage?: CodexRawUsage;
+    total_token_usage?: CodexRawUsage;
+}
+
+interface CodexPayload {
+    type?: string;
+    model?: string;
+    info?: CodexInfo;
+}
+
+interface CodexLine {
+    type?: string;
+    timestamp?: string;
+    payload?: CodexPayload;
+}
+
+interface CodexState {
+    /** Sticky model from the last `turn_context` line. */
+    model?: string;
+    /** Last cumulative `total_token_usage`, for the diff fallback. */
+    totals?: CodexRawUsage;
+}
+
+function num(value: number | undefined): number {
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function readState(state: unknown): CodexState {
+    if (!isRecord(state)) {
+        return {};
+    }
+
+    const model = typeof state.model === "string" ? state.model : undefined;
+    const totals = isRecord(state.totals) ? (state.totals as CodexRawUsage) : undefined;
+
+    return { model, totals };
+}
+
+function sameTotals(a: CodexRawUsage | undefined, b: CodexRawUsage | undefined): boolean {
+    if (!a || !b) {
+        return false;
+    }
+
+    return (
+        num(a.input_tokens) === num(b.input_tokens) &&
+        num(a.cached_input_tokens) === num(b.cached_input_tokens) &&
+        num(a.output_tokens) === num(b.output_tokens) &&
+        num(a.reasoning_output_tokens) === num(b.reasoning_output_tokens) &&
+        num(a.total_tokens) === num(b.total_tokens)
+    );
+}
+
+function subtractTotals(current: CodexRawUsage, previous: CodexRawUsage | undefined): CodexRawUsage {
+    const sub = (a: number | undefined, b: number | undefined): number => Math.max(0, num(a) - num(b));
+
+    return {
+        input_tokens: sub(current.input_tokens, previous?.input_tokens),
+        cached_input_tokens: sub(current.cached_input_tokens, previous?.cached_input_tokens),
+        output_tokens: sub(current.output_tokens, previous?.output_tokens),
+        reasoning_output_tokens: sub(current.reasoning_output_tokens, previous?.reasoning_output_tokens),
+        total_tokens: sub(current.total_tokens, previous?.total_tokens),
+    };
+}
+
+/**
+ * Codex ships plan-specific and task-specific variants of the base OpenAI
+ * models (`gpt-5.6-sol`, `gpt-5-codex`, `gpt-5.3-codex-spark`). The catalog
+ * only carries the base ids with rates, so peel one known suffix at a time and
+ * retry. `codex-auto-review` peels to nothing and stays unpriced.
+ */
+const CODEX_MODEL_SUFFIXES = ["-spark", "-codex", "-sol", "-terra", "-luna"];
+
+function codexPriceCandidates(model: string): string[] {
+    const candidates: string[] = [];
+    const push = (value: string | null): void => {
+        if (value && !candidates.includes(value)) {
+            candidates.push(value);
+        }
+    };
+
+    push(model);
+    push(stripModelVariantSuffix(model));
+
+    let current = model;
+    let peeled = true;
+
+    while (peeled) {
+        peeled = false;
+
+        for (const suffix of CODEX_MODEL_SUFFIXES) {
+            if (current.endsWith(suffix) && current.length > suffix.length) {
+                current = current.slice(0, -suffix.length);
+                push(current);
+                peeled = true;
+                break;
+            }
+        }
+    }
+
+    return candidates;
+}
+
+function codexHomes(home: string): string[] {
+    const override = env.codex.getHomeOverride();
+
+    if (override) {
+        const homes = override
+            .split(",")
+            .map((path) => path.trim())
+            .filter((path) => path.length > 0);
+
+        if (homes.length > 0) {
+            return homes;
+        }
+    }
+
+    return [join(home, ".codex")];
+}
+
+export const codexDriver: MonitorDriver = {
+    id: "codex",
+
+    roots(home: string): string[] {
+        const roots: string[] = [];
+
+        for (const codexHome of codexHomes(home)) {
+            for (const dir of [join(codexHome, "sessions"), join(codexHome, "archived_sessions")]) {
+                if (!roots.includes(dir)) {
+                    roots.push(dir);
+                }
+            }
+        }
+
+        return roots;
+    },
+
+    isTranscript(name: string): boolean {
+        return name.endsWith(".jsonl");
+    },
+
+    // sessions/YYYY/MM/DD/rollout-*.jsonl
+    maxDepth: 4,
+
+    createParser(options: CreateParserOptions): DriverLineParser {
+        const state = readState(options.state);
+
+        return {
+            parseLine(line: string, emit: (event: DriverUsageEvent) => void): void {
+                const trimmed = line.trim();
+
+                if (!trimmed) {
+                    return;
+                }
+
+                let parsed: unknown;
+                try {
+                    parsed = SafeJSON.parse(trimmed, { strict: true });
+                } catch (err) {
+                    logger.debug({ err }, "ai-spend codex: skipping malformed rollout line");
+
+                    return;
+                }
+
+                if (!isRecord(parsed)) {
+                    return;
+                }
+
+                const raw = parsed as CodexLine;
+
+                if (raw.type === "turn_context") {
+                    const model = raw.payload?.model;
+
+                    if (typeof model === "string" && model.length > 0) {
+                        state.model = model;
+                    }
+
+                    return;
+                }
+
+                if (raw.type !== "event_msg" || raw.payload?.type !== "token_count") {
+                    return;
+                }
+
+                const info = raw.payload.info;
+                const totals = info?.total_token_usage;
+                // Codex re-emits the same cumulative total on some events; when it
+                // has NOT advanced, `last_token_usage` is a repeat of a turn that
+                // was already counted.
+                const advanced = !totals || !sameTotals(totals, state.totals);
+                const last = advanced ? info?.last_token_usage : undefined;
+                const usage = last ?? (totals ? subtractTotals(totals, state.totals) : undefined);
+
+                if (totals) {
+                    state.totals = totals;
+                }
+
+                if (!usage) {
+                    return;
+                }
+
+                const inputTotal = num(usage.input_tokens);
+                const cached = Math.min(num(usage.cached_input_tokens), inputTotal);
+                const output = num(usage.output_tokens);
+                const reasoning = num(usage.reasoning_output_tokens);
+
+                if (inputTotal === 0 && cached === 0 && output === 0 && reasoning === 0) {
+                    return;
+                }
+
+                const timestamp = typeof raw.timestamp === "string" ? raw.timestamp : "";
+                const model = raw.payload.model ?? info?.model ?? state.model ?? "unknown";
+                const inputTokens = inputTotal - cached;
+
+                emit({
+                    id: `${timestamp}|${model}|${inputTokens}|${cached}|${output}`,
+                    model,
+                    timestamp,
+                    inputTokens,
+                    outputTokens: output,
+                    cacheCreationTokens: 0,
+                    cacheReadTokens: cached,
+                });
+            },
+            snapshot(): unknown {
+                return state;
+            },
+        };
+    },
+
+    priceCandidates: codexPriceCandidates,
+};

--- a/src/ai-spend/lib/drivers/driver-test-helpers.ts
+++ b/src/ai-spend/lib/drivers/driver-test-helpers.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { costOf, DEFAULT_PRICING } from "../pricing";
 import type { DriverUsageEvent, MonitorDriver } from "./types";
 
@@ -7,12 +9,11 @@ import type { DriverUsageEvent, MonitorDriver } from "./types";
  * account name, session id or path ever appears in a fixture.
  */
 
+/** A path that does not have to exist: only the grok driver reads a sibling of it. */
+const FIXTURE_FILE = join(tmpdir(), "ai-spend-fixture", "updates.jsonl");
+
 /** Run `lines` through a fresh parser and collect every event it emits. */
-export function collectEvents(
-    driver: MonitorDriver,
-    lines: string[],
-    file = "/tmp/fixture/updates.jsonl"
-): DriverUsageEvent[] {
+export function collectEvents(driver: MonitorDriver, lines: string[], file = FIXTURE_FILE): DriverUsageEvent[] {
     const parser = driver.createParser({ file, state: undefined });
     const events: DriverUsageEvent[] = [];
 

--- a/src/ai-spend/lib/drivers/driver-test-helpers.ts
+++ b/src/ai-spend/lib/drivers/driver-test-helpers.ts
@@ -1,0 +1,49 @@
+import { costOf, DEFAULT_PRICING } from "../pricing";
+import type { DriverUsageEvent, MonitorDriver } from "./types";
+
+/**
+ * Shared harness for the per-driver fixture tests. Fixture line shapes are
+ * copied from the REAL formats on disk with synthetic ids and cwds; no live
+ * account name, session id or path ever appears in a fixture.
+ */
+
+/** Run `lines` through a fresh parser and collect every event it emits. */
+export function collectEvents(
+    driver: MonitorDriver,
+    lines: string[],
+    file = "/tmp/fixture/updates.jsonl"
+): DriverUsageEvent[] {
+    const parser = driver.createParser({ file, state: undefined });
+    const events: DriverUsageEvent[] = [];
+
+    for (const line of lines) {
+        parser.parseLine(line, (event) => events.push(event));
+    }
+
+    return events;
+}
+
+/** What `monitor` would bill for one event: the recorded cost, else catalog rates, else $0. */
+export function billedCost(driver: MonitorDriver, event: DriverUsageEvent): number {
+    if (event.recordedCostUsd !== undefined) {
+        return event.recordedCostUsd;
+    }
+
+    for (const candidate of driver.priceCandidates(event.model)) {
+        const price = DEFAULT_PRICING[candidate];
+
+        if (price) {
+            return costOf(
+                {
+                    input: event.inputTokens,
+                    output: event.outputTokens,
+                    cacheWrite: event.cacheCreationTokens,
+                    cacheRead: event.cacheReadTokens,
+                },
+                price
+            );
+        }
+    }
+
+    return 0;
+}

--- a/src/ai-spend/lib/drivers/grok.test.ts
+++ b/src/ai-spend/lib/drivers/grok.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
@@ -7,6 +7,10 @@ import { SafeJSON } from "@genesiscz/utils/json";
 import { DEFAULT_PRICING } from "../pricing";
 import { billedCost, collectEvents } from "./driver-test-helpers";
 import { grokDriver } from "./grok";
+import { isolateAgentHomeEnv } from "./test-env";
+
+// An ambient GROK_HOME would relocate the root asserted below.
+isolateAgentHomeEnv();
 
 const turnCompleted = (eventId: string, usage: Record<string, unknown>): string =>
     SafeJSON.stringify({
@@ -116,21 +120,85 @@ describe("grok driver", () => {
 
     test("no modelUsage map falls back to summary.json's current_model_id", () => {
         const dir = mkdtempSync(join(tmpdir(), "ai-spend-grok-"));
-        const sessionDir = join(dir, "sess-x");
-        mkdirSync(sessionDir, { recursive: true });
-        writeFileSync(
-            join(sessionDir, "summary.json"),
-            SafeJSON.stringify({ info: { id: "sess-x" }, current_model_id: "grok-4.6" })
-        );
 
-        const events = collectEvents(
-            grokDriver,
-            [turnCompleted("evt-4", { inputTokens: 50, outputTokens: 5, cachedReadTokens: 10 })],
-            join(sessionDir, "updates.jsonl")
-        );
+        try {
+            const sessionDir = join(dir, "sess-x");
+            mkdirSync(sessionDir, { recursive: true });
+            writeFileSync(
+                join(sessionDir, "summary.json"),
+                SafeJSON.stringify({ info: { id: "sess-x" }, current_model_id: "grok-4.6" })
+            );
+
+            const events = collectEvents(
+                grokDriver,
+                [turnCompleted("evt-4", { inputTokens: 50, outputTokens: 5, cachedReadTokens: 10 })],
+                join(sessionDir, "updates.jsonl")
+            );
+
+            expect(events).toHaveLength(1);
+            expect(events[0]).toMatchObject({
+                model: "grok-4.6",
+                inputTokens: 40,
+                cacheReadTokens: 10,
+                outputTokens: 5,
+            });
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("a turn-level costUsdTicks survives when the SOLE model row omits it", () => {
+        const events = collectEvents(grokDriver, [
+            turnCompleted("evt-sole", {
+                inputTokens: 100,
+                outputTokens: 20,
+                cachedReadTokens: 40,
+                costUsdTicks: 185_192_000,
+                modelUsage: {
+                    "grok-4.5-build": { inputTokens: 100, outputTokens: 20, cachedReadTokens: 40 },
+                },
+            }),
+        ]);
 
         expect(events).toHaveLength(1);
-        expect(events[0]).toMatchObject({ model: "grok-4.6", inputTokens: 40, cacheReadTokens: 10, outputTokens: 5 });
+        // A sum over one term IS that term, so the turn figure is the row's cost.
+        expect(events[0].recordedCostUsd).toBeCloseTo(0.0185192, 12);
+    });
+
+    test("a turn-level costUsdTicks is NOT split across two model rows", () => {
+        const events = collectEvents(grokDriver, [
+            turnCompleted("evt-two", {
+                costUsdTicks: 185_192_000,
+                modelUsage: {
+                    "model-a": { inputTokens: 10, outputTokens: 2 },
+                    "model-b": { inputTokens: 20, outputTokens: 4 },
+                },
+            }),
+        ]);
+
+        expect(events).toHaveLength(2);
+        // Neither row may claim the whole turn total — that would double-bill it.
+        expect(events[0].recordedCostUsd).toBeUndefined();
+        expect(events[1].recordedCostUsd).toBeUndefined();
+    });
+
+    test("an out-of-range timestamp yields an empty stamp instead of throwing", () => {
+        // 1e15 SECONDS becomes 1e18 ms, far past the 8.64e15 Date limit. An
+        // unguarded toISOString() would throw and abandon the rest of the file.
+        const line = SafeJSON.stringify({
+            timestamp: 1e15,
+            params: {
+                sessionId: "sess-overflow",
+                update: { sessionUpdate: "turn_completed", usage: { inputTokens: 10, outputTokens: 1 } },
+            },
+        });
+
+        let events: ReturnType<typeof collectEvents> = [];
+        expect(() => {
+            events = collectEvents(grokDriver, [line]);
+        }).not.toThrow();
+        expect(events).toHaveLength(1);
+        expect(events[0].timestamp).toBe("");
     });
 
     test("non-usage updates, zero rows and hook lines are skipped", () => {

--- a/src/ai-spend/lib/drivers/grok.test.ts
+++ b/src/ai-spend/lib/drivers/grok.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { DEFAULT_PRICING } from "../pricing";
+import { billedCost, collectEvents } from "./driver-test-helpers";
+import { grokDriver } from "./grok";
+
+const turnCompleted = (eventId: string, usage: Record<string, unknown>): string =>
+    SafeJSON.stringify({
+        timestamp: 1_787_418_712,
+        method: "_x.ai/session/update",
+        params: {
+            sessionId: "sess-grok-1",
+            update: { sessionUpdate: "turn_completed", prompt_id: "prompt-1", stop_reason: "end_turn", usage },
+            _meta: { eventId, agentTimestampMs: 1_787_418_712_439 },
+        },
+    });
+
+describe("grok driver", () => {
+    test("splits inputTokens into uncached/read/write and trusts costUsdTicks", () => {
+        const events = collectEvents(grokDriver, [
+            turnCompleted("evt-1", {
+                inputTokens: 89_502,
+                outputTokens: 936,
+                totalTokens: 90_438,
+                cachedReadTokens: 59_008,
+                cacheCreationTokens: 0,
+                reasoningTokens: 793,
+                costUsdTicks: 163_383_600,
+                modelUsage: {
+                    "grok-4.6-build": {
+                        inputTokens: 89_502,
+                        outputTokens: 936,
+                        cachedReadTokens: 59_008,
+                        cacheCreationTokens: 0,
+                        reasoningTokens: 793,
+                        costUsdTicks: 163_383_600,
+                    },
+                },
+            }),
+        ]);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            id: "evt-1|grok-4.6-build",
+            model: "grok-4.6-build",
+            inputTokens: 30_494,
+            outputTokens: 936,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 59_008,
+        });
+        // One tick is 1e-10 USD: 163383600 / 1e10 = $0.01633836.
+        expect(events[0].recordedCostUsd).toBeCloseTo(0.01633836, 12);
+        expect(billedCost(grokDriver, events[0])).toBeCloseTo(0.01633836, 12);
+        // The agent's own figure survives even though xai carries no catalog rate.
+        expect(DEFAULT_PRICING["grok-4.6"]).toBeUndefined();
+    });
+
+    test("the envelope timestamp is Unix SECONDS, `_meta.agentTimestampMs` is millis", () => {
+        const withMeta = collectEvents(grokDriver, [turnCompleted("evt-ms", { inputTokens: 10, outputTokens: 1 })]);
+        expect(withMeta[0].timestamp).toBe(new Date(1_787_418_712_439).toISOString());
+
+        const secondsOnly = collectEvents(grokDriver, [
+            SafeJSON.stringify({
+                timestamp: 1_787_418_712,
+                params: {
+                    sessionId: "sess-grok-1",
+                    update: { sessionUpdate: "turn_completed", usage: { inputTokens: 10, outputTokens: 1 } },
+                },
+            }),
+        ]);
+        expect(secondsOnly[0].timestamp).toBe(new Date(1_787_418_712_000).toISOString());
+    });
+
+    test("cacheCreationTokens is a sibling subset, not an extra bucket", () => {
+        const events = collectEvents(grokDriver, [
+            turnCompleted("evt-2", {
+                modelUsage: {
+                    "grok-4.5-build": {
+                        inputTokens: 100,
+                        outputTokens: 20,
+                        cachedReadTokens: 40,
+                        cacheCreationTokens: 25,
+                        reasoningTokens: 10,
+                    },
+                },
+            }),
+        ]);
+
+        expect(events[0]).toMatchObject({ inputTokens: 35, cacheReadTokens: 40, cacheCreationTokens: 25 });
+        // The three parts sum back to inputTokens.
+        expect(events[0].inputTokens + events[0].cacheReadTokens + events[0].cacheCreationTokens).toBe(100);
+        // No ticks recorded and xai is unpriced → $0.
+        expect(events[0].recordedCostUsd).toBeUndefined();
+        expect(billedCost(grokDriver, events[0])).toBe(0);
+    });
+
+    test("one turn billing two models yields two events, sorted by model id", () => {
+        const events = collectEvents(grokDriver, [
+            turnCompleted("evt-3", {
+                modelUsage: {
+                    "model-b": { inputTokens: 20, outputTokens: 4, cachedReadTokens: 5, costUsdTicks: 20_000_000 },
+                    "model-a": { inputTokens: 10, outputTokens: 2, costUsdTicks: 10_000_000 },
+                },
+            }),
+        ]);
+
+        expect(events.map((event) => event.model)).toEqual(["model-a", "model-b"]);
+        expect(events.map((event) => event.id)).toEqual(["evt-3|model-a", "evt-3|model-b"]);
+        expect(events[0].recordedCostUsd).toBeCloseTo(0.001, 12);
+        expect(events[1].recordedCostUsd).toBeCloseTo(0.002, 12);
+    });
+
+    test("no modelUsage map falls back to summary.json's current_model_id", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ai-spend-grok-"));
+        const sessionDir = join(dir, "sess-x");
+        mkdirSync(sessionDir, { recursive: true });
+        writeFileSync(
+            join(sessionDir, "summary.json"),
+            SafeJSON.stringify({ info: { id: "sess-x" }, current_model_id: "grok-4.6" })
+        );
+
+        const events = collectEvents(
+            grokDriver,
+            [turnCompleted("evt-4", { inputTokens: 50, outputTokens: 5, cachedReadTokens: 10 })],
+            join(sessionDir, "updates.jsonl")
+        );
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({ model: "grok-4.6", inputTokens: 40, cacheReadTokens: 10, outputTokens: 5 });
+    });
+
+    test("non-usage updates, zero rows and hook lines are skipped", () => {
+        const events = collectEvents(grokDriver, [
+            SafeJSON.stringify({
+                timestamp: 1_787_798_628,
+                params: { update: { sessionUpdate: "hook_execution", event_name: "session_start" } },
+            }),
+            SafeJSON.stringify({ timestamp: 1, params: { update: { sessionUpdate: "turn_completed" } } }),
+            turnCompleted("evt-zero", {
+                modelUsage: {
+                    "grok-4.5": { inputTokens: 0, outputTokens: 0, cachedReadTokens: 0, reasoningTokens: 0 },
+                },
+            }),
+            "",
+        ]);
+
+        expect(events).toEqual([]);
+    });
+
+    test("only updates.jsonl counts, and GROK_HOME moves the root", async () => {
+        expect(grokDriver.isTranscript("updates.jsonl")).toBe(true);
+        expect(grokDriver.isTranscript("events.jsonl")).toBe(false);
+        expect(grokDriver.isTranscript("chat_history.jsonl")).toBe(false);
+        expect(grokDriver.roots("/home/u")).toEqual(["/home/u/.grok/sessions"]);
+
+        await env.testing.withOverrides({ GROK_HOME: "/elsewhere/grok" }, () => {
+            expect(grokDriver.roots("/home/u")).toEqual(["/elsewhere/grok/sessions"]);
+        });
+    });
+
+    test("price candidates peel the -build suffix", () => {
+        expect(grokDriver.priceCandidates("grok-4.6-build")).toEqual(["grok-4.6-build", "grok-4.6"]);
+        expect(grokDriver.priceCandidates("grok-3-fast-latest")).toEqual(["grok-3-fast-latest", "grok-3-fast"]);
+    });
+});

--- a/src/ai-spend/lib/drivers/grok.ts
+++ b/src/ai-spend/lib/drivers/grok.ts
@@ -4,6 +4,7 @@ import { stripModelVariantSuffix } from "@genesiscz/utils/ai/catalog";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
+import { isRecord, num } from "./parse-helpers";
 import type { CreateParserOptions, DriverLineParser, DriverUsageEvent, MonitorDriver } from "./types";
 
 /**
@@ -63,12 +64,21 @@ interface GrokLine {
     };
 }
 
-function num(value: number | undefined): number {
-    return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
+/** The widest epoch a JS Date accepts; beyond it `toISOString()` throws RangeError. */
+const MAX_EPOCH_MS = 8.64e15;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
+/**
+ * ISO-8601 for an epoch, or "" when the record's clock is unusable. A corrupt
+ * `timestamp` (seconds are multiplied by 1000 here) can overflow the Date range,
+ * and an unguarded `toISOString()` would throw out of `parseLine` and abandon
+ * every remaining line of the file.
+ */
+function isoFromEpochMs(ms: number): string {
+    if (ms <= 0 || ms > MAX_EPOCH_MS) {
+        return "";
+    }
+
+    return new Date(ms).toISOString();
 }
 
 /** Split `inputTokens` into its uncached, cache-read and cache-write parts. */
@@ -187,7 +197,7 @@ export const grokDriver: MonitorDriver = {
                 const agentMs = num(meta?.agentTimestampMs);
                 // Grok writes Unix SECONDS on the envelope and milliseconds on `_meta`.
                 const ms = agentMs > 0 ? agentMs : num(raw.timestamp) * 1000;
-                const timestamp = ms > 0 ? new Date(ms).toISOString() : "";
+                const timestamp = isoFromEpochMs(ms);
                 const sessionId = raw.params?.sessionId ?? fallbackSessionId;
                 const usage = update.usage;
                 const perModel = usage.modelUsage;
@@ -202,6 +212,14 @@ export const grokDriver: MonitorDriver = {
 
                     rows = [[sessionModel ?? "unknown", usage]];
                 }
+
+                // `costUsdTicks` normally appears on both the turn and each model row.
+                // When the turn recorded a figure and the SOLE model row did not, the
+                // turn total IS that row's cost — a sum over one term. With two or more
+                // rows the total cannot be attributed, so it is left alone rather than
+                // guessed at.
+                const turnTicks = num(usage.costUsdTicks);
+                const soleRowTicks = rows.length === 1 && num(rows[0][1].costUsdTicks) === 0 ? turnTicks : 0;
 
                 for (const [model, modelUsage] of rows) {
                     const [inputTokens, cacheReadTokens, cacheCreationTokens] = splitInput(
@@ -222,7 +240,7 @@ export const grokDriver: MonitorDriver = {
                         continue;
                     }
 
-                    const ticks = num(modelUsage.costUsdTicks);
+                    const ticks = num(modelUsage.costUsdTicks) || soleRowTicks;
                     const eventId = meta?.eventId;
                     const event: DriverUsageEvent = {
                         id: eventId

--- a/src/ai-spend/lib/drivers/grok.ts
+++ b/src/ai-spend/lib/drivers/grok.ts
@@ -1,0 +1,253 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { stripModelVariantSuffix } from "@genesiscz/utils/ai/catalog";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import type { CreateParserOptions, DriverLineParser, DriverUsageEvent, MonitorDriver } from "./types";
+
+/**
+ * Grok CLI sessions: `~/.grok/sessions/<url-encoded-cwd>/<session-id>/updates.jsonl`
+ * (`GROK_HOME` overrides the root). Only `updates.jsonl` carries usage —
+ * `events.jsonl` and `chat_history.jsonl` are ignored, matching ccusage's
+ * discovery (`rust/adapters/grok/src/paths.rs:32` `discover_session_files`).
+ *
+ * The usage line is a JSON-RPC notification:
+ * `{"timestamp":…,"params":{"update":{"sessionUpdate":"turn_completed","usage":{…}}}}`,
+ * with a per-model breakdown under `usage.modelUsage`.
+ *
+ * Token and cost semantics mirror `parse_session_files`
+ * (`rust/adapters/grok/src/parser.rs:207-325`):
+ *   - `cachedReadTokens` and `cacheCreationTokens` are SUBSETS of `inputTokens`,
+ *     so billable input is `input - cachedRead - cacheCreation`
+ *     (`split_input_tokens`, parser.rs:170).
+ *   - `reasoningTokens` is a subset of `outputTokens` and is never billed twice.
+ *   - `costUsdTicks` is fixed-point USD at 1e-10 per tick and is AUTHORITATIVE
+ *     (parser.rs:140-153): Grok prices each API request separately and a
+ *     `turn_completed` row only carries the per-turn sum, so recomputing from
+ *     those totals cannot reproduce the figure Grok actually billed.
+ *   - dedup is `eventId|model`, falling back to the token fingerprint.
+ */
+
+const COST_USD_TICKS_PER_USD = 1e10;
+
+interface GrokModelUsage {
+    inputTokens?: number;
+    outputTokens?: number;
+    cachedReadTokens?: number;
+    cacheCreationTokens?: number;
+    reasoningTokens?: number;
+    costUsdTicks?: number;
+}
+
+interface GrokUsage extends GrokModelUsage {
+    modelUsage?: Record<string, GrokModelUsage>;
+}
+
+interface GrokUpdate {
+    sessionUpdate?: string;
+    usage?: GrokUsage;
+}
+
+interface GrokMeta {
+    eventId?: string;
+    agentTimestampMs?: number;
+}
+
+interface GrokLine {
+    timestamp?: number;
+    params?: {
+        sessionId?: string;
+        update?: GrokUpdate;
+        _meta?: GrokMeta;
+    };
+}
+
+function num(value: number | undefined): number {
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+/** Split `inputTokens` into its uncached, cache-read and cache-write parts. */
+function splitInput(input: number, cachedRead: number, cacheCreation: number): [number, number, number] {
+    const read = Math.min(cachedRead, input);
+    const remainder = input - read;
+    const created = Math.min(cacheCreation, remainder);
+
+    return [remainder - created, read, created];
+}
+
+/** `summary.json` next to `updates.jsonl` names the session's model. */
+function readSessionModel(file: string): string | undefined {
+    const summary = join(dirname(file), "summary.json");
+
+    if (!existsSync(summary)) {
+        return undefined;
+    }
+
+    try {
+        const parsed: unknown = SafeJSON.parse(readFileSync(summary, "utf8"), { strict: true });
+
+        if (isRecord(parsed) && typeof parsed.current_model_id === "string") {
+            return parsed.current_model_id;
+        }
+    } catch (err) {
+        logger.debug({ err, summary }, "ai-spend grok: unreadable session summary");
+    }
+
+    return undefined;
+}
+
+/**
+ * `grok-4.6-build` is the build-agent flavour of `grok-4.6`, so peel the
+ * `-build` suffix as ccusage's `pricing_candidates` does
+ * (`rust/adapters/grok/src/parser.rs:177`). The `xai/` and `x-ai/` prefixed
+ * candidates ccusage also tries are skipped: this tool's pricing table is keyed
+ * by bare catalog ids, so a prefixed key can never hit.
+ */
+function grokPriceCandidates(model: string): string[] {
+    const candidates: string[] = [];
+    const push = (value: string | null): void => {
+        if (value && !candidates.includes(value)) {
+            candidates.push(value);
+        }
+    };
+
+    const stripped = model.startsWith("[grok] ") ? model.slice("[grok] ".length).trim() : model.trim();
+
+    push(stripped);
+    push(stripModelVariantSuffix(stripped));
+
+    if (stripped.endsWith("-build")) {
+        const base = stripped.slice(0, -"-build".length);
+        push(base);
+        push(stripModelVariantSuffix(base));
+    }
+
+    return candidates;
+}
+
+export const grokDriver: MonitorDriver = {
+    id: "grok",
+
+    roots(home: string): string[] {
+        const override = env.grok.getHomeOverride();
+
+        return [join(override ?? join(home, ".grok"), "sessions")];
+    },
+
+    isTranscript(name: string): boolean {
+        return name === "updates.jsonl";
+    },
+
+    // sessions/<encoded-cwd>/<session-id>/updates.jsonl
+    maxDepth: 3,
+
+    createParser(options: CreateParserOptions): DriverLineParser {
+        // Only ever needed when a turn omits `modelUsage`, so it stays lazy: the
+        // common path never opens the sibling file.
+        let sessionModel: string | undefined | null = null;
+        const fallbackSessionId = basename(dirname(options.file));
+
+        return {
+            parseLine(line: string, emit: (event: DriverUsageEvent) => void): void {
+                const trimmed = line.trim();
+
+                // Cheap prefilter before the JSON parse — most update lines are
+                // tool calls and hook runs, not usage. ccusage does the same
+                // (`LinePrefilter::all(&[b"\"turn_completed\""])`, parser.rs:215).
+                if (!trimmed.includes('"turn_completed"')) {
+                    return;
+                }
+
+                let parsed: unknown;
+                try {
+                    parsed = SafeJSON.parse(trimmed, { strict: true });
+                } catch (err) {
+                    logger.debug({ err }, "ai-spend grok: skipping malformed update line");
+
+                    return;
+                }
+
+                if (!isRecord(parsed)) {
+                    return;
+                }
+
+                const raw = parsed as GrokLine;
+                const update = raw.params?.update;
+
+                if (update?.sessionUpdate !== "turn_completed" || !update.usage) {
+                    return;
+                }
+
+                const meta = raw.params?._meta;
+                const agentMs = num(meta?.agentTimestampMs);
+                // Grok writes Unix SECONDS on the envelope and milliseconds on `_meta`.
+                const ms = agentMs > 0 ? agentMs : num(raw.timestamp) * 1000;
+                const timestamp = ms > 0 ? new Date(ms).toISOString() : "";
+                const sessionId = raw.params?.sessionId ?? fallbackSessionId;
+                const usage = update.usage;
+                const perModel = usage.modelUsage;
+                let rows: [string, GrokModelUsage][];
+
+                if (perModel && Object.keys(perModel).length > 0) {
+                    rows = Object.entries(perModel).sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+                } else {
+                    if (sessionModel === null) {
+                        sessionModel = readSessionModel(options.file);
+                    }
+
+                    rows = [[sessionModel ?? "unknown", usage]];
+                }
+
+                for (const [model, modelUsage] of rows) {
+                    const [inputTokens, cacheReadTokens, cacheCreationTokens] = splitInput(
+                        num(modelUsage.inputTokens),
+                        num(modelUsage.cachedReadTokens),
+                        num(modelUsage.cacheCreationTokens)
+                    );
+                    const outputTokens = num(modelUsage.outputTokens);
+                    const reasoningTokens = num(modelUsage.reasoningTokens);
+
+                    if (
+                        inputTokens === 0 &&
+                        cacheReadTokens === 0 &&
+                        cacheCreationTokens === 0 &&
+                        outputTokens === 0 &&
+                        reasoningTokens === 0
+                    ) {
+                        continue;
+                    }
+
+                    const ticks = num(modelUsage.costUsdTicks);
+                    const eventId = meta?.eventId;
+                    const event: DriverUsageEvent = {
+                        id: eventId
+                            ? `${eventId}|${model}`
+                            : `${sessionId}|${ms}|${model}|${inputTokens}|${outputTokens}|${cacheReadTokens}|${cacheCreationTokens}|${reasoningTokens}`,
+                        model,
+                        timestamp,
+                        inputTokens,
+                        outputTokens,
+                        cacheCreationTokens,
+                        cacheReadTokens,
+                    };
+
+                    if (ticks > 0) {
+                        event.recordedCostUsd = ticks / COST_USD_TICKS_PER_USD;
+                    }
+
+                    emit(event);
+                }
+            },
+            snapshot(): unknown {
+                return undefined;
+            },
+        };
+    },
+
+    priceCandidates: grokPriceCandidates,
+};

--- a/src/ai-spend/lib/drivers/index.ts
+++ b/src/ai-spend/lib/drivers/index.ts
@@ -1,0 +1,13 @@
+import { claudeDriver } from "./claude";
+import { codexDriver } from "./codex";
+import { grokDriver } from "./grok";
+import type { MonitorDriver } from "./types";
+
+export { claudeDriver } from "./claude";
+export { codexDriver } from "./codex";
+export { grokDriver } from "./grok";
+export type { AgentId, CreateParserOptions, DriverLineParser, DriverUsageEvent, MonitorDriver } from "./types";
+export { AGENT_IDS } from "./types";
+
+/** Walk order is the report order. Claude first: it is the biggest tree. */
+export const MONITOR_DRIVERS: readonly MonitorDriver[] = [claudeDriver, codexDriver, grokDriver];

--- a/src/ai-spend/lib/drivers/parse-helpers.ts
+++ b/src/ai-spend/lib/drivers/parse-helpers.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared JSONL-parsing primitives for the agent drivers. Each driver had its own
+ * identical copy, which is one place for the two to drift the moment one of them
+ * is hardened.
+ */
+
+/** A missing, NaN or Infinite token count is 0, never a value that poisons the arithmetic. */
+export function num(value: number | undefined): number {
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}

--- a/src/ai-spend/lib/drivers/test-env.ts
+++ b/src/ai-spend/lib/drivers/test-env.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach } from "bun:test";
+import { env } from "@genesiscz/utils/env";
+import type { EnvSnapshot } from "@genesiscz/utils/env/env-testing";
+
+/**
+ * Every agent driver honours a home override: `CLAUDE_CONFIG_DIR` adds a third
+ * Claude root, `CODEX_HOME` and `GROK_HOME` relocate the Codex and Grok roots
+ * entirely. A developer machine with any of them set would make a fixture-home
+ * test walk REAL transcript trees, which both breaks exact root assertions and
+ * inflates the file counts. Call this at the top of any suite that pins a
+ * fixture home or an exact root list.
+ */
+const AGENT_HOME_KEYS = ["CLAUDE_CONFIG_DIR", "CODEX_HOME", "GROK_HOME"] as const;
+
+export function isolateAgentHomeEnv(): void {
+    let snapshot: EnvSnapshot;
+
+    beforeEach(() => {
+        snapshot = env.testing.snapshot();
+
+        for (const key of AGENT_HOME_KEYS) {
+            env.testing.unset(key);
+        }
+    });
+
+    afterEach(() => {
+        env.testing.restore(snapshot);
+    });
+}

--- a/src/ai-spend/lib/drivers/types.ts
+++ b/src/ai-spend/lib/drivers/types.ts
@@ -1,0 +1,83 @@
+/**
+ * `ai-spend monitor` reads more than one coding agent. Every agent writes its
+ * own JSONL dialect in its own directory tree, so the walker, the mtime
+ * pruning, the incremental tail cache and the 10-minute sweep live ONCE in
+ * `monitor.ts`, and each agent contributes only the three things that actually
+ * differ: where its transcripts live, which file names count, and how one line
+ * turns into a usage event.
+ *
+ * Line shapes and token semantics mirror ccusage's Rust adapters
+ * (`rust/adapters/{claude,codex,grok}` in the ccusage repo) so the numbers line
+ * up with what ccusage reports for the same files.
+ */
+
+/** The agents `monitor` knows how to read. */
+export type AgentId = "claude" | "codex" | "grok";
+
+export const AGENT_IDS: readonly AgentId[] = ["claude", "codex", "grok"];
+
+export interface DriverUsageEvent {
+    /**
+     * Dedup key, unique within one transcript. Agents that stamp a message or
+     * event id use it verbatim; the rest synthesize one from the fields that
+     * make a request unique (timestamp, model, token counts).
+     */
+    id: string;
+    model: string;
+    /** ISO-8601 timestamp. "" when the line carried none (the event is dropped). */
+    timestamp: string;
+    /** Billable, NON-cached input tokens (cache reads/writes are separate below). */
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    /**
+     * Cost in USD that the agent itself recorded for this event. Authoritative
+     * when present: Grok prices each API request separately and only reports
+     * the per-turn sum, so recomputing from the summed tokens cannot land on
+     * the same figure. Absent means "derive it from the catalog rates".
+     */
+    recordedCostUsd?: number;
+}
+
+/**
+ * A parser bound to ONE transcript. Codex carries state across lines (the
+ * sticky `turn_context` model, the previous cumulative totals), and the
+ * incremental cache resumes a file mid-way, so that state has to survive
+ * between runs — hence `snapshot()`, which is persisted next to the file's
+ * byte offset and handed back on the next run.
+ */
+export interface DriverLineParser {
+    /**
+     * Emit every usage event on this line. One line can bill several models
+     * (Grok's per-turn `modelUsage` map), and most lines bill none, so events
+     * are pushed rather than returned — no array is allocated for the common
+     * case of a line that carries no usage at all.
+     */
+    parseLine(line: string, emit: (event: DriverUsageEvent) => void): void;
+    /** JSON-serializable resume state, or undefined for stateless drivers. */
+    snapshot(): unknown;
+}
+
+export interface CreateParserOptions {
+    /** Absolute path of the transcript being parsed (siblings, session ids). */
+    file: string;
+    /** Whatever `snapshot()` returned last run, or undefined on a fresh parse. */
+    state: unknown;
+}
+
+export interface MonitorDriver {
+    id: AgentId;
+    /** Directory trees to walk. Missing directories are skipped, not an error. */
+    roots(home: string): string[];
+    /** File-name test, applied BEFORE stat() so non-transcripts cost nothing. */
+    isTranscript(name: string): boolean;
+    /** How deep below a root transcripts can sit. */
+    maxDepth: number;
+    createParser(options: CreateParserOptions): DriverLineParser;
+    /**
+     * Pricing-table keys to try for a raw model id, most specific first. An id
+     * that matches nothing is unpriced and costs $0 — never a guessed rate.
+     */
+    priceCandidates(model: string): string[];
+}

--- a/src/ai-spend/lib/monitor.test.ts
+++ b/src/ai-spend/lib/monitor.test.ts
@@ -2,10 +2,18 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { Storage } from "@genesiscz/utils/storage/storage";
 import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
-import { buildMonitorReport, findRecentTranscripts, localDayString, mondayOfWeek, transcriptRoots } from "./monitor";
+import {
+    buildMonitorReport,
+    findRecentTranscripts,
+    localDayString,
+    type MonitorReport,
+    mondayOfWeek,
+    transcriptRoots,
+} from "./monitor";
 import { DEFAULT_PRICING } from "./pricing";
 
 setupStorageSandbox();
@@ -168,5 +176,138 @@ describe("monitor report", () => {
         const files = findRecentTranscripts(roots, Date.now() - 60_000);
         expect(files.every((f) => f.startsWith(roots[0]) || f.startsWith(roots[1]))).toBe(true);
         expect(files.some((f) => f.endsWith("old.jsonl"))).toBe(false);
+    });
+});
+
+/** Every agent root must resolve under the fixture home, never an ambient override. */
+const FIXTURE_HOME_ONLY = { CLAUDE_CONFIG_DIR: undefined, CODEX_HOME: undefined, GROK_HOME: undefined };
+
+describe("multi-agent monitor report", () => {
+    let home: string;
+
+    beforeEach(() => {
+        home = mkdtempSync(join(tmpdir(), "ai-spend-agents-"));
+        const iso = new Date().toISOString();
+
+        const claudeDir = join(home, ".claude", "projects", "p1");
+        mkdirSync(claudeDir, { recursive: true });
+        // 1M input on claude-3-5-haiku = $0.80.
+        writeFileSync(join(claudeDir, "s1.jsonl"), line("msg-a", iso, { input_tokens: 1_000_000 }));
+
+        const codexDir = join(home, ".codex", "sessions", "2026", "08", "27");
+        mkdirSync(codexDir, { recursive: true });
+        // gpt-5: $1.25 in · $10 out · $0.125 cacheRead per Mtok.
+        // 1M uncached in + 1M cacheRead + 0.1M out = 1.25 + 0.125 + 1.00 = $2.375
+        writeFileSync(
+            join(codexDir, "rollout-2026-08-27T09-00-00-synthetic.jsonl"),
+            `${SafeJSON.stringify({
+                timestamp: iso,
+                type: "turn_context",
+                payload: { turn_id: "t1", cwd: "/tmp/proj", model: "gpt-5" },
+            })}\n${SafeJSON.stringify({
+                timestamp: iso,
+                type: "event_msg",
+                payload: {
+                    type: "token_count",
+                    info: {
+                        total_token_usage: {
+                            input_tokens: 2_000_000,
+                            cached_input_tokens: 1_000_000,
+                            output_tokens: 100_000,
+                            total_tokens: 2_100_000,
+                        },
+                        last_token_usage: {
+                            input_tokens: 2_000_000,
+                            cached_input_tokens: 1_000_000,
+                            output_tokens: 100_000,
+                            total_tokens: 2_100_000,
+                        },
+                    },
+                },
+            })}\n`
+        );
+
+        const grokDir = join(home, ".grok", "sessions", "%2Ftmp%2Fproj", "sess-grok-1");
+        mkdirSync(grokDir, { recursive: true });
+        // 500_000_000 ticks / 1e10 = $0.05, recorded by grok itself.
+        writeFileSync(
+            join(grokDir, "updates.jsonl"),
+            `${SafeJSON.stringify({
+                timestamp: Math.floor(Date.now() / 1000),
+                method: "_x.ai/session/update",
+                params: {
+                    sessionId: "sess-grok-1",
+                    update: {
+                        sessionUpdate: "turn_completed",
+                        usage: {
+                            modelUsage: {
+                                "grok-4.6-build": {
+                                    inputTokens: 100_000,
+                                    outputTokens: 2_000,
+                                    cachedReadTokens: 60_000,
+                                    costUsdTicks: 500_000_000,
+                                },
+                            },
+                        },
+                    },
+                    _meta: { eventId: "evt-1", agentTimestampMs: Date.now() },
+                },
+            })}\n`
+        );
+        // events.jsonl sits next to it and must never be read.
+        writeFileSync(join(grokDir, "events.jsonl"), `${SafeJSON.stringify({ nonsense: true })}\n`);
+    });
+
+    test("splits today/week per agent and sums them at the top level", async () => {
+        const opened: string[] = [];
+        let report!: MonitorReport;
+        await env.testing.withOverrides(FIXTURE_HOME_ONLY, () => {
+            report = buildMonitorReport({
+                home,
+                pricing: DEFAULT_PRICING,
+                storage: new Storage("ai-spend"),
+                sweepTtlMs: 0,
+                readTailFn: (path, _offset, _size) => {
+                    opened.push(path);
+
+                    return readFileSync(path, "utf8");
+                },
+            });
+        });
+
+        expect(report.agents.claude.today.cost).toBeCloseTo(0.8, 6);
+        expect(report.agents.claude.today.tokens).toBe(1_000_000);
+        expect(report.agents.codex.today.cost).toBeCloseTo(2.375, 6);
+        expect(report.agents.codex.today.tokens).toBe(2_100_000);
+        expect(report.agents.grok.today.cost).toBeCloseTo(0.05, 8);
+        expect(report.agents.grok.today.tokens).toBe(102_000);
+
+        expect(report.today.cost).toBeCloseTo(0.8 + 2.375 + 0.05, 6);
+        expect(report.today.tokens).toBe(1_000_000 + 2_100_000 + 102_000);
+        expect(report.week).toEqual(report.today);
+
+        // One transcript per agent, and grok's events.jsonl was never opened.
+        expect(report.recentFiles).toBe(3);
+        expect(report.parsedFiles).toBe(3);
+        expect(opened.some((path) => path.endsWith("events.jsonl"))).toBe(false);
+    });
+
+    test("the cache is keyed per agent — a second run parses nothing", async () => {
+        const storage = new Storage("ai-spend");
+        const run = async (): Promise<MonitorReport> => {
+            let report!: MonitorReport;
+            await env.testing.withOverrides(FIXTURE_HOME_ONLY, () => {
+                report = buildMonitorReport({ home, pricing: DEFAULT_PRICING, storage, sweepTtlMs: 0 });
+            });
+
+            return report;
+        };
+
+        const first = await run();
+        const second = await run();
+
+        expect(second.parsedFiles).toBe(0);
+        expect(second.today.cost).toBeCloseTo(first.today.cost, 10);
+        expect(second.agents).toEqual(first.agents);
     });
 });

--- a/src/ai-spend/lib/monitor.test.ts
+++ b/src/ai-spend/lib/monitor.test.ts
@@ -7,15 +7,9 @@ import { Storage } from "@genesiscz/utils/storage/storage";
 import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
 import { claudeDriver, codexDriver, grokDriver } from "./drivers";
 import { isolateAgentHomeEnv } from "./drivers/test-env";
-import {
-    buildMonitorReport,
-    findRecentTranscripts,
-    localDayString,
-    type MonitorReport,
-    mondayOfWeek,
-    transcriptRoots,
-} from "./monitor";
+import { buildMonitorReport, findRecentTranscripts, localDayString, type MonitorReport, mondayOfWeek } from "./monitor";
 import { DEFAULT_PRICING } from "./pricing";
+import type { PricingTable } from "./types";
 
 setupStorageSandbox();
 // CLAUDE_CONFIG_DIR / CODEX_HOME / GROK_HOME would drag real transcript trees
@@ -179,11 +173,11 @@ describe("monitor report", () => {
         expect(second.today.tokens).toBe(2_850_000 + 1_000_000 + 1_000_000 + 500_000);
     });
 
-    test("transcriptRoots and findRecentTranscripts never look outside the fixed roots", () => {
-        const roots = transcriptRoots(home);
+    test("the claude roots and findRecentTranscripts never look outside the fixed roots", () => {
+        const roots = claudeDriver.roots(home);
         expect(roots).toEqual([join(home, ".claude", "projects"), join(home, ".config", "claude", "projects")]);
 
-        const files = findRecentTranscripts(roots, Date.now() - 60_000);
+        const files = findRecentTranscripts(roots, Date.now() - 60_000, claudeDriver);
         expect(files.every((f) => f.startsWith(roots[0]) || f.startsWith(roots[1]))).toBe(true);
         expect(files.some((f) => f.endsWith("old.jsonl"))).toBe(false);
     });
@@ -426,5 +420,53 @@ describe("multi-agent monitor report", () => {
             join(home, ".codex", "sessions"),
             join(home, ".codex", "archived_sessions"),
         ]);
+    });
+});
+
+/**
+ * Regression test: the monitor path never called resolvePrice, so it billed every
+ * event at the catalog's list rate and ignored the dated promotions and
+ * long-context bands aggregate.ts already honoured. `ModelPriceEntry` extends
+ * `ModelPrice`, so dropping the rules type-checked silently.
+ *
+ * Drives buildMonitorReport, not resolvePrice — a test of the resolver alone
+ * would pass both before and after the fix.
+ */
+describe("monitor honours dated and context-banded pricing", () => {
+    let home: string;
+
+    afterEach(() => {
+        rmSync(home, { recursive: true, force: true });
+    });
+
+    beforeEach(() => {
+        home = mkdtempSync(join(tmpdir(), "ai-spend-rules-"));
+        const projDir = join(home, ".claude", "projects", "p1");
+        mkdirSync(projDir, { recursive: true });
+        writeFileSync(join(projDir, "s1.jsonl"), line("msg-r", new Date().toISOString(), { input_tokens: 1_000_000 }));
+    });
+
+    test("a dated rule beats the list rate for an event inside its window", () => {
+        // List rate $100/1M; a rule in force since 2020 drops input to $1/1M.
+        const ruled: PricingTable = {
+            [MODEL]: {
+                input: 100,
+                output: 100,
+                cacheWrite: 100,
+                cacheRead: 100,
+                rules: [{ from: "2020-01-01", inputPer1M: 1, outputPer1M: 1 }],
+            },
+        };
+
+        const report = buildMonitorReport({
+            home,
+            pricing: ruled,
+            storage: new Storage("ai-spend"),
+            sweepTtlMs: 0,
+            readTailFn: (path) => readFileSync(path, "utf8"),
+        });
+
+        // 1M input tokens: $1 under the rule, $100 if the rules are dropped.
+        expect(report.today.cost).toBeCloseTo(1, 5);
     });
 });

--- a/src/ai-spend/lib/monitor.test.ts
+++ b/src/ai-spend/lib/monitor.test.ts
@@ -1,11 +1,12 @@
-import { beforeEach, describe, expect, test } from "bun:test";
-import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { Storage } from "@genesiscz/utils/storage/storage";
 import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
+import { claudeDriver, codexDriver, grokDriver } from "./drivers";
+import { isolateAgentHomeEnv } from "./drivers/test-env";
 import {
     buildMonitorReport,
     findRecentTranscripts,
@@ -17,6 +18,9 @@ import {
 import { DEFAULT_PRICING } from "./pricing";
 
 setupStorageSandbox();
+// CLAUDE_CONFIG_DIR / CODEX_HOME / GROK_HOME would drag real transcript trees
+// into every fixture-home assertion below.
+isolateAgentHomeEnv();
 
 // claude-3-5-haiku (literal legacy rates): input $0.8/M, output $4/M, cacheWrite $1.0/M, cacheRead $0.08/M.
 const MODEL = "claude-3-5-haiku";
@@ -52,6 +56,12 @@ describe("monitor report", () => {
     let home: string;
     let mainFile: string;
     let oldFile: string;
+
+    // The suite writes real transcript trees; leaving them behind accumulates
+    // across runs and lets one run's files leak into the next one's roots.
+    afterEach(() => {
+        rmSync(home, { recursive: true, force: true });
+    });
 
     beforeEach(() => {
         home = mkdtempSync(join(tmpdir(), "ai-spend-monitor-"));
@@ -177,13 +187,41 @@ describe("monitor report", () => {
         expect(files.every((f) => f.startsWith(roots[0]) || f.startsWith(roots[1]))).toBe(true);
         expect(files.some((f) => f.endsWith("old.jsonl"))).toBe(false);
     });
-});
 
-/** Every agent root must resolve under the fixture home, never an ambient override. */
-const FIXTURE_HOME_ONLY = { CLAUDE_CONFIG_DIR: undefined, CODEX_HOME: undefined, GROK_HOME: undefined };
+    test("a timestamp-less record does not burn its id for the real record that follows", () => {
+        const iso = new Date().toISOString();
+        // Claude Code rewrites a streaming message in place, so the same id can appear
+        // first without a timestamp and again complete. Counting the first one into the
+        // dedup frontier would make the second — the billable one — invisible forever.
+        writeFileSync(
+            join(home, ".claude", "projects", "p1", "stream.jsonl"),
+            `${SafeJSON.stringify({
+                type: "assistant",
+                cwd: "/tmp/proj",
+                sessionId: "s9",
+                message: { id: "msg-stream", model: MODEL, usage: { output_tokens: 250_000 } },
+            })}\n${line("msg-stream", iso, { output_tokens: 250_000 })}`
+        );
+
+        const report = buildMonitorReport({
+            home,
+            pricing: DEFAULT_PRICING,
+            storage: new Storage("ai-spend"),
+            sweepTtlMs: 0,
+        });
+
+        // 0.25M output at $4/M = $1.00, counted exactly once on top of the $3.48 fixture.
+        expect(report.today.cost).toBeCloseTo(4.48, 5);
+        expect(report.today.tokens).toBe(2_850_000 + 250_000);
+    });
+});
 
 describe("multi-agent monitor report", () => {
     let home: string;
+
+    afterEach(() => {
+        rmSync(home, { recursive: true, force: true });
+    });
 
     beforeEach(() => {
         home = mkdtempSync(join(tmpdir(), "ai-spend-agents-"));
@@ -258,21 +296,18 @@ describe("multi-agent monitor report", () => {
         writeFileSync(join(grokDir, "events.jsonl"), `${SafeJSON.stringify({ nonsense: true })}\n`);
     });
 
-    test("splits today/week per agent and sums them at the top level", async () => {
+    test("splits today/week per agent and sums them at the top level", () => {
         const opened: string[] = [];
-        let report!: MonitorReport;
-        await env.testing.withOverrides(FIXTURE_HOME_ONLY, () => {
-            report = buildMonitorReport({
-                home,
-                pricing: DEFAULT_PRICING,
-                storage: new Storage("ai-spend"),
-                sweepTtlMs: 0,
-                readTailFn: (path, _offset, _size) => {
-                    opened.push(path);
+        const report = buildMonitorReport({
+            home,
+            pricing: DEFAULT_PRICING,
+            storage: new Storage("ai-spend"),
+            sweepTtlMs: 0,
+            readTailFn: (path, _offset, _size) => {
+                opened.push(path);
 
-                    return readFileSync(path, "utf8");
-                },
-            });
+                return readFileSync(path, "utf8");
+            },
         });
 
         expect(report.agents.claude.today.cost).toBeCloseTo(0.8, 6);
@@ -292,22 +327,104 @@ describe("multi-agent monitor report", () => {
         expect(opened.some((path) => path.endsWith("events.jsonl"))).toBe(false);
     });
 
-    test("the cache is keyed per agent — a second run parses nothing", async () => {
+    test("the cache is keyed per agent — a second run parses nothing", () => {
         const storage = new Storage("ai-spend");
-        const run = async (): Promise<MonitorReport> => {
-            let report!: MonitorReport;
-            await env.testing.withOverrides(FIXTURE_HOME_ONLY, () => {
-                report = buildMonitorReport({ home, pricing: DEFAULT_PRICING, storage, sweepTtlMs: 0 });
-            });
+        const run = (): MonitorReport => buildMonitorReport({ home, pricing: DEFAULT_PRICING, storage, sweepTtlMs: 0 });
 
-            return report;
-        };
-
-        const first = await run();
-        const second = await run();
+        const first = run();
+        const second = run();
 
         expect(second.parsedFiles).toBe(0);
         expect(second.today.cost).toBeCloseTo(first.today.cost, 10);
         expect(second.agents).toEqual(first.agents);
+    });
+
+    test("a driver subset reports only the agents it scanned, never stale cached ones", () => {
+        const storage = new Storage("ai-spend");
+        const all = buildMonitorReport({ home, pricing: DEFAULT_PRICING, storage, sweepTtlMs: 0 });
+        expect(all.agents.codex.today.tokens).toBe(2_100_000);
+        expect(all.agents.grok.today.tokens).toBe(102_000);
+
+        // Codex and Grok day sums are now cached. Asking for claude alone must not
+        // report them, and must not fold them into the top-level totals either.
+        const claudeOnly = buildMonitorReport({
+            home,
+            pricing: DEFAULT_PRICING,
+            storage,
+            sweepTtlMs: 0,
+            drivers: [claudeDriver],
+        });
+
+        expect(claudeOnly.agents.codex).toEqual({ today: { cost: 0, tokens: 0 }, week: { cost: 0, tokens: 0 } });
+        expect(claudeOnly.agents.grok).toEqual({ today: { cost: 0, tokens: 0 }, week: { cost: 0, tokens: 0 } });
+        expect(claudeOnly.today.cost).toBeCloseTo(0.8, 6);
+        expect(claudeOnly.today.tokens).toBe(1_000_000);
+    });
+
+    test("a tail ending mid-line is re-read whole once the writer completes it", () => {
+        const storage = new Storage("ai-spend");
+        const codexFile = join(
+            home,
+            ".codex",
+            "sessions",
+            "2026",
+            "08",
+            "27",
+            "rollout-2026-08-27T09-00-00-synthetic.jsonl"
+        );
+        const iso = new Date().toISOString();
+        const nextEvent = SafeJSON.stringify({
+            timestamp: iso,
+            type: "event_msg",
+            payload: {
+                type: "token_count",
+                info: {
+                    total_token_usage: {
+                        input_tokens: 3_000_000,
+                        cached_input_tokens: 1_000_000,
+                        output_tokens: 100_000,
+                    },
+                    last_token_usage: { input_tokens: 1_000_000, output_tokens: 0, total_tokens: 1_000_000 },
+                },
+            },
+        });
+
+        buildMonitorReport({ home, pricing: DEFAULT_PRICING, storage, sweepTtlMs: 0, drivers: [codexDriver] });
+
+        // Append HALF of a line, exactly as a stat landing mid-write would observe.
+        const split = Math.floor(nextEvent.length / 2);
+        appendFileSync(codexFile, nextEvent.slice(0, split));
+
+        const partial = buildMonitorReport({
+            home,
+            pricing: DEFAULT_PRICING,
+            storage,
+            sweepTtlMs: 0,
+            drivers: [codexDriver],
+        });
+        // The fragment is not parseable, so nothing new is counted yet.
+        expect(partial.agents.codex.today.tokens).toBe(2_100_000);
+
+        // The writer finishes the line. Its FIRST half must not have been consumed.
+        appendFileSync(codexFile, `${nextEvent.slice(split)}\n`);
+
+        const complete = buildMonitorReport({
+            home,
+            pricing: DEFAULT_PRICING,
+            storage,
+            sweepTtlMs: 0,
+            drivers: [codexDriver],
+        });
+        // +1M uncached input on gpt-5 = +$1.25 on top of $2.375.
+        expect(complete.agents.codex.today.tokens).toBe(2_100_000 + 1_000_000);
+        expect(complete.agents.codex.today.cost).toBeCloseTo(2.375 + 1.25, 6);
+    });
+
+    test("grok's roots follow GROK_HOME even when the fixture home has its own tree", () => {
+        expect(grokDriver.roots(home)).toEqual([join(home, ".grok", "sessions")]);
+        expect(codexDriver.roots(home)).toEqual([
+            join(home, ".codex", "sessions"),
+            join(home, ".codex", "archived_sessions"),
+        ]);
     });
 });

--- a/src/ai-spend/lib/monitor.test.ts
+++ b/src/ai-spend/lib/monitor.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { Storage } from "@genesiscz/utils/storage/storage";
+import { setupStorageSandbox } from "@genesiscz/utils/storage/test-sandbox";
+import { buildMonitorReport, findRecentTranscripts, localDayString, mondayOfWeek, transcriptRoots } from "./monitor";
+import { DEFAULT_PRICING } from "./pricing";
+
+setupStorageSandbox();
+
+// claude-3-5-haiku (literal legacy rates): input $0.8/M, output $4/M, cacheWrite $1.0/M, cacheRead $0.08/M.
+const MODEL = "claude-3-5-haiku";
+
+function line(id: string, iso: string, usage: Record<string, number>): string {
+    return `${SafeJSON.stringify({
+        type: "assistant",
+        timestamp: iso,
+        cwd: "/tmp/proj",
+        sessionId: "s1",
+        message: { id, model: MODEL, usage },
+    })}\n`;
+}
+
+describe("local time helpers", () => {
+    test("localDayString uses local clock fields", () => {
+        expect(localDayString(new Date(2026, 0, 5, 0, 30))).toBe("2026-01-05");
+        expect(localDayString(new Date(2026, 11, 31, 23, 59))).toBe("2026-12-31");
+    });
+
+    test("mondayOfWeek returns the local Monday midnight (Monday week start)", () => {
+        // 2026-08-27 is a Thursday; 2026-08-30 a Sunday — both map to Monday 2026-08-24.
+        expect(localDayString(mondayOfWeek(new Date(2026, 7, 27, 15, 0)))).toBe("2026-08-24");
+        expect(localDayString(mondayOfWeek(new Date(2026, 7, 30, 1, 0)))).toBe("2026-08-24");
+        // A Monday maps to itself.
+        expect(localDayString(mondayOfWeek(new Date(2026, 7, 24, 0, 0)))).toBe("2026-08-24");
+        const monday = mondayOfWeek(new Date(2026, 7, 27, 15, 42));
+        expect([monday.getHours(), monday.getMinutes()]).toEqual([0, 0]);
+    });
+});
+
+describe("monitor report", () => {
+    let home: string;
+    let mainFile: string;
+    let oldFile: string;
+
+    beforeEach(() => {
+        home = mkdtempSync(join(tmpdir(), "ai-spend-monitor-"));
+        const projDir = join(home, ".claude", "projects", "p1");
+        const subDir = join(projDir, "subagents");
+        const cfgDir = join(home, ".config", "claude", "projects", "p2");
+        mkdirSync(subDir, { recursive: true });
+        mkdirSync(cfgDir, { recursive: true });
+
+        const now = new Date();
+        const iso = now.toISOString();
+        mainFile = join(projDir, "s1.jsonl");
+        // msg-a duplicated with huge usage — dedup must keep the first.
+        writeFileSync(
+            mainFile,
+            line("msg-a", iso, { input_tokens: 1_000_000 }) +
+                line("msg-a", iso, { input_tokens: 999_000_000 }) +
+                line("msg-b", iso, { output_tokens: 500_000, cache_read_input_tokens: 1_000_000 })
+        );
+        // Subagent transcript nests deeper — must be found by recursion.
+        writeFileSync(join(subDir, "sub.jsonl"), line("msg-c", iso, { output_tokens: 100_000 }));
+        // Second root: ~/.config/claude/projects.
+        writeFileSync(join(cfgDir, "x.jsonl"), line("msg-d", iso, { input_tokens: 250_000 }));
+
+        // A transcript last touched WAY before the week start must never be opened.
+        oldFile = join(projDir, "old.jsonl");
+        writeFileSync(oldFile, line("msg-old", "2026-01-01T10:00:00Z", { output_tokens: 900_000_000 }));
+        const old = new Date("2026-01-02T00:00:00Z");
+        utimesSync(oldFile, old, old);
+    });
+
+    test("pins today/week numbers, skips the old file, recurses both roots", () => {
+        const opened: string[] = [];
+        const report = buildMonitorReport({
+            home,
+            pricing: DEFAULT_PRICING,
+            storage: new Storage("ai-spend"),
+            sweepTtlMs: 0,
+            readTailFn: (path, _offset, _size) => {
+                opened.push(path);
+
+                return readFileSync(path, "utf8");
+            },
+        });
+
+        // msg-a: 1M input = $0.80 · msg-b: 0.5M out = $2.00 + 1M cacheRead = $0.08
+        // msg-c: 0.1M out = $0.40 · msg-d: 0.25M input = $0.20 → $3.48 total
+        expect(report.today.cost).toBeCloseTo(3.48, 5);
+        expect(report.today.tokens).toBe(2_850_000);
+        // Every fixture event is stamped "now", so week == today.
+        expect(report.week).toEqual(report.today);
+        expect(report.todayDate).toBe(localDayString(new Date()));
+        expect(report.weekStart).toBe(localDayString(mondayOfWeek(new Date())));
+        expect(report.timezone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+
+        // The stale file was never opened (mtime pruning), and 3 recent files were.
+        expect(opened.some((p) => p.includes("old.jsonl"))).toBe(false);
+        expect(report.recentFiles).toBe(3);
+        expect(report.parsedFiles).toBe(3);
+    });
+
+    test("second run is a full cache hit; appended lines parse only the tail", () => {
+        buildMonitorReport({ home, pricing: DEFAULT_PRICING, storage: new Storage("ai-spend"), sweepTtlMs: 0 });
+
+        const second = buildMonitorReport({
+            home,
+            pricing: DEFAULT_PRICING,
+            storage: new Storage("ai-spend"),
+            sweepTtlMs: 0,
+        });
+        expect(second.parsedFiles).toBe(0);
+        expect(second.today.cost).toBeCloseTo(3.48, 5);
+
+        // Append one event → exactly one file re-parses, from a non-zero offset.
+        const offsets: number[] = [];
+        appendFileSync(mainFile, line("msg-e", new Date().toISOString(), { output_tokens: 1_000_000 }));
+
+        const third = buildMonitorReport({
+            home,
+            pricing: DEFAULT_PRICING,
+            storage: new Storage("ai-spend"),
+            sweepTtlMs: 0,
+            readTailFn: (path, offset, _size) => {
+                offsets.push(offset);
+
+                return readFileSync(path, "utf8").slice(offset);
+            },
+        });
+        expect(third.parsedFiles).toBe(1);
+        expect(offsets).toHaveLength(1);
+        expect(offsets[0]).toBeGreaterThan(0);
+        expect(third.today.cost).toBeCloseTo(3.48 + 4.0, 5);
+        expect(third.today.tokens).toBe(3_850_000);
+    });
+
+    test("fast path within sweep TTL catches appends, new siblings, and new project dirs", () => {
+        const storage = new Storage("ai-spend");
+        const iso = new Date().toISOString();
+        // Rebase the cache on THIS home with a forced sweep, then stay inside the TTL.
+        buildMonitorReport({ home, pricing: DEFAULT_PRICING, storage, sweepTtlMs: 0 });
+
+        appendFileSync(mainFile, line("msg-f", iso, { output_tokens: 1_000_000 }));
+        writeFileSync(
+            join(home, ".claude", "projects", "p1", "s2.jsonl"),
+            line("msg-g", iso, { input_tokens: 1_000_000 })
+        );
+        const p3 = join(home, ".claude", "projects", "p3");
+        mkdirSync(p3, { recursive: true });
+        writeFileSync(join(p3, "y.jsonl"), line("msg-h", iso, { input_tokens: 500_000 }));
+
+        const second = buildMonitorReport({ home, pricing: DEFAULT_PRICING, storage, sweepTtlMs: 60 * 60 * 1000 });
+        expect(second.parsedFiles).toBe(3);
+        // +$4.00 append, +$0.80 sibling, +$0.40 new project dir on top of $3.48.
+        expect(second.today.cost).toBeCloseTo(8.68, 5);
+        expect(second.today.tokens).toBe(2_850_000 + 1_000_000 + 1_000_000 + 500_000);
+    });
+
+    test("transcriptRoots and findRecentTranscripts never look outside the fixed roots", () => {
+        const roots = transcriptRoots(home);
+        expect(roots).toEqual([join(home, ".claude", "projects"), join(home, ".config", "claude", "projects")]);
+
+        const files = findRecentTranscripts(roots, Date.now() - 60_000);
+        expect(files.every((f) => f.startsWith(roots[0]) || f.startsWith(roots[1]))).toBe(true);
+        expect(files.some((f) => f.endsWith("old.jsonl"))).toBe(false);
+    });
+});

--- a/src/ai-spend/lib/monitor.test.ts
+++ b/src/ai-spend/lib/monitor.test.ts
@@ -439,11 +439,14 @@ describe("monitor honours dated and context-banded pricing", () => {
         rmSync(home, { recursive: true, force: true });
     });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         home = mkdtempSync(join(tmpdir(), "ai-spend-rules-"));
         const projDir = join(home, ".claude", "projects", "p1");
         mkdirSync(projDir, { recursive: true });
-        writeFileSync(join(projDir, "s1.jsonl"), line("msg-r", new Date().toISOString(), { input_tokens: 1_000_000 }));
+        await Bun.write(
+            join(projDir, "s1.jsonl"),
+            line("msg-r", new Date().toISOString(), { input_tokens: 1_000_000 })
+        );
     });
 
     test("a dated rule beats the list rate for an event inside its window", () => {
@@ -468,5 +471,34 @@ describe("monitor honours dated and context-banded pricing", () => {
 
         // 1M input tokens: $1 under the rule, $100 if the rules are dropped.
         expect(report.today.cost).toBeCloseTo(1, 5);
+    });
+
+    test("the context band is picked by the event's own prompt size", () => {
+        // Two disjoint bands over the same list rate. The fixture event carries
+        // 1M input and no cache tokens, so only the lower band may apply. A caller
+        // that forgets contextTokens matches neither band and falls back to $100/1M.
+        const banded: PricingTable = {
+            [MODEL]: {
+                input: 100,
+                output: 100,
+                cacheWrite: 100,
+                cacheRead: 100,
+                rules: [
+                    { ctxTo: 1_999_999, inputPer1M: 2 },
+                    { ctxFrom: 2_000_000, inputPer1M: 50 },
+                ],
+            },
+        };
+
+        const report = buildMonitorReport({
+            home,
+            pricing: banded,
+            storage: new Storage("ai-spend"),
+            sweepTtlMs: 0,
+            readTailFn: (path) => readFileSync(path, "utf8"),
+        });
+
+        // $2 in the matching band; $50 in the wrong one, $100 with no band at all.
+        expect(report.today.cost).toBeCloseTo(2, 5);
     });
 });

--- a/src/ai-spend/lib/monitor.ts
+++ b/src/ai-spend/lib/monitor.ts
@@ -4,16 +4,9 @@ import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import { atomicWriteFileSync, Storage } from "@genesiscz/utils/storage/storage";
-import {
-    AGENT_IDS,
-    type AgentId,
-    claudeDriver,
-    type DriverUsageEvent,
-    MONITOR_DRIVERS,
-    type MonitorDriver,
-} from "./drivers";
-import { costOf } from "./pricing";
-import type { ModelPrice, PricingTable } from "./types";
+import { AGENT_IDS, type AgentId, type DriverUsageEvent, MONITOR_DRIVERS, type MonitorDriver } from "./drivers";
+import { costOf, resolvePrice } from "./pricing";
+import type { ModelPriceEntry, PricingTable } from "./types";
 
 /**
  * `ai-spend monitor` — today + current week (local timezone, Monday start)
@@ -76,14 +69,8 @@ export function mondayOfWeek(date: Date): Date {
     return midnight;
 }
 
-/** Claude Code transcript roots. Kept exported: the claude driver owns the list. */
-export function transcriptRoots(home: string): string[] {
-    return claudeDriver.roots(home);
-}
-
 /** All transcripts under `roots` whose mtime is >= minMtimeMs, per the driver's file test. */
-export function findRecentTranscripts(roots: string[], minMtimeMs: number, driver?: MonitorDriver): string[] {
-    const activeDriver = driver ?? claudeDriver;
+export function findRecentTranscripts(roots: string[], minMtimeMs: number, driver: MonitorDriver): string[] {
     const out: string[] = [];
 
     const walk = (dir: string, depth: number): void => {
@@ -100,14 +87,14 @@ export function findRecentTranscripts(roots: string[], minMtimeMs: number, drive
             const full = join(dir, entry.name);
 
             if (entry.isDirectory()) {
-                if (depth < activeDriver.maxDepth) {
+                if (depth < driver.maxDepth) {
                     walk(full, depth + 1);
                 }
 
                 continue;
             }
 
-            if (!entry.isFile() || !activeDriver.isTranscript(entry.name)) {
+            if (!entry.isFile() || !driver.isTranscript(entry.name)) {
                 continue;
             }
 
@@ -328,7 +315,16 @@ function readTail(path: string, offset: number, size: number): string {
     }
 }
 
-function priceForDriver(driver: MonitorDriver, model: string, pricing: PricingTable): ModelPrice | null {
+/**
+ * Returns the catalog ENTRY, not a flat price. The caller resolves it against
+ * the event's own timestamp and size — a dated promotion or a long-context band
+ * only means something per event.
+ *
+ * This used to return `ModelPrice`, and because `ModelPriceEntry extends
+ * ModelPrice` the rules were dropped with no type error: the monitor billed
+ * every event at the list rate while aggregate.ts honoured the rules.
+ */
+function priceForDriver(driver: MonitorDriver, model: string, pricing: PricingTable): ModelPriceEntry | null {
     for (const candidate of driver.priceCandidates(model)) {
         const price = pricing[candidate];
 
@@ -377,8 +373,8 @@ function parseChunk(options: ParseChunkOptions): void {
         let cost = event.recordedCostUsd;
 
         if (cost === undefined) {
-            const price = priceForDriver(driver, event.model, pricing);
-            cost = price
+            const entry = priceForDriver(driver, event.model, pricing);
+            cost = entry
                 ? costOf(
                       {
                           input: event.inputTokens,
@@ -386,7 +382,10 @@ function parseChunk(options: ParseChunkOptions): void {
                           cacheWrite: event.cacheCreationTokens,
                           cacheRead: event.cacheReadTokens,
                       },
-                      price
+                      resolvePrice(entry, {
+                          at: Number.isNaN(when.getTime()) ? undefined : when,
+                          contextTokens: event.inputTokens + event.cacheReadTokens + event.cacheCreationTokens,
+                      })
                   )
                 : 0;
         }

--- a/src/ai-spend/lib/monitor.ts
+++ b/src/ai-spend/lib/monitor.ts
@@ -1,0 +1,456 @@
+import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { atomicWriteFileSync, Storage } from "@genesiscz/utils/storage/storage";
+import { parseTranscriptLine } from "./parse";
+import { costOf, priceFor } from "./pricing";
+import type { PricingTable } from "./types";
+
+/**
+ * `ai-spend monitor` — today + current week (local timezone, Monday start)
+ * in well under a second. Two tricks keep it fast:
+ *
+ * 1. mtime pruning: a transcript whose mtime predates the local week start
+ *    cannot contain events inside the week (transcripts are append-only), so
+ *    it is never opened.
+ * 2. incremental cache: per file we persist (size, mtime, byte offset, per-day
+ *    sums). An unchanged file is never re-read; a grown file is parsed only
+ *    from the previous end-of-file offset.
+ *
+ * The walker touches ONLY the fixed transcript roots (~/.claude/projects and
+ * ~/.config/claude/projects, recursively — subagent transcripts nest deeper).
+ * It never lists process.cwd() or $HOME.
+ */
+
+export interface MonitorTotals {
+    cost: number;
+    tokens: number;
+}
+
+export interface MonitorReport {
+    today: MonitorTotals;
+    week: MonitorTotals;
+    todayDate: string;
+    weekStart: string;
+    timezone: string;
+    /** Files parsed (fully or incrementally) on this run — cache misses. */
+    parsedFiles: number;
+    /** Recent files considered (mtime within the week). */
+    recentFiles: number;
+}
+
+/** Local-clock YYYY-MM-DD (NOT the UTC slice of toISOString). */
+export function localDayString(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+
+    return `${y}-${m}-${d}`;
+}
+
+/** Local midnight of the Monday of `date`'s week. */
+export function mondayOfWeek(date: Date): Date {
+    const midnight = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    // getDay(): Sunday=0 … Saturday=6; Monday-start offset.
+    const offset = (midnight.getDay() + 6) % 7;
+    midnight.setDate(midnight.getDate() - offset);
+
+    return midnight;
+}
+
+export function transcriptRoots(home: string): string[] {
+    const roots = [join(home, ".claude", "projects"), join(home, ".config", "claude", "projects")];
+    const configDir = env.paths.getClaudeConfigDir();
+
+    if (configDir) {
+        const extra = join(configDir, "projects");
+
+        if (!roots.includes(extra)) {
+            roots.push(extra);
+        }
+    }
+
+    return roots;
+}
+
+const MAX_WALK_DEPTH = 6;
+
+/** All *.jsonl under the fixed roots whose mtime is >= minMtimeMs. */
+export function findRecentTranscripts(roots: string[], minMtimeMs: number): string[] {
+    const out: string[] = [];
+
+    const walk = (dir: string, depth: number): void => {
+        let entries: import("node:fs").Dirent[];
+        try {
+            entries = readdirSync(dir, { withFileTypes: true });
+        } catch (err) {
+            logger.debug({ err, dir }, "ai-spend monitor: unreadable dir skipped");
+
+            return;
+        }
+
+        for (const entry of entries) {
+            const full = join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                if (depth < MAX_WALK_DEPTH) {
+                    walk(full, depth + 1);
+                }
+
+                continue;
+            }
+
+            if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+                continue;
+            }
+
+            try {
+                if (statSync(full).mtimeMs >= minMtimeMs) {
+                    out.push(full);
+                }
+            } catch (err) {
+                logger.debug({ err, file: full }, "ai-spend monitor: stat failed");
+            }
+        }
+    };
+
+    for (const root of roots) {
+        if (existsSync(root)) {
+            walk(root, 0);
+        }
+    }
+
+    return out;
+}
+
+interface DaySums {
+    cost: number;
+    tokens: number;
+}
+
+interface FileCacheEntry {
+    size: number;
+    mtimeMs: number;
+    /** Byte offset already parsed (== size unless the file shrank). */
+    offset: number;
+    days: Record<string, DaySums>;
+    /**
+     * Message-id dedup frontier: transcript duplicates of one message id sit
+     * adjacent (streaming rewrites), so a bounded tail window is enough.
+     */
+    recentIds: string[];
+}
+
+interface MonitorCache {
+    version: 2;
+    /** Epoch ms of the last FULL tree sweep. */
+    sweepAt: number;
+    /** First-level children (project dirs) of the roots at the last sweep. */
+    rootChildren: string[];
+    files: Record<string, FileCacheEntry>;
+}
+
+const RECENT_ID_WINDOW = 50;
+
+/**
+ * A full walk of ~/.claude/projects costs seconds on a large tree (11k+ files;
+ * even warm `find` takes ~6s on this class of machine), so it runs at most
+ * once per TTL. Between sweeps the fast path stats only the known-recent files
+ * and readdirs their parent dirs — appends, new sibling transcripts and brand
+ * new project dirs are caught immediately; a genuinely new file in a
+ * previously-quiet DEEP directory waits for the next sweep.
+ */
+const SWEEP_TTL_MS = 10 * 60 * 1000;
+
+function cachePath(storage: Storage): string {
+    return join(storage.getCacheDir(), "monitor-cache.json");
+}
+
+function freshCache(): MonitorCache {
+    return { version: 2, sweepAt: 0, rootChildren: [], files: {} };
+}
+
+function loadCache(storage: Storage): MonitorCache {
+    const path = cachePath(storage);
+
+    if (!existsSync(path)) {
+        return freshCache();
+    }
+
+    try {
+        const raw = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as MonitorCache;
+
+        if (raw?.version === 2 && raw.files) {
+            return raw;
+        }
+    } catch (err) {
+        logger.debug({ err, path }, "ai-spend monitor: cache unreadable, rebuilding");
+    }
+
+    return freshCache();
+}
+
+function listRootChildren(roots: string[]): string[] {
+    const children: string[] = [];
+
+    for (const root of roots) {
+        if (!existsSync(root)) {
+            continue;
+        }
+
+        try {
+            for (const entry of readdirSync(root, { withFileTypes: true })) {
+                if (entry.isDirectory()) {
+                    children.push(join(root, entry.name));
+                }
+            }
+        } catch (err) {
+            logger.debug({ err, root }, "ai-spend monitor: root unreadable");
+        }
+    }
+
+    return children;
+}
+
+/** Between sweeps: known files + new siblings in hot dirs + fully-walked new project dirs. */
+function fastCandidates(roots: string[], cache: MonitorCache, minMtimeMs: number): string[] {
+    const out = new Set(Object.keys(cache.files));
+    const hotDirs = new Set<string>();
+
+    for (const file of out) {
+        hotDirs.add(join(file, ".."));
+    }
+
+    const knownChildren = new Set(cache.rootChildren);
+
+    for (const child of listRootChildren(roots)) {
+        if (knownChildren.has(child)) {
+            continue;
+        }
+
+        for (const file of findRecentTranscripts([child], minMtimeMs)) {
+            out.add(file);
+        }
+
+        cache.rootChildren.push(child);
+    }
+
+    for (const dir of hotDirs) {
+        let entries: import("node:fs").Dirent[];
+        try {
+            entries = readdirSync(dir, { withFileTypes: true });
+        } catch (err) {
+            logger.debug({ err, dir }, "ai-spend monitor: hot dir unreadable");
+            continue;
+        }
+
+        for (const entry of entries) {
+            if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+                continue;
+            }
+
+            const full = join(dir, entry.name);
+
+            if (out.has(full)) {
+                continue;
+            }
+
+            try {
+                if (statSync(full).mtimeMs >= minMtimeMs) {
+                    out.add(full);
+                }
+            } catch (err) {
+                logger.debug({ err, file: full }, "ai-spend monitor: sibling stat failed");
+            }
+        }
+    }
+
+    return [...out];
+}
+
+/** Read the file from `offset` to EOF (append-only tail). */
+function readTail(path: string, offset: number, size: number): string {
+    const length = size - offset;
+    const fd = openSync(path, "r");
+
+    try {
+        const buffer = Buffer.alloc(length);
+        let read = 0;
+
+        while (read < length) {
+            const n = readSync(fd, buffer, read, length - read, offset + read);
+
+            if (n <= 0) {
+                break;
+            }
+
+            read += n;
+        }
+
+        return buffer.subarray(0, read).toString("utf8");
+    } finally {
+        closeSync(fd);
+    }
+}
+
+function parseChunk(entry: FileCacheEntry, chunk: string, pricing: PricingTable): void {
+    const seen = new Set(entry.recentIds);
+
+    for (const line of chunk.split("\n")) {
+        const ev = parseTranscriptLine(line);
+
+        if (!ev || seen.has(ev.messageId)) {
+            continue;
+        }
+
+        seen.add(ev.messageId);
+        entry.recentIds.push(ev.messageId);
+
+        const when = new Date(ev.timestamp);
+
+        if (Number.isNaN(when.getTime())) {
+            continue;
+        }
+
+        const day = localDayString(when);
+        const price = priceFor(ev.model, pricing);
+        const tokens = ev.inputTokens + ev.outputTokens + ev.cacheCreationTokens + ev.cacheReadTokens;
+        const cost = price
+            ? costOf(
+                  {
+                      input: ev.inputTokens,
+                      output: ev.outputTokens,
+                      cacheWrite: ev.cacheCreationTokens,
+                      cacheRead: ev.cacheReadTokens,
+                  },
+                  price
+              )
+            : 0;
+        let sums = entry.days[day];
+
+        if (!sums) {
+            sums = { cost: 0, tokens: 0 };
+            entry.days[day] = sums;
+        }
+
+        sums.cost += cost;
+        sums.tokens += tokens;
+    }
+
+    if (entry.recentIds.length > RECENT_ID_WINDOW) {
+        entry.recentIds = entry.recentIds.slice(-RECENT_ID_WINDOW);
+    }
+}
+
+export interface BuildMonitorOptions {
+    home?: string;
+    now?: Date;
+    storage?: Storage;
+    pricing: PricingTable;
+    /** Injectable readers (tests spy on which files get opened). */
+    readTailFn?: typeof readTail;
+    /** Full-sweep interval override (tests; 0 = sweep every run). */
+    sweepTtlMs?: number;
+}
+
+export function buildMonitorReport(options: BuildMonitorOptions): MonitorReport {
+    const now = options.now ?? new Date();
+    const home = options.home ?? homedir();
+    const storage = options.storage ?? new Storage("ai-spend");
+    const tailReader = options.readTailFn ?? readTail;
+    const weekStartDate = mondayOfWeek(now);
+    const todayDate = localDayString(now);
+    const weekStart = localDayString(weekStartDate);
+    const cache = loadCache(storage);
+    const roots = transcriptRoots(home);
+    const minMtimeMs = weekStartDate.getTime();
+    const sweepDue = now.getTime() - cache.sweepAt >= (options.sweepTtlMs ?? SWEEP_TTL_MS);
+    let files: string[];
+
+    if (sweepDue) {
+        files = findRecentTranscripts(roots, minMtimeMs);
+        cache.sweepAt = now.getTime();
+        cache.rootChildren = listRootChildren(roots);
+    } else {
+        files = fastCandidates(roots, cache, minMtimeMs);
+    }
+
+    let parsedFiles = 0;
+
+    for (const file of files) {
+        let stat: import("node:fs").Stats;
+        try {
+            stat = statSync(file);
+        } catch (err) {
+            logger.debug({ err, file }, "ai-spend monitor: file vanished mid-run");
+            delete cache.files[file];
+            continue;
+        }
+
+        const cached = cache.files[file];
+
+        if (cached && cached.size === stat.size && cached.mtimeMs === stat.mtimeMs) {
+            continue;
+        }
+
+        let entry: FileCacheEntry;
+
+        if (cached && stat.size >= cached.offset && cached.offset > 0) {
+            // Append-only growth: parse just the tail.
+            entry = cached;
+        } else {
+            entry = { size: 0, mtimeMs: 0, offset: 0, days: {}, recentIds: [] };
+        }
+
+        const chunk = tailReader(file, entry.offset, stat.size);
+        parseChunk(entry, chunk, options.pricing);
+        entry.size = stat.size;
+        entry.mtimeMs = stat.mtimeMs;
+        entry.offset = stat.size;
+        cache.files[file] = entry;
+        parsedFiles++;
+    }
+
+    if (sweepDue) {
+        // Drop cache rows for files that fell out of the window (or were deleted).
+        const live = new Set(files);
+
+        for (const key of Object.keys(cache.files)) {
+            if (!live.has(key)) {
+                delete cache.files[key];
+            }
+        }
+    }
+
+    atomicWriteFileSync(cachePath(storage), SafeJSON.stringify(cache, { strict: true }));
+
+    const today: MonitorTotals = { cost: 0, tokens: 0 };
+    const week: MonitorTotals = { cost: 0, tokens: 0 };
+
+    for (const entry of Object.values(cache.files)) {
+        for (const [day, sums] of Object.entries(entry.days)) {
+            if (day >= weekStart && day <= todayDate) {
+                week.cost += sums.cost;
+                week.tokens += sums.tokens;
+            }
+
+            if (day === todayDate) {
+                today.cost += sums.cost;
+                today.tokens += sums.tokens;
+            }
+        }
+    }
+
+    return {
+        today,
+        week,
+        todayDate,
+        weekStart,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        parsedFiles,
+        recentFiles: files.length,
+    };
+}

--- a/src/ai-spend/lib/monitor.ts
+++ b/src/ai-spend/lib/monitor.ts
@@ -253,6 +253,11 @@ function fastCandidates(driver: MonitorDriver, roots: string[], cache: AgentCach
 
     const knownChildren = new Set(cache.rootChildren);
 
+    // ⚠️ This block MUTATES `cache.rootChildren`, and the caller persists the
+    // cache afterwards. That is deliberate: a project directory created since
+    // the last sweep has to be recorded, or every later fast pass would rescan
+    // it from scratch. Keep the mutation here rather than hiding it in a helper
+    // that reads as pure discovery.
     for (const child of listRootChildren(roots)) {
         if (knownChildren.has(child)) {
             continue;
@@ -349,18 +354,23 @@ function parseChunk(options: ParseChunkOptions): void {
     const seen = new Set(entry.recentIds);
 
     const emit = (event: DriverUsageEvent): void => {
+        const when = new Date(event.timestamp);
+
+        // Validate BEFORE the dedup bookkeeping. Recording the id first would burn
+        // it on an unusable event, and a later well-formed record carrying the same
+        // id (a streaming rewrite that finally has a timestamp) would be suppressed.
+        if (Number.isNaN(when.getTime())) {
+            logger.debug({ agent: driver.id, id: event.id }, "ai-spend monitor: event has no usable timestamp");
+
+            return;
+        }
+
         if (seen.has(event.id)) {
             return;
         }
 
         seen.add(event.id);
         entry.recentIds.push(event.id);
-
-        const when = new Date(event.timestamp);
-
-        if (Number.isNaN(when.getTime())) {
-            return;
-        }
 
         const day = localDayString(when);
         const tokens = event.inputTokens + event.outputTokens + event.cacheCreationTokens + event.cacheReadTokens;
@@ -474,10 +484,17 @@ function scanAgent(options: ScanOptions): ScanResult {
         }
 
         const chunk = tailReader(file, entry.offset, stat.size);
-        parseChunk({ driver, file, entry, chunk, pricing });
+        // A live agent appends to these files, so a stat can land mid-line. Parse
+        // only through the last newline and leave the offset there: the trailing
+        // fragment is re-read whole once the writer finishes it. Advancing to
+        // stat.size instead would split that line across two runs, and neither
+        // half would parse, so the request would never be counted.
+        const lastNewline = chunk.lastIndexOf("\n");
+        const complete = lastNewline >= 0 ? chunk.slice(0, lastNewline + 1) : "";
+        parseChunk({ driver, file, entry, chunk: complete, pricing });
+        entry.offset += Buffer.byteLength(complete, "utf8");
         entry.size = stat.size;
         entry.mtimeMs = stat.mtimeMs;
-        entry.offset = stat.size;
         cache.files[file] = entry;
         parsedFiles++;
     }
@@ -545,7 +562,16 @@ export function buildMonitorReport(options: BuildMonitorOptions): MonitorReport 
     const today: MonitorTotals = { cost: 0, tokens: 0 };
     const week: MonitorTotals = { cost: 0, tokens: 0 };
 
+    // Only the agents scanned on this run may contribute. An unscanned agent still
+    // has cached day sums on disk, and reporting those next to freshly refreshed
+    // ones would silently mix stale and current figures.
+    const scanned = new Set(drivers.map((driver) => driver.id));
+
     for (const id of AGENT_IDS) {
+        if (!scanned.has(id)) {
+            continue;
+        }
+
         const totals = agents[id];
 
         for (const entry of Object.values(cache.agents[id].files)) {

--- a/src/ai-spend/lib/monitor.ts
+++ b/src/ai-spend/lib/monitor.ts
@@ -1,33 +1,46 @@
 import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger } from "@genesiscz/utils/logger";
 import { atomicWriteFileSync, Storage } from "@genesiscz/utils/storage/storage";
-import { parseTranscriptLine } from "./parse";
-import { costOf, priceFor } from "./pricing";
-import type { PricingTable } from "./types";
+import {
+    AGENT_IDS,
+    type AgentId,
+    claudeDriver,
+    type DriverUsageEvent,
+    MONITOR_DRIVERS,
+    type MonitorDriver,
+} from "./drivers";
+import { costOf } from "./pricing";
+import type { ModelPrice, PricingTable } from "./types";
 
 /**
  * `ai-spend monitor` — today + current week (local timezone, Monday start)
- * in well under a second. Two tricks keep it fast:
+ * in well under a second, across every agent that leaves usage on disk.
+ * Two tricks keep it fast:
  *
  * 1. mtime pruning: a transcript whose mtime predates the local week start
  *    cannot contain events inside the week (transcripts are append-only), so
  *    it is never opened.
  * 2. incremental cache: per file we persist (size, mtime, byte offset, per-day
- *    sums). An unchanged file is never re-read; a grown file is parsed only
- *    from the previous end-of-file offset.
+ *    sums, driver resume state). An unchanged file is never re-read; a grown
+ *    file is parsed only from the previous end-of-file offset.
  *
- * The walker touches ONLY the fixed transcript roots (~/.claude/projects and
- * ~/.config/claude/projects, recursively — subagent transcripts nest deeper).
- * It never lists process.cwd() or $HOME.
+ * The walker touches ONLY each driver's fixed roots (~/.claude/projects,
+ * ~/.codex/sessions, ~/.grok/sessions and their documented overrides). It never
+ * lists process.cwd() or $HOME. Which files and which line shapes each agent
+ * contributes lives in `drivers/`, never here.
  */
 
 export interface MonitorTotals {
     cost: number;
     tokens: number;
+}
+
+export interface AgentTotals {
+    today: MonitorTotals;
+    week: MonitorTotals;
 }
 
 export interface MonitorReport {
@@ -36,6 +49,8 @@ export interface MonitorReport {
     todayDate: string;
     weekStart: string;
     timezone: string;
+    /** Per-agent split of the same today/week windows. Sums to the top level. */
+    agents: Record<AgentId, AgentTotals>;
     /** Files parsed (fully or incrementally) on this run — cache misses. */
     parsedFiles: number;
     /** Recent files considered (mtime within the week). */
@@ -61,25 +76,14 @@ export function mondayOfWeek(date: Date): Date {
     return midnight;
 }
 
+/** Claude Code transcript roots. Kept exported: the claude driver owns the list. */
 export function transcriptRoots(home: string): string[] {
-    const roots = [join(home, ".claude", "projects"), join(home, ".config", "claude", "projects")];
-    const configDir = env.paths.getClaudeConfigDir();
-
-    if (configDir) {
-        const extra = join(configDir, "projects");
-
-        if (!roots.includes(extra)) {
-            roots.push(extra);
-        }
-    }
-
-    return roots;
+    return claudeDriver.roots(home);
 }
 
-const MAX_WALK_DEPTH = 6;
-
-/** All *.jsonl under the fixed roots whose mtime is >= minMtimeMs. */
-export function findRecentTranscripts(roots: string[], minMtimeMs: number): string[] {
+/** All transcripts under `roots` whose mtime is >= minMtimeMs, per the driver's file test. */
+export function findRecentTranscripts(roots: string[], minMtimeMs: number, driver?: MonitorDriver): string[] {
+    const activeDriver = driver ?? claudeDriver;
     const out: string[] = [];
 
     const walk = (dir: string, depth: number): void => {
@@ -96,14 +100,14 @@ export function findRecentTranscripts(roots: string[], minMtimeMs: number): stri
             const full = join(dir, entry.name);
 
             if (entry.isDirectory()) {
-                if (depth < MAX_WALK_DEPTH) {
+                if (depth < activeDriver.maxDepth) {
                     walk(full, depth + 1);
                 }
 
                 continue;
             }
 
-            if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+            if (!entry.isFile() || !activeDriver.isTranscript(entry.name)) {
                 continue;
             }
 
@@ -138,14 +142,15 @@ interface FileCacheEntry {
     offset: number;
     days: Record<string, DaySums>;
     /**
-     * Message-id dedup frontier: transcript duplicates of one message id sit
+     * Event-id dedup frontier: transcript duplicates of one event sit
      * adjacent (streaming rewrites), so a bounded tail window is enough.
      */
     recentIds: string[];
+    /** Driver resume state (codex's sticky model and cumulative totals). */
+    state?: unknown;
 }
 
-interface MonitorCache {
-    version: 2;
+interface AgentCache {
     /** Epoch ms of the last FULL tree sweep. */
     sweepAt: number;
     /** First-level children (project dirs) of the roots at the last sweep. */
@@ -153,14 +158,19 @@ interface MonitorCache {
     files: Record<string, FileCacheEntry>;
 }
 
+interface MonitorCache {
+    version: 3;
+    agents: Record<AgentId, AgentCache>;
+}
+
 const RECENT_ID_WINDOW = 50;
 
 /**
- * A full walk of ~/.claude/projects costs seconds on a large tree (11k+ files;
- * even warm `find` takes ~6s on this class of machine), so it runs at most
- * once per TTL. Between sweeps the fast path stats only the known-recent files
- * and readdirs their parent dirs — appends, new sibling transcripts and brand
- * new project dirs are caught immediately; a genuinely new file in a
+ * A full walk of the transcript trees costs seconds on this class of machine
+ * (~11.5k Claude files, ~33k Grok directory entries), so it runs at most once
+ * per TTL. Between sweeps the fast path stats only the known-recent files and
+ * readdirs their parent dirs — appends, new sibling transcripts and brand new
+ * project dirs are caught immediately; a genuinely new file in a
  * previously-quiet DEEP directory waits for the next sweep.
  */
 const SWEEP_TTL_MS = 10 * 60 * 1000;
@@ -169,8 +179,15 @@ function cachePath(storage: Storage): string {
     return join(storage.getCacheDir(), "monitor-cache.json");
 }
 
+function freshAgentCache(): AgentCache {
+    return { sweepAt: 0, rootChildren: [], files: {} };
+}
+
 function freshCache(): MonitorCache {
-    return { version: 2, sweepAt: 0, rootChildren: [], files: {} };
+    return {
+        version: 3,
+        agents: { claude: freshAgentCache(), codex: freshAgentCache(), grok: freshAgentCache() },
+    };
 }
 
 function loadCache(storage: Storage): MonitorCache {
@@ -183,8 +200,18 @@ function loadCache(storage: Storage): MonitorCache {
     try {
         const raw = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as MonitorCache;
 
-        if (raw?.version === 2 && raw.files) {
-            return raw;
+        if (raw?.version === 3 && raw.agents) {
+            const cache = freshCache();
+
+            for (const id of AGENT_IDS) {
+                const agent = raw.agents[id];
+
+                if (agent?.files) {
+                    cache.agents[id] = agent;
+                }
+            }
+
+            return cache;
         }
     } catch (err) {
         logger.debug({ err, path }, "ai-spend monitor: cache unreadable, rebuilding");
@@ -216,7 +243,7 @@ function listRootChildren(roots: string[]): string[] {
 }
 
 /** Between sweeps: known files + new siblings in hot dirs + fully-walked new project dirs. */
-function fastCandidates(roots: string[], cache: MonitorCache, minMtimeMs: number): string[] {
+function fastCandidates(driver: MonitorDriver, roots: string[], cache: AgentCache, minMtimeMs: number): string[] {
     const out = new Set(Object.keys(cache.files));
     const hotDirs = new Set<string>();
 
@@ -231,7 +258,7 @@ function fastCandidates(roots: string[], cache: MonitorCache, minMtimeMs: number
             continue;
         }
 
-        for (const file of findRecentTranscripts([child], minMtimeMs)) {
+        for (const file of findRecentTranscripts([child], minMtimeMs, driver)) {
             out.add(file);
         }
 
@@ -248,7 +275,7 @@ function fastCandidates(roots: string[], cache: MonitorCache, minMtimeMs: number
         }
 
         for (const entry of entries) {
-            if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+            if (!entry.isFile() || !driver.isTranscript(entry.name)) {
                 continue;
             }
 
@@ -296,39 +323,64 @@ function readTail(path: string, offset: number, size: number): string {
     }
 }
 
-function parseChunk(entry: FileCacheEntry, chunk: string, pricing: PricingTable): void {
+function priceForDriver(driver: MonitorDriver, model: string, pricing: PricingTable): ModelPrice | null {
+    for (const candidate of driver.priceCandidates(model)) {
+        const price = pricing[candidate];
+
+        if (price) {
+            return price;
+        }
+    }
+
+    return null;
+}
+
+interface ParseChunkOptions {
+    driver: MonitorDriver;
+    file: string;
+    entry: FileCacheEntry;
+    chunk: string;
+    pricing: PricingTable;
+}
+
+function parseChunk(options: ParseChunkOptions): void {
+    const { driver, entry, chunk, pricing } = options;
+    const parser = driver.createParser({ file: options.file, state: entry.state });
     const seen = new Set(entry.recentIds);
 
-    for (const line of chunk.split("\n")) {
-        const ev = parseTranscriptLine(line);
-
-        if (!ev || seen.has(ev.messageId)) {
-            continue;
+    const emit = (event: DriverUsageEvent): void => {
+        if (seen.has(event.id)) {
+            return;
         }
 
-        seen.add(ev.messageId);
-        entry.recentIds.push(ev.messageId);
+        seen.add(event.id);
+        entry.recentIds.push(event.id);
 
-        const when = new Date(ev.timestamp);
+        const when = new Date(event.timestamp);
 
         if (Number.isNaN(when.getTime())) {
-            continue;
+            return;
         }
 
         const day = localDayString(when);
-        const price = priceFor(ev.model, pricing);
-        const tokens = ev.inputTokens + ev.outputTokens + ev.cacheCreationTokens + ev.cacheReadTokens;
-        const cost = price
-            ? costOf(
-                  {
-                      input: ev.inputTokens,
-                      output: ev.outputTokens,
-                      cacheWrite: ev.cacheCreationTokens,
-                      cacheRead: ev.cacheReadTokens,
-                  },
-                  price
-              )
-            : 0;
+        const tokens = event.inputTokens + event.outputTokens + event.cacheCreationTokens + event.cacheReadTokens;
+        let cost = event.recordedCostUsd;
+
+        if (cost === undefined) {
+            const price = priceForDriver(driver, event.model, pricing);
+            cost = price
+                ? costOf(
+                      {
+                          input: event.inputTokens,
+                          output: event.outputTokens,
+                          cacheWrite: event.cacheCreationTokens,
+                          cacheRead: event.cacheReadTokens,
+                      },
+                      price
+                  )
+                : 0;
+        }
+
         let sums = entry.days[day];
 
         if (!sums) {
@@ -338,7 +390,13 @@ function parseChunk(entry: FileCacheEntry, chunk: string, pricing: PricingTable)
 
         sums.cost += cost;
         sums.tokens += tokens;
+    };
+
+    for (const line of chunk.split("\n")) {
+        parser.parseLine(line, emit);
     }
+
+    entry.state = parser.snapshot();
 
     if (entry.recentIds.length > RECENT_ID_WINDOW) {
         entry.recentIds = entry.recentIds.slice(-RECENT_ID_WINDOW);
@@ -354,28 +412,38 @@ export interface BuildMonitorOptions {
     readTailFn?: typeof readTail;
     /** Full-sweep interval override (tests; 0 = sweep every run). */
     sweepTtlMs?: number;
+    /** Subset of agents to read. Defaults to all of them. */
+    drivers?: readonly MonitorDriver[];
 }
 
-export function buildMonitorReport(options: BuildMonitorOptions): MonitorReport {
-    const now = options.now ?? new Date();
-    const home = options.home ?? homedir();
-    const storage = options.storage ?? new Storage("ai-spend");
-    const tailReader = options.readTailFn ?? readTail;
-    const weekStartDate = mondayOfWeek(now);
-    const todayDate = localDayString(now);
-    const weekStart = localDayString(weekStartDate);
-    const cache = loadCache(storage);
-    const roots = transcriptRoots(home);
-    const minMtimeMs = weekStartDate.getTime();
-    const sweepDue = now.getTime() - cache.sweepAt >= (options.sweepTtlMs ?? SWEEP_TTL_MS);
+interface ScanResult {
+    parsedFiles: number;
+    recentFiles: number;
+}
+
+interface ScanOptions {
+    driver: MonitorDriver;
+    cache: AgentCache;
+    home: string;
+    now: Date;
+    minMtimeMs: number;
+    sweepTtlMs: number;
+    pricing: PricingTable;
+    tailReader: typeof readTail;
+}
+
+function scanAgent(options: ScanOptions): ScanResult {
+    const { driver, cache, now, minMtimeMs, pricing, tailReader } = options;
+    const roots = driver.roots(options.home);
+    const sweepDue = now.getTime() - cache.sweepAt >= options.sweepTtlMs;
     let files: string[];
 
     if (sweepDue) {
-        files = findRecentTranscripts(roots, minMtimeMs);
+        files = findRecentTranscripts(roots, minMtimeMs, driver);
         cache.sweepAt = now.getTime();
         cache.rootChildren = listRootChildren(roots);
     } else {
-        files = fastCandidates(roots, cache, minMtimeMs);
+        files = fastCandidates(driver, roots, cache, minMtimeMs);
     }
 
     let parsedFiles = 0;
@@ -406,7 +474,7 @@ export function buildMonitorReport(options: BuildMonitorOptions): MonitorReport 
         }
 
         const chunk = tailReader(file, entry.offset, stat.size);
-        parseChunk(entry, chunk, options.pricing);
+        parseChunk({ driver, file, entry, chunk, pricing });
         entry.size = stat.size;
         entry.mtimeMs = stat.mtimeMs;
         entry.offset = stat.size;
@@ -425,21 +493,76 @@ export function buildMonitorReport(options: BuildMonitorOptions): MonitorReport 
         }
     }
 
+    logger.debug(
+        { agent: driver.id, roots, sweepDue, files: files.length, parsedFiles },
+        "ai-spend monitor: agent scanned"
+    );
+
+    return { parsedFiles, recentFiles: files.length };
+}
+
+function emptyAgentTotals(): AgentTotals {
+    return { today: { cost: 0, tokens: 0 }, week: { cost: 0, tokens: 0 } };
+}
+
+export function buildMonitorReport(options: BuildMonitorOptions): MonitorReport {
+    const now = options.now ?? new Date();
+    const home = options.home ?? homedir();
+    const storage = options.storage ?? new Storage("ai-spend");
+    const tailReader = options.readTailFn ?? readTail;
+    const drivers = options.drivers ?? MONITOR_DRIVERS;
+    const weekStartDate = mondayOfWeek(now);
+    const todayDate = localDayString(now);
+    const weekStart = localDayString(weekStartDate);
+    const cache = loadCache(storage);
+    const minMtimeMs = weekStartDate.getTime();
+    const sweepTtlMs = options.sweepTtlMs ?? SWEEP_TTL_MS;
+    const agents: Record<AgentId, AgentTotals> = {
+        claude: emptyAgentTotals(),
+        codex: emptyAgentTotals(),
+        grok: emptyAgentTotals(),
+    };
+    let parsedFiles = 0;
+    let recentFiles = 0;
+
+    for (const driver of drivers) {
+        const result = scanAgent({
+            driver,
+            cache: cache.agents[driver.id],
+            home,
+            now,
+            minMtimeMs,
+            sweepTtlMs,
+            pricing: options.pricing,
+            tailReader,
+        });
+        parsedFiles += result.parsedFiles;
+        recentFiles += result.recentFiles;
+    }
+
     atomicWriteFileSync(cachePath(storage), SafeJSON.stringify(cache, { strict: true }));
 
     const today: MonitorTotals = { cost: 0, tokens: 0 };
     const week: MonitorTotals = { cost: 0, tokens: 0 };
 
-    for (const entry of Object.values(cache.files)) {
-        for (const [day, sums] of Object.entries(entry.days)) {
-            if (day >= weekStart && day <= todayDate) {
-                week.cost += sums.cost;
-                week.tokens += sums.tokens;
-            }
+    for (const id of AGENT_IDS) {
+        const totals = agents[id];
 
-            if (day === todayDate) {
-                today.cost += sums.cost;
-                today.tokens += sums.tokens;
+        for (const entry of Object.values(cache.agents[id].files)) {
+            for (const [day, sums] of Object.entries(entry.days)) {
+                if (day >= weekStart && day <= todayDate) {
+                    totals.week.cost += sums.cost;
+                    totals.week.tokens += sums.tokens;
+                    week.cost += sums.cost;
+                    week.tokens += sums.tokens;
+                }
+
+                if (day === todayDate) {
+                    totals.today.cost += sums.cost;
+                    totals.today.tokens += sums.tokens;
+                    today.cost += sums.cost;
+                    today.tokens += sums.tokens;
+                }
             }
         }
     }
@@ -450,7 +573,8 @@ export function buildMonitorReport(options: BuildMonitorOptions): MonitorReport 
         todayDate,
         weekStart,
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        agents,
         parsedFiles,
-        recentFiles: files.length,
+        recentFiles,
     };
 }

--- a/src/ai-spend/lib/pricing.test.ts
+++ b/src/ai-spend/lib/pricing.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_PRICING, priceFor } from "./pricing";
+
+describe("pricing table", () => {
+    test("anthropic and openai rates are billable", () => {
+        expect(DEFAULT_PRICING["gpt-5.6"]).toEqual({ input: 5, output: 30, cacheWrite: 6.25, cacheRead: 0.5 });
+        expect(DEFAULT_PRICING["gpt-5"]).toEqual({
+            input: 1.25,
+            output: 10,
+            cacheWrite: 1.25 * 1.25,
+            cacheRead: 0.125,
+        });
+        expect(DEFAULT_PRICING["claude-3-5-haiku"]).toEqual({
+            input: 0.8,
+            output: 4,
+            cacheWrite: 1.0,
+            cacheRead: 0.08,
+        });
+    });
+
+    test("an unpriced catalog entry never shadows a priced id of the same name", () => {
+        // `openai-sub` also carries gpt-5.4, with no rates. The `openai` entry wins.
+        expect(DEFAULT_PRICING["gpt-5.4"]?.input).toBe(2.5);
+    });
+
+    test("subscription and CLI-plan ids stay unpriced, so they cost $0", () => {
+        expect(DEFAULT_PRICING["grok-4.6"]).toBeUndefined();
+        expect(DEFAULT_PRICING["grok-4.6-build"]).toBeUndefined();
+        expect(DEFAULT_PRICING["gpt-5.6-sol"]).toBeUndefined();
+        expect(DEFAULT_PRICING["codex-auto-review"]).toBeUndefined();
+        expect(priceFor("grok-4.6", DEFAULT_PRICING)).toBeNull();
+    });
+
+    test("priceFor falls back to the variant-stripped id, never a prefix guess", () => {
+        expect(priceFor("gpt-5", DEFAULT_PRICING)?.input).toBe(1.25);
+        // A prefix match would resolve this to gpt-5. It must not.
+        expect(priceFor("gpt-5-something-invented", DEFAULT_PRICING)).toBeNull();
+    });
+});

--- a/src/ai-spend/lib/pricing.ts
+++ b/src/ai-spend/lib/pricing.ts
@@ -7,27 +7,47 @@ import type { ModelPrice, PricingTable, TokenTotals } from "./types";
  * open-ended prefix match — an unlisted id reports unpriced rather than
  * costing at a guessed family rate. Rates come from the curated registry
  * (`@genesiscz/utils/ai/catalog`); update them there.
+ *
+ * Monitor drivers widen the lookup with their own candidate ladders (codex
+ * peels `-codex` / `-sol`, grok peels `-build`), but every candidate still has
+ * to hit an EXACT key here.
  */
+
+/**
+ * Providers whose catalog rates the monitor can bill against.
+ *
+ * `openai-sub` and `xai` carry NO rates in the catalog (they are subscription
+ * and CLI-plan models, not metered API ids), so they contribute nothing today
+ * and every id they own is unpriced. They are listed anyway so that the day a
+ * rate lands in the catalog it flows straight through. Grok does not need them:
+ * it records its own `costUsdTicks` per turn, which the driver reports as the
+ * authoritative cost.
+ */
+const PRICED_PROVIDERS = ["anthropic", "openai", "openai-sub", "xai"] as const;
 
 /** $/Mtok. cacheWrite ≈ 1.25× input, cacheRead ≈ 0.1× input (Anthropic public ratios). */
 function fromRegistry(): PricingTable {
     const table: PricingTable = {};
 
-    for (const model of byProvider("anthropic")) {
-        if (!model.pricing) {
-            continue;
-        }
+    for (const provider of PRICED_PROVIDERS) {
+        for (const model of byProvider(provider)) {
+            if (!model.pricing) {
+                continue;
+            }
 
-        const price: ModelPrice = {
-            input: model.pricing.inputPer1M,
-            output: model.pricing.outputPer1M,
-            cacheWrite: model.pricing.cachedCreatePer1M ?? model.pricing.inputPer1M * 1.25,
-            cacheRead: model.pricing.cachedReadPer1M ?? model.pricing.inputPer1M * 0.1,
-        };
+            const price: ModelPrice = {
+                input: model.pricing.inputPer1M,
+                output: model.pricing.outputPer1M,
+                cacheWrite: model.pricing.cachedCreatePer1M ?? model.pricing.inputPer1M * 1.25,
+                cacheRead: model.pricing.cachedReadPer1M ?? model.pricing.inputPer1M * 0.1,
+            };
 
-        for (const id of [model.id, model.flags?.cli?.id]) {
-            if (id) {
-                table[id] = price;
+            for (const id of [model.id, model.flags?.cli?.id]) {
+                // First provider to name an id wins, so an unpriced duplicate can
+                // never shadow a priced one.
+                if (id && !table[id]) {
+                    table[id] = price;
+                }
             }
         }
     }

--- a/src/ai-spend/lib/pricing.ts
+++ b/src/ai-spend/lib/pricing.ts
@@ -1,5 +1,5 @@
-import { byProvider, stripModelVariantSuffix } from "@genesiscz/utils/ai/catalog";
-import type { ModelPrice, PricingTable, TokenTotals } from "./types";
+import { byProvider, effectivePricing, stripModelVariantSuffix } from "@genesiscz/utils/ai/catalog";
+import type { ModelPrice, ModelPriceEntry, PricingTable, TokenTotals } from "./types";
 
 /**
  * EXACT id match, with one boundary-safe fallback: a trailing `-YYYYMMDD` /
@@ -35,11 +35,15 @@ function fromRegistry(): PricingTable {
                 continue;
             }
 
-            const price: ModelPrice = {
+            // `rules` rides along: flattening the catalog to four numbers billed
+            // every event at the list rate, so dated promotions (the Sonnet 5
+            // $2/$10 window) and long-context bands never reached the report.
+            const price: ModelPriceEntry = {
                 input: model.pricing.inputPer1M,
                 output: model.pricing.outputPer1M,
                 cacheWrite: model.pricing.cachedCreatePer1M ?? model.pricing.inputPer1M * 1.25,
                 cacheRead: model.pricing.cachedReadPer1M ?? model.pricing.inputPer1M * 0.1,
+                rules: model.pricing.rules,
             };
 
             for (const id of [model.id, model.flags?.cli?.id]) {
@@ -62,7 +66,7 @@ const LEGACY_PRICING: PricingTable = {
 
 export const DEFAULT_PRICING: PricingTable = { ...fromRegistry(), ...LEGACY_PRICING };
 
-export function priceFor(model: string, pricing: PricingTable): ModelPrice | null {
+export function priceFor(model: string, pricing: PricingTable): ModelPriceEntry | null {
     const exact = pricing[model];
 
     if (exact) {
@@ -71,6 +75,35 @@ export function priceFor(model: string, pricing: PricingTable): ModelPrice | nul
 
     const base = stripModelVariantSuffix(model);
     return (base && pricing[base]) || null;
+}
+
+/**
+ * Apply the catalog's dated / context-banded rules to ONE event's own moment and
+ * size. `effectivePricing` is the single resolver for that (see the AI-subsystem
+ * rules); this only translates its per-1M fields into the flat shape costOf wants.
+ */
+export function resolvePrice(entry: ModelPriceEntry, context: { at?: Date; contextTokens?: number } = {}): ModelPrice {
+    if (!entry.rules?.length) {
+        return entry;
+    }
+
+    const resolved = effectivePricing(
+        {
+            inputPer1M: entry.input,
+            outputPer1M: entry.output,
+            cachedCreatePer1M: entry.cacheWrite,
+            cachedReadPer1M: entry.cacheRead,
+            rules: entry.rules,
+        },
+        context
+    );
+
+    return {
+        input: resolved.inputPer1M,
+        output: resolved.outputPer1M,
+        cacheWrite: resolved.cachedCreatePer1M ?? resolved.inputPer1M * 1.25,
+        cacheRead: resolved.cachedReadPer1M ?? resolved.inputPer1M * 0.1,
+    };
 }
 
 export function costOf(tokens: TokenTotals, price: ModelPrice): number {

--- a/src/ai-spend/lib/register.ts
+++ b/src/ai-spend/lib/register.ts
@@ -5,6 +5,7 @@ import type { Command } from "commander";
 import { aggregate } from "./aggregate";
 import { loadPricing } from "./config";
 import { findTranscriptFiles, readEvents } from "./discover";
+import { buildMonitorReport } from "./monitor";
 import { renderSessions, renderSummary, renderToday } from "./render";
 import { resolveSince } from "./since";
 import type { Report } from "./types";
@@ -97,6 +98,36 @@ export function registerSpendCommand(program: Command): Command {
             await runSpend(cmd, "today");
         }
     );
+
+    program
+        .command("monitor")
+        .description("Today + current week (local timezone, Monday start) in <1s — for status bars/monitors")
+        .option("--json", "Emit {today, week, todayDate, weekStart, timezone} as JSON")
+        .action(async (_opts: { json?: boolean }, cmd: Command) => {
+            // Root also defines --json (addSpendOptions), so commander binds it there;
+            // optsWithGlobals() merges it back — same as runSpend above.
+            const opts = cmd.optsWithGlobals() as { json?: boolean };
+            const storage = new Storage("ai-spend");
+            const pricing = await loadPricing(storage);
+            const report = buildMonitorReport({ pricing, storage });
+
+            if (opts.json) {
+                out.result({
+                    today: report.today,
+                    week: report.week,
+                    todayDate: report.todayDate,
+                    weekStart: report.weekStart,
+                    timezone: report.timezone,
+                });
+
+                return;
+            }
+
+            out.println(
+                `today ${report.todayDate}: $${report.today.cost.toFixed(2)} (${report.today.tokens.toLocaleString()} tok)\n` +
+                    `week from ${report.weekStart}: $${report.week.cost.toFixed(2)} (${report.week.tokens.toLocaleString()} tok) [${report.timezone}]`
+            );
+        });
 
     return program;
 }

--- a/src/ai-spend/lib/register.ts
+++ b/src/ai-spend/lib/register.ts
@@ -5,6 +5,7 @@ import type { Command } from "commander";
 import { aggregate } from "./aggregate";
 import { loadPricing } from "./config";
 import { findTranscriptFiles, readEvents } from "./discover";
+import { AGENT_IDS } from "./drivers";
 import { buildMonitorReport } from "./monitor";
 import { renderSessions, renderSummary, renderToday } from "./render";
 import { resolveSince } from "./since";
@@ -101,8 +102,10 @@ export function registerSpendCommand(program: Command): Command {
 
     program
         .command("monitor")
-        .description("Today + current week (local timezone, Monday start) in <1s — for status bars/monitors")
-        .option("--json", "Emit {today, week, todayDate, weekStart, timezone} as JSON")
+        .description(
+            "Today + current week (local timezone, Monday start) across claude/codex/grok in <1s — for status bars/monitors"
+        )
+        .option("--json", "Emit {today, week, todayDate, weekStart, timezone, agents} as JSON")
         .action(async (_opts: { json?: boolean }, cmd: Command) => {
             // Root also defines --json (addSpendOptions), so commander binds it there;
             // optsWithGlobals() merges it back — same as runSpend above.
@@ -118,14 +121,20 @@ export function registerSpendCommand(program: Command): Command {
                     todayDate: report.todayDate,
                     weekStart: report.weekStart,
                     timezone: report.timezone,
+                    agents: report.agents,
                 });
 
                 return;
             }
 
+            const perAgent = AGENT_IDS.filter((id) => report.agents[id].week.tokens > 0)
+                .map((id) => `${id} $${report.agents[id].today.cost.toFixed(2)}`)
+                .join(" · ");
+
             out.println(
                 `today ${report.todayDate}: $${report.today.cost.toFixed(2)} (${report.today.tokens.toLocaleString()} tok)\n` +
-                    `week from ${report.weekStart}: $${report.week.cost.toFixed(2)} (${report.week.tokens.toLocaleString()} tok) [${report.timezone}]`
+                    `week from ${report.weekStart}: $${report.week.cost.toFixed(2)} (${report.week.tokens.toLocaleString()} tok) [${report.timezone}]` +
+                    (perAgent ? `\ntoday by agent: ${perAgent}` : "")
             );
         });
 

--- a/src/ai-spend/lib/types.ts
+++ b/src/ai-spend/lib/types.ts
@@ -1,3 +1,4 @@
+import type { ModelPricing } from "@genesiscz/utils/ai/catalog";
 export interface UsageEvent {
     messageId: string;
     model: string;
@@ -20,7 +21,17 @@ export interface ModelPrice {
     cacheRead: number;
 }
 
-export type PricingTable = Record<string, ModelPrice>;
+/**
+ * Catalog rules the flat rates above cannot express: dated promotions and
+ * long-context bands. Kept on the entry so `resolvePrice()` can apply them per
+ * EVENT — flattening them away billed every event at the list rate and silently
+ * ignored e.g. the dated Sonnet 5 promotion.
+ */
+export interface ModelPriceEntry extends ModelPrice {
+    rules?: ModelPricing["rules"];
+}
+
+export type PricingTable = Record<string, ModelPriceEntry>;
 
 export interface TokenTotals {
     input: number;

--- a/src/utils/env/envVariables.ts
+++ b/src/utils/env/envVariables.ts
@@ -67,6 +67,13 @@ export const env = {
 
     grok: {
         getHome: () => getWithDefault("GROK_HOME", `${homedir()}/.grok`),
+        /** The raw override, with NO homedir fallback — callers that resolve their own home base. */
+        getHomeOverride: () => getTrimmed("GROK_HOME"),
+    },
+
+    codex: {
+        /** Codex CLI data root override. Codex accepts a comma-separated list of homes. */
+        getHomeOverride: () => getTrimmed("CODEX_HOME"),
     },
 
     copilot: {


### PR DESCRIPTION
`tools ai-spend monitor` read Claude Code transcripts only. It now reads Codex and Grok too, through a driver layer, and reports each agent separately while keeping the existing top-level JSON shape.

## What the drivers do

Each agent contributes one folder under `src/ai-spend/lib/drivers/`. A driver declares four things and nothing else: which directories to walk, which file names are transcripts, how deep to recurse, and how one JSONL line becomes a `DriverUsageEvent`. The walker, the mtime pruning, the incremental tail cache and the 10-minute sweep stay in `monitor.ts` and were generalized, not forked per agent.

| Agent | Files | Usage line | Cost source |
|---|---|---|---|
| `claude` | `~/.claude/projects/**/*.jsonl`, `~/.config/claude/projects/**`, `$CLAUDE_CONFIG_DIR/projects/**` | `type: "assistant"` with `message.usage` | catalog rates for `anthropic` |
| `codex` | `~/.codex/{sessions,archived_sessions}/**/*.jsonl`, or every `$CODEX_HOME` in the comma-separated list | `type: "event_msg"` + `payload.type: "token_count"`; model from the preceding `turn_context` line | catalog rates for `openai` |
| `grok` | `~/.grok/sessions/**/updates.jsonl`, or under `$GROK_HOME` | `params.update.sessionUpdate: "turn_completed"`, one event per `usage.modelUsage` entry | the `costUsdTicks` Grok recorded (1 tick = 1e-10 USD) |

Codex carries state across lines (the sticky `turn_context` model, the previous cumulative totals) and the cache resumes a file mid-way, so `DriverLineParser.snapshot()` persists that state next to the file's byte offset and it is handed back on the next run. A test pins that the sticky model survives a resume.

## ccusage functions mirrored

Read from the local ccusage clone at `/Users/Martin/Tresors/Projects/_Playgrounds/ccusage` (tip `a8e32cf`), whose loaders are now Rust crates under `rust/adapters/`:

- `rust/adapters/codex/src/paths.rs:104` `codex_home_paths` — `CODEX_HOME` as a comma-separated list, then `~/.codex`.
- `rust/adapters/codex/src/paths.rs:20` `codex_usage_sources_from_homes` — `sessions` plus `archived_sessions` under each home.
- `rust/adapters/codex/src/parser.rs:317-367` `visit_codex_session_entry` — prefer `last_token_usage`, but only when `total_token_usage` ADVANCED since the previous line; otherwise fall back to the difference of the cumulative totals. Drop an all-zero event. Clamp `cached_input_tokens` to `input_tokens`.
- `rust/adapters/codex/src/parser.rs:286-291` — the model comes off `turn_context` and sticks for the rest of the file.
- `rust/adapters/codex/src/parser.rs:1063` `subtract_codex_raw_usage` — saturating field-wise difference.
- `rust/adapters/codex/src/report.rs:85` `non_cached_input_tokens` — billable input is `input − cached`.
- `rust/adapters/grok/src/paths.rs:32` `discover_session_files` — only `updates.jsonl` under `<root>/sessions`, `GROK_HOME` first.
- `rust/adapters/grok/src/parser.rs:170` `split_input_tokens` — `cachedReadTokens` and `cacheCreationTokens` are subsets of `inputTokens`, so the three parts sum back to `inputTokens`.
- `rust/adapters/grok/src/parser.rs:140-153` `COST_USD_TICKS_PER_USD` / `cost_usd_from_ticks` — ticks are fixed-point USD at 1e-10, and they are authoritative because a `turn_completed` row is a per-turn SUM over separately-priced requests.
- `rust/adapters/grok/src/parser.rs:405` `resolve_timestamp_ms` — `_meta.agentTimestampMs` is millis, the envelope `timestamp` is Unix seconds.
- `rust/adapters/grok/src/parser.rs:429` `dedupe_key` — `eventId|model`, falling back to a token fingerprint.
- `rust/adapters/grok/src/parser.rs:177` `pricing_candidates` — peel the `-build` suffix before the pricing lookup.
- `rust/adapters/grok/src/parser.rs:215` `LinePrefilter::all(&[b"\"turn_completed\""])` — substring prefilter before the JSON parse.

### Deliberately NOT mirrored

- **LiteLLM / OpenRouter pricing fetches.** ccusage resolves rates through a downloaded price map. This tool stays offline: rates come from `@genesiscz/utils/ai/catalog` only, and an unpriced id costs $0 rather than a guessed family rate. That is why `codex-auto-review` and every `xai` id contribute $0 (Grok is unaffected in practice — it reports its own cost).
- **`xai/` and `x-ai/` prefixed pricing candidates** (`grok/src/parser.rs:199-203`). This tool's pricing table is keyed by bare catalog ids, so a prefixed key can never hit.
- **Codex long-context tiering** (`codex/src/report.rs:187-219`, the >272K input bucket priced at `input_above_200k`). The catalog carries no banded OpenAI rates for these ids, so there is nothing to tier against. Adding rules to the catalog would make it flow through unchanged.
- **Codex service tiers** (`thread_settings_applied` → standard/fast buckets) and the **headless `codex exec` result shape**. `monitor` reads interactive rollouts, and a status bar has no use for a tier split.
- **ccusage's file-level dedup across homes** (`collect_deduped_codex_usage_files`). `monitor` keys its cache by absolute path, so the same file reached through two roots is one cache row already.
- **Grok `summary.json` eager reads.** ccusage loads the session summary for every file; this driver reads it lazily, only when a turn omits `modelUsage`, so the common path never opens the sibling.

## Validated against live data on this machine

Independent `jq` sums over the real files, compared to what `monitor` reported:

- Codex, week of 2026-08-24: `jq` over `~/.codex/sessions/2026/08/26/*.jsonl` gave 16 `last_token_usage` events, 426,929 input / 376,832 cached / 2,112 output / **429,041 total**. `monitor` reported **429,041** tokens and **$0.5022610** — which is exactly `50,097×$5/M + 2,112×$30/M + 376,832×$0.5/M` at `gpt-5.6` rates.
- Grok, today: `jq` over every `updates.jsonl` touched today, deduped on `eventId|model`, gave 3 rows, **3,504,406** tokens and **$0.60859116** of ticks. `monitor` reported exactly the same two numbers.

## Perf

Gate: after a warm-up run, 5 interleaved `/usr/bin/time -p` runs from the repo worktree and 5 from `$HOME`. The cache was moved aside first, so the warm-up did a full cold rebuild of all three trees.

| cwd | runs (s) | min | median | max |
|---|---|---|---|---|
| repo worktree | 0.12, 0.11, 0.10, 0.11, 0.10 | 0.10 | **0.11** | 0.12 |
| `$HOME` | 0.09, 0.09, 0.09, 0.09, 0.09 | 0.09 | **0.09** | 0.09 |
| combined | — | 0.09 | **0.095** | **0.12** |

Median 0.095s < 1.00s, max 0.12s < 1.5s. For reference: the cold rebuild is ~1.47s, and the 10-minute full sweep with a warm cache costs 193–268ms across 882 in-window files (11.5k Claude transcripts, 207 Codex rollouts, 2.9k Grok sessions on disk).

## Tests

`bun run test src/ai-spend src/utils/env` → **64 pass, 0 fail, 180 expect() calls, 8 files.**

| File | Tests |
|---|---|
| `lib/drivers/claude.test.ts` | 4 |
| `lib/drivers/codex.test.ts` | 7 |
| `lib/drivers/grok.test.ts` | 8 |
| `lib/pricing.test.ts` | 4 |
| `lib/monitor.test.ts` | 8 (6 pre-existing, unchanged, plus 2 new multi-agent) |

Fixture line shapes are copied from the real formats on disk with synthetic ids, session ids and cwds. Every driver test pins exact token counts, and a dollar figure wherever the model is priced.

`tsgo --noEmit` clean, `biome check` clean, `bun run lint:rules` clean.

## JSON shape

The top level is unchanged and is the sum across agents:

```json
{
  "today": { "cost": 404.96, "tokens": 358954522 },
  "week": { "cost": 2612.44, "tokens": 3254443009 },
  "todayDate": "2026-08-27",
  "weekStart": "2026-08-24",
  "timezone": "Europe/Prague",
  "agents": {
    "claude": { "today": { "cost": 404.36, "tokens": 355450116 }, "week": { "cost": 2550.61, "tokens": 2872579230 } },
    "codex":  { "today": { "cost": 0, "tokens": 0 },              "week": { "cost": 0.50, "tokens": 429041 } },
    "grok":   { "today": { "cost": 0.61, "tokens": 3504406 },     "week": { "cost": 61.34, "tokens": 381434738 } }
  }
}
```

The cache format moved from v2 to v3 (per-agent buckets plus a driver `state` field). A v2 file is discarded and rebuilt on the next run, which costs one cold sweep and nothing else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AI spend monitoring for Claude Code, Codex, and Grok.
  - Added daily and weekly cost/token summaries with per-agent breakdowns.
  - Added human-readable and JSON output through the `monitor` command.
  - Added local-time reporting, incremental scanning, duplicate prevention, and configurable transcript locations.
  - Added pricing support for Anthropic, OpenAI, OpenAI-compatible, and xAI models, including context-aware rates.

- **Documentation**
  - Documented monitoring behavior, supported agents, pricing, output formats, and performance characteristics.

- **Tests**
  - Added comprehensive coverage for parsing, billing, discovery, caching, deduplication, pricing, and multi-agent aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->