### PR TITLE
feat(azure-devops): sprint and iteration backlog commands with team scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ is large, and as skills they would load into sessions that never needed them.
 |-------|--------------|
 | `agents-talk` | Cross-agent messaging protocol via `tools agents`. Invoke before spawning subagents that must talk to each other. |
 | `analyze-har` | Token-efficient HAR analysis. The rule it enforces: never `cat` or `jq` a HAR file. |
-| `azure-devops` | Work items, queries, dashboards. Defers time logging to `/gt:timelog`. |
+| `azure-devops` | Work items, queries, sprints, dashboards. Defers time logging to `/gt:timelog`. |
 | `claude-history` | Find a past Claude Code conversation by topic, file, or date. |
 | `debugging-master` | Hypothesis-driven runtime debugging with temporary, auto-cleanable instrumentation (Node/TS, PHP, browser). |
 | `git-rebaser` | Cascade rebase for a parent branch plus the children stacked on it, using `git rebase --onto`. |
@@ -377,7 +377,7 @@ onto the merged base first, then optionally deletes the head branch.
 
 | Tool | What it does | Key subcommands |
 |------|--------------|-----------------|
-| [`azure-devops`](src/azure-devops/README.md) | Azure DevOps work items, queries, dashboards, and time logs, with caching and change detection. | `configure` `query` `workitem` `workitem-create` `list` `dashboard` `timelog` `history` |
+| [`azure-devops`](src/azure-devops/README.md) | Azure DevOps work items, queries, sprints, dashboards, and time logs, with caching and change detection. | `configure` `query` `workitem` `workitem-create` `list` `iterations` `sprint` `dashboard` `timelog` `history` |
 | [`timely`](src/timely/README.md) | Timely time tracking: OAuth login, accounts and projects, events, auto-tracked memories, monthly exports. | `login` `status` `accounts` `projects` `events` `memories` `create` `export-month` `cache` |
 | [`clarity`](src/clarity/README.md) | CA PPM Clarity timesheet management, filled from Azure DevOps time logs and Timely activity. | `configure` `timesheet` `fill` `link-workitems` `ui` |
 | [`timer`](src/timer/README.md) | Focus timer with live countdown, background mode, Pomodoro cycles, and completion hooks. | `list` `cancel` |

--- a/plugins/genesis-tools/skills/azure-devops/SKILL.md
+++ b/plugins/genesis-tools/skills/azure-devops/SKILL.md
@@ -16,6 +16,8 @@ tools azure-devops workitem <id|ids>             # Fetch work item(s)
 tools azure-devops query <id|url|name>           # Fetch query results (supports name matching)
 tools azure-devops query <id> --download-workitems  # Download all to files
 tools azure-devops dashboard <id|url>            # Get dashboard queries
+tools azure-devops iterations                    # List the team's sprints (alias: sprints)
+tools azure-devops sprint [nameOrPath]           # Work items of one sprint (default: current)
 tools azure-devops list                          # List cached items
 tools azure-devops workitem-create               # Create work item
 tools azure-devops timelog configure             # Interactive: setup API key, user, allowed types
@@ -46,6 +48,46 @@ tools azure-devops timelog import <file>         # Bulk import time logs (with p
 | `--attachments-suffix <suffix>` | Only attachments ending with this (e.g. .har) |
 | `--output-dir <path>` | Custom directory for downloaded attachments |
 | `--images` | Download inline images from description/comments |
+
+### Sprint backlog
+
+`sprint` reproduces the ADO Backlog tab from the CLI, so a board screenshot is no longer needed.
+
+```bash
+tools azure-devops iterations                                  # sprints + which one contains today
+tools azure-devops sprint --mine --totals                      # current sprint, my items, effort sums
+tools azure-devops sprint "17. Sprint 20.08." --mine --order    # one sprint, Backlog stack-rank order
+tools azure-devops sprint --mine -f json                        # machine-readable rows
+```
+
+Columns: `ID | Type | Title | State | AssignedTo | CompletedWork | RemainingWork`, plus `Order` with `--order` and `ChangedDate` in `md` / `json`.
+
+| Option | Description |
+|--------|-------------|
+| `--team <name>` | Team name; overrides `config.team`. Also valid before the subcommand. |
+| `--mine` | Only items assigned to me (WIQL `@Me`) |
+| `--assigned-to <name>` | Only items assigned to this display name or unique name |
+| `--totals` | Task-only CompletedWork / RemainingWork sums |
+| `--order` | Sort by Backlog stack rank and show the Order column |
+
+Rules that matter when reading the output:
+
+- **Task** rows carry spendable effort. **User Story** and **Feature** rows are context only. **Bug** and **Incident** rows need their children checked first.
+- `--totals` sums Tasks only, so a User Story and its child Task are never counted twice.
+- The iteration argument resolves as exact path, then exact name, then case-insensitive substring. An ambiguous substring exits 1 and lists every candidate. Omit it for the sprint containing today.
+
+**Never use `@CurrentIteration`.** The macro needs a team context and fails with `VS402612: The macro '@CurrentIteration' is not supported without a team context`. `sprint` resolves the iteration from the team settings endpoint and sends an explicit `[System.IterationPath] = '<path>'` predicate instead. The two saved queries that look right, `FE Tasky aktualniho sprintu` (`dbfe2de1-abb1-48ca-80ce-cefd42e11917`) and `MF - Not Closed` (`7a4cbaea-0c7a-460a-a82f-ce2d97ad9d1a`), return `VS402612` from the CLI both project-scoped and team-scoped, because their stored WIQL names a team that no longer exists. Do not retry them.
+
+**Never scan the local work item cache instead.** `.claude/azure/tasks/**` accumulates every work item ever fetched and its `RemainingWork` is never zeroed, so filtering it produces sprints full of items closed months earlier.
+
+Team setup, once per project:
+
+```bash
+tools azure-devops configure \
+  "https://dev.azure.com/MyOrg/MyProject/_backlogs/backlog/Delivery%20Team%20C/Stories"
+```
+
+The board URL carries the team, and `configure` stores it as `team` in `.claude/azure/config.json`. Without it, pass `--team "Delivery Team C"` per run.
 
 ### Output Paths
 
@@ -187,6 +229,9 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
 | User Request | Action |
 |--------------|--------|
 | "Get workitem 261575" | `tools azure-devops workitem 261575` |
+| "What is in the current sprint" | `tools azure-devops sprint --mine --totals` |
+| "List the sprints" | `tools azure-devops iterations` |
+| "Show sprint 17 in backlog order" | `tools azure-devops sprint "17. Sprint" --mine --order` |
 | "Show query results for X" | `tools azure-devops query X` |
 | "Show Open Bugs query" | `tools azure-devops query "Open Bugs"` |
 | "Fetch Otevřené bugy" | `tools azure-devops query "Otevřené bugy"` |

--- a/plugins/genesis-tools/skills/azure-devops/SKILL.md
+++ b/plugins/genesis-tools/skills/azure-devops/SKILL.md
@@ -56,7 +56,7 @@ tools azure-devops timelog import <file>         # Bulk import time logs (with p
 ```bash
 tools azure-devops iterations                                  # sprints + which one contains today
 tools azure-devops sprint --mine --totals                      # current sprint, my items, effort sums
-tools azure-devops sprint "17. Sprint 20.08." --mine --order    # one sprint, Backlog stack-rank order
+tools azure-devops sprint "Sprint 17" --mine --order    # one sprint, Backlog stack-rank order
 tools azure-devops sprint --mine -f json                        # machine-readable rows
 ```
 
@@ -87,7 +87,7 @@ tools azure-devops configure \
   "https://dev.azure.com/MyOrg/MyProject/_backlogs/backlog/Delivery%20Team%20C/Stories"
 ```
 
-The board URL carries the team, and `configure` stores it as `team` in `.claude/azure/config.json`. Without it, pass `--team "Delivery Team C"` per run.
+The board URL carries the team, and `configure` stores it as `team` in `.claude/azure/config.json`. Without it, pass `--team "<Your Team>"` per run.
 
 ### Output Paths
 
@@ -231,7 +231,7 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
 | "Get workitem 261575" | `tools azure-devops workitem 261575` |
 | "What is in the current sprint" | `tools azure-devops sprint --mine --totals` |
 | "List the sprints" | `tools azure-devops iterations` |
-| "Show sprint 17 in backlog order" | `tools azure-devops sprint "17. Sprint" --mine --order` |
+| "Show sprint 17 in backlog order" | `tools azure-devops sprint "Sprint 17" --mine --order` |
 | "Show query results for X" | `tools azure-devops query X` |
 | "Show Open Bugs query" | `tools azure-devops query "Open Bugs"` |
 | "Fetch Otevřené bugy" | `tools azure-devops query "Otevřené bugy"` |

--- a/src/azure-devops/README.md
+++ b/src/azure-devops/README.md
@@ -26,29 +26,29 @@ Both commands are team-scoped, because iteration settings belong to a team, not 
 ```bash
 # Store the team in .claude/azure/config.json (the URL carries it)
 tools azure-devops configure \
-  "https://dev.azure.com/MyOrg/MyProject/_backlogs/backlog/Delivery%20Team%20C/Stories"
+  "https://dev.azure.com/MyOrg/MyProject/_backlogs/backlog/{team}/Stories"
 
 # List the team's sprints; the one containing today is marked
 tools azure-devops iterations
-tools azure-devops iterations --team "Delivery Team C" -f json
+tools azure-devops iterations --team "Payments Team" -f json
 
 # The current sprint, everything assigned to me, with the Task-only effort sums
 tools azure-devops sprint --mine --totals
 
 # Name a sprint by substring or by full iteration path (both resolve to the same one)
-tools azure-devops sprint "17. Sprint 20.08."
-tools azure-devops sprint "MŮJ ČEZ\17. Sprint 20.08. - 02.09."
+tools azure-devops sprint "Sprint 17"
+tools azure-devops sprint "Widgets\Sprint 17"
 
 # Backlog stack-rank order, with the Order column, as markdown for a report
-tools azure-devops sprint "17. Sprint 20.08." --mine --order -f md
+tools azure-devops sprint "Sprint 17" --mine --order -f md
 ```
 
-Worked example, `17. Sprint 20.08. - 02.09.` with `--mine --totals`:
+Worked example, `Sprint 17` with `--mine --totals`:
 
 ```
 │ ID     │ TYPE       │ TITLE                    │ STATE       │ ASSIGNED  │ DONE │ LEFT │
-│ 285747 │ Task       │ Vývoj - ...              │ New         │ ...       │ 0    │ 4    │
-│ 296936 │ Task       │ FE analýza/vývoj - ...   │ In Progress │ ...       │ 85   │ 56   │
+│ 41207  │ Task       │ Build the checkout form  │ New         │ ...       │ 0    │ 4    │
+│ 41219  │ Task       │ Wire the payments API    │ In Progress │ ...       │ 85   │ 56   │
 
   Totals
   Items: 17 (Tasks: 9)
@@ -60,9 +60,9 @@ Worked example, `17. Sprint 20.08. - 02.09.` with `--mine --totals`:
 
 The `[nameOrPath]` argument resolves in this order:
 
-1. Exact `System.IterationPath` (case-insensitive), e.g. `MŮJ ČEZ\17. Sprint 20.08. - 02.09.`
-2. Exact iteration name (case-insensitive), e.g. `17. Sprint 20.08. - 02.09.`
-3. Case-insensitive substring of the name or the path, e.g. `17. Sprint 20.08.`
+1. Exact `System.IterationPath` (case-insensitive), e.g. `Widgets\Sprint 17`
+2. Exact iteration name (case-insensitive), e.g. `Sprint 17`
+3. Case-insensitive substring of the name or the path, e.g. `Sprint 1`
 
 Omit the argument (or pass `current`) to get the iteration whose date range contains today. The finish date is inclusive, so the last day of a sprint still counts as current.
 

--- a/src/azure-devops/README.md
+++ b/src/azure-devops/README.md
@@ -15,6 +15,91 @@ CLI tool for fetching, tracking, and managing Azure DevOps work items, queries, 
 -   ✅ **Batch Operations**: Fetch multiple work items or download all items from a query
 -   ✅ **Filtering**: Filter queries by state and severity
 -   ✅ **Multiple Output Formats**: AI-optimized, Markdown, or JSON output
+-   ✅ **Sprint Backlog**: List a team's iterations and the work items of one sprint, with the effort columns the ADO Backlog tab shows
+
+## Sprint / iteration commands
+
+`iterations` lists a team's sprints. `sprint` lists the work items of one of them. Together they replace the manual screenshot of the ADO Backlog tab.
+
+Both commands are team-scoped, because iteration settings belong to a team, not to the project. Set the team once with `configure` using a board or backlog URL, or pass `--team` per run.
+
+```bash
+# Store the team in .claude/azure/config.json (the URL carries it)
+tools azure-devops configure \
+  "https://dev.azure.com/MyOrg/MyProject/_backlogs/backlog/Delivery%20Team%20C/Stories"
+
+# List the team's sprints; the one containing today is marked
+tools azure-devops iterations
+tools azure-devops iterations --team "Delivery Team C" -f json
+
+# The current sprint, everything assigned to me, with the Task-only effort sums
+tools azure-devops sprint --mine --totals
+
+# Name a sprint by substring or by full iteration path (both resolve to the same one)
+tools azure-devops sprint "17. Sprint 20.08."
+tools azure-devops sprint "MŮJ ČEZ\17. Sprint 20.08. - 02.09."
+
+# Backlog stack-rank order, with the Order column, as markdown for a report
+tools azure-devops sprint "17. Sprint 20.08." --mine --order -f md
+```
+
+Worked example, `17. Sprint 20.08. - 02.09.` with `--mine --totals`:
+
+```
+│ ID     │ TYPE       │ TITLE                    │ STATE       │ ASSIGNED  │ DONE │ LEFT │
+│ 285747 │ Task       │ Vývoj - ...              │ New         │ ...       │ 0    │ 4    │
+│ 296936 │ Task       │ FE analýza/vývoj - ...   │ In Progress │ ...       │ 85   │ 56   │
+
+  Totals
+  Items: 17 (Tasks: 9)
+  Task CompletedWork: 139.75 h
+  Task RemainingWork: 88 h
+```
+
+### Iteration resolution
+
+The `[nameOrPath]` argument resolves in this order:
+
+1. Exact `System.IterationPath` (case-insensitive), e.g. `MŮJ ČEZ\17. Sprint 20.08. - 02.09.`
+2. Exact iteration name (case-insensitive), e.g. `17. Sprint 20.08. - 02.09.`
+3. Case-insensitive substring of the name or the path, e.g. `17. Sprint 20.08.`
+
+Omit the argument (or pass `current`) to get the iteration whose date range contains today. The finish date is inclusive, so the last day of a sprint still counts as current.
+
+A substring that matches several iterations is refused: the command lists every candidate and exits 1. It never guesses.
+
+### Why not `@CurrentIteration`
+
+`@CurrentIteration` is a WIQL macro resolved by the server from a team context. Two problems make it unusable here:
+
+-   Without a team context Azure DevOps answers `VS402612: The macro '@CurrentIteration' is not supported without a team context` and the request fails with HTTP 500.
+-   Even when it resolves, the CLI cannot tell which iteration the server picked, so the output cannot be checked.
+
+These commands therefore resolve the iteration first, through `GET {org}/{project}/{team}/_apis/work/teamsettings/iterations`, and then send an explicit `[System.IterationPath] = '<path>'` predicate. Single quotes in the path are doubled; backslashes are literal in WIQL and need no escaping.
+
+The two saved queries that look like they would do this job cannot be run from the CLI at all:
+
+-   `Shared Queries/FE Tasky aktuálního sprintu` (`dbfe2de1-abb1-48ca-80ce-cefd42e11917`)
+-   `Shared Queries/Vyhodnocování/Team A/MF - Not Closed` (`7a4cbaea-0c7a-460a-a82f-ce2d97ad9d1a`)
+
+Both return `VS402612`, project-scoped and team-scoped alike, because their stored WIQL calls `@currentIteration` with a team that no longer exists. Adding a team route segment does not fix them. Use `sprint` instead.
+
+### Sprint options
+
+| Option                 | Description                                                                      | Default |
+| ---------------------- | -------------------------------------------------------------------------------- | ------- |
+| `--team <name>`        | Team name; overrides `config.team`. Also accepted before the subcommand.          | config  |
+| `--mine`               | Only items assigned to me (WIQL `@Me`)                                            | -       |
+| `--assigned-to <name>` | Only items assigned to this display name or unique name                           | -       |
+| `--totals`             | Print the Task-only CompletedWork / RemainingWork sums                            | -       |
+| `--order`              | Sort by Backlog stack rank instead of id, and show the Order column               | -       |
+| `-f, --format <fmt>`   | `ai` (box table), `md` (markdown table), `json` (array of row objects)             | `ai`    |
+
+`--totals` sums Tasks only. A User Story and its child Task both sit in the sprint and both carry a Remaining value, so summing every type would count the same work twice. Bug, Incident and Feature rows are excluded from the sum for the same reason; they are still listed.
+
+`--order` sorts by `Microsoft.VSTS.Common.StackRank`, falling back to `Microsoft.VSTS.Common.BacklogPriority`. Only backlog-level types carry a rank, so Tasks usually have none. Unranked rows sort last by ascending id, which is deterministic across runs.
+
+`-f json` emits one object per row with the keys `id`, `type`, `title`, `state`, `assignedTo`, `completedWork`, `remainingWork`, `order`, `changedDate`. `completedWork` and `remainingWork` are always numbers; a missing field reads as `0`. `order` is `null` when the item is unranked. Adding `--totals` wraps the array as `{ iteration, items, totals }`.
 
 ## CLI Usage
 
@@ -89,6 +174,8 @@ tools azure-devops --create --type Bug --title "Error in checkout" --severity "A
 | `--dashboard`  | Extract queries from a dashboard               |
 | `--list`       | List all cached work items                     |
 | `--create`     | Create new work items (interactive or from template) |
+| `iterations`   | List the team's sprints (alias `sprints`)      |
+| `sprint`       | List the work items of one sprint              |
 
 ### Options
 

--- a/src/azure-devops/api.ts
+++ b/src/azure-devops/api.ts
@@ -12,6 +12,8 @@ import type {
     DashboardsListResponse,
     GetWorkItemsOptions,
     QueryNode,
+    TeamIteration,
+    TeamIterationsResponse,
     TeamMembersResponse,
     TeamsListResponse,
 } from "@app/azure-devops/api.types";
@@ -127,6 +129,28 @@ export class Api {
         return buildUrl({
             base: config.org,
             segments: [encodeURIComponent(config.project), "_apis", ...path],
+            queryParams: { "api-version": apiVersion, ...Api.filterParams(queryParams) },
+        });
+    }
+
+    /**
+     * Team-scoped API URL: `{org}/{project}/{team}/_apis/{path}?api-version=...`
+     *
+     * Azure DevOps resolves team macros (`@CurrentIteration`) and team settings
+     * (`work/teamsettings/iterations`) from this route segment. A project-scoped
+     * URL falls back to the project's default team, which owns a different
+     * iteration set, so team-specific reads must go through here.
+     */
+    static teamApiUrl(
+        config: AzureConfig,
+        team: string,
+        path: string[],
+        queryParams?: Record<string, string | undefined>,
+        apiVersion = "7.1"
+    ): string {
+        return buildUrl({
+            base: config.org,
+            segments: [encodeURIComponent(config.project), encodeURIComponent(team), "_apis", ...path],
             queryParams: { "api-version": apiVersion, ...Api.filterParams(queryParams) },
         });
     }
@@ -791,9 +815,57 @@ export class Api {
 
     // ============= History & Reporting Methods =============
 
-    async runWiql(wiql: string, options?: { top?: number }): Promise<WiqlResponse> {
-        const url = Api.witUrl(this.config, "wiql", { $top: options?.top ? String(options.top) : undefined });
+    /**
+     * Run an ad-hoc WIQL query.
+     * Pass `team` to execute in a team context, which is required by macros such
+     * as `@CurrentIteration`.
+     */
+    async runWiql(wiql: string, options?: { top?: number; team?: string }): Promise<WiqlResponse> {
+        const queryParams = { $top: options?.top ? String(options.top) : undefined };
+        const url = options?.team
+            ? Api.teamApiUrl(this.config, options.team, ["wit", "wiql"], queryParams)
+            : Api.witUrl(this.config, "wiql", queryParams);
         return this.post<WiqlResponse>(url, { query: wiql }, "application/json", "WIQL query");
+    }
+
+    /**
+     * List the iterations (sprints) configured for one team.
+     * Project-scoped callers get the default team's iterations instead, which is
+     * usually not what the caller means, so `team` is required here.
+     */
+    async getTeamIterations(team: string): Promise<TeamIteration[]> {
+        const url = Api.teamApiUrl(this.config, team, ["work", "teamsettings", "iterations"]);
+        const data = await this.get<TeamIterationsResponse>(url, `iterations for team "${team}"`);
+        logger.debug(`[api] Team "${team}" has ${data.value?.length ?? 0} iterations`);
+        return data.value ?? [];
+    }
+
+    /**
+     * Batch-fetch a fixed field set for many work items (200 per request).
+     * Cheaper than getWorkItems(), which always expands relations and comments.
+     */
+    async getWorkItemFields(ids: number[], fields: string[]): Promise<Map<number, Record<string, unknown>>> {
+        const result = new Map<number, Record<string, unknown>>();
+        const batchSize = 200;
+
+        for (let i = 0; i < ids.length; i += batchSize) {
+            const batchIds = ids.slice(i, i + batchSize);
+            const url = Api.orgUrl(this.config, ["wit", "workitems"], {
+                ids: batchIds.join(","),
+                fields: fields.join(","),
+            });
+            const response = await this.get<{ value: Array<{ id: number; fields?: Record<string, unknown> }> }>(
+                url,
+                `fields batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(ids.length / batchSize)}`
+            );
+
+            for (const item of response.value) {
+                result.set(item.id, item.fields ?? {});
+            }
+        }
+
+        logger.debug(`[api] Fetched fields for ${result.size}/${ids.length} work items`);
+        return result;
     }
 
     /**

--- a/src/azure-devops/api.types.ts
+++ b/src/azure-devops/api.types.ts
@@ -39,6 +39,25 @@ export interface TeamsListResponse {
     value: Array<{ id: string; name: string }>;
 }
 
+/** One iteration (sprint) as returned by `work/teamsettings/iterations` */
+export interface TeamIteration {
+    id: string;
+    name: string;
+    path: string;
+    attributes?: {
+        startDate?: string | null;
+        finishDate?: string | null;
+        /** Azure's own classification: "past" | "current" | "future" */
+        timeFrame?: string;
+    };
+}
+
+/** Raw response from the team iterations endpoint */
+export interface TeamIterationsResponse {
+    count: number;
+    value: TeamIteration[];
+}
+
 /** Raw response from team members */
 export interface TeamMembersResponse {
     value: Array<{ identity: IdentityRef }>;

--- a/src/azure-devops/commands/configure.ts
+++ b/src/azure-devops/commands/configure.ts
@@ -51,21 +51,25 @@ async function handleConfigure(url: string): Promise<void> {
     out.println(`  Project: ${newConfig.project}`);
     out.println(`  Project ID: ${newConfig.projectId}`);
 
-    if (newConfig.team) {
-        out.println(`  Team: ${newConfig.team}`);
+    const configDir = getLocalConfigDir();
+    // Report what was SAVED, not what the URL carried. A same-project reconfigure
+    // keeps the team and the timelog block, so printing newConfig said
+    // "Team: (none)" while the file on disk still had one (PR #333 review t7).
+    const saved = saveAdoConfig(newConfig, configDir);
+
+    if (saved.config.team) {
+        const kept = newConfig.team ? "" : " (kept from the existing config)";
+        out.println(`  Team: ${saved.config.team}${kept}`);
     } else {
         out.println(
             "  Team: (none — pass a board/backlog URL to capture it, or use --team on `iterations` / `sprint`)"
         );
     }
 
-    const configDir = getLocalConfigDir();
-    const configPath = saveAdoConfig(newConfig, configDir);
-
-    out.println(`\n✅ Configuration saved to: ${configPath}`);
+    out.println(`\n✅ Configuration saved to: ${saved.path}`);
     out.println("\nConfig values:");
     out.println("```json");
-    out.println(SafeJSON.stringify(newConfig, null, 2));
+    out.println(SafeJSON.stringify(saved.config, null, 2));
     out.println("```");
 
     out.println("\nConfiguring az devops defaults...");

--- a/src/azure-devops/commands/configure.ts
+++ b/src/azure-devops/commands/configure.ts
@@ -51,6 +51,14 @@ async function handleConfigure(url: string): Promise<void> {
     out.println(`  Project: ${newConfig.project}`);
     out.println(`  Project ID: ${newConfig.projectId}`);
 
+    if (newConfig.team) {
+        out.println(`  Team: ${newConfig.team}`);
+    } else {
+        out.println(
+            "  Team: (none — pass a board/backlog URL to capture it, or use --team on `iterations` / `sprint`)"
+        );
+    }
+
     const configDir = getLocalConfigDir();
     const configPath = saveAdoConfig(newConfig, configDir);
 

--- a/src/azure-devops/commands/sprint.ts
+++ b/src/azure-devops/commands/sprint.ts
@@ -1,0 +1,438 @@
+/**
+ * Azure DevOps CLI - Sprint / iteration commands.
+ *
+ * `iterations` lists a team's sprints. `sprint` lists the work items of one of
+ * them, with the effort columns the ADO Backlog tab shows.
+ *
+ * The queries never use `@CurrentIteration`. That macro needs a team context,
+ * fails with `VS402612` when none is available, and hides which iteration the
+ * server picked even when it works. We resolve the iteration from the team
+ * settings endpoint and put an explicit `[System.IterationPath]` predicate in
+ * the WIQL instead.
+ */
+
+import { Api } from "@app/azure-devops/api";
+import type { TeamIteration } from "@app/azure-devops/api.types";
+import { findCurrentIteration, iterationContainsDate, resolveIteration } from "@app/azure-devops/lib/iterations";
+import {
+    buildSprintWiql,
+    mapSprintRow,
+    SPRINT_FIELDS,
+    type SprintRow,
+    sortByBacklogOrder,
+    sortById,
+    sumTaskEffort,
+} from "@app/azure-devops/lib/sprint";
+import { NO_TEAM_MESSAGE, resolveTeam } from "@app/azure-devops/lib/team";
+import type { AzureConfig, OutputFormat } from "@app/azure-devops/types";
+import { requireConfig } from "@app/azure-devops/utils";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger, out } from "@genesiscz/utils/logger";
+import { createBoxTable, renderCliHeader, renderCliSection, truncateDisplay } from "@genesiscz/utils/table";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+// ============= Options =============
+
+interface IterationsOptions {
+    format: OutputFormat;
+    team?: string;
+}
+
+interface SprintOptions {
+    format: OutputFormat;
+    team?: string;
+    mine?: boolean;
+    assignedTo?: string;
+    totals?: boolean;
+    order?: boolean;
+}
+
+// ============= Shared helpers =============
+
+function parseFormat(raw: string | undefined): OutputFormat {
+    const value = (raw ?? "ai").toLowerCase();
+
+    if (value === "ai" || value === "md" || value === "json") {
+        return value;
+    }
+
+    out.error(`Unknown --format "${raw}". Use one of: ai, md, json.`);
+    process.exit(1);
+}
+
+/** Resolve the team, or exit naming both ways to set it. */
+function requireTeam(config: AzureConfig, explicit?: string): string {
+    const resolved = resolveTeam(config, explicit);
+
+    if (!resolved) {
+        out.error(NO_TEAM_MESSAGE);
+        process.exit(1);
+    }
+
+    logger.debug(`[sprint] Using team "${resolved.team}" (source: ${resolved.source})`);
+    return resolved.team;
+}
+
+function formatDate(iso: string | null | undefined): string {
+    if (!iso) {
+        return "-";
+    }
+
+    return iso.slice(0, 10);
+}
+
+/** Hours render as integers when they are whole, so "8" does not print as "8.00". */
+function formatEffort(value: number): string {
+    return Number.isInteger(value) ? String(value) : String(Number(value.toFixed(2)));
+}
+
+/** A literal pipe would break the markdown row. */
+function escapeMd(value: string): string {
+    return value.replace(/\|/g, "\\|");
+}
+
+function mdRow(cells: string[]): string {
+    return `| ${cells.join(" | ")} |`;
+}
+
+// ============= iterations =============
+
+async function handleIterations(options: IterationsOptions): Promise<void> {
+    const config = requireConfig();
+    const team = requireTeam(config, options.team);
+    const api = new Api(config);
+    const iterations = await api.getTeamIterations(team);
+
+    if (iterations.length === 0) {
+        out.error(`Team "${team}" has no iterations configured.`);
+        process.exit(1);
+    }
+
+    const now = new Date();
+    const current = findCurrentIteration(iterations, now);
+
+    if (options.format === "json") {
+        out.result(
+            SafeJSON.stringify(
+                iterations.map((it) => ({
+                    id: it.id,
+                    name: it.name,
+                    path: it.path,
+                    startDate: it.attributes?.startDate ?? null,
+                    finishDate: it.attributes?.finishDate ?? null,
+                    isCurrent: iterationContainsDate(it, now),
+                })),
+                null,
+                2
+            )
+        );
+        return;
+    }
+
+    if (options.format === "md") {
+        const lines = [
+            `# Iterations - ${escapeMd(team)}`,
+            "",
+            mdRow(["Current", "Name", "Path", "Start", "Finish"]),
+            mdRow(["---", "---", "---", "---", "---"]),
+            ...iterations.map((it) =>
+                mdRow([
+                    iterationContainsDate(it, now) ? "**now**" : "",
+                    escapeMd(it.name),
+                    `\`${escapeMd(it.path)}\``,
+                    formatDate(it.attributes?.startDate),
+                    formatDate(it.attributes?.finishDate),
+                ])
+            ),
+        ];
+        out.result(`${lines.join("\n")}\n`);
+        return;
+    }
+
+    renderCliHeader("Iterations", `team ${team}`);
+    const table = createBoxTable(["", "NAME", "PATH", "START", "FINISH"]);
+
+    for (const it of iterations) {
+        const isCurrent = iterationContainsDate(it, now);
+        const name = truncateDisplay(it.name, 44);
+        table.push([
+            isCurrent ? pc.green("*") : " ",
+            isCurrent ? pc.green(name) : name,
+            pc.dim(truncateDisplay(it.path, 46)),
+            formatDate(it.attributes?.startDate),
+            formatDate(it.attributes?.finishDate),
+        ]);
+    }
+
+    out.println(table.toString());
+    renderCliSection("Current");
+    out.println(
+        current
+            ? `  * ${current.name}  (${formatDate(current.attributes?.startDate)} -> ${formatDate(current.attributes?.finishDate)})`
+            : "  none: no iteration's date range contains today"
+    );
+    out.println(pc.dim("\nNext: tools azure-devops sprint --mine --totals"));
+}
+
+// ============= sprint =============
+
+/** Print every candidate and exit non-zero rather than guessing. */
+function exitAmbiguous(query: string, candidates: TeamIteration[]): never {
+    out.error(`"${query}" matches ${candidates.length} iterations. Narrow it down:`);
+
+    for (const candidate of candidates) {
+        out.printlnErr(`  ${candidate.name}   (${candidate.path})`);
+    }
+
+    process.exit(1);
+}
+
+async function resolveSprintIteration(api: Api, team: string, nameOrPath: string | undefined): Promise<TeamIteration> {
+    const iterations = await api.getTeamIterations(team);
+    const resolution = resolveIteration(iterations, nameOrPath, new Date());
+
+    if (resolution.kind === "resolved") {
+        logger.debug(`[sprint] Resolved iteration "${resolution.iteration.path}" by ${resolution.matchedBy}`);
+        return resolution.iteration;
+    }
+
+    if (resolution.kind === "ambiguous") {
+        exitAmbiguous(nameOrPath ?? "", resolution.candidates);
+    }
+
+    if (resolution.kind === "no-current") {
+        out.error(
+            `No iteration of team "${team}" contains today. Name one explicitly, for example: tools azure-devops sprint "17. Sprint"`
+        );
+        process.exit(1);
+    }
+
+    out.error(
+        `No iteration of team "${team}" matches "${resolution.query}". List them with: tools azure-devops iterations --team "${team}"`
+    );
+    process.exit(1);
+}
+
+async function fetchSprintRows(
+    api: Api,
+    iteration: TeamIteration,
+    assignedTo: string | undefined
+): Promise<SprintRow[]> {
+    const wiql = buildSprintWiql({ iterationPath: iteration.path, assignedTo });
+    logger.debug(`[sprint] WIQL: ${wiql}`);
+
+    const result = await api.runWiql(wiql);
+    const ids = (result.workItems ?? []).map((wi) => wi.id);
+    logger.debug(`[sprint] WIQL returned ${ids.length} work item ids`);
+
+    if (ids.length === 0) {
+        return [];
+    }
+
+    const fieldsById = await api.getWorkItemFields(ids, SPRINT_FIELDS);
+    return ids.map((id) => mapSprintRow(id, fieldsById.get(id) ?? {}));
+}
+
+function toJsonItems(rows: SprintRow[]): Array<Record<string, unknown>> {
+    return rows.map((row) => ({
+        id: row.id,
+        type: row.type,
+        title: row.title,
+        state: row.state,
+        assignedTo: row.assignedTo,
+        completedWork: row.completedWork,
+        remainingWork: row.remainingWork,
+        order: row.order,
+        changedDate: row.changedDate,
+    }));
+}
+
+function renderSprintMd(rows: SprintRow[], iteration: TeamIteration, withOrder: boolean): string {
+    const header = ["ID", "Type", "Title", "State", "AssignedTo", "CompletedWork", "RemainingWork"];
+
+    if (withOrder) {
+        header.push("Order");
+    }
+
+    header.push("ChangedDate");
+
+    const body = rows.map((row) => {
+        const cells = [
+            String(row.id),
+            escapeMd(row.type),
+            escapeMd(row.title),
+            escapeMd(row.state),
+            escapeMd(row.assignedTo),
+            formatEffort(row.completedWork),
+            formatEffort(row.remainingWork),
+        ];
+
+        if (withOrder) {
+            cells.push(row.order === null ? "-" : String(row.order));
+        }
+
+        cells.push(formatDate(row.changedDate));
+        return mdRow(cells);
+    });
+
+    return [
+        `# ${escapeMd(iteration.name)}`,
+        "",
+        `Iteration path: \`${iteration.path}\``,
+        "",
+        mdRow(header),
+        mdRow(header.map(() => "---")),
+        ...body,
+    ].join("\n");
+}
+
+function renderSprintTable(rows: SprintRow[], iteration: TeamIteration, withOrder: boolean): void {
+    renderCliHeader(iteration.name, iteration.path);
+
+    const headers = ["ID", "TYPE", "TITLE", "STATE", "ASSIGNED", "DONE", "LEFT"];
+
+    if (withOrder) {
+        headers.push("ORDER");
+    }
+
+    const table = createBoxTable(headers);
+
+    for (const row of rows) {
+        const remaining = formatEffort(row.remainingWork);
+        const cells = [
+            pc.cyan(String(row.id)),
+            truncateDisplay(row.type, 12),
+            truncateDisplay(row.title, 52),
+            truncateDisplay(row.state, 18),
+            truncateDisplay(row.assignedTo, 20),
+            formatEffort(row.completedWork),
+            row.remainingWork > 0 ? pc.yellow(remaining) : remaining,
+        ];
+
+        if (withOrder) {
+            cells.push(row.order === null ? pc.dim("-") : String(row.order));
+        }
+
+        table.push(cells);
+    }
+
+    out.println(table.toString());
+}
+
+async function handleSprint(nameOrPath: string | undefined, options: SprintOptions): Promise<void> {
+    if (options.mine && options.assignedTo) {
+        out.error("--mine and --assigned-to are mutually exclusive.");
+        process.exit(1);
+    }
+
+    const config = requireConfig();
+    const team = requireTeam(config, options.team);
+    const assignedTo = options.mine ? "@Me" : options.assignedTo;
+    const api = new Api(config);
+    const iteration = await resolveSprintIteration(api, team, nameOrPath);
+    const fetched = await fetchSprintRows(api, iteration, assignedTo);
+    const withOrder = options.order === true;
+    const rows = withOrder ? sortByBacklogOrder(fetched) : sortById(fetched);
+    const totals = sumTaskEffort(rows);
+
+    if (options.format === "json") {
+        const items = toJsonItems(rows);
+        const payload = options.totals
+            ? {
+                  iteration: { name: iteration.name, path: iteration.path },
+                  items,
+                  totals: {
+                      itemCount: totals.itemCount,
+                      taskCount: totals.taskCount,
+                      taskCompletedWork: totals.completedWork,
+                      taskRemainingWork: totals.remainingWork,
+                  },
+              }
+            : items;
+        out.result(SafeJSON.stringify(payload, null, 2));
+        return;
+    }
+
+    const totalsLines = [
+        `Items: ${totals.itemCount} (Tasks: ${totals.taskCount})`,
+        `Task CompletedWork: ${formatEffort(totals.completedWork)} h`,
+        `Task RemainingWork: ${formatEffort(totals.remainingWork)} h`,
+        "Non-Task rows are excluded, so a User Story and its child Task are not counted twice.",
+    ];
+
+    if (options.format === "md") {
+        const md = renderSprintMd(rows, iteration, withOrder);
+        const withTotals = options.totals
+            ? `${md}\n\n## Totals\n\n${totalsLines.map((line) => `- ${line}`).join("\n")}`
+            : md;
+        out.result(`${withTotals}\n`);
+        return;
+    }
+
+    renderSprintTable(rows, iteration, withOrder);
+
+    if (options.totals) {
+        renderCliSection("Totals");
+
+        for (const line of totalsLines) {
+            out.println(`  ${line}`);
+        }
+    }
+}
+
+// ============= Registration =============
+
+interface RawSprintOptions {
+    format?: string;
+    team?: string;
+    mine?: boolean;
+    assignedTo?: string;
+    totals?: boolean;
+    order?: boolean;
+}
+
+/**
+ * Merge the subcommand's own options with the program-level `--team`.
+ * `optsWithGlobals()` cannot be used: it lets the parent's undefined `team`
+ * overwrite a value passed after the subcommand.
+ */
+function optionsWithGlobalTeam(command: Command): RawSprintOptions {
+    const local = command.opts<RawSprintOptions>();
+    const globals = command.parent?.opts<{ team?: string }>() ?? {};
+    return { ...local, team: local.team ?? globals.team };
+}
+
+export function registerSprintCommands(program: Command): void {
+    program
+        .command("iterations")
+        .alias("sprints")
+        .description("List the team's iterations (sprints) with dates and the current one marked")
+        .option("-f, --format <format>", "Output format: ai, md, json", "ai")
+        .option("--team <name>", "Team name (overrides the global --team and config.team)")
+        .action(async (_opts: RawSprintOptions, command: Command) => {
+            const opts = optionsWithGlobalTeam(command);
+            await handleIterations({ format: parseFormat(opts.format), team: opts.team });
+        });
+
+    program
+        .command("sprint [nameOrPath]")
+        .description("List the work items of one iteration (defaults to the iteration containing today)")
+        .option("-f, --format <format>", "Output format: ai, md, json", "ai")
+        .option("--team <name>", "Team name (overrides the global --team and config.team)")
+        .option("--mine", "Only work items assigned to me (@Me)")
+        .option("--assigned-to <name>", "Only work items assigned to this display name or unique name")
+        .option("--totals", "Print the Task-only CompletedWork / RemainingWork sums")
+        .option("--order", "Sort by Backlog stack rank instead of id, and show the Order column")
+        .action(async (nameOrPath: string | undefined, _opts: RawSprintOptions, command: Command) => {
+            const opts = optionsWithGlobalTeam(command);
+            await handleSprint(nameOrPath, {
+                format: parseFormat(opts.format),
+                team: opts.team,
+                mine: opts.mine,
+                assignedTo: opts.assignedTo,
+                totals: opts.totals,
+                order: opts.order,
+            });
+        });
+}

--- a/src/azure-devops/commands/sprint.ts
+++ b/src/azure-devops/commands/sprint.ts
@@ -248,7 +248,14 @@ function toJsonItems(rows: SprintRow[]): Array<Record<string, unknown>> {
     }));
 }
 
-function renderSprintMd(rows: SprintRow[], iteration: TeamIteration, withOrder: boolean): string {
+/** Both renderers take the same three, and `withOrder` is unreadable positionally. */
+interface SprintRenderArgs {
+    rows: SprintRow[];
+    iteration: TeamIteration;
+    withOrder: boolean;
+}
+
+function renderSprintMd({ rows, iteration, withOrder }: SprintRenderArgs): string {
     const header = ["ID", "Type", "Title", "State", "AssignedTo", "CompletedWork", "RemainingWork"];
 
     if (withOrder) {
@@ -287,7 +294,7 @@ function renderSprintMd(rows: SprintRow[], iteration: TeamIteration, withOrder: 
     ].join("\n");
 }
 
-function renderSprintTable(rows: SprintRow[], iteration: TeamIteration, withOrder: boolean): void {
+function renderSprintTable({ rows, iteration, withOrder }: SprintRenderArgs): void {
     renderCliHeader(iteration.name, iteration.path);
 
     const headers = ["ID", "TYPE", "TITLE", "STATE", "ASSIGNED", "DONE", "LEFT"];
@@ -332,7 +339,7 @@ async function handleSprint(nameOrPath: string | undefined, options: SprintOptio
     const api = new Api(config);
     const iteration = await resolveSprintIteration(api, team, nameOrPath);
     const fetched = await fetchSprintRows(api, iteration, assignedTo);
-    const withOrder = options.order === true;
+    const withOrder = options.order ?? false;
     const rows = withOrder ? sortByBacklogOrder(fetched) : sortById(fetched);
     const totals = sumTaskEffort(rows);
 
@@ -362,7 +369,7 @@ async function handleSprint(nameOrPath: string | undefined, options: SprintOptio
     ];
 
     if (options.format === "md") {
-        const md = renderSprintMd(rows, iteration, withOrder);
+        const md = renderSprintMd({ rows, iteration, withOrder });
         const withTotals = options.totals
             ? `${md}\n\n## Totals\n\n${totalsLines.map((line) => `- ${line}`).join("\n")}`
             : md;
@@ -370,7 +377,7 @@ async function handleSprint(nameOrPath: string | undefined, options: SprintOptio
         return;
     }
 
-    renderSprintTable(rows, iteration, withOrder);
+    renderSprintTable({ rows, iteration, withOrder });
 
     if (options.totals) {
         renderCliSection("Totals");

--- a/src/azure-devops/commands/timelog.ts
+++ b/src/azure-devops/commands/timelog.ts
@@ -21,16 +21,16 @@ Commands:
   import   Import time logs from JSON file
 
 Examples:
-  tools azure-devops timelog add --workitem 268935 --hours 2 --type "Development"
-  tools azure-devops timelog add --workitem 268935 --hours 1 --minutes 30 --type "Code Review" --comment "PR review"
-  tools azure-devops timelog add --workitem 268935 --interactive
-  tools azure-devops timelog list --workitem 268935
+  tools azure-devops timelog add --workitem 12345 --hours 2 --type "Development"
+  tools azure-devops timelog add --workitem 12345 --hours 1 --minutes 30 --type "Code Review" --comment "PR review"
+  tools azure-devops timelog add --workitem 12345 --interactive
+  tools azure-devops timelog list --workitem 12345
   tools azure-devops timelog list --day 2026-01-30
   tools azure-devops timelog list --since 2026-01-01 --upto 2026-01-31 --user "Martin"
   tools azure-devops timelog list --day 2026-01-30 --format table
   tools azure-devops timelog delete <timeLogId> --yes
   tools azure-devops timelog delete <timeLogId> --dry-run
-  tools azure-devops timelog delete --workitem 268935   (interactive picker)
+  tools azure-devops timelog delete --workitem 12345   (interactive picker)
   tools azure-devops timelog delete <timeLogId> --no-effort --yes
   tools azure-devops timelog types
   tools azure-devops timelog import entries.json

--- a/src/azure-devops/commands/timelog/add.ts
+++ b/src/azure-devops/commands/timelog/add.ts
@@ -46,11 +46,11 @@ Optional:
 Note: If using only minutes, specify --hours 0 --minutes <n> to confirm intent.
 
 Examples:
-  tools azure-devops timelog add -w 268935 -h 2 -t "Development"
-  tools azure-devops timelog add -w 268935 -h 1 -m 30 -t "Code Review" -c "PR review"
-  tools azure-devops timelog add -w 268935 -h 0 -m 30 -t "Test" -d 2026-02-03
+  tools azure-devops timelog add -w 12345 -h 2 -t "Development"
+  tools azure-devops timelog add -w 12345 -h 1 -m 30 -t "Code Review" -c "PR review"
+  tools azure-devops timelog add -w 12345 -h 0 -m 30 -t "Test" -d 2026-02-03
   tools azure-devops timelog add -i
-  tools azure-devops timelog add -w 268935 -i
+  tools azure-devops timelog add -w 12345 -i
 `);
 }
 
@@ -99,12 +99,12 @@ Missing required options for non-interactive mode.
 Required: --workitem, --hours, --type
 
 Examples:
-  tools azure-devops timelog add -w 268935 -h 2 -t "Development"
-  tools azure-devops timelog add -w 268935 -h 1 -m 30 -t "Code Review" -c "PR review"
+  tools azure-devops timelog add -w 12345 -h 2 -t "Development"
+  tools azure-devops timelog add -w 12345 -h 1 -m 30 -t "Code Review" -c "PR review"
 
 Or use interactive mode:
   tools azure-devops timelog add -i
-  tools azure-devops timelog add -w 268935 -i
+  tools azure-devops timelog add -w 12345 -i
 `);
                     process.exit(1);
                 }

--- a/src/azure-devops/commands/timelog/delete.ts
+++ b/src/azure-devops/commands/timelog/delete.ts
@@ -46,7 +46,7 @@ export function registerDeleteSubcommand(parent: Command): void {
                         out.error("Provide a timeLogId or --workitem for interactive selection");
                         out.error("\nExamples:");
                         out.error("  tools azure-devops timelog delete <timeLogId> --yes");
-                        out.error("  tools azure-devops timelog delete --workitem 268935");
+                        out.error("  tools azure-devops timelog delete --workitem 12345");
                         out.error("  tools azure-devops timelog delete <timeLogId> --dry-run");
                         process.exit(1);
                     }

--- a/src/azure-devops/docs/work-items-queries.md
+++ b/src/azure-devops/docs/work-items-queries.md
@@ -119,16 +119,17 @@ CREATE TABLE workItemLinks (
 [Custom.ApprovalRM]                 BOOLEAN,    -- RM approval required
 
 -- String selections
-[Custom.Aplikace]                   VARCHAR(256),   -- Application name (Czech)
 [Custom.Application]                VARCHAR(256),   -- Application name (English)
 [Custom.Applicationsubcategories]   VARCHAR(256),   -- App subcategories
 [Custom.ApplicatonorSystem]         VARCHAR(256),   -- App or System
 [Custom.AssignedGroup]              VARCHAR(256),   -- Team/Group assignment
 
--- Czech-specific
-[Custom.d099ca66-d0ca-4125-813c-773ff61eeab3]   VARCHAR(256),   -- Číslo SD
-[Custom.d3a5f967-2afb-4070-8bd0-e3b5ec50fab5]   VARCHAR(256),   -- Číslo transportu
-[Custom.aececa28-281f-42f2-95f5-d3898b867d7f]   VARCHAR(256),   -- Bezpečnostně významná změna
+-- GUID-named custom fields. Azure DevOps mints these when a field is created
+-- through the UI rather than with a reference name, so the id carries no meaning
+-- and the label lives only in the process template. Query them by the exact id.
+[Custom.00000000-0000-0000-0000-000000000001]   VARCHAR(256),   -- Service desk ticket
+[Custom.00000000-0000-0000-0000-000000000002]   VARCHAR(256),   -- Transport number
+[Custom.00000000-0000-0000-0000-000000000003]   VARCHAR(256),   -- Security-relevant change
 ```
 
 ### Work Item Types (organisation-specific)

--- a/src/azure-devops/docs/work-items-queries.md
+++ b/src/azure-devops/docs/work-items-queries.md
@@ -1,6 +1,6 @@
-# Work Items Queries Reference (CEZ/col-fe)
+# Work Items Queries Reference
 
-> Tested against: `cez-azuredevops` / `MŮJ ČEZ` project
+> Tested against: `contoso` / `Widgets` project
 
 ---
 
@@ -19,10 +19,10 @@ CREATE TABLE workitems (
     [System.WorkItemType]           VARCHAR(100),           -- Bug, Task, Feature, User Story, Epic, etc.
 
     -- Classification
-    [System.TeamProject]            VARCHAR(300),           -- Project name (e.g., "MŮJ ČEZ")
-    [System.AreaPath]               TREEPATH,               -- Area hierarchy (e.g., "MŮJ ČEZ\Backend")
+    [System.TeamProject]            VARCHAR(300),           -- Project name (e.g., "Widgets")
+    [System.AreaPath]               TREEPATH,               -- Area hierarchy (e.g., "Widgets\Backend")
     [System.AreaId]                 INTEGER,                -- Area node ID
-    [System.IterationPath]          TREEPATH,               -- Sprint path (e.g., "MŮJ ČEZ\Sprint 5")
+    [System.IterationPath]          TREEPATH,               -- Sprint path (e.g., "Widgets\Sprint 5")
     [System.IterationId]            INTEGER,                -- Iteration node ID
 
     -- State & Workflow
@@ -108,10 +108,10 @@ CREATE TABLE workItemLinks (
 -- 'Microsoft.VSTS.Common.Affects-Reverse'  -- Affected By
 ```
 
-### CEZ Custom Fields
+### Organisation-specific custom fields
 
 ```sql
--- Custom fields specific to CEZ/col-fe project
+-- Custom fields specific to this organisation's process template
 -- Reference names use Custom.* prefix
 
 -- Boolean flags
@@ -131,10 +131,10 @@ CREATE TABLE workItemLinks (
 [Custom.aececa28-281f-42f2-95f5-d3898b867d7f]   VARCHAR(256),   -- Bezpečnostně významná změna
 ```
 
-### Work Item Types (CEZ)
+### Work Item Types (organisation-specific)
 
 ```sql
--- Available work item types in cez-azuredevops/MŮJ ČEZ
+-- Available work item types in contoso/Widgets
 
 -- Agile Process
 'Bug'               -- Defect tracking
@@ -145,10 +145,10 @@ CREATE TABLE workItemLinks (
 'Issue'             -- Impediment tracking
 
 -- Custom Types
-'BN'                -- Business Need (CEZ custom)
-'JDZ Task'          -- JDZ-specific task (CEZ custom)
-'Incident'          -- Incident tracking (CEZ custom)
-'Deployment'        -- Deployment tracking (CEZ custom)
+'BN'                -- Business Need (organisation custom)
+'Domain Task'       -- Domain-specific task (organisation custom)
+'Incident'          -- Incident tracking (organisation custom)
+'Deployment'        -- Deployment tracking (organisation custom)
 
 -- Testing
 'Test Plan'         -- Test plan container
@@ -279,17 +279,17 @@ WHERE [System.Description] CONTAINS WORDS 'authentication error'
 -- ✅ VERIFIED (Note: returns 20k+ items for root)
 SELECT [System.Id], [System.Title], [System.AreaPath]
 FROM workitems
-WHERE [System.AreaPath] UNDER 'MŮJ ČEZ\Backend'
+WHERE [System.AreaPath] UNDER 'Widgets\Backend'
 
 -- Items NOT under specific area
 SELECT [System.Id], [System.Title]
 FROM workitems
-WHERE NOT [System.AreaPath] UNDER 'MŮJ ČEZ\Archive'
+WHERE NOT [System.AreaPath] UNDER 'Widgets\Archive'
 
 -- Exact iteration path match
 SELECT [System.Id], [System.Title]
 FROM workitems
-WHERE [System.IterationPath] = 'MŮJ ČEZ\Sprint 5'
+WHERE [System.IterationPath] = 'Widgets\Sprint 5'
 ```
 
 ### Historical Queries (ASOF)
@@ -345,10 +345,10 @@ SELECT [System.Id], [System.Title], [System.WorkItemType]
 FROM workitems
 WHERE [System.WorkItemType] IN ('Bug', 'Task', 'User Story')
 
--- CEZ custom types
+-- organisation custom types
 SELECT [System.Id], [System.Title]
 FROM workitems
-WHERE [System.WorkItemType] = 'JDZ Task'
+WHERE [System.WorkItemType] = 'Domain Task'
 ```
 
 ### Priority/Severity Queries
@@ -528,7 +528,7 @@ az boards query --wiql "SELECT [System.Id], [System.Title] FROM workitems WHERE 
 az boards query --wiql "..." -o table
 
 # Query specific project (overrides default)
-az boards query --wiql "..." --project "MŮJ ČEZ"
+az boards query --wiql "..." --project "Widgets"
 
 # Query with JMESPath filtering
 az boards query --wiql "..." --query "[].fields.{ID: 'System.Id', Title: 'System.Title'}"

--- a/src/azure-devops/index.ts
+++ b/src/azure-devops/index.ts
@@ -184,7 +184,7 @@ Examples:
 Sprint Commands:
   tools azure-devops iterations                          List the team's sprints
   tools azure-devops sprint --mine --totals               Current sprint, my items, effort sums
-  tools azure-devops sprint "17. Sprint 20.08." --order   One sprint in Backlog order
+  tools azure-devops sprint "Sprint 17" --order   One sprint in Backlog order
   # These never use @CurrentIteration: that macro needs a team context and
   # fails with VS402612. An explicit [System.IterationPath] predicate is used.
 

--- a/src/azure-devops/index.ts
+++ b/src/azure-devops/index.ts
@@ -33,6 +33,7 @@ import { registerConfigureCommand } from "@app/azure-devops/commands/configure";
 import { registerDashboardCommand } from "@app/azure-devops/commands/dashboard";
 import { registerHistoryCommand } from "@app/azure-devops/commands/history";
 import { registerQueryCommand, setWorkItemHandler } from "@app/azure-devops/commands/query";
+import { registerSprintCommands } from "@app/azure-devops/commands/sprint";
 import { registerTimelogCommand } from "@app/azure-devops/commands/timelog";
 import { handleWorkItem, registerWorkitemCommand } from "@app/azure-devops/commands/workitem";
 import { registerWorkitemCacheCommand } from "@app/azure-devops/commands/workitem-cache";
@@ -51,6 +52,7 @@ program
     .version("1.0.0")
     .showHelpAfterError(true)
     .option("-v, --verbose", "Enable verbose debug logging")
+    .option("--team <name>", "Azure DevOps team name for team-scoped commands (overrides config.team)")
     .option("-?, --help-full", "Show detailed help with examples")
     .on("option:help-full", () => {
         showHelpFull();
@@ -66,6 +68,7 @@ registerWorkitemCacheCommand(program);
 registerDashboardCommand(program);
 registerTimelogCommand(program);
 registerHistoryCommand(program);
+registerSprintCommands(program);
 
 function showHelpFull(): void {
     out.println(`
@@ -83,6 +86,18 @@ Commands:
   workitem-create        Create a new work item (interactive or from template)
   timelog                Manage time log entries (add, list, delete, types, import)
   history                Work item history commands (show, search, sync)
+  iterations             List the team's sprints (alias: sprints)
+  sprint [nameOrPath]    List the work items of one sprint
+
+Global Options:
+  --team <name>          Team for team-scoped commands (overrides config.team)
+
+Sprint Options:
+  -f, --format <fmt>     ai | md | json (default: ai)
+  --mine                 Only work items assigned to me (@Me)
+  --assigned-to <name>   Only work items assigned to this person
+  --totals               Task-only CompletedWork / RemainingWork sums
+  --order                Sort by Backlog stack rank and show the Order column
 
 Query Options:
   --format <ai|md|json>  Output format (default: ai)
@@ -165,6 +180,13 @@ Examples:
   tools azure-devops timelog list --workitem 268935
   tools azure-devops timelog delete <timeLogId> --yes
   tools azure-devops timelog types
+
+Sprint Commands:
+  tools azure-devops iterations                          List the team's sprints
+  tools azure-devops sprint --mine --totals               Current sprint, my items, effort sums
+  tools azure-devops sprint "17. Sprint 20.08." --order   One sprint in Backlog order
+  # These never use @CurrentIteration: that macro needs a team context and
+  # fails with VS402612. An explicit [System.IterationPath] predicate is used.
 
 History Commands:
   tools azure-devops history show <id>          Show history for a work item

--- a/src/azure-devops/lib/ado-configure.test.ts
+++ b/src/azure-devops/lib/ado-configure.test.ts
@@ -29,7 +29,7 @@ describe("saveAdoConfig", () => {
         const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
         writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
 
-        const path = saveAdoConfig(
+        const { path } = saveAdoConfig(
             {
                 org: "contoso",
                 project: "Widgets",
@@ -50,7 +50,7 @@ describe("saveAdoConfig", () => {
         const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
         writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
 
-        const path = saveAdoConfig(
+        const { path } = saveAdoConfig(
             {
                 org: "contoso",
                 project: "Widgets",
@@ -75,7 +75,7 @@ describe("saveAdoConfig", () => {
         const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
         writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
 
-        const path = saveAdoConfig(
+        const { path } = saveAdoConfig(
             {
                 org: "fabrikam",
                 project: "Gadgets",
@@ -103,7 +103,7 @@ describe("saveAdoConfig", () => {
         const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
         writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
 
-        const path = saveAdoConfig(
+        const { path } = saveAdoConfig(
             {
                 org: "fabrikam",
                 project: "Gadgets",
@@ -124,7 +124,7 @@ describe("saveAdoConfig", () => {
         const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
         writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
 
-        const path = saveAdoConfig(
+        const { path } = saveAdoConfig(
             {
                 org: "contoso",
                 project: "Gadgets",
@@ -163,7 +163,7 @@ describe("saveAdoConfig", () => {
 `
         );
 
-        const path = saveAdoConfig(
+        const { path } = saveAdoConfig(
             {
                 org: "contoso",
                 project: "Widgets",
@@ -179,10 +179,34 @@ describe("saveAdoConfig", () => {
         expect(saved.timelog?.functionsKey).toBe("kept-secret");
     });
 
+    /**
+     * Regression test: PR #333 review t7. `configure` printed the team from the
+     * config it was ABOUT to save, so after the merge landed it announced
+     * "Team: (none)" while the file it had just written still carried one.
+     */
+    test("returns what was written, not what was passed in", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
+        writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
+
+        const saved = saveAdoConfig(
+            {
+                org: "contoso",
+                project: "Widgets",
+                projectId: "00000000-0000-0000-0000-000000000001",
+                apiResource: "499b84ac-0000-0000-0000-000000000000",
+            },
+            dir
+        );
+
+        expect(saved.config.team).toBe("Payments Team");
+        expect(saved.config.timelog?.functionsKey).toBe("kept-secret");
+        expect(SafeJSON.parse(readFileSync(saved.path, "utf8"), { strict: true })).toEqual(saved.config);
+    });
+
     test("writes a fresh config when none exists", () => {
         const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
 
-        const path = saveAdoConfig(
+        const { path } = saveAdoConfig(
             {
                 org: "contoso",
                 project: "Widgets",

--- a/src/azure-devops/lib/ado-configure.test.ts
+++ b/src/azure-devops/lib/ado-configure.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveAdoConfig } from "@app/azure-devops/lib/ado-configure";
+import type { AzureConfigWithTimeLog } from "@app/azure-devops/types";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+function existingConfig(): AzureConfigWithTimeLog {
+    return {
+        org: "contoso",
+        project: "Widgets",
+        projectId: "00000000-0000-0000-0000-000000000001",
+        apiResource: "499b84ac-0000-0000-0000-000000000000",
+        team: "Payments Team",
+        orgId: "00000000-0000-0000-0000-000000000002",
+        timelog: { functionsUrl: "https://example.invalid/api", functionsKey: "kept-secret" },
+    } as AzureConfigWithTimeLog;
+}
+
+/**
+ * Regression test: PR #333 review t9. `saveAdoConfig` wrote the incoming object
+ * over the whole file, so re-running `configure` with a URL that carries no
+ * team silently dropped the configured team — and, worse, the `timelog` block,
+ * which holds the Azure Functions key. That key exists nowhere else.
+ */
+describe("saveAdoConfig", () => {
+    test("keeps settings the incoming config cannot carry", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
+        writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
+
+        const path = saveAdoConfig(
+            {
+                org: "contoso",
+                project: "Widgets",
+                projectId: "00000000-0000-0000-0000-000000000001",
+                apiResource: "499b84ac-0000-0000-0000-000000000000",
+            },
+            dir
+        );
+
+        const saved = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as AzureConfigWithTimeLog;
+
+        expect(saved.team).toBe("Payments Team");
+        expect(saved.timelog?.functionsKey).toBe("kept-secret");
+        expect(saved.orgId).toBe("00000000-0000-0000-0000-000000000002");
+    });
+
+    test("a team in the new config replaces the old one", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
+        writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
+
+        const path = saveAdoConfig(
+            {
+                org: "contoso",
+                project: "Widgets",
+                projectId: "00000000-0000-0000-0000-000000000001",
+                apiResource: "499b84ac-0000-0000-0000-000000000000",
+                team: "Billing Team",
+            },
+            dir
+        );
+
+        const saved = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as AzureConfigWithTimeLog;
+
+        expect(saved.team).toBe("Billing Team");
+        expect(saved.timelog?.functionsKey).toBe("kept-secret");
+    });
+
+    /**
+     * Pointing configure at a different project must not leave the previous
+     * project's identifiers merged into the new one.
+     */
+    test("switching project overwrites the project identity rather than merging it", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
+        writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
+
+        const path = saveAdoConfig(
+            {
+                org: "fabrikam",
+                project: "Gadgets",
+                projectId: "00000000-0000-0000-0000-0000000000ff",
+                apiResource: "499b84ac-0000-0000-0000-000000000000",
+            },
+            dir
+        );
+
+        const saved = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as AzureConfigWithTimeLog;
+
+        expect(saved.org).toBe("fabrikam");
+        expect(saved.project).toBe("Gadgets");
+        expect(saved.projectId).toBe("00000000-0000-0000-0000-0000000000ff");
+    });
+
+    test("writes a fresh config when none exists", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
+
+        const path = saveAdoConfig(
+            {
+                org: "contoso",
+                project: "Widgets",
+                projectId: "00000000-0000-0000-0000-000000000001",
+                apiResource: "499b84ac-0000-0000-0000-000000000000",
+            },
+            dir
+        );
+
+        const saved = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as AzureConfigWithTimeLog;
+
+        expect(saved.org).toBe("contoso");
+        expect(saved.team).toBeUndefined();
+    });
+});

--- a/src/azure-devops/lib/ado-configure.test.ts
+++ b/src/azure-devops/lib/ado-configure.test.ts
@@ -140,6 +140,45 @@ describe("saveAdoConfig", () => {
         expect(saved.timelog).toBeUndefined();
     });
 
+    /**
+     * Regression test: PR #333 review t13. readExistingConfig parsed with
+     * { strict: true }, but NO_TEAM_MESSAGE tells users to add `"team"` to this
+     * file by hand — so a `//` comment or a trailing comma made the parse throw,
+     * the catch returned {}, and the whole config was overwritten. That destroys
+     * timelog.functionsKey, which is the exact loss the merge was added to stop.
+     */
+    test("a hand-edited config with a comment and a trailing comma is still preserved", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
+        writeFileSync(
+            join(dir, "config.json"),
+            `{
+    // added by hand, per the message the tool prints
+    "org": "contoso",
+    "project": "Widgets",
+    "projectId": "00000000-0000-0000-0000-000000000001",
+    "apiResource": "499b84ac-0000-0000-0000-000000000000",
+    "team": "Payments Team",
+    "timelog": { "functionsUrl": "https://example.invalid/api", "functionsKey": "kept-secret" },
+}
+`
+        );
+
+        const path = saveAdoConfig(
+            {
+                org: "contoso",
+                project: "Widgets",
+                projectId: "00000000-0000-0000-0000-000000000001",
+                apiResource: "499b84ac-0000-0000-0000-000000000000",
+            },
+            dir
+        );
+
+        const saved = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as AzureConfigWithTimeLog;
+
+        expect(saved.team).toBe("Payments Team");
+        expect(saved.timelog?.functionsKey).toBe("kept-secret");
+    });
+
     test("writes a fresh config when none exists", () => {
         const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
 

--- a/src/azure-devops/lib/ado-configure.test.ts
+++ b/src/azure-devops/lib/ado-configure.test.ts
@@ -92,6 +92,54 @@ describe("saveAdoConfig", () => {
         expect(saved.projectId).toBe("00000000-0000-0000-0000-0000000000ff");
     });
 
+    /**
+     * Regression test: PR #333 review t1, a defect introduced by the t9 fix.
+     * Preserving supplemental settings is only correct WITHIN a project. Carried
+     * across a project switch, the stale team is silently reused by
+     * `iterations` / `sprint`, which then query a team that does not exist in
+     * the new project, and the stale timelog endpoint points at the old one.
+     */
+    test("switching project drops the previous project's team and timelog", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
+        writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
+
+        const path = saveAdoConfig(
+            {
+                org: "fabrikam",
+                project: "Gadgets",
+                projectId: "00000000-0000-0000-0000-0000000000ff",
+                apiResource: "499b84ac-0000-0000-0000-000000000000",
+            },
+            dir
+        );
+
+        const saved = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as AzureConfigWithTimeLog;
+
+        expect(saved.team).toBeUndefined();
+        expect(saved.timelog).toBeUndefined();
+        expect(saved.orgId).toBeUndefined();
+    });
+
+    test("switching only the project within the same org also drops them", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
+        writeFileSync(join(dir, "config.json"), SafeJSON.stringify(existingConfig(), null, 2));
+
+        const path = saveAdoConfig(
+            {
+                org: "contoso",
+                project: "Gadgets",
+                projectId: "00000000-0000-0000-0000-0000000000ff",
+                apiResource: "499b84ac-0000-0000-0000-000000000000",
+            },
+            dir
+        );
+
+        const saved = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }) as AzureConfigWithTimeLog;
+
+        expect(saved.team).toBeUndefined();
+        expect(saved.timelog).toBeUndefined();
+    });
+
     test("writes a fresh config when none exists", () => {
         const dir = mkdtempSync(join(tmpdir(), "ado-config-"));
 

--- a/src/azure-devops/lib/ado-configure.ts
+++ b/src/azure-devops/lib/ado-configure.ts
@@ -53,7 +53,16 @@ export function saveAdoConfig(config: AzureConfig, configDir: string): string {
     }
 
     const configPath = join(configDir, "config.json");
-    const merged = { ...readExistingConfig(configPath), ...config };
+    const existing = readExistingConfig(configPath);
+
+    // Supplemental settings are only meaningful within one project. `team` names
+    // a team of THAT project and `timelog` points at its endpoint, so carrying
+    // them across a switch leaves `iterations` / `sprint` querying a team the
+    // new project does not have (PR #333 review t1, a defect introduced by the
+    // fix for t9 — preserving everything was too broad).
+    const sameProject = existing.org === config.org && existing.project === config.project;
+    const merged = sameProject ? { ...existing, ...config } : { ...config };
+
     writeFileSync(configPath, SafeJSON.stringify(merged, null, 2));
     return configPath;
 }

--- a/src/azure-devops/lib/ado-configure.ts
+++ b/src/azure-devops/lib/ado-configure.ts
@@ -73,7 +73,13 @@ function readExistingConfig(configPath: string): Partial<AzureConfigWithTimeLog>
     }
 
     try {
-        return SafeJSON.parse(readFileSync(configPath, "utf8"), { strict: true }) as Partial<AzureConfigWithTimeLog>;
+        // Lenient on purpose. NO_TEAM_MESSAGE tells users to add "team" to this
+        // file by hand, so it really does grow `//` comments and trailing commas.
+        // Under { strict: true } those threw, the catch below returned {}, and the
+        // whole config — including timelog.functionsKey — was overwritten
+        // (PR #333 review t13). SafeJSON is a comment-json wrapper; leniency here
+        // is the point of using it.
+        return SafeJSON.parse(readFileSync(configPath, "utf8")) as Partial<AzureConfigWithTimeLog>;
     } catch (err) {
         // A corrupt file must not take the new configuration down with it, but
         // it also must not be silent: whatever was in there is about to be

--- a/src/azure-devops/lib/ado-configure.ts
+++ b/src/azure-devops/lib/ado-configure.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Api, AZURE_DEVOPS_RESOURCE_ID } from "@app/azure-devops/api";
 import { azLoginSuggestionBlock } from "@app/azure-devops/lib/az-cli.utils";
-import type { AzureConfig } from "@app/azure-devops/types";
+import type { AzureConfig, AzureConfigWithTimeLog } from "@app/azure-devops/types";
 import { extractTeamFromUrl, parseAzureDevOpsUrl } from "@app/azure-devops/url-parser";
 import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
 import { $ } from "bun";
 
 export async function checkAzureCliLogin(): Promise<void> {
@@ -34,12 +35,41 @@ export async function buildAdoConfig(url: string): Promise<AzureConfig & { orgId
     return config;
 }
 
+/**
+ * Write the config, keeping settings the caller could not have supplied.
+ *
+ * This used to write `config` over the whole file. A URL only ever carries org,
+ * project and (sometimes) team, so re-running `configure` with a plain project
+ * URL silently dropped the configured `team` — and with it the `timelog` block,
+ * which holds the Azure Functions key. That key exists nowhere else, so the
+ * only recovery was to fetch it again by hand (PR #333 review t9).
+ *
+ * Project identity is still authoritative from the caller: switching projects
+ * must not merge the previous project's ids into the new one.
+ */
 export function saveAdoConfig(config: AzureConfig, configDir: string): string {
     if (!existsSync(configDir)) {
         mkdirSync(configDir, { recursive: true });
     }
 
     const configPath = join(configDir, "config.json");
-    writeFileSync(configPath, SafeJSON.stringify(config, null, 2));
+    const merged = { ...readExistingConfig(configPath), ...config };
+    writeFileSync(configPath, SafeJSON.stringify(merged, null, 2));
     return configPath;
+}
+
+function readExistingConfig(configPath: string): Partial<AzureConfigWithTimeLog> {
+    if (!existsSync(configPath)) {
+        return {};
+    }
+
+    try {
+        return SafeJSON.parse(readFileSync(configPath, "utf8"), { strict: true }) as Partial<AzureConfigWithTimeLog>;
+    } catch (err) {
+        // A corrupt file must not take the new configuration down with it, but
+        // it also must not be silent: whatever was in there is about to be
+        // replaced rather than merged.
+        logger.warn({ err, configPath }, "existing Azure DevOps config is unreadable; writing a fresh one");
+        return {};
+    }
 }

--- a/src/azure-devops/lib/ado-configure.ts
+++ b/src/azure-devops/lib/ado-configure.ts
@@ -47,7 +47,13 @@ export async function buildAdoConfig(url: string): Promise<AzureConfig & { orgId
  * Project identity is still authoritative from the caller: switching projects
  * must not merge the previous project's ids into the new one.
  */
-export function saveAdoConfig(config: AzureConfig, configDir: string): string {
+export interface SavedAdoConfig {
+    path: string;
+    /** What was actually written — the merge may retain a team the URL did not carry. */
+    config: AzureConfigWithTimeLog;
+}
+
+export function saveAdoConfig(config: AzureConfig, configDir: string): SavedAdoConfig {
     if (!existsSync(configDir)) {
         mkdirSync(configDir, { recursive: true });
     }
@@ -64,7 +70,7 @@ export function saveAdoConfig(config: AzureConfig, configDir: string): string {
     const merged = sameProject ? { ...existing, ...config } : { ...config };
 
     writeFileSync(configPath, SafeJSON.stringify(merged, null, 2));
-    return configPath;
+    return { path: configPath, config: merged as AzureConfigWithTimeLog };
 }
 
 function readExistingConfig(configPath: string): Partial<AzureConfigWithTimeLog> {

--- a/src/azure-devops/lib/ado-configure.ts
+++ b/src/azure-devops/lib/ado-configure.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { Api, AZURE_DEVOPS_RESOURCE_ID } from "@app/azure-devops/api";
 import { azLoginSuggestionBlock } from "@app/azure-devops/lib/az-cli.utils";
 import type { AzureConfig } from "@app/azure-devops/types";
-import { parseAzureDevOpsUrl } from "@app/azure-devops/url-parser";
+import { extractTeamFromUrl, parseAzureDevOpsUrl } from "@app/azure-devops/url-parser";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { $ } from "bun";
 
@@ -18,7 +18,20 @@ export async function checkAzureCliLogin(): Promise<void> {
 export async function buildAdoConfig(url: string): Promise<AzureConfig & { orgId: string }> {
     const { org, project } = parseAzureDevOpsUrl(url);
     const [projectId, orgId] = await Promise.all([Api.getProjectId(org, project), Api.getOrgId(org)]);
-    return { org, project, projectId, orgId, apiResource: AZURE_DEVOPS_RESOURCE_ID };
+    const team = extractTeamFromUrl(url);
+    const config: AzureConfig & { orgId: string } = {
+        org,
+        project,
+        projectId,
+        orgId,
+        apiResource: AZURE_DEVOPS_RESOURCE_ID,
+    };
+
+    if (team) {
+        config.team = team;
+    }
+
+    return config;
 }
 
 export function saveAdoConfig(config: AzureConfig, configDir: string): string {

--- a/src/azure-devops/lib/iterations.test.ts
+++ b/src/azure-devops/lib/iterations.test.ts
@@ -36,6 +36,53 @@ describe("iterationContainsDate", () => {
     });
 });
 
+/**
+ * Regression test: PR #333 review t9. `iterationContainsDate` compares a
+ * UTC-derived date string (datePart slices the API's ISO timestamp) against a
+ * LOCAL one (formatLocalDate reads getFullYear/getMonth/getDate). Sprint
+ * boundaries are calendar days, so local is the semantic we want — but that
+ * only holds if the comparison is pinned, because a timestamp comparison here
+ * would silently drop the whole final day.
+ */
+describe("iterationContainsDate across the local midnight boundary", () => {
+    const withTz = (tz: string, run: () => void): void => {
+        const original = process.env.TZ;
+        process.env.TZ = tz;
+
+        try {
+            run();
+        } finally {
+            process.env.TZ = original;
+        }
+    };
+
+    const sprint = ITERATIONS[1]; // 2026-08-20 .. 2026-09-02
+
+    test("the last day counts until local midnight, not until the UTC timestamp", () => {
+        // 23:59 local on the finish day is still inside the sprint.
+        expect(iterationContainsDate(sprint, new Date(2026, 8, 2, 23, 59))).toBe(true);
+        // 00:01 local the next day is not.
+        expect(iterationContainsDate(sprint, new Date(2026, 8, 3, 0, 1))).toBe(false);
+    });
+
+    test("the first day counts from local midnight", () => {
+        expect(iterationContainsDate(sprint, new Date(2026, 7, 20, 0, 0))).toBe(true);
+        expect(iterationContainsDate(sprint, new Date(2026, 7, 19, 23, 59))).toBe(false);
+    });
+
+    test("a timezone far from UTC still resolves by local calendar day", () => {
+        withTz("Pacific/Auckland", () => {
+            expect(iterationContainsDate(sprint, new Date(2026, 8, 2, 12, 0))).toBe(true);
+            expect(iterationContainsDate(sprint, new Date(2026, 8, 3, 12, 0))).toBe(false);
+        });
+
+        withTz("America/Los_Angeles", () => {
+            expect(iterationContainsDate(sprint, new Date(2026, 7, 20, 12, 0))).toBe(true);
+            expect(iterationContainsDate(sprint, new Date(2026, 7, 19, 12, 0))).toBe(false);
+        });
+    });
+});
+
 describe("findCurrentIteration", () => {
     test("picks the iteration whose range contains today", () => {
         const current = findCurrentIteration(ITERATIONS, new Date(2026, 7, 27));

--- a/src/azure-devops/lib/iterations.test.ts
+++ b/src/azure-devops/lib/iterations.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import type { TeamIteration } from "@app/azure-devops/api.types";
+import { findCurrentIteration, iterationContainsDate, resolveIteration } from "@app/azure-devops/lib/iterations";
+
+function iteration(name: string, start: string, finish: string, project = "Contoso"): TeamIteration {
+    return {
+        id: `id-${name}`,
+        name,
+        path: `${project}\\${name}`,
+        attributes: { startDate: `${start}T00:00:00Z`, finishDate: `${finish}T00:00:00Z` },
+    };
+}
+
+const ITERATIONS: TeamIteration[] = [
+    iteration("16. Sprint 06.08. - 19.08.", "2026-08-06", "2026-08-19"),
+    iteration("17. Sprint 20.08. - 02.09.", "2026-08-20", "2026-09-02"),
+    iteration("18. Sprint 03.09. - 16.09.", "2026-09-03", "2026-09-16"),
+];
+
+describe("iterationContainsDate", () => {
+    test("includes the start day", () => {
+        expect(iterationContainsDate(ITERATIONS[1], new Date(2026, 7, 20, 9, 0))).toBe(true);
+    });
+
+    test("includes the finish day, not just the midnight boundary", () => {
+        expect(iterationContainsDate(ITERATIONS[1], new Date(2026, 8, 2, 23, 30))).toBe(true);
+    });
+
+    test("excludes the day after the finish day", () => {
+        expect(iterationContainsDate(ITERATIONS[1], new Date(2026, 8, 3, 0, 1))).toBe(false);
+    });
+
+    test("an iteration without dates never contains a date", () => {
+        const undated: TeamIteration = { id: "x", name: "Backlog", path: "Contoso" };
+        expect(iterationContainsDate(undated, new Date(2026, 7, 27))).toBe(false);
+    });
+});
+
+describe("findCurrentIteration", () => {
+    test("picks the iteration whose range contains today", () => {
+        const current = findCurrentIteration(ITERATIONS, new Date(2026, 7, 27));
+        expect(current?.name).toBe("17. Sprint 20.08. - 02.09.");
+    });
+
+    test("returns null when no range contains today", () => {
+        expect(findCurrentIteration(ITERATIONS, new Date(2026, 0, 15))).toBeNull();
+    });
+});
+
+describe("resolveIteration", () => {
+    const now = new Date(2026, 7, 27);
+
+    test("resolves an exact iteration path", () => {
+        const result = resolveIteration(ITERATIONS, "Contoso\\17. Sprint 20.08. - 02.09.", now);
+        expect(result).toMatchObject({ kind: "resolved", matchedBy: "path" });
+    });
+
+    test("path match is case-insensitive", () => {
+        const result = resolveIteration(ITERATIONS, "contoso\\17. sprint 20.08. - 02.09.", now);
+        expect(result).toMatchObject({ kind: "resolved", matchedBy: "path" });
+    });
+
+    test("resolves an exact iteration name", () => {
+        const result = resolveIteration(ITERATIONS, "17. Sprint 20.08. - 02.09.", now);
+        expect(result).toMatchObject({ kind: "resolved", matchedBy: "name" });
+    });
+
+    test("resolves a unique case-insensitive substring", () => {
+        const result = resolveIteration(ITERATIONS, "17. sprint 20.08.", now);
+
+        if (result.kind !== "resolved") {
+            throw new Error(`expected resolved, got ${result.kind}`);
+        }
+
+        expect(result.iteration.name).toBe("17. Sprint 20.08. - 02.09.");
+        expect(result.matchedBy).toBe("substring");
+    });
+
+    test("path form and substring form resolve to the same iteration", () => {
+        const byPath = resolveIteration(ITERATIONS, "Contoso\\17. Sprint 20.08. - 02.09.", now);
+        const bySubstring = resolveIteration(ITERATIONS, "17. Sprint 20.08.", now);
+
+        if (byPath.kind !== "resolved" || bySubstring.kind !== "resolved") {
+            throw new Error("both forms must resolve");
+        }
+
+        expect(byPath.iteration.path).toBe(bySubstring.iteration.path);
+    });
+
+    test("refuses an ambiguous substring and lists every candidate", () => {
+        const result = resolveIteration(ITERATIONS, "Sprint", now);
+
+        if (result.kind !== "ambiguous") {
+            throw new Error(`expected ambiguous, got ${result.kind}`);
+        }
+
+        expect(result.candidates).toHaveLength(3);
+    });
+
+    test("an empty argument resolves the iteration containing today", () => {
+        const result = resolveIteration(ITERATIONS, undefined, now);
+        expect(result).toMatchObject({ kind: "resolved", matchedBy: "current" });
+    });
+
+    test('the literal "current" resolves by date range too', () => {
+        const result = resolveIteration(ITERATIONS, "current", now);
+        expect(result).toMatchObject({ kind: "resolved", matchedBy: "current" });
+    });
+
+    test("reports no-current when nothing contains today", () => {
+        expect(resolveIteration(ITERATIONS, undefined, new Date(2026, 0, 15))).toEqual({ kind: "no-current" });
+    });
+
+    test("reports not-found for a query that matches nothing", () => {
+        expect(resolveIteration(ITERATIONS, "99. Sprint", now)).toEqual({ kind: "not-found", query: "99. Sprint" });
+    });
+});

--- a/src/azure-devops/lib/iterations.test.ts
+++ b/src/azure-devops/lib/iterations.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { TeamIteration } from "@app/azure-devops/api.types";
 import { findCurrentIteration, iterationContainsDate, resolveIteration } from "@app/azure-devops/lib/iterations";
 
-function iteration(name: string, start: string, finish: string, project = "Contoso"): TeamIteration {
+function iteration(name: string, start: string, finish: string, project = "Widgets"): TeamIteration {
     return {
         id: `id-${name}`,
         name,
@@ -12,9 +12,9 @@ function iteration(name: string, start: string, finish: string, project = "Conto
 }
 
 const ITERATIONS: TeamIteration[] = [
-    iteration("16. Sprint 06.08. - 19.08.", "2026-08-06", "2026-08-19"),
-    iteration("17. Sprint 20.08. - 02.09.", "2026-08-20", "2026-09-02"),
-    iteration("18. Sprint 03.09. - 16.09.", "2026-09-03", "2026-09-16"),
+    iteration("Q3 Sprint 4", "2026-08-06", "2026-08-19"),
+    iteration("Q3 Sprint 5", "2026-08-20", "2026-09-02"),
+    iteration("Q3 Sprint 6", "2026-09-03", "2026-09-16"),
 ];
 
 describe("iterationContainsDate", () => {
@@ -31,7 +31,7 @@ describe("iterationContainsDate", () => {
     });
 
     test("an iteration without dates never contains a date", () => {
-        const undated: TeamIteration = { id: "x", name: "Backlog", path: "Contoso" };
+        const undated: TeamIteration = { id: "x", name: "Backlog", path: "Widgets" };
         expect(iterationContainsDate(undated, new Date(2026, 7, 27))).toBe(false);
     });
 });
@@ -39,7 +39,7 @@ describe("iterationContainsDate", () => {
 describe("findCurrentIteration", () => {
     test("picks the iteration whose range contains today", () => {
         const current = findCurrentIteration(ITERATIONS, new Date(2026, 7, 27));
-        expect(current?.name).toBe("17. Sprint 20.08. - 02.09.");
+        expect(current?.name).toBe("Q3 Sprint 5");
     });
 
     test("returns null when no range contains today", () => {
@@ -51,34 +51,34 @@ describe("resolveIteration", () => {
     const now = new Date(2026, 7, 27);
 
     test("resolves an exact iteration path", () => {
-        const result = resolveIteration(ITERATIONS, "Contoso\\17. Sprint 20.08. - 02.09.", now);
+        const result = resolveIteration(ITERATIONS, "Widgets\\Q3 Sprint 5", now);
         expect(result).toMatchObject({ kind: "resolved", matchedBy: "path" });
     });
 
     test("path match is case-insensitive", () => {
-        const result = resolveIteration(ITERATIONS, "contoso\\17. sprint 20.08. - 02.09.", now);
+        const result = resolveIteration(ITERATIONS, "widgets\\q3 sprint 5", now);
         expect(result).toMatchObject({ kind: "resolved", matchedBy: "path" });
     });
 
     test("resolves an exact iteration name", () => {
-        const result = resolveIteration(ITERATIONS, "17. Sprint 20.08. - 02.09.", now);
+        const result = resolveIteration(ITERATIONS, "Q3 Sprint 5", now);
         expect(result).toMatchObject({ kind: "resolved", matchedBy: "name" });
     });
 
     test("resolves a unique case-insensitive substring", () => {
-        const result = resolveIteration(ITERATIONS, "17. sprint 20.08.", now);
+        const result = resolveIteration(ITERATIONS, "sprint 5", now);
 
         if (result.kind !== "resolved") {
             throw new Error(`expected resolved, got ${result.kind}`);
         }
 
-        expect(result.iteration.name).toBe("17. Sprint 20.08. - 02.09.");
+        expect(result.iteration.name).toBe("Q3 Sprint 5");
         expect(result.matchedBy).toBe("substring");
     });
 
     test("path form and substring form resolve to the same iteration", () => {
-        const byPath = resolveIteration(ITERATIONS, "Contoso\\17. Sprint 20.08. - 02.09.", now);
-        const bySubstring = resolveIteration(ITERATIONS, "17. Sprint 20.08.", now);
+        const byPath = resolveIteration(ITERATIONS, "Widgets\\Q3 Sprint 5", now);
+        const bySubstring = resolveIteration(ITERATIONS, "Sprint 5", now);
 
         if (byPath.kind !== "resolved" || bySubstring.kind !== "resolved") {
             throw new Error("both forms must resolve");
@@ -112,6 +112,6 @@ describe("resolveIteration", () => {
     });
 
     test("reports not-found for a query that matches nothing", () => {
-        expect(resolveIteration(ITERATIONS, "99. Sprint", now)).toEqual({ kind: "not-found", query: "99. Sprint" });
+        expect(resolveIteration(ITERATIONS, "Sprint 99", now)).toEqual({ kind: "not-found", query: "Sprint 99" });
     });
 });

--- a/src/azure-devops/lib/iterations.ts
+++ b/src/azure-devops/lib/iterations.ts
@@ -1,0 +1,103 @@
+/**
+ * Iteration (sprint) resolution.
+ *
+ * Pure logic only: no API calls, no output. The caller fetches the iteration
+ * list with `Api.getTeamIterations()` and passes it in.
+ *
+ * Why not `@CurrentIteration`: that WIQL macro needs a team context and is
+ * resolved server-side, so the CLI cannot tell which iteration it picked. We
+ * resolve the iteration here and put an explicit `[System.IterationPath]`
+ * predicate in the query instead.
+ */
+
+import type { TeamIteration } from "@app/azure-devops/api.types";
+import { formatLocalDate } from "@genesiscz/utils/date";
+
+export type IterationResolution =
+    | { kind: "resolved"; iteration: TeamIteration; matchedBy: "path" | "name" | "substring" | "current" }
+    | { kind: "ambiguous"; candidates: TeamIteration[] }
+    | { kind: "not-found"; query: string }
+    | { kind: "no-current" };
+
+/** Iteration date attributes are ISO timestamps at midnight; compare on the date part only. */
+function datePart(value: string | null | undefined): string | null {
+    if (!value) {
+        return null;
+    }
+    return value.slice(0, 10);
+}
+
+/**
+ * True when `now` falls inside the iteration, inclusive on both ends.
+ * The finish date is stored as midnight of the last day, so a timestamp
+ * comparison would drop the whole final day. Comparing YYYY-MM-DD keeps it.
+ */
+export function iterationContainsDate(iteration: TeamIteration, now: Date): boolean {
+    const start = datePart(iteration.attributes?.startDate);
+    const finish = datePart(iteration.attributes?.finishDate);
+
+    if (!start || !finish) {
+        return false;
+    }
+
+    const today = formatLocalDate(now);
+    return start <= today && today <= finish;
+}
+
+/** The iteration whose date range contains `now`, or null when none does. */
+export function findCurrentIteration(iterations: TeamIteration[], now: Date): TeamIteration | null {
+    return iterations.find((it) => iterationContainsDate(it, now)) ?? null;
+}
+
+/**
+ * Resolve a user-supplied iteration argument.
+ *
+ * Order: exact IterationPath, then exact name, then case-insensitive substring
+ * on name or path. An empty argument (or the literal "current") resolves by
+ * date range. A substring matching several iterations is refused, never guessed.
+ */
+export function resolveIteration(
+    iterations: TeamIteration[],
+    query: string | undefined,
+    now: Date
+): IterationResolution {
+    const trimmed = query?.trim() ?? "";
+
+    if (trimmed === "" || trimmed.toLowerCase() === "current") {
+        const current = findCurrentIteration(iterations, now);
+
+        if (!current) {
+            return { kind: "no-current" };
+        }
+
+        return { kind: "resolved", iteration: current, matchedBy: "current" };
+    }
+
+    const needle = trimmed.toLowerCase();
+
+    const byPath = iterations.find((it) => it.path.toLowerCase() === needle);
+
+    if (byPath) {
+        return { kind: "resolved", iteration: byPath, matchedBy: "path" };
+    }
+
+    const byName = iterations.find((it) => it.name.toLowerCase() === needle);
+
+    if (byName) {
+        return { kind: "resolved", iteration: byName, matchedBy: "name" };
+    }
+
+    const candidates = iterations.filter(
+        (it) => it.name.toLowerCase().includes(needle) || it.path.toLowerCase().includes(needle)
+    );
+
+    if (candidates.length === 1) {
+        return { kind: "resolved", iteration: candidates[0], matchedBy: "substring" };
+    }
+
+    if (candidates.length > 1) {
+        return { kind: "ambiguous", candidates };
+    }
+
+    return { kind: "not-found", query: trimmed };
+}

--- a/src/azure-devops/lib/sprint.test.ts
+++ b/src/azure-devops/lib/sprint.test.ts
@@ -18,15 +18,15 @@ function row(overrides: Partial<SprintRow> & { id: number }): SprintRow {
         remainingWork: 0,
         order: null,
         changedDate: "2026-08-20T10:00:00Z",
-        iterationPath: "Contoso\\17. Sprint 20.08. - 02.09.",
+        iterationPath: "Contoso\\Sprint 17",
         ...overrides,
     };
 }
 
 describe("buildSprintWiql", () => {
     test("uses an explicit IterationPath predicate, never @CurrentIteration", () => {
-        const wiql = buildSprintWiql({ iterationPath: "Contoso\\17. Sprint 20.08. - 02.09." });
-        expect(wiql).toContain("[System.IterationPath] = 'Contoso\\17. Sprint 20.08. - 02.09.'");
+        const wiql = buildSprintWiql({ iterationPath: "Contoso\\Sprint 17" });
+        expect(wiql).toContain("[System.IterationPath] = 'Contoso\\Sprint 17'");
         expect(wiql).not.toContain("@CurrentIteration");
     });
 

--- a/src/azure-devops/lib/sprint.test.ts
+++ b/src/azure-devops/lib/sprint.test.ts
@@ -66,7 +66,7 @@ describe("mapSprintRow", () => {
     });
 
     test("reads effort, identity and rank fields", () => {
-        const mapped = mapSprintRow(296936, {
+        const mapped = mapSprintRow(10007, {
             "System.WorkItemType": "Task",
             "System.Title": "Build the thing",
             "System.State": "In Progress",
@@ -77,7 +77,7 @@ describe("mapSprintRow", () => {
             "Microsoft.VSTS.Common.StackRank": 1999962089,
         });
         expect(mapped).toMatchObject({
-            id: 296936,
+            id: 10007,
             type: "Task",
             state: "In Progress",
             assignedTo: "Alice Example",
@@ -104,17 +104,17 @@ describe("mapSprintRow", () => {
 describe("sortByBacklogOrder", () => {
     test("ranked rows come first in ascending rank, unranked last by id", () => {
         const rows = [
-            row({ id: 303543, type: "Incident" }),
-            row({ id: 285745, type: "User Story", order: 1999999373 }),
-            row({ id: 246829, type: "User Story", order: 1999962089 }),
-            row({ id: 292767, type: "Incident" }),
-            row({ id: 297040, type: "User Story", order: 1999981901 }),
-            row({ id: 302921, type: "User Story" }),
-            row({ id: 279041, type: "User Story", order: 1999986965 }),
-            row({ id: 277429, type: "User Story", order: 1999985333 }),
+            row({ id: 10010, type: "Incident" }),
+            row({ id: 10004, type: "User Story", order: 1999999373 }),
+            row({ id: 10001, type: "User Story", order: 1999962089 }),
+            row({ id: 10006, type: "Incident" }),
+            row({ id: 10008, type: "User Story", order: 1999981901 }),
+            row({ id: 10009, type: "User Story" }),
+            row({ id: 10003, type: "User Story", order: 1999986965 }),
+            row({ id: 10002, type: "User Story", order: 1999985333 }),
         ];
         expect(sortByBacklogOrder(rows).map((r) => r.id)).toEqual([
-            246829, 297040, 277429, 279041, 285745, 292767, 302921, 303543,
+            10001, 10008, 10002, 10003, 10004, 10006, 10009, 10010,
         ]);
     });
 

--- a/src/azure-devops/lib/sprint.test.ts
+++ b/src/azure-devops/lib/sprint.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import {
+    buildSprintWiql,
+    mapSprintRow,
+    type SprintRow,
+    sortByBacklogOrder,
+    sortById,
+    sumTaskEffort,
+} from "@app/azure-devops/lib/sprint";
+
+function row(overrides: Partial<SprintRow> & { id: number }): SprintRow {
+    return {
+        type: "Task",
+        title: "t",
+        state: "New",
+        assignedTo: "Alice Example",
+        completedWork: 0,
+        remainingWork: 0,
+        order: null,
+        changedDate: "2026-08-20T10:00:00Z",
+        iterationPath: "Contoso\\17. Sprint 20.08. - 02.09.",
+        ...overrides,
+    };
+}
+
+describe("buildSprintWiql", () => {
+    test("uses an explicit IterationPath predicate, never @CurrentIteration", () => {
+        const wiql = buildSprintWiql({ iterationPath: "Contoso\\17. Sprint 20.08. - 02.09." });
+        expect(wiql).toContain("[System.IterationPath] = 'Contoso\\17. Sprint 20.08. - 02.09.'");
+        expect(wiql).not.toContain("@CurrentIteration");
+    });
+
+    test("backslashes in the path are passed through verbatim", () => {
+        const wiql = buildSprintWiql({ iterationPath: "Proj\\Sub\\Sprint 1" });
+        expect(wiql).toContain("'Proj\\Sub\\Sprint 1'");
+        expect(wiql).not.toContain("\\\\");
+    });
+
+    test("a single quote in the path is doubled so the literal stays closed", () => {
+        const wiql = buildSprintWiql({ iterationPath: "Proj\\Sprint O'Brien" });
+        expect(wiql).toContain("'Proj\\Sprint O''Brien'");
+    });
+
+    test("@Me is emitted as a bare macro, not a quoted string", () => {
+        const wiql = buildSprintWiql({ iterationPath: "Proj\\S1", assignedTo: "@Me" });
+        expect(wiql).toContain("[System.AssignedTo] = @Me");
+        expect(wiql).not.toContain("'@Me'");
+    });
+
+    test("a display name is quoted and escaped", () => {
+        const wiql = buildSprintWiql({ iterationPath: "Proj\\S1", assignedTo: "O'Hara Alice" });
+        expect(wiql).toContain("[System.AssignedTo] = 'O''Hara Alice'");
+    });
+
+    test("no assignee means no AssignedTo clause", () => {
+        expect(buildSprintWiql({ iterationPath: "Proj\\S1" })).not.toContain("System.AssignedTo");
+    });
+});
+
+describe("mapSprintRow", () => {
+    test("absent effort fields become 0, not blanks or strings", () => {
+        const mapped = mapSprintRow(1, { "System.WorkItemType": "Task" });
+        expect(mapped.completedWork).toBe(0);
+        expect(mapped.remainingWork).toBe(0);
+        expect(typeof mapped.completedWork).toBe("number");
+    });
+
+    test("reads effort, identity and rank fields", () => {
+        const mapped = mapSprintRow(296936, {
+            "System.WorkItemType": "Task",
+            "System.Title": "Build the thing",
+            "System.State": "In Progress",
+            "System.AssignedTo": { displayName: "Alice Example", uniqueName: "alice@example.com" },
+            "System.ChangedDate": "2026-08-26T08:00:00Z",
+            "Microsoft.VSTS.Scheduling.CompletedWork": 85,
+            "Microsoft.VSTS.Scheduling.RemainingWork": 56,
+            "Microsoft.VSTS.Common.StackRank": 1999962089,
+        });
+        expect(mapped).toMatchObject({
+            id: 296936,
+            type: "Task",
+            state: "In Progress",
+            assignedTo: "Alice Example",
+            completedWork: 85,
+            remainingWork: 56,
+            order: 1999962089,
+        });
+    });
+
+    test("falls back to BacklogPriority when StackRank is absent", () => {
+        const mapped = mapSprintRow(2, { "Microsoft.VSTS.Common.BacklogPriority": 1200 });
+        expect(mapped.order).toBe(1200);
+    });
+
+    test("an unranked item keeps order null, which is not rank 0", () => {
+        expect(mapSprintRow(3, {}).order).toBeNull();
+    });
+
+    test("fractional effort survives as a number", () => {
+        expect(mapSprintRow(4, { "Microsoft.VSTS.Scheduling.CompletedWork": 5.75 }).completedWork).toBe(5.75);
+    });
+});
+
+describe("sortByBacklogOrder", () => {
+    test("ranked rows come first in ascending rank, unranked last by id", () => {
+        const rows = [
+            row({ id: 303543, type: "Incident" }),
+            row({ id: 285745, type: "User Story", order: 1999999373 }),
+            row({ id: 246829, type: "User Story", order: 1999962089 }),
+            row({ id: 292767, type: "Incident" }),
+            row({ id: 297040, type: "User Story", order: 1999981901 }),
+            row({ id: 302921, type: "User Story" }),
+            row({ id: 279041, type: "User Story", order: 1999986965 }),
+            row({ id: 277429, type: "User Story", order: 1999985333 }),
+        ];
+        expect(sortByBacklogOrder(rows).map((r) => r.id)).toEqual([
+            246829, 297040, 277429, 279041, 285745, 292767, 302921, 303543,
+        ]);
+    });
+
+    test("equal ranks fall back to id so the order is stable", () => {
+        const rows = [row({ id: 20, order: 5 }), row({ id: 10, order: 5 })];
+        expect(sortByBacklogOrder(rows).map((r) => r.id)).toEqual([10, 20]);
+    });
+
+    test("does not mutate the input array", () => {
+        const rows = [row({ id: 2, order: 2 }), row({ id: 1, order: 1 })];
+        sortByBacklogOrder(rows);
+        expect(rows.map((r) => r.id)).toEqual([2, 1]);
+    });
+});
+
+describe("sortById", () => {
+    test("sorts ascending by id", () => {
+        expect(sortById([row({ id: 30 }), row({ id: 10 }), row({ id: 20 })]).map((r) => r.id)).toEqual([10, 20, 30]);
+    });
+});
+
+describe("sumTaskEffort", () => {
+    test("a User Story parent contributes nothing, only its child Task counts", () => {
+        const rows = [
+            row({ id: 1, type: "User Story", remainingWork: 40, completedWork: 10 }),
+            row({ id: 2, type: "Task", remainingWork: 8, completedWork: 4 }),
+        ];
+        const totals = sumTaskEffort(rows);
+        expect(totals.remainingWork).toBe(8);
+        expect(totals.completedWork).toBe(4);
+        expect(totals.taskCount).toBe(1);
+        expect(totals.itemCount).toBe(2);
+    });
+
+    test("Feature, Bug and Incident rows are excluded from the Task sum", () => {
+        const rows = [
+            row({ id: 1, type: "Feature", remainingWork: 100 }),
+            row({ id: 2, type: "Bug", remainingWork: 5 }),
+            row({ id: 3, type: "Incident", remainingWork: 1 }),
+            row({ id: 4, type: "Task", remainingWork: 8 }),
+        ];
+        expect(sumTaskEffort(rows).remainingWork).toBe(8);
+    });
+
+    test("fractional Task effort sums exactly", () => {
+        const rows = [row({ id: 1, completedWork: 5.75 }), row({ id: 2, completedWork: 4.25 })];
+        expect(sumTaskEffort(rows).completedWork).toBe(10);
+    });
+
+    test("an empty sprint totals to zero", () => {
+        expect(sumTaskEffort([])).toEqual({ taskCount: 0, itemCount: 0, completedWork: 0, remainingWork: 0 });
+    });
+});

--- a/src/azure-devops/lib/sprint.ts
+++ b/src/azure-devops/lib/sprint.ts
@@ -1,0 +1,183 @@
+/**
+ * Sprint backlog: WIQL construction, field mapping, ordering and totals.
+ *
+ * Pure logic only. The command layer fetches ids with `Api.runWiql()` and
+ * fields with `Api.getWorkItemFields()`, then calls into here.
+ */
+
+import { escapeWiqlValue } from "@app/azure-devops/wiql-builder";
+
+/** Field set requested for every sprint row. */
+export const SPRINT_FIELDS = [
+    "System.Id",
+    "System.WorkItemType",
+    "System.Title",
+    "System.State",
+    "System.AssignedTo",
+    "System.ChangedDate",
+    "System.IterationPath",
+    "Microsoft.VSTS.Scheduling.CompletedWork",
+    "Microsoft.VSTS.Scheduling.RemainingWork",
+    "Microsoft.VSTS.Common.StackRank",
+    "Microsoft.VSTS.Common.BacklogPriority",
+];
+
+/** Work item types that carry their own spendable effort. */
+const EFFORT_BEARING_TYPE = "Task";
+
+export interface SprintRow {
+    id: number;
+    type: string;
+    title: string;
+    state: string;
+    assignedTo: string;
+    completedWork: number;
+    remainingWork: number;
+    /** Backlog stack rank; null when the type carries no rank. */
+    order: number | null;
+    changedDate: string;
+    iterationPath: string;
+}
+
+export interface SprintTotals {
+    /** Rows counted (Tasks only). */
+    taskCount: number;
+    /** Rows present in the sprint, all types. */
+    itemCount: number;
+    completedWork: number;
+    remainingWork: number;
+}
+
+/**
+ * Build the sprint WIQL.
+ *
+ * Uses an explicit `[System.IterationPath]` equality predicate rather than
+ * `@CurrentIteration`, which fails project-scoped with VS402612 and hides which
+ * iteration the server chose even when it works.
+ *
+ * @param assignedTo - "@Me" (unquoted macro) or a display name / unique name.
+ */
+export function buildSprintWiql(options: { iterationPath: string; assignedTo?: string }): string {
+    const clauses = [
+        "[System.TeamProject] = @project",
+        `[System.IterationPath] = '${escapeWiqlValue(options.iterationPath)}'`,
+    ];
+
+    if (options.assignedTo) {
+        const assignee = options.assignedTo === "@Me" ? "@Me" : `'${escapeWiqlValue(options.assignedTo)}'`;
+        clauses.push(`[System.AssignedTo] = ${assignee}`);
+    }
+
+    return `SELECT [System.Id] FROM WorkItems WHERE ${clauses.join(" AND ")} ORDER BY [System.Id]`;
+}
+
+/** Coerce an Azure numeric field to a number; absent or unparseable becomes 0. */
+function toNumber(value: unknown): number {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === "string") {
+        const parsed = Number(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return 0;
+}
+
+/** Coerce a rank field; absent means "unranked", which is distinct from rank 0. */
+function toRank(value: unknown): number | null {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value);
+
+        if (Number.isFinite(parsed)) {
+            return parsed;
+        }
+    }
+
+    return null;
+}
+
+function toDisplayName(value: unknown): string {
+    if (value && typeof value === "object" && "displayName" in value) {
+        const name = (value as { displayName?: unknown }).displayName;
+        return typeof name === "string" ? name : "";
+    }
+
+    if (typeof value === "string") {
+        return value;
+    }
+
+    return "";
+}
+
+function toStringField(value: unknown): string {
+    return typeof value === "string" ? value : "";
+}
+
+/** Map one raw Azure DevOps field bag to a sprint row. */
+export function mapSprintRow(id: number, fields: Record<string, unknown>): SprintRow {
+    return {
+        id,
+        type: toStringField(fields["System.WorkItemType"]),
+        title: toStringField(fields["System.Title"]),
+        state: toStringField(fields["System.State"]),
+        assignedTo: toDisplayName(fields["System.AssignedTo"]),
+        completedWork: toNumber(fields["Microsoft.VSTS.Scheduling.CompletedWork"]),
+        remainingWork: toNumber(fields["Microsoft.VSTS.Scheduling.RemainingWork"]),
+        order:
+            toRank(fields["Microsoft.VSTS.Common.StackRank"]) ??
+            toRank(fields["Microsoft.VSTS.Common.BacklogPriority"]),
+        changedDate: toStringField(fields["System.ChangedDate"]),
+        iterationPath: toStringField(fields["System.IterationPath"]),
+    };
+}
+
+/**
+ * Sort into Backlog stack-rank order: ranked rows ascending first, then
+ * unranked rows by id ascending so the output is stable across runs.
+ */
+export function sortByBacklogOrder(rows: SprintRow[]): SprintRow[] {
+    return [...rows].sort((a, b) => {
+        if (a.order !== null && b.order !== null && a.order !== b.order) {
+            return a.order - b.order;
+        }
+
+        if (a.order !== null && b.order === null) {
+            return -1;
+        }
+
+        if (a.order === null && b.order !== null) {
+            return 1;
+        }
+
+        return a.id - b.id;
+    });
+}
+
+export function sortById(rows: SprintRow[]): SprintRow[] {
+    return [...rows].sort((a, b) => a.id - b.id);
+}
+
+/**
+ * Sum effort over Tasks only.
+ *
+ * A User Story and its child Task both sit in the sprint and both carry a
+ * Remaining value, so summing every type double counts the same work.
+ */
+export function sumTaskEffort(rows: SprintRow[]): SprintTotals {
+    const tasks = rows.filter((row) => row.type === EFFORT_BEARING_TYPE);
+    return {
+        taskCount: tasks.length,
+        itemCount: rows.length,
+        completedWork: tasks.reduce((sum, row) => sum + row.completedWork, 0),
+        remainingWork: tasks.reduce((sum, row) => sum + row.remainingWork, 0),
+    };
+}

--- a/src/azure-devops/lib/team.test.ts
+++ b/src/azure-devops/lib/team.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { NO_TEAM_MESSAGE, resolveTeam } from "@app/azure-devops/lib/team";
+import type { AzureConfig } from "@app/azure-devops/types";
+
+const BASE: AzureConfig = {
+    org: "https://dev.azure.com/contoso",
+    project: "Widgets",
+    projectId: "00000000-0000-0000-0000-000000000000",
+    apiResource: "499b84ac-1321-427f-aa17-267ca6975798",
+};
+
+describe("resolveTeam", () => {
+    test("the explicit flag wins over config", () => {
+        expect(resolveTeam({ ...BASE, team: "Team A" }, "Team B")).toEqual({ team: "Team B", source: "flag" });
+    });
+
+    test("falls back to config when no flag is passed", () => {
+        expect(resolveTeam({ ...BASE, team: "Team A" }, undefined)).toEqual({ team: "Team A", source: "config" });
+    });
+
+    test("a blank flag does not shadow config", () => {
+        expect(resolveTeam({ ...BASE, team: "Team A" }, "   ")).toEqual({ team: "Team A", source: "config" });
+    });
+
+    test("returns null when neither is set", () => {
+        expect(resolveTeam(BASE, undefined)).toBeNull();
+    });
+
+    test("the failure message names both the flag and configure", () => {
+        expect(NO_TEAM_MESSAGE).toContain("--team");
+        expect(NO_TEAM_MESSAGE).toContain("tools azure-devops configure");
+    });
+});

--- a/src/azure-devops/lib/team.ts
+++ b/src/azure-devops/lib/team.ts
@@ -1,0 +1,42 @@
+/**
+ * Team resolution for team-scoped Azure DevOps endpoints.
+ */
+
+import type { AzureConfig } from "@app/azure-devops/types";
+
+export interface TeamResolution {
+    team: string;
+    source: "flag" | "config";
+}
+
+/**
+ * Resolve the team from an explicit `--team` flag, falling back to config.
+ * Returns null when neither is set; the caller prints the fix.
+ */
+export function resolveTeam(config: AzureConfig, explicit?: string): TeamResolution | null {
+    const flag = explicit?.trim();
+
+    if (flag) {
+        return { team: flag, source: "flag" };
+    }
+
+    const fromConfig = config.team?.trim();
+
+    if (fromConfig) {
+        return { team: fromConfig, source: "config" };
+    }
+
+    return null;
+}
+
+/** Message shown when no team is configured and none was passed. */
+export const NO_TEAM_MESSAGE = [
+    "No Azure DevOps team is configured.",
+    "",
+    "This command reads team settings, so it needs a team name. Either:",
+    '  1. Pass it for this run:   tools azure-devops sprint --team "Delivery Team C"',
+    "  2. Store it in config:     tools azure-devops configure \\",
+    '       "https://dev.azure.com/{org}/{project}/_backlogs/backlog/Delivery%20Team%20C/Stories"',
+    "",
+    'Or add "team": "Delivery Team C" to .claude/azure/config.json by hand.',
+].join("\n");

--- a/src/azure-devops/lib/team.ts
+++ b/src/azure-devops/lib/team.ts
@@ -34,9 +34,9 @@ export const NO_TEAM_MESSAGE = [
     "No Azure DevOps team is configured.",
     "",
     "This command reads team settings, so it needs a team name. Either:",
-    '  1. Pass it for this run:   tools azure-devops sprint --team "Delivery Team C"',
+    '  1. Pass it for this run:   tools azure-devops sprint --team "<Your Team>"',
     "  2. Store it in config:     tools azure-devops configure \\",
-    '       "https://dev.azure.com/{org}/{project}/_backlogs/backlog/Delivery%20Team%20C/Stories"',
+    '       "https://dev.azure.com/{org}/{project}/_backlogs/backlog/{team}/Stories"',
     "",
-    'Or add "team": "Delivery Team C" to .claude/azure/config.json by hand.',
+    'Or add "team": "<Your Team>" to .claude/azure/config.json by hand.',
 ].join("\n");

--- a/src/azure-devops/lib/timelog/delete-entry.test.ts
+++ b/src/azure-devops/lib/timelog/delete-entry.test.ts
@@ -39,7 +39,7 @@ function queryEntry(overrides: Partial<TimeLogQueryEntry> = {}): TimeLogQueryEnt
         userName: user.userName,
         userEmail: user.userEmail,
         projectId: "proj-1",
-        workItemId: 296936,
+        workItemId: 10007,
         createdOn: "2026-08-19T13:00:00Z",
         createdBy: user.userId,
         updatedOn: null,
@@ -169,7 +169,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         await appendEffortJournal(
             {
                 ts: "2026-08-19T13:03:11.482Z",
-                workItemId: 296936,
+                workItemId: 10007,
                 timeLogIds: ["log-1"],
                 minutes: 120,
                 remainingBefore: 10,
@@ -181,7 +181,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         );
         const apis = makeApis({ remaining: 8, completed: 6 });
         const result = await deleteTimeLogEntryWithEffort(
-            baseOpts(apis, { workItemId: 296936, knownMinutes: 120, journalPath })
+            baseOpts(apis, { workItemId: 10007, knownMinutes: 120, journalPath })
         );
 
         expect(result.status).toBe("deleted");
@@ -201,7 +201,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         await appendEffortJournal(
             {
                 ts: "2026-08-19T13:03:11.482Z",
-                workItemId: 303818,
+                workItemId: 10012,
                 timeLogIds: ["log-1"],
                 minutes: 480,
                 remainingBefore: 3,
@@ -213,7 +213,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         );
         const apis = makeApis({ remaining: 0, completed: 8 });
         const result = await deleteTimeLogEntryWithEffort(
-            baseOpts(apis, { workItemId: 303818, knownMinutes: 480, journalPath })
+            baseOpts(apis, { workItemId: 10012, knownMinutes: 480, journalPath })
         );
 
         expect(apis.patches[0].map((op) => op.value)).toEqual([3, 0]);
@@ -227,7 +227,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         const journalPath = join(root, "no-journal.jsonl");
         const apis = makeApis({ remaining: 0, completed: 38 });
         const result = await deleteTimeLogEntryWithEffort(
-            baseOpts(apis, { workItemId: 296936, knownMinutes: 480, journalPath })
+            baseOpts(apis, { workItemId: 10007, knownMinutes: 480, journalPath })
         );
 
         expect(apis.patches[0].map((op) => op.value)).toEqual([8, 30]);
@@ -275,7 +275,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
     test("--dry-run writes nothing at all", async () => {
         const apis = makeApis({ remaining: 8, completed: 6 });
         const result = await deleteTimeLogEntryWithEffort(
-            baseOpts(apis, { dryRun: true, workItemId: 296936, knownMinutes: 120 })
+            baseOpts(apis, { dryRun: true, workItemId: 10007, knownMinutes: 120 })
         );
         expect(result.status).toBe("dry-run");
         expect(apis.calls).toEqual(["get"]);
@@ -288,7 +288,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
             completed: 6,
             updateError: new Error("TF401320: InvalidNotEmpty"),
         });
-        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { workItemId: 297506, knownMinutes: 120 }));
+        const result = await deleteTimeLogEntryWithEffort(baseOpts(apis, { workItemId: 10011, knownMinutes: 120 }));
         expect(result.status).toBe("deleted");
         expect(apis.calls).toContain("delete");
 
@@ -314,7 +314,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         expect(apis.calls).toContain("query");
 
         if (result.status === "deleted") {
-            expect(result.resolved).toEqual({ workItemId: 296936, minutes: 120, source: "query" });
+            expect(result.resolved).toEqual({ workItemId: 10007, minutes: 120, source: "query" });
         }
     });
 
@@ -332,7 +332,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         await appendEffortJournal(
             {
                 ts: "2026-08-19T13:03:11.482Z",
-                workItemId: 303818,
+                workItemId: 10012,
                 timeLogIds: ["log-1"],
                 minutes: 90,
                 remainingBefore: 5,
@@ -348,7 +348,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         expect(apis.calls.filter((c) => c === "query")).toHaveLength(0);
 
         if (result.status === "deleted") {
-            expect(result.resolved).toEqual({ workItemId: 303818, minutes: 90, source: "journal" });
+            expect(result.resolved).toEqual({ workItemId: 10012, minutes: 90, source: "journal" });
             expect(result.plan?.reason).toBe("exact-journal");
             expect(apis.patches[0].map((op) => op.value)).toEqual([5, 1]);
         }
@@ -367,7 +367,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         expect(apis.calls.filter((c) => c === "query")).toHaveLength(2);
 
         if (result.status === "deleted") {
-            expect(result.resolved).toEqual({ workItemId: 296936, minutes: 120, source: "query" });
+            expect(result.resolved).toEqual({ workItemId: 10007, minutes: 120, source: "query" });
         }
     });
 
@@ -389,7 +389,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
         await appendEffortJournal(
             {
                 ts: "2026-08-19T13:03:11.482Z",
-                workItemId: 296936,
+                workItemId: 10007,
                 timeLogIds: ["log-1"],
                 minutes: 120,
                 remainingBefore: 10,
@@ -400,7 +400,7 @@ describe("deleteTimeLogEntryWithEffort", () => {
             journalPath
         );
         const apis = makeApis({ remaining: 8, completed: 6 });
-        await deleteTimeLogEntryWithEffort(baseOpts(apis, { workItemId: 296936, knownMinutes: 120, journalPath }));
+        await deleteTimeLogEntryWithEffort(baseOpts(apis, { workItemId: 10007, knownMinutes: 120, journalPath }));
         const records = readEffortJournal(journalPath);
         expect(records).toHaveLength(1);
         expect(records[0].minutes).toBe(120);

--- a/src/azure-devops/lib/timelog/effort-restore.test.ts
+++ b/src/azure-devops/lib/timelog/effort-restore.test.ts
@@ -7,7 +7,7 @@ const id = "56489ac9-aaaa-bbbb-cccc-ddddeeeeffff";
 function journal(overrides: Partial<EffortJournalRecord> = {}): EffortJournalRecord {
     return {
         ts: "2026-08-19T13:03:11.482Z",
-        workItemId: 296936,
+        workItemId: 10007,
         timeLogIds: [id],
         minutes: 120,
         remainingBefore: 10,
@@ -21,7 +21,7 @@ function journal(overrides: Partial<EffortJournalRecord> = {}): EffortJournalRec
 describe("planEffortRestore", () => {
     test("exact journal restore after a 2h add", () => {
         const plan = planEffortRestore({
-            workItemId: 296936,
+            workItemId: 10007,
             minutes: 120,
             timeLogId: id,
             currentRemaining: 8,
@@ -38,13 +38,13 @@ describe("planEffortRestore", () => {
 
     test("exact journal restore survives a Remaining clamp", () => {
         const plan = planEffortRestore({
-            workItemId: 303818,
+            workItemId: 10012,
             minutes: 390,
             timeLogId: id,
             currentRemaining: 0,
             currentCompleted: 6.5,
             journal: journal({
-                workItemId: 303818,
+                workItemId: 10012,
                 minutes: 390,
                 remainingBefore: 3,
                 completedBefore: 0,
@@ -59,7 +59,7 @@ describe("planEffortRestore", () => {
 
     test("no journal uses arithmetic and warns", () => {
         const plan = planEffortRestore({
-            workItemId: 296936,
+            workItemId: 10007,
             minutes: 480,
             timeLogId: id,
             currentRemaining: 0,
@@ -96,7 +96,7 @@ describe("planEffortRestore", () => {
 
     test("drifted fields fall back to arithmetic", () => {
         const plan = planEffortRestore({
-            workItemId: 296936,
+            workItemId: 10007,
             minutes: 120,
             timeLogId: id,
             currentRemaining: 7,

--- a/src/azure-devops/timelog-effort.test.ts
+++ b/src/azure-devops/timelog-effort.test.ts
@@ -92,7 +92,7 @@ describe("updateWorkItemEffort", () => {
             "Microsoft.VSTS.Scheduling.CompletedWork": 4,
         });
         const journalPath = join(root, "case-add.jsonl");
-        const result = await updateWorkItemEffort(api, 296936, 120, {
+        const result = await updateWorkItemEffort(api, 10007, 120, {
             timeLogIds: ["abc-1"],
             journalPath,
         });
@@ -109,7 +109,7 @@ describe("updateWorkItemEffort", () => {
         const records = readEffortJournal(journalPath);
         expect(records).toHaveLength(1);
         expect(records[0]).toMatchObject({
-            workItemId: 296936,
+            workItemId: 10007,
             timeLogIds: ["abc-1"],
             minutes: 120,
             remainingBefore: 10,
@@ -145,7 +145,7 @@ describe("updateWorkItemEffort", () => {
             "Microsoft.VSTS.Scheduling.RemainingWork": 0,
             "Microsoft.VSTS.Scheduling.CompletedWork": 8,
         });
-        const result = await updateWorkItemEffort(api, 303818, -480, {
+        const result = await updateWorkItemEffort(api, 10012, -480, {
             journal: false,
             values: { remaining: 3, completed: 0 },
         });
@@ -176,7 +176,7 @@ describe("updateWorkItemEffort", () => {
             throw new Error("TF401320: InvalidNotEmpty");
         };
         const journalPath = join(root, "case-locked.jsonl");
-        const result = await updateWorkItemEffort(api, 297506, 60, { journalPath, timeLogIds: ["locked"] });
+        const result = await updateWorkItemEffort(api, 10011, 60, { journalPath, timeLogIds: ["locked"] });
         expect(result).toBeNull();
         expect(readEffortJournal(journalPath)).toEqual([]);
     });

--- a/src/azure-devops/timelog-prompts-clack.ts
+++ b/src/azure-devops/timelog-prompts-clack.ts
@@ -32,7 +32,7 @@ export async function runInteractiveAddClack(
     } else {
         const workItemInput = await p.text({
             message: "Work Item ID:",
-            placeholder: "268935",
+            placeholder: "12345",
             validate: (value) => {
                 if (!value) {
                     return "Work item ID is required";

--- a/src/azure-devops/types.ts
+++ b/src/azure-devops/types.ts
@@ -409,7 +409,7 @@ export interface TimeLogEntry {
     timeTypeDescription: string; // "Development"
     minutes: number; // 120 (NOT hours!)
     date: string; // "2026-02-04" (YYYY-MM-DD)
-    userId: string; // "57c2e420-edce-6083-8a6a-a58deb1c6769"
+    userId: string; // "00000000-0000-0000-0000-000000000000"
     userName: string; // "John Doe"
     userEmail: string; // "user@example.com"
 }
@@ -427,8 +427,8 @@ export interface CreateTimeLogRequest {
     timeTypeDescription: string; // "Development" (display name, not UUID!)
     comment: string; // "analýza, fixing"
     date: string; // "2026-02-04"
-    workItemId: number; // 268935
-    projectId: string; // "de25c7dd-75d8-467a-bac0-f15fac9b560d"
+    workItemId: number; // 12345
+    projectId: string; // "00000000-0000-0000-0000-000000000000"
     users: TimeLogUser[];
     userMakingChange: string; // "John Doe"
 }

--- a/src/azure-devops/types.ts
+++ b/src/azure-devops/types.ts
@@ -16,6 +16,11 @@ export interface AzureConfig {
     project: string;
     projectId: string;
     apiResource: string;
+    /**
+     * Team name used for team-scoped endpoints (iterations, team-context WIQL).
+     * Optional: only the `iterations` / `sprint` commands need it.
+     */
+    team?: string;
 }
 
 // ============= Output Types =============

--- a/src/azure-devops/url-parser.test.ts
+++ b/src/azure-devops/url-parser.test.ts
@@ -4,16 +4,16 @@ import { extractTeamFromUrl } from "@app/azure-devops/url-parser";
 describe("extractTeamFromUrl", () => {
     test("reads the team from a backlog URL and decodes it", () => {
         expect(
-            extractTeamFromUrl("https://dev.azure.com/contoso/Widgets/_backlogs/backlog/Delivery%20Team%20C/Stories")
-        ).toBe("Delivery Team C");
+            extractTeamFromUrl("https://dev.azure.com/contoso/Widgets/_backlogs/backlog/Payments%20Team/Stories")
+        ).toBe("Payments Team");
     });
 
     test("reads the team from a sprint taskboard URL", () => {
         expect(
             extractTeamFromUrl(
-                "https://dev.azure.com/contoso/Widgets/_sprints/taskboard/Delivery%20Team%20C/Widgets/Sprint%201"
+                "https://dev.azure.com/contoso/Widgets/_sprints/taskboard/Payments%20Team/Widgets/Sprint%201"
             )
-        ).toBe("Delivery Team C");
+        ).toBe("Payments Team");
     });
 
     test("reads the team from a /_boards/board/t/ URL", () => {
@@ -45,7 +45,7 @@ describe("extractTeamFromUrl", () => {
     test("returns null for a query URL", () => {
         expect(
             extractTeamFromUrl(
-                "https://dev.azure.com/contoso/Widgets/_queries/query/dbfe2de1-abb1-48ca-80ce-cefd42e11917"
+                "https://dev.azure.com/contoso/Widgets/_queries/query/00000000-0000-0000-0000-000000000000"
             )
         ).toBeNull();
     });

--- a/src/azure-devops/url-parser.test.ts
+++ b/src/azure-devops/url-parser.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { extractTeamFromUrl } from "@app/azure-devops/url-parser";
+
+describe("extractTeamFromUrl", () => {
+    test("reads the team from a backlog URL and decodes it", () => {
+        expect(
+            extractTeamFromUrl("https://dev.azure.com/contoso/Widgets/_backlogs/backlog/Delivery%20Team%20C/Stories")
+        ).toBe("Delivery Team C");
+    });
+
+    test("reads the team from a sprint taskboard URL", () => {
+        expect(
+            extractTeamFromUrl(
+                "https://dev.azure.com/contoso/Widgets/_sprints/taskboard/Delivery%20Team%20C/Widgets/Sprint%201"
+            )
+        ).toBe("Delivery Team C");
+    });
+
+    test("reads the team from a /_boards/board/t/ URL", () => {
+        expect(extractTeamFromUrl("https://dev.azure.com/contoso/Widgets/_boards/board/t/Team%20A/Stories")).toBe(
+            "Team A"
+        );
+    });
+
+    test("reads the team from a /_boards/board/<team>/<level> URL", () => {
+        expect(extractTeamFromUrl("https://dev.azure.com/contoso/Widgets/_boards/board/Team%20B/Stories")).toBe(
+            "Team B"
+        );
+    });
+
+    test("a team query parameter wins over the path", () => {
+        expect(extractTeamFromUrl("https://dev.azure.com/contoso/Widgets/_workitems?team=Team%20D&view=list")).toBe(
+            "Team D"
+        );
+    });
+
+    test("a plus sign in the query parameter decodes to a space", () => {
+        expect(extractTeamFromUrl("https://dev.azure.com/contoso/Widgets/_workitems?team=Team+D")).toBe("Team D");
+    });
+
+    test("returns null for a work item URL, which carries no team", () => {
+        expect(extractTeamFromUrl("https://dev.azure.com/contoso/Widgets/_workitems/edit/12345")).toBeNull();
+    });
+
+    test("returns null for a query URL", () => {
+        expect(
+            extractTeamFromUrl(
+                "https://dev.azure.com/contoso/Widgets/_queries/query/dbfe2de1-abb1-48ca-80ce-cefd42e11917"
+            )
+        ).toBeNull();
+    });
+});

--- a/src/azure-devops/url-parser.ts
+++ b/src/azure-devops/url-parser.ts
@@ -131,6 +131,44 @@ export function extractDashboardId(input: string): string {
     return match[1];
 }
 
+/**
+ * Extract the team name from a board / backlog / sprint URL.
+ *
+ * Azure DevOps puts the team either in a `team` query parameter or as a path
+ * segment right after the view name. Returns null when the URL carries no team
+ * (work item, query and dashboard URLs do not).
+ */
+export function extractTeamFromUrl(url: string): string | null {
+    const queryMatch = url.match(/[?&]team=([^&#]+)/i);
+
+    if (queryMatch) {
+        return decodeURIComponent(queryMatch[1].replace(/\+/g, " "));
+    }
+
+    // /_backlogs/backlog/<team>/..., /_backlogs/taskboard/<team>/..., /_sprints/taskboard/<team>/...
+    const viewMatch = url.match(/\/_(?:backlogs|sprints)\/[^/?#]+\/([^/?#]+)/i);
+
+    if (viewMatch) {
+        return decodeURIComponent(viewMatch[1]);
+    }
+
+    // /_boards/board/t/<team>/... (the "t" segment marks a team-scoped board)
+    const boardTeamMatch = url.match(/\/_boards\/board\/t\/([^/?#]+)/i);
+
+    if (boardTeamMatch) {
+        return decodeURIComponent(boardTeamMatch[1]);
+    }
+
+    // /_boards/board/<team>/<backlogLevel>
+    const boardMatch = url.match(/\/_boards\/board\/([^/?#]+)\/[^/?#]+/i);
+
+    if (boardMatch) {
+        return decodeURIComponent(boardMatch[1]);
+    }
+
+    return null;
+}
+
 export function parseAzureDevOpsUrl(url: string): ParsedUrl {
     const devAzureMatch = url.match(/https:\/\/dev\.azure\.com\/([^/]+)\/([^/]+)/i);
 


### PR DESCRIPTION
Adds sprint and iteration backlog commands to `tools azure-devops`, so the current sprint's work items and their effort can be read from the CLI instead of transcribed from a board screenshot.

## What it adds

- **`tools azure-devops iterations`** (alias `sprints`) — the team's iterations with name, full `IterationPath`, start and finish dates, and a marker on the one containing today. The marker comes from the date range, not from a server field or a macro.
- **`tools azure-devops sprint [nameOrPath]`** — the work items of one iteration. Resolution order: exact `IterationPath`, then exact name, then case-insensitive substring, then the iteration containing today when the argument is omitted. An ambiguous substring exits 1 and lists every candidate rather than guessing.
- **`--mine` / `--assigned-to <name>`**, `--order` (backlog stack rank), `--totals` (Task-only sums), and `-f ai|md|json`.
- **Team scoping**: `Api.teamApiUrl()`, a `team` field on `AzureConfig` that `configure` picks up from a board URL, and a `--team` override.

## Why an explicit IterationPath, not `@CurrentIteration`

`Api.witUrl` builds a project-scoped URL, and a saved query whose stored WIQL calls
`@currentIteration('[<project>]\<team> <id:…>')` returns `VS402612` from the CLI when that team
no longer exists — **no route segment can fix that**, since the team is baked into the query
text. `sprint` sidesteps the macro entirely with `[System.IterationPath] = '<path>'`, escaped
through the existing `escapeWiqlValue`.

## Verification

Exercised end to end against a live Azure DevOps organisation:

- `sprint --mine` on a two-week iteration returns exactly the expected work-item set, with per-item `CompletedWork` / `RemainingWork` as numbers (0 when the field is absent, never blank or a string).
- `--order` reproduces the Backlog tab's stack-rank ordering; items with no rank sort last, deterministically by id.
- `--totals` sums **Tasks only**, so a User Story and its child Task are never double counted.
- The substring form and the full-path form resolve to the same iteration; an ambiguous substring exits 1 and lists candidates.

Unit tests cover the pure logic: iteration resolution order, the ambiguity refusal, WIQL escaping, and the Task-only totals.

## Known caveat

The `--team` requirement is stricter than it needs to be. Iterations are project-level
classification nodes and a team merely subscribes to them, so the same work items come back
with or without a team. A follow-up makes `--team` an optional narrowing filter and falls back
to the project's classification nodes. Tracked separately.

## Status

`tsgo --noEmit` clean · `bun run test src/azure-devops` 79 pass 0 fail · biome clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure DevOps `iterations` and `sprint` commands.
  * View sprint backlogs with assignee filters, backlog ordering, task-effort totals, and AI, Markdown, or JSON output.
  * Added team selection and automatic team detection from Azure DevOps URLs.
  * Added explicit and current-iteration resolution with clear handling for missing or ambiguous matches.
* **Documentation**
  * Added command references, configuration guidance, filtering details, output options, and usage examples.
* **Bug Fixes**
  * Improved configuration feedback when a team is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->