### PR TITLE
feat(azure-devops): make --team optional, resolve iterations project-scoped

### DIFF
--- a/plugins/genesis-tools/skills/azure-devops/SKILL.md
+++ b/plugins/genesis-tools/skills/azure-devops/SKILL.md
@@ -16,7 +16,7 @@ tools azure-devops workitem <id|ids>             # Fetch work item(s)
 tools azure-devops query <id|url|name>           # Fetch query results (supports name matching)
 tools azure-devops query <id> --download-workitems  # Download all to files
 tools azure-devops dashboard <id|url>            # Get dashboard queries
-tools azure-devops iterations                    # List the team's sprints (alias: sprints)
+tools azure-devops iterations                    # List the project's sprints (alias: sprints)
 tools azure-devops sprint [nameOrPath]           # Work items of one sprint (default: current)
 tools azure-devops list                          # List cached items
 tools azure-devops workitem-create               # Create work item
@@ -64,7 +64,7 @@ Columns: `ID | Type | Title | State | AssignedTo | CompletedWork | RemainingWork
 
 | Option | Description |
 |--------|-------------|
-| `--team <name>` | Team name; overrides `config.team`. Also valid before the subcommand. |
+| `--team <name>` | Optional. Narrows the iteration list to one team's subscriptions. Also valid before the subcommand. |
 | `--mine` | Only items assigned to me (WIQL `@Me`) |
 | `--assigned-to <name>` | Only items assigned to this display name or unique name |
 | `--totals` | Task-only CompletedWork / RemainingWork sums |
@@ -76,18 +76,20 @@ Rules that matter when reading the output:
 - `--totals` sums Tasks only, so a User Story and its child Task are never counted twice.
 - The iteration argument resolves as exact path, then exact name, then case-insensitive substring. An ambiguous substring exits 1 and lists every candidate. Omit it for the sprint containing today.
 
-**Never use `@CurrentIteration`.** The macro needs a team context and fails with `VS402612: The macro '@CurrentIteration' is not supported without a team context`. `sprint` resolves the iteration from the team settings endpoint and sends an explicit `[System.IterationPath] = '<path>'` predicate instead. The two saved queries that look right, `FE Tasky aktualniho sprintu` (`dbfe2de1-abb1-48ca-80ce-cefd42e11917`) and `MF - Not Closed` (`7a4cbaea-0c7a-460a-a82f-ce2d97ad9d1a`), return `VS402612` from the CLI both project-scoped and team-scoped, because their stored WIQL names a team that no longer exists. Do not retry them.
+**Never use `@CurrentIteration`.** The macro needs a team context and fails with `VS402612: The macro '@CurrentIteration' is not supported without a team context`. `sprint` resolves the iteration itself and sends an explicit `[System.IterationPath] = '<path>'` predicate instead. A saved query whose stored WIQL calls `@currentIteration` against a team that no longer exists returns `VS402612` from the CLI both project-scoped and team-scoped. Do not retry it.
 
 **Never scan the local work item cache instead.** `.claude/azure/tasks/**` accumulates every work item ever fetched and its `RemainingWork` is never zeroed, so filtering it produces sprints full of items closed months earlier.
 
-Team setup, once per project:
+**No team is required.** Iterations are project-level classification nodes; a team only subscribes to a subset of them, and `System.IterationPath` never contains a team. With no team, `iterations` and `sprint` read `wit/classificationnodes/iterations` and get every dated iteration in the project. `--team` narrows that list to one team's subscriptions and never changes which work items come back. Both commands print which source they used, and `-f json` carries it as a `source` field.
+
+Optional team setup, once per project:
 
 ```bash
 tools azure-devops configure \
-  "https://dev.azure.com/MyOrg/MyProject/_backlogs/backlog/Delivery%20Team%20C/Stories"
+  "https://dev.azure.com/MyOrg/MyProject/_backlogs/backlog/Payments%20Team/Stories"
 ```
 
-The board URL carries the team, and `configure` stores it as `team` in `.claude/azure/config.json`. Without it, pass `--team "<Your Team>"` per run.
+The board URL carries the team, and `configure` stores it as `team` in `.claude/azure/config.json`. You can also pass `--team "<Your Team>"` per run.
 
 ### Output Paths
 
@@ -118,10 +120,10 @@ Inline images (screenshots embedded in description/comments HTML) are downloaded
 ### Fetch Work Items
 
 ```bash
-tools azure-devops workitem 261575
-tools azure-devops workitem 261575,261576,261577
-tools azure-devops workitem 261575 --category react19
-tools azure-devops workitem 261575 --force
+tools azure-devops workitem 12345
+tools azure-devops workitem 12345,12346,12347
+tools azure-devops workitem 12345 --category react19
+tools azure-devops workitem 12345 --force
 ```
 
 ### Fetch Query
@@ -130,7 +132,7 @@ The `--query` option supports three input formats:
 
 1. **Query ID (GUID)**: `d6e14134-9d22-4cbb-b897-b1514f888667`
 2. **Full URL**: `https://dev.azure.com/org/project/_queries/query/abc123`
-3. **Query Name**: `"Otevřené bugy"` (fuzzy matching supported)
+3. **Query Name**: `"Open bugs"` (fuzzy matching supported)
 
 ```bash
 # By ID
@@ -138,7 +140,7 @@ tools azure-devops query d6e14134-9d22-4cbb-b897-b1514f888667
 
 # By name (uses fuzzy matching to find the query)
 tools azure-devops query "Open Bugs"
-tools azure-devops query "Otevřené bugy"
+tools azure-devops query "Open bugs"
 
 # With filters
 tools azure-devops query <id> --state Active,Development
@@ -194,8 +196,8 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
    ```
 
 5. Write `.analysis.md` next to the work item file:
-   - Work item: `.claude/azure/tasks/261575-Title.md`
-   - Analysis: `.claude/azure/tasks/261575-Title.analysis.md`
+   - Work item: `.claude/azure/tasks/12345-Title.md`
+   - Analysis: `.claude/azure/tasks/12345-Title.analysis.md`
 
 ### Analysis Document Format
 
@@ -228,20 +230,20 @@ When user says "analyze workitem/task X" or "analyze tasks from query Y":
 
 | User Request | Action |
 |--------------|--------|
-| "Get workitem 261575" | `tools azure-devops workitem 261575` |
+| "Get workitem 12345" | `tools azure-devops workitem 12345` |
 | "What is in the current sprint" | `tools azure-devops sprint --mine --totals` |
 | "List the sprints" | `tools azure-devops iterations` |
 | "Show sprint 17 in backlog order" | `tools azure-devops sprint "Sprint 17" --mine --order` |
 | "Show query results for X" | `tools azure-devops query X` |
 | "Show Open Bugs query" | `tools azure-devops query "Open Bugs"` |
-| "Fetch Otevřené bugy" | `tools azure-devops query "Otevřené bugy"` |
+| "Fetch Open bugs" | `tools azure-devops query "Open bugs"` |
 | "Download React19 bugs" | `tools azure-devops query "React19 Bugs" --download-workitems --category react19` |
-| "Analyze task 261575" | Fetch → Explore agent → Write .analysis.md |
+| "Analyze task 12345" | Fetch → Explore agent → Write .analysis.md |
 | "Analyze all active bugs" | Fetch query with --download-workitems → Parallel Explore agents → Write .analysis.md files |
 | "Download .har files from task 12345" | `tools azure-devops workitem 12345 --attachments-suffix .har` |
 | "Get attachments from last hour for 12345" | Compute datetime 1h ago, then `tools azure-devops workitem 12345 --attachments-from "2026-02-12T10:00:00"` |
 | "Download all attachments for task 12345" | `tools azure-devops workitem 12345 --attachments-from 2000-01-01` |
-| "Get task 261575 with screenshots" | `tools azure-devops workitem 261575 --task-folders --images` |
+| "Get task 12345 with screenshots" | `tools azure-devops workitem 12345 --task-folders --images` |
 | "Analyze bug with images" | Fetch with `--images` → Read images → Explore agent with visual context |
 
 ## Creating Work Items
@@ -462,7 +464,7 @@ tools azure-devops timelog types --format json  # JSON output
 
 ```bash
 tools azure-devops timelog list -w <workItemId>
-tools azure-devops timelog list -w 268935 --format md
+tools azure-devops timelog list -w 12345 --format md
 tools azure-devops timelog list --from 2026-02-01 --to 2026-02-08 --format json
 tools azure-devops timelog list --from 2026-02-01 --to 2026-02-08 --user @me --format json
 ```
@@ -474,12 +476,12 @@ The `--user @me` resolves to the configured default username. Use `--from`/`--to
 ```bash
 # Quick mode (all options on CLI)
 tools azure-devops timelog add -w <id> -h <hours> -t <type>
-tools azure-devops timelog add -w 268935 -h 2 -t "Development"
-tools azure-devops timelog add -w 268935 -h 1 -m 30 -t "Code Review" -c "PR review"
+tools azure-devops timelog add -w 12345 -h 2 -t "Development"
+tools azure-devops timelog add -w 12345 -h 1 -m 30 -t "Code Review" -c "PR review"
 
 # Interactive mode
 tools azure-devops timelog add -i
-tools azure-devops timelog add -w 268935 -i
+tools azure-devops timelog add -w 12345 -i
 ```
 
 Before creating the entry, the command runs a workitem type precheck (see Workitem Type Validation below).
@@ -491,7 +493,7 @@ The `prepare-import` workflow allows you to stage, review, and validate entries 
 ```bash
 # Stage entries for review
 tools azure-devops timelog prepare-import add --from 2026-02-01 --to 2026-02-08 --entry '{
-  "workItemId": 268935,
+  "workItemId": 12345,
   "date": "2026-02-04",
   "hours": 2,
   "timeType": "Development",
@@ -519,7 +521,7 @@ tools azure-devops timelog prepare-import clear --name 2026-02-01.2026-02-08
 
 The name is auto-generated from `--from` and `--to` as `<from>.<to>` (e.g., `2026-02-01.2026-02-08`). Each entry is validated with Zod schema and runs workitem type precheck before being added.
 
-Do **not** include `workItemTitle` in staged `--entry` JSON unless you already have the exact ADO title. Precheck backfills it on `prepare-import add`; `prepare-import list` and `import --dry-run` fill any still-missing titles. Run from the project directory that has `.claude/azure/config.json` (e.g. `col-fe/`).
+Do **not** include `workItemTitle` in staged `--entry` JSON unless you already have the exact ADO title. Precheck backfills it on `prepare-import add`; `prepare-import list` and `import --dry-run` fill any still-missing titles. Run from the project directory that has `.claude/azure/config.json` (e.g. `web-app/`).
 
 ### Import Time Logs
 
@@ -562,9 +564,9 @@ Before creating time log entries, the tool validates that the workitem type is c
 
 | User Request | Action |
 |--------------|--------|
-| "Log 2 hours on task 268935" | `tools azure-devops timelog add -w 268935 -h 2 -t "Development"` |
+| "Log 2 hours on task 12345" | `tools azure-devops timelog add -w 12345 -h 2 -t "Development"` |
 | "What time types are available?" | `tools azure-devops timelog types` |
-| "Show time logged on 268935" | `tools azure-devops timelog list -w 268935` |
+| "Show time logged on 12345" | `tools azure-devops timelog list -w 12345` |
 | "Help me log time" | `tools azure-devops timelog add -i` |
 | "Stage entries for review" | `tools azure-devops timelog prepare-import add --from ... --to ... --entry '{...}'` |
 | "Review staged entries" | `tools azure-devops timelog prepare-import list --name 2026-02-01.2026-02-08` |
@@ -582,9 +584,9 @@ When user asks to log time in natural language, parse their request and construc
 - "2 hours 15 minutes" → `-h 2 -m 15`
 
 **2. Extract Work Item IDs:**
-- From explicit mention: "on task 268935", "workitem #268935", "WI 268935"
-- From git branch: `feature/268935-fix-login` → work item 268935
-- From recent commits: `feat(#268935): fix login bug` → work item 268935
+- From explicit mention: "on task 12345", "workitem #12345", "WI 12345"
+- From git branch: `feature/12345-fix-login` → work item 12345
+- From recent commits: `feat(#12345): fix login bug` → work item 12345
 
 To extract from git context:
 ```bash
@@ -623,7 +625,7 @@ Use the commit subject line as the time log comment.
 
 | User Request | Parsed Command |
 |--------------|----------------|
-| "log 1h on 268935 for Development" | `timelog add -w 268935 -h 1 -t "Development"` |
+| "log 1h on 12345 for Development" | `timelog add -w 12345 -h 1 -t "Development"` |
 | "spent 30min reviewing PR on task 789" | `timelog add -w 789 -h 0 -m 30 -t "Code Review"` |
 | "log 2 hours, use last commit message" | Get work item from branch/commit, use commit msg as comment |
 | "log my work on the current task" | Extract ID from branch, infer type from commits |
@@ -635,9 +637,9 @@ When user says "log time for my work" without explicit details:
 
 1. **Get work item ID**:
    ```bash
-   git branch --show-current  # e.g., feature/268935-fix-login
+   git branch --show-current  # e.g., feature/12345-fix-login
    ```
-   Extract number: 268935
+   Extract number: 12345
 
 2. **Get commit messages for note**:
    ```bash
@@ -650,7 +652,7 @@ When user says "log time for my work" without explicit details:
 
 5. **Execute**:
    ```bash
-   tools azure-devops timelog add -w 268935 -h <hours> -t "<inferred-type>" -c "<commit-message>"
+   tools azure-devops timelog add -w 12345 -h <hours> -t "<inferred-type>" -c "<commit-message>"
    ```
 
 ## Integration with `tools git`

--- a/src/azure-devops/README.md
+++ b/src/azure-devops/README.md
@@ -15,21 +15,19 @@ CLI tool for fetching, tracking, and managing Azure DevOps work items, queries, 
 -   ✅ **Batch Operations**: Fetch multiple work items or download all items from a query
 -   ✅ **Filtering**: Filter queries by state and severity
 -   ✅ **Multiple Output Formats**: AI-optimized, Markdown, or JSON output
--   ✅ **Sprint Backlog**: List a team's iterations and the work items of one sprint, with the effort columns the ADO Backlog tab shows
+-   ✅ **Sprint Backlog**: List the project's iterations and the work items of one sprint, with the effort columns the ADO Backlog tab shows
 
 ## Sprint / iteration commands
 
-`iterations` lists a team's sprints. `sprint` lists the work items of one of them. Together they replace the manual screenshot of the ADO Backlog tab.
+`iterations` lists the project's sprints. `sprint` lists the work items of one of them. Together they replace the manual screenshot of the ADO Backlog tab.
 
-Both commands are team-scoped, because iteration settings belong to a team, not to the project. Set the team once with `configure` using a board or backlog URL, or pass `--team` per run.
+**Neither command needs a team.** `--team` is an optional narrowing filter, never a precondition. See "No team required" below for why.
 
 ```bash
-# Store the team in .claude/azure/config.json (the URL carries it)
-tools azure-devops configure \
-  "https://dev.azure.com/MyOrg/MyProject/_backlogs/backlog/{team}/Stories"
-
-# List the team's sprints; the one containing today is marked
+# List the project's sprints; the one containing today is marked
 tools azure-devops iterations
+
+# Narrow to the iterations one team subscribes to
 tools azure-devops iterations --team "Payments Team" -f json
 
 # The current sprint, everything assigned to me, with the Task-only effort sums
@@ -43,17 +41,63 @@ tools azure-devops sprint "Widgets\Sprint 17"
 tools azure-devops sprint "Sprint 17" --mine --order -f md
 ```
 
-Worked example, `Sprint 17` with `--mine --totals`:
+Worked example, `Sprint 17` with `--mine --totals` and no team configured:
 
-```
-│ ID     │ TYPE       │ TITLE                    │ STATE       │ ASSIGNED  │ DONE │ LEFT │
-│ 41207  │ Task       │ Build the checkout form  │ New         │ ...       │ 0    │ 4    │
-│ 41219  │ Task       │ Wire the payments API    │ In Progress │ ...       │ 85   │ 56   │
+```text
+  Sprint 17
+  Widgets\Sprint 17  ·  source: project classification nodes (26 iterations)
+
+│ ID    │ TYPE  │ TITLE                     │ STATE       │ ASSIGNED    │ DONE │ LEFT │
+│ 10005 │ Task  │ Build the payment form    │ New         │ Jane Doe    │ 0    │ 4    │
+│ 10007 │ Task  │ Wire the refund endpoint  │ In Progress │ Jane Doe    │ 85   │ 56   │
 
   Totals
   Items: 17 (Tasks: 9)
   Task CompletedWork: 139.75 h
   Task RemainingWork: 88 h
+```
+
+### No team required
+
+Iterations are **project-level classification nodes**. A team does not own them; it merely subscribes to a subset of them. `System.IterationPath` never contains a team segment, so the work items a sprint contains do not depend on which team you ask through.
+
+The commands therefore read from one of two sources:
+
+| When | Endpoint | Returns |
+| ---- | -------- | ------- |
+| Team known (`--team` or `config.team`) | `GET {org}/{project}/{team}/_apis/work/teamsettings/iterations` | only that team's subscribed iterations |
+| No team at all | `GET {org}/{project}/_apis/wit/classificationnodes/iterations?$depth=3` | every dated iteration in the project |
+
+The project-wide list is a superset, so it can contain iterations the team list does not. Which source was used is always printed, and `-f json` carries it as a `source` field, so the row-count difference is never a silent surprise:
+
+```
+source: team "Payments Team" (22 iterations)
+source: project classification nodes (26 iterations)
+```
+
+The two sources resolve the same sprint to the same `System.IterationPath`, so the work items returned are identical either way.
+
+**Path normalisation.** Classification nodes report a structural path that `System.IterationPath` does not use. It carries a leading backslash and an extra `Iteration` segment:
+
+```
+\Widgets\Iteration\Sprint 17     classification node path
+Widgets\Sprint 17                System.IterationPath, which is what WIQL needs
+```
+
+Strip one leading backslash, then remove the `\Iteration` segment. Nested release folders survive: `\Widgets\Iteration\Release 3\Sprint 17` becomes `Widgets\Release 3\Sprint 17`. Nodes with no start date are structural containers rather than sprints and are dropped.
+
+Worked no-team example:
+
+```bash
+$ tools azure-devops iterations
+  Iterations
+  project classification nodes (26 iterations)
+  ...
+  Current
+  * Sprint 17  (2026-08-20 -> 2026-09-02)
+
+$ tools azure-devops sprint --mine --totals
+  # resolves Sprint 17 by date range, queries [System.IterationPath] = 'Widgets\Sprint 17'
 ```
 
 ### Iteration resolution
@@ -75,20 +119,15 @@ A substring that matches several iterations is refused: the command lists every 
 -   Without a team context Azure DevOps answers `VS402612: The macro '@CurrentIteration' is not supported without a team context` and the request fails with HTTP 500.
 -   Even when it resolves, the CLI cannot tell which iteration the server picked, so the output cannot be checked.
 
-These commands therefore resolve the iteration first, through `GET {org}/{project}/{team}/_apis/work/teamsettings/iterations`, and then send an explicit `[System.IterationPath] = '<path>'` predicate. Single quotes in the path are doubled; backslashes are literal in WIQL and need no escaping.
+These commands therefore resolve the iteration first, from whichever source the "No team required" section describes, and then send an explicit `[System.IterationPath] = '<path>'` predicate. Single quotes in the path are doubled; backslashes are literal in WIQL and need no escaping.
 
-The two saved queries that look like they would do this job cannot be run from the CLI at all:
-
--   `Shared Queries/FE Tasky aktuálního sprintu` (`dbfe2de1-abb1-48ca-80ce-cefd42e11917`)
--   `Shared Queries/Vyhodnocování/Team A/MF - Not Closed` (`7a4cbaea-0c7a-460a-a82f-ce2d97ad9d1a`)
-
-Both return `VS402612`, project-scoped and team-scoped alike, because their stored WIQL calls `@currentIteration` with a team that no longer exists. Adding a team route segment does not fix them. Use `sprint` instead.
+A saved query whose stored WIQL calls `@currentIteration` cannot be run from the CLI either. Such a query returns `VS402612` both project-scoped and team-scoped whenever the team it was authored against no longer exists, and adding a team route segment does not fix it. Use `sprint` instead.
 
 ### Sprint options
 
 | Option                 | Description                                                                      | Default |
 | ---------------------- | -------------------------------------------------------------------------------- | ------- |
-| `--team <name>`        | Team name; overrides `config.team`. Also accepted before the subcommand.          | config  |
+| `--team <name>`        | Optional. Narrows the iteration list to one team's subscriptions. Also accepted before the subcommand. | config  |
 | `--mine`               | Only items assigned to me (WIQL `@Me`)                                            | -       |
 | `--assigned-to <name>` | Only items assigned to this display name or unique name                           | -       |
 | `--totals`             | Print the Task-only CompletedWork / RemainingWork sums                            | -       |
@@ -99,7 +138,9 @@ Both return `VS402612`, project-scoped and team-scoped alike, because their stor
 
 `--order` sorts by `Microsoft.VSTS.Common.StackRank`, falling back to `Microsoft.VSTS.Common.BacklogPriority`. Only backlog-level types carry a rank, so Tasks usually have none. Unranked rows sort last by ascending id, which is deterministic across runs.
 
-`-f json` emits one object per row with the keys `id`, `type`, `title`, `state`, `assignedTo`, `completedWork`, `remainingWork`, `order`, `changedDate`. `completedWork` and `remainingWork` are always numbers; a missing field reads as `0`. `order` is `null` when the item is unranked. Adding `--totals` wraps the array as `{ iteration, items, totals }`.
+`-f json` emits `{ iteration, source, items }`, where `items` holds one object per row with the keys `id`, `type`, `title`, `state`, `assignedTo`, `completedWork`, `remainingWork`, `order`, `changedDate`. `completedWork` and `remainingWork` are always numbers; a missing field reads as `0`. `order` is `null` when the item is unranked. Adding `--totals` adds a `totals` key. `source` names the iteration list the sprint was resolved from: `{ kind: "team" | "project", team, count, label }`.
+
+`tools azure-devops iterations -f json` emits `{ source, iterations }` with the same `source` shape.
 
 ## CLI Usage
 
@@ -174,7 +215,7 @@ tools azure-devops --create --type Bug --title "Error in checkout" --severity "A
 | `--dashboard`  | Extract queries from a dashboard               |
 | `--list`       | List all cached work items                     |
 | `--create`     | Create new work items (interactive or from template) |
-| `iterations`   | List the team's sprints (alias `sprints`)      |
+| `iterations`   | List the project's sprints (alias `sprints`)      |
 | `sprint`       | List the work items of one sprint              |
 
 ### Options
@@ -701,17 +742,17 @@ tools azure-devops timelog types
 tools azure-devops timelog types --format json
 
 # List time logs for a work item
-tools azure-devops timelog list -w 268935
-tools azure-devops timelog list -w 268935 --format md
+tools azure-devops timelog list -w 12345
+tools azure-devops timelog list -w 12345 --format md
 
 # Add time log entry (quick)
-tools azure-devops timelog add -w 268935 -h 2 -t "Development"
-tools azure-devops timelog add -w 268935 -h 1 -m 30 -t "Code Review" -c "PR review"
-tools azure-devops timelog add -w 268935 -h 0 -m 30 -t "Test"
+tools azure-devops timelog add -w 12345 -h 2 -t "Development"
+tools azure-devops timelog add -w 12345 -h 1 -m 30 -t "Code Review" -c "PR review"
+tools azure-devops timelog add -w 12345 -h 0 -m 30 -t "Test"
 
 # Add time log entry (interactive)
 tools azure-devops timelog add -i
-tools azure-devops timelog add -w 268935 -i
+tools azure-devops timelog add -w 12345 -i
 
 # Bulk import from JSON file
 tools azure-devops timelog import entries.json
@@ -724,14 +765,14 @@ tools azure-devops timelog import entries.json --dry-run
 {
   "entries": [
     {
-      "workItemId": 268935,
+      "workItemId": 12345,
       "hours": 2,
       "timeType": "Development",
       "date": "2026-02-04",
       "comment": "Implemented feature X"
     },
     {
-      "workItemId": 268936,
+      "workItemId": 12346,
       "hours": 1,
       "minutes": 30,
       "timeType": "Code Review",

--- a/src/azure-devops/api.ts
+++ b/src/azure-devops/api.ts
@@ -11,6 +11,7 @@ import type {
     DashboardDetailResponse,
     DashboardsListResponse,
     GetWorkItemsOptions,
+    IterationClassificationNode,
     QueryNode,
     TeamIteration,
     TeamIterationsResponse,
@@ -19,6 +20,7 @@ import type {
 } from "@app/azure-devops/api.types";
 import { loadTeamMembersCache, saveTeamMembersCache } from "@app/azure-devops/cache";
 import { AzAuthError, extractAzLoginSuggestion } from "@app/azure-devops/cli.utils";
+import { flattenIterationNodes } from "@app/azure-devops/lib/iterations";
 import type {
     AzureConfig,
     AzWorkItemRaw,
@@ -838,6 +840,21 @@ export class Api {
         const data = await this.get<TeamIterationsResponse>(url, `iterations for team "${team}"`);
         logger.debug(`[api] Team "${team}" has ${data.value?.length ?? 0} iterations`);
         return data.value ?? [];
+    }
+
+    /**
+     * Every dated iteration of the project, with no team involved.
+     *
+     * Iterations are project-level classification nodes; a team merely subscribes
+     * to a subset of them. This endpoint therefore returns a superset of what
+     * `getTeamIterations()` returns, which is what makes `--team` optional.
+     */
+    async getProjectIterations(): Promise<TeamIteration[]> {
+        const url = Api.witUrl(this.config, ["classificationnodes", "iterations"], { $depth: "3" });
+        const root = await this.get<IterationClassificationNode>(url, "project iteration classification nodes");
+        const iterations = flattenIterationNodes(root);
+        logger.debug(`[api] Project "${this.config.project}" has ${iterations.length} dated iterations`);
+        return iterations;
     }
 
     /**

--- a/src/azure-devops/api.ts
+++ b/src/azure-devops/api.ts
@@ -20,7 +20,7 @@ import type {
 } from "@app/azure-devops/api.types";
 import { loadTeamMembersCache, saveTeamMembersCache } from "@app/azure-devops/cache";
 import { AzAuthError, extractAzLoginSuggestion } from "@app/azure-devops/cli.utils";
-import { flattenIterationNodes } from "@app/azure-devops/lib/iterations";
+import { findTruncatedNodes, flattenIterationNodes } from "@app/azure-devops/lib/iterations";
 import type {
     AzureConfig,
     AzWorkItemRaw,
@@ -843,6 +843,14 @@ export class Api {
     }
 
     /**
+     * How far `classificationnodes` is asked to walk. Deep enough for
+     * `Project > Year > Release > Sprint` style hierarchies with headroom;
+     * anything past it is reported by findTruncatedNodes() rather than dropped
+     * without a word.
+     */
+    private static readonly ITERATION_NODE_DEPTH = 10;
+
+    /**
      * Every dated iteration of the project, with no team involved.
      *
      * Iterations are project-level classification nodes; a team merely subscribes
@@ -850,8 +858,20 @@ export class Api {
      * `getTeamIterations()` returns, which is what makes `--team` optional.
      */
     async getProjectIterations(): Promise<TeamIteration[]> {
-        const url = Api.witUrl(this.config, ["classificationnodes", "iterations"], { $depth: "3" });
+        // Depth 3 covered the common `Project > Release > Sprint` shape and
+        // silently dropped anything nested deeper, which the caller could not
+        // tell apart from "that sprint does not exist" (review t1).
+        const url = Api.witUrl(this.config, ["classificationnodes", "iterations"], {
+            $depth: String(Api.ITERATION_NODE_DEPTH),
+        });
         const root = await this.get<IterationClassificationNode>(url, "project iteration classification nodes");
+        const truncated = findTruncatedNodes(root);
+        if (truncated.length > 0) {
+            logger.warn(
+                `[api] iteration tree truncated at depth ${Api.ITERATION_NODE_DEPTH}; ${truncated.length} node(s) have unlisted children, first: ${truncated[0]}`
+            );
+        }
+
         const iterations = flattenIterationNodes(root);
         logger.debug(`[api] Project "${this.config.project}" has ${iterations.length} dated iterations`);
         return iterations;

--- a/src/azure-devops/api.types.ts
+++ b/src/azure-devops/api.types.ts
@@ -96,3 +96,22 @@ export interface QueryNode {
     hasChildren?: boolean;
     children?: QueryNode[];
 }
+
+/**
+ * One node of the project's iteration classification tree, as returned by
+ * `wit/classificationnodes/iterations`. Only leaf-ish nodes carry dates.
+ */
+export interface IterationClassificationNode {
+    id: number;
+    identifier: string;
+    name: string;
+    /** Structural path, e.g. `\Widgets\Iteration\Sprint 17` (note the `Iteration` segment). */
+    path: string;
+    structureType?: string;
+    hasChildren?: boolean;
+    attributes?: {
+        startDate?: string | null;
+        finishDate?: string | null;
+    };
+    children?: IterationClassificationNode[];
+}

--- a/src/azure-devops/commands/sprint.ts
+++ b/src/azure-devops/commands/sprint.ts
@@ -458,7 +458,7 @@ export function registerSprintCommands(program: Command): void {
     program
         .command("iterations")
         .alias("sprints")
-        .description("List the team's iterations (sprints) with dates and the current one marked")
+        .description("List the project's iterations (sprints) with dates and the current one marked")
         .option("-f, --format <format>", "Output format: ai, md, json", "ai")
         .option("--team <name>", "Optional: narrow to one team's subscribed iterations (overrides config.team)")
         .action(async (_opts: RawSprintOptions, command: Command) => {

--- a/src/azure-devops/commands/sprint.ts
+++ b/src/azure-devops/commands/sprint.ts
@@ -295,7 +295,7 @@ interface SprintRenderArgs {
     sourceLabel: string;
 }
 
-function renderSprintMd({ rows, iteration, withOrder }: SprintRenderArgs): string {
+function renderSprintMd({ rows, iteration, withOrder, sourceLabel }: SprintRenderArgs): string {
     const header = ["ID", "Type", "Title", "State", "AssignedTo", "CompletedWork", "RemainingWork"];
 
     if (withOrder) {

--- a/src/azure-devops/commands/sprint.ts
+++ b/src/azure-devops/commands/sprint.ts
@@ -1,19 +1,29 @@
 /**
  * Azure DevOps CLI - Sprint / iteration commands.
  *
- * `iterations` lists a team's sprints. `sprint` lists the work items of one of
- * them, with the effort columns the ADO Backlog tab shows.
+ * `iterations` lists the project's sprints. `sprint` lists the work items of one
+ * of them, with the effort columns the ADO Backlog tab shows.
+ *
+ * `--team` is optional. Iterations are project-level classification nodes and a
+ * team only subscribes to a subset of them, so a team narrows the list without
+ * ever changing which work items come back. With no team these commands read
+ * the project's classification nodes instead of failing.
  *
  * The queries never use `@CurrentIteration`. That macro needs a team context,
  * fails with `VS402612` when none is available, and hides which iteration the
- * server picked even when it works. We resolve the iteration from the team
- * settings endpoint and put an explicit `[System.IterationPath]` predicate in
- * the WIQL instead.
+ * server picked even when it works. We resolve the iteration ourselves and put
+ * an explicit `[System.IterationPath]` predicate in the WIQL instead.
  */
 
 import { Api } from "@app/azure-devops/api";
 import type { TeamIteration } from "@app/azure-devops/api.types";
-import { findCurrentIteration, iterationContainsDate, resolveIteration } from "@app/azure-devops/lib/iterations";
+import {
+    describeIterationSource,
+    findCurrentIteration,
+    type IterationSource,
+    iterationContainsDate,
+    resolveIteration,
+} from "@app/azure-devops/lib/iterations";
 import {
     buildSprintWiql,
     mapSprintRow,
@@ -23,7 +33,7 @@ import {
     sortById,
     sumTaskEffort,
 } from "@app/azure-devops/lib/sprint";
-import { NO_TEAM_MESSAGE, resolveTeam } from "@app/azure-devops/lib/team";
+import { resolveTeam } from "@app/azure-devops/lib/team";
 import type { AzureConfig, OutputFormat } from "@app/azure-devops/types";
 import { requireConfig } from "@app/azure-devops/utils";
 import { SafeJSON } from "@genesiscz/utils/json";
@@ -61,17 +71,35 @@ function parseFormat(raw: string | undefined): OutputFormat {
     process.exit(1);
 }
 
-/** Resolve the team, or exit naming both ways to set it. */
-function requireTeam(config: AzureConfig, explicit?: string): string {
+/** The team narrows the iteration list when it is set. Absent is normal, not an error. */
+function optionalTeam(config: AzureConfig, explicit?: string): string | null {
     const resolved = resolveTeam(config, explicit);
 
     if (!resolved) {
-        out.error(NO_TEAM_MESSAGE);
-        process.exit(1);
+        logger.debug("[sprint] No team set; reading the project's iteration classification nodes");
+        return null;
     }
 
     logger.debug(`[sprint] Using team "${resolved.team}" (source: ${resolved.source})`);
     return resolved.team;
+}
+
+/**
+ * Team-subscribed iterations when a team is known, the project's classification
+ * nodes otherwise. The source travels with the list so the row-count difference
+ * between the two is never a silent surprise.
+ */
+async function loadIterations(
+    api: Api,
+    team: string | null
+): Promise<{ iterations: TeamIteration[]; source: IterationSource }> {
+    if (team) {
+        const iterations = await api.getTeamIterations(team);
+        return { iterations, source: { kind: "team", team, count: iterations.length } };
+    }
+
+    const iterations = await api.getProjectIterations();
+    return { iterations, source: { kind: "project", team: null, count: iterations.length } };
 }
 
 function formatDate(iso: string | null | undefined): string {
@@ -100,12 +128,13 @@ function mdRow(cells: string[]): string {
 
 async function handleIterations(options: IterationsOptions): Promise<void> {
     const config = requireConfig();
-    const team = requireTeam(config, options.team);
+    const team = optionalTeam(config, options.team);
     const api = new Api(config);
-    const iterations = await api.getTeamIterations(team);
+    const { iterations, source } = await loadIterations(api, team);
+    const sourceLabel = describeIterationSource(source);
 
     if (iterations.length === 0) {
-        out.error(`Team "${team}" has no iterations configured.`);
+        out.error(`No iterations found: ${sourceLabel}.`);
         process.exit(1);
     }
 
@@ -115,14 +144,17 @@ async function handleIterations(options: IterationsOptions): Promise<void> {
     if (options.format === "json") {
         out.result(
             SafeJSON.stringify(
-                iterations.map((it) => ({
-                    id: it.id,
-                    name: it.name,
-                    path: it.path,
-                    startDate: it.attributes?.startDate ?? null,
-                    finishDate: it.attributes?.finishDate ?? null,
-                    isCurrent: iterationContainsDate(it, now),
-                })),
+                {
+                    source: { ...source, label: sourceLabel },
+                    iterations: iterations.map((it) => ({
+                        id: it.id,
+                        name: it.name,
+                        path: it.path,
+                        startDate: it.attributes?.startDate ?? null,
+                        finishDate: it.attributes?.finishDate ?? null,
+                        isCurrent: iterationContainsDate(it, now),
+                    })),
+                },
                 null,
                 2
             )
@@ -132,7 +164,9 @@ async function handleIterations(options: IterationsOptions): Promise<void> {
 
     if (options.format === "md") {
         const lines = [
-            `# Iterations - ${escapeMd(team)}`,
+            "# Iterations",
+            "",
+            `Source: ${escapeMd(sourceLabel)}`,
             "",
             mdRow(["Current", "Name", "Path", "Start", "Finish"]),
             mdRow(["---", "---", "---", "---", "---"]),
@@ -150,7 +184,7 @@ async function handleIterations(options: IterationsOptions): Promise<void> {
         return;
     }
 
-    renderCliHeader("Iterations", `team ${team}`);
+    renderCliHeader("Iterations", sourceLabel);
     const table = createBoxTable(["", "NAME", "PATH", "START", "FINISH"]);
 
     for (const it of iterations) {
@@ -188,13 +222,18 @@ function exitAmbiguous(query: string, candidates: TeamIteration[]): never {
     process.exit(1);
 }
 
-async function resolveSprintIteration(api: Api, team: string, nameOrPath: string | undefined): Promise<TeamIteration> {
-    const iterations = await api.getTeamIterations(team);
+async function resolveSprintIteration(
+    api: Api,
+    team: string | null,
+    nameOrPath: string | undefined
+): Promise<{ iteration: TeamIteration; source: IterationSource }> {
+    const { iterations, source } = await loadIterations(api, team);
+    const sourceLabel = describeIterationSource(source);
     const resolution = resolveIteration(iterations, nameOrPath, new Date());
 
     if (resolution.kind === "resolved") {
         logger.debug(`[sprint] Resolved iteration "${resolution.iteration.path}" by ${resolution.matchedBy}`);
-        return resolution.iteration;
+        return { iteration: resolution.iteration, source };
     }
 
     if (resolution.kind === "ambiguous") {
@@ -203,13 +242,13 @@ async function resolveSprintIteration(api: Api, team: string, nameOrPath: string
 
     if (resolution.kind === "no-current") {
         out.error(
-            `No iteration of team "${team}" contains today. Name one explicitly, for example: tools azure-devops sprint "17. Sprint"`
+            `No iteration in ${sourceLabel} contains today. Name one explicitly, for example: tools azure-devops sprint "Sprint 17"`
         );
         process.exit(1);
     }
 
     out.error(
-        `No iteration of team "${team}" matches "${resolution.query}". List them with: tools azure-devops iterations --team "${team}"`
+        `No iteration in ${sourceLabel} matches "${resolution.query}". List them with: tools azure-devops iterations`
     );
     process.exit(1);
 }
@@ -248,11 +287,12 @@ function toJsonItems(rows: SprintRow[]): Array<Record<string, unknown>> {
     }));
 }
 
-/** Both renderers take the same three, and `withOrder` is unreadable positionally. */
+/** Both renderers take the same four, and the two trailing values are unreadable positionally. */
 interface SprintRenderArgs {
     rows: SprintRow[];
     iteration: TeamIteration;
     withOrder: boolean;
+    sourceLabel: string;
 }
 
 function renderSprintMd({ rows, iteration, withOrder }: SprintRenderArgs): string {
@@ -287,6 +327,7 @@ function renderSprintMd({ rows, iteration, withOrder }: SprintRenderArgs): strin
         `# ${escapeMd(iteration.name)}`,
         "",
         `Iteration path: \`${iteration.path}\``,
+        `Source: ${escapeMd(sourceLabel)}`,
         "",
         mdRow(header),
         mdRow(header.map(() => "---")),
@@ -294,8 +335,8 @@ function renderSprintMd({ rows, iteration, withOrder }: SprintRenderArgs): strin
     ].join("\n");
 }
 
-function renderSprintTable({ rows, iteration, withOrder }: SprintRenderArgs): void {
-    renderCliHeader(iteration.name, iteration.path);
+function renderSprintTable({ rows, iteration, withOrder, sourceLabel }: SprintRenderArgs): void {
+    renderCliHeader(iteration.name, `${iteration.path}  ·  source: ${sourceLabel}`);
 
     const headers = ["ID", "TYPE", "TITLE", "STATE", "ASSIGNED", "DONE", "LEFT"];
 
@@ -334,29 +375,32 @@ async function handleSprint(nameOrPath: string | undefined, options: SprintOptio
     }
 
     const config = requireConfig();
-    const team = requireTeam(config, options.team);
+    const team = optionalTeam(config, options.team);
     const assignedTo = options.mine ? "@Me" : options.assignedTo;
     const api = new Api(config);
-    const iteration = await resolveSprintIteration(api, team, nameOrPath);
+    const { iteration, source } = await resolveSprintIteration(api, team, nameOrPath);
+    const sourceLabel = describeIterationSource(source);
     const fetched = await fetchSprintRows(api, iteration, assignedTo);
     const withOrder = options.order ?? false;
     const rows = withOrder ? sortByBacklogOrder(fetched) : sortById(fetched);
     const totals = sumTaskEffort(rows);
 
     if (options.format === "json") {
-        const items = toJsonItems(rows);
-        const payload = options.totals
-            ? {
-                  iteration: { name: iteration.name, path: iteration.path },
-                  items,
-                  totals: {
-                      itemCount: totals.itemCount,
-                      taskCount: totals.taskCount,
-                      taskCompletedWork: totals.completedWork,
-                      taskRemainingWork: totals.remainingWork,
-                  },
-              }
-            : items;
+        const payload = {
+            iteration: { name: iteration.name, path: iteration.path },
+            source: { ...source, label: sourceLabel },
+            items: toJsonItems(rows),
+            ...(options.totals
+                ? {
+                      totals: {
+                          itemCount: totals.itemCount,
+                          taskCount: totals.taskCount,
+                          taskCompletedWork: totals.completedWork,
+                          taskRemainingWork: totals.remainingWork,
+                      },
+                  }
+                : {}),
+        };
         out.result(SafeJSON.stringify(payload, null, 2));
         return;
     }
@@ -369,7 +413,7 @@ async function handleSprint(nameOrPath: string | undefined, options: SprintOptio
     ];
 
     if (options.format === "md") {
-        const md = renderSprintMd({ rows, iteration, withOrder });
+        const md = renderSprintMd({ rows, iteration, withOrder, sourceLabel });
         const withTotals = options.totals
             ? `${md}\n\n## Totals\n\n${totalsLines.map((line) => `- ${line}`).join("\n")}`
             : md;
@@ -377,7 +421,7 @@ async function handleSprint(nameOrPath: string | undefined, options: SprintOptio
         return;
     }
 
-    renderSprintTable({ rows, iteration, withOrder });
+    renderSprintTable({ rows, iteration, withOrder, sourceLabel });
 
     if (options.totals) {
         renderCliSection("Totals");
@@ -416,7 +460,7 @@ export function registerSprintCommands(program: Command): void {
         .alias("sprints")
         .description("List the team's iterations (sprints) with dates and the current one marked")
         .option("-f, --format <format>", "Output format: ai, md, json", "ai")
-        .option("--team <name>", "Team name (overrides the global --team and config.team)")
+        .option("--team <name>", "Optional: narrow to one team's subscribed iterations (overrides config.team)")
         .action(async (_opts: RawSprintOptions, command: Command) => {
             const opts = optionsWithGlobalTeam(command);
             await handleIterations({ format: parseFormat(opts.format), team: opts.team });
@@ -426,7 +470,7 @@ export function registerSprintCommands(program: Command): void {
         .command("sprint [nameOrPath]")
         .description("List the work items of one iteration (defaults to the iteration containing today)")
         .option("-f, --format <format>", "Output format: ai, md, json", "ai")
-        .option("--team <name>", "Team name (overrides the global --team and config.team)")
+        .option("--team <name>", "Optional: narrow to one team's subscribed iterations (overrides config.team)")
         .option("--mine", "Only work items assigned to me (@Me)")
         .option("--assigned-to <name>", "Only work items assigned to this display name or unique name")
         .option("--totals", "Print the Task-only CompletedWork / RemainingWork sums")

--- a/src/azure-devops/index.ts
+++ b/src/azure-devops/index.ts
@@ -52,7 +52,7 @@ program
     .version("1.0.0")
     .showHelpAfterError(true)
     .option("-v, --verbose", "Enable verbose debug logging")
-    .option("--team <name>", "Azure DevOps team name for team-scoped commands (overrides config.team)")
+    .option("--team <name>", "Optional Azure DevOps team name; narrows team-scoped lists (overrides config.team)")
     .option("-?, --help-full", "Show detailed help with examples")
     .on("option:help-full", () => {
         showHelpFull();
@@ -86,11 +86,11 @@ Commands:
   workitem-create        Create a new work item (interactive or from template)
   timelog                Manage time log entries (add, list, delete, types, import)
   history                Work item history commands (show, search, sync)
-  iterations             List the team's sprints (alias: sprints)
+  iterations             List the project's sprints (alias: sprints)
   sprint [nameOrPath]    List the work items of one sprint
 
 Global Options:
-  --team <name>          Team for team-scoped commands (overrides config.team)
+  --team <name>          Optional team; narrows team-scoped lists (overrides config.team)
 
 Sprint Options:
   -f, --format <fmt>     ai | md | json (default: ai)
@@ -176,13 +176,13 @@ Examples:
   tools azure-devops workitem-create --type Task --title "Fix login bug"
 
   # Time logging
-  tools azure-devops timelog add --workitem 268935 --hours 2 --type "Development"
-  tools azure-devops timelog list --workitem 268935
+  tools azure-devops timelog add --workitem 12345 --hours 2 --type "Development"
+  tools azure-devops timelog list --workitem 12345
   tools azure-devops timelog delete <timeLogId> --yes
   tools azure-devops timelog types
 
 Sprint Commands:
-  tools azure-devops iterations                          List the team's sprints
+  tools azure-devops iterations                          List the project's sprints
   tools azure-devops sprint --mine --totals               Current sprint, my items, effort sums
   tools azure-devops sprint "Sprint 17" --order   One sprint in Backlog order
   # These never use @CurrentIteration: that macro needs a team context and

--- a/src/azure-devops/lib/iterations.test.ts
+++ b/src/azure-devops/lib/iterations.test.ts
@@ -276,6 +276,53 @@ describe("describeIterationSource", () => {
  * walks `$depth` levels, so sprints nested deeper were absent from every
  * result with nothing saying so.
  */
+describe("flattenIterationNodes edge shapes", () => {
+    let edgeId = 100;
+    const node = (name: string, extra: Partial<IterationClassificationNode> = {}): IterationClassificationNode => ({
+        id: edgeId++,
+        identifier: name,
+        name,
+        path: `\\Widgets\\Iteration\\${name}`,
+        ...extra,
+    });
+
+    /**
+     * PR #334 review t1. Both shapes come back from the real API: a container
+     * node carries no dates, and a leaf reached at the depth limit can arrive
+     * with `children: []` rather than the key being absent.
+     */
+    test("a node with no attributes is a container, not an iteration", () => {
+        expect(flattenIterationNodes(node("Widgets", { children: [node("FY26")] }))).toEqual([]);
+    });
+
+    test("an explicitly empty children array terminates the walk", () => {
+        const root = node("Widgets", {
+            children: [node("Q3 Sprint 5", { attributes: { startDate: "2026-08-20" }, children: [] })],
+        });
+
+        expect(flattenIterationNodes(root)).toHaveLength(1);
+        expect(flattenIterationNodes(root)[0]?.name).toBe("Q3 Sprint 5");
+    });
+
+    test("a dated node with no finishDate keeps a null rather than dropping the field", () => {
+        const root = node("Q3 Sprint 5", { attributes: { startDate: "2026-08-20" } });
+
+        expect(flattenIterationNodes(root)[0]?.attributes).toEqual({
+            startDate: "2026-08-20",
+            finishDate: null,
+        });
+    });
+
+    test("a dated container yields itself and its dated children", () => {
+        const root = node("FY26", {
+            attributes: { startDate: "2026-07-01", finishDate: "2027-06-30" },
+            children: [node("Q3 Sprint 5", { attributes: { startDate: "2026-08-20", finishDate: "2026-09-02" } })],
+        });
+
+        expect(flattenIterationNodes(root).map((i) => i.name)).toEqual(["FY26", "Q3 Sprint 5"]);
+    });
+});
+
 describe("findTruncatedNodes", () => {
     let nextId = 1;
     const node = (name: string, extra: Partial<IterationClassificationNode> = {}): IterationClassificationNode => ({

--- a/src/azure-devops/lib/iterations.test.ts
+++ b/src/azure-devops/lib/iterations.test.ts
@@ -3,6 +3,7 @@ import type { IterationClassificationNode, TeamIteration } from "@app/azure-devo
 import {
     describeIterationSource,
     findCurrentIteration,
+    findTruncatedNodes,
     flattenIterationNodes,
     iterationContainsDate,
     resolveIteration,
@@ -267,5 +268,43 @@ describe("describeIterationSource", () => {
         expect(describeIterationSource({ kind: "project", team: null, count: 26 })).toBe(
             "project classification nodes (26 iterations)"
         );
+    });
+});
+
+/**
+ * Regression test: PR #334 review t1. The classification-node request only
+ * walks `$depth` levels, so sprints nested deeper were absent from every
+ * result with nothing saying so.
+ */
+describe("findTruncatedNodes", () => {
+    let nextId = 1;
+    const node = (name: string, extra: Partial<IterationClassificationNode> = {}): IterationClassificationNode => ({
+        id: nextId++,
+        identifier: name,
+        name,
+        path: `\\Widgets\\Iteration\\${name}`,
+        ...extra,
+    });
+
+    test("reports a container the API said has children but did not return", () => {
+        const root = node("Widgets", {
+            hasChildren: true,
+            children: [node("FY26", { hasChildren: true })],
+        });
+
+        expect(findTruncatedNodes(root)).toEqual(["Widgets\\FY26"]);
+    });
+
+    test("a fully returned tree reports nothing", () => {
+        const root = node("Widgets", {
+            hasChildren: true,
+            children: [node("FY26", { hasChildren: true, children: [node("Q3 Sprint 5")] })],
+        });
+
+        expect(findTruncatedNodes(root)).toEqual([]);
+    });
+
+    test("a childless leaf is not truncation", () => {
+        expect(findTruncatedNodes(node("Q3 Sprint 5"))).toEqual([]);
     });
 });

--- a/src/azure-devops/lib/iterations.test.ts
+++ b/src/azure-devops/lib/iterations.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import type { TeamIteration } from "@app/azure-devops/api.types";
-import { findCurrentIteration, iterationContainsDate, resolveIteration } from "@app/azure-devops/lib/iterations";
+import type { IterationClassificationNode, TeamIteration } from "@app/azure-devops/api.types";
+import {
+    describeIterationSource,
+    findCurrentIteration,
+    flattenIterationNodes,
+    iterationContainsDate,
+    resolveIteration,
+    toIterationPath,
+} from "@app/azure-devops/lib/iterations";
 
 function iteration(name: string, start: string, finish: string, project = "Widgets"): TeamIteration {
     return {
@@ -160,5 +167,105 @@ describe("resolveIteration", () => {
 
     test("reports not-found for a query that matches nothing", () => {
         expect(resolveIteration(ITERATIONS, "Sprint 99", now)).toEqual({ kind: "not-found", query: "Sprint 99" });
+    });
+});
+
+describe("toIterationPath", () => {
+    test("strips the leading backslash and the Iteration segment", () => {
+        expect(toIterationPath("\\Widgets\\Iteration\\Sprint 17")).toBe("Widgets\\Sprint 17");
+    });
+
+    test("keeps a nested release folder below the Iteration segment", () => {
+        expect(toIterationPath("\\Widgets\\Iteration\\Release 3\\Sprint 17")).toBe("Widgets\\Release 3\\Sprint 17");
+    });
+
+    test("the project root node collapses to the project name", () => {
+        expect(toIterationPath("\\Widgets\\Iteration")).toBe("Widgets");
+    });
+
+    test("a path already in System.IterationPath form is left alone", () => {
+        expect(toIterationPath("Widgets\\Sprint 17")).toBe("Widgets\\Sprint 17");
+    });
+
+    test("only the Iteration segment goes, not a sprint whose name starts with it", () => {
+        expect(toIterationPath("\\Widgets\\Iteration\\Iteration planning")).toBe("Widgets\\Iteration planning");
+    });
+});
+
+describe("flattenIterationNodes", () => {
+    const ROOT: IterationClassificationNode = {
+        id: 1,
+        identifier: "00000000-0000-0000-0000-000000000001",
+        name: "Widgets",
+        path: "\\Widgets\\Iteration",
+        structureType: "iteration",
+        hasChildren: true,
+        children: [
+            {
+                id: 2,
+                identifier: "00000000-0000-0000-0000-000000000002",
+                name: "Sprint 16",
+                path: "\\Widgets\\Iteration\\Sprint 16",
+                attributes: { startDate: "2026-08-06T00:00:00Z", finishDate: "2026-08-19T00:00:00Z" },
+            },
+            {
+                id: 3,
+                identifier: "00000000-0000-0000-0000-000000000003",
+                name: "Release 3",
+                path: "\\Widgets\\Iteration\\Release 3",
+                hasChildren: true,
+                children: [
+                    {
+                        id: 4,
+                        identifier: "00000000-0000-0000-0000-000000000004",
+                        name: "Sprint 17",
+                        path: "\\Widgets\\Iteration\\Release 3\\Sprint 17",
+                        attributes: { startDate: "2026-08-20T00:00:00Z", finishDate: "2026-09-02T00:00:00Z" },
+                    },
+                ],
+            },
+        ],
+    };
+
+    test("normalises every path to System.IterationPath form", () => {
+        expect(flattenIterationNodes(ROOT).map((it) => it.path)).toEqual([
+            "Widgets\\Sprint 16",
+            "Widgets\\Release 3\\Sprint 17",
+        ]);
+    });
+
+    test("drops undated container nodes: the project root and the release folder", () => {
+        expect(flattenIterationNodes(ROOT).map((it) => it.name)).toEqual(["Sprint 16", "Sprint 17"]);
+    });
+
+    test("carries the node guid and both dates through", () => {
+        expect(flattenIterationNodes(ROOT)[0]).toEqual({
+            id: "00000000-0000-0000-0000-000000000002",
+            name: "Sprint 16",
+            path: "Widgets\\Sprint 16",
+            attributes: { startDate: "2026-08-06T00:00:00Z", finishDate: "2026-08-19T00:00:00Z" },
+        });
+    });
+
+    test("the flattened list feeds resolveIteration unchanged", () => {
+        const flat = flattenIterationNodes(ROOT);
+        expect(resolveIteration(flat, undefined, new Date(2026, 7, 27))).toMatchObject({
+            kind: "resolved",
+            matchedBy: "current",
+        });
+    });
+});
+
+describe("describeIterationSource", () => {
+    test("names the team and the row count", () => {
+        expect(describeIterationSource({ kind: "team", team: "Payments Team", count: 22 })).toBe(
+            'team "Payments Team" (22 iterations)'
+        );
+    });
+
+    test("names the project fallback and the row count", () => {
+        expect(describeIterationSource({ kind: "project", team: null, count: 26 })).toBe(
+            "project classification nodes (26 iterations)"
+        );
     });
 });

--- a/src/azure-devops/lib/iterations.ts
+++ b/src/azure-devops/lib/iterations.ts
@@ -44,11 +44,6 @@ export function toIterationPath(nodePath: string): string {
 }
 
 /**
- * Flatten the iteration classification tree into the shape `getTeamIterations()`
- * returns. Nodes without a start date are structural containers (the project root,
- * a release folder) rather than sprints, so they are dropped.
- */
-/**
  * Container nodes the API said have children but did not return any.
  *
  * `classificationnodes` only walks `$depth` levels down. A project that nests
@@ -76,6 +71,11 @@ export function findTruncatedNodes(root: IterationClassificationNode): string[] 
     return truncated;
 }
 
+/**
+ * Flatten the iteration classification tree into the shape `getTeamIterations()`
+ * returns. Nodes without a start date are structural containers (the project root,
+ * a release folder) rather than sprints, so they are dropped.
+ */
 export function flattenIterationNodes(root: IterationClassificationNode): TeamIteration[] {
     const flat: TeamIteration[] = [];
 

--- a/src/azure-devops/lib/iterations.ts
+++ b/src/azure-devops/lib/iterations.ts
@@ -48,6 +48,34 @@ export function toIterationPath(nodePath: string): string {
  * returns. Nodes without a start date are structural containers (the project root,
  * a release folder) rather than sprints, so they are dropped.
  */
+/**
+ * Container nodes the API said have children but did not return any.
+ *
+ * `classificationnodes` only walks `$depth` levels down. A project that nests
+ * its iterations deeper than that gets a silently truncated tree, and the
+ * dated sprints below the cap simply do not exist as far as the caller is
+ * concerned — `iterations` would not list them and `sprint` could not resolve
+ * them (PR #334 review t1). `hasChildren` on a childless node is the tell, so
+ * truncation can be reported instead of guessed at.
+ */
+export function findTruncatedNodes(root: IterationClassificationNode): string[] {
+    const truncated: string[] = [];
+
+    const walk = (node: IterationClassificationNode): void => {
+        const children = node.children ?? [];
+        if (node.hasChildren && children.length === 0) {
+            truncated.push(toIterationPath(node.path));
+        }
+
+        for (const child of children) {
+            walk(child);
+        }
+    };
+
+    walk(root);
+    return truncated;
+}
+
 export function flattenIterationNodes(root: IterationClassificationNode): TeamIteration[] {
     const flat: TeamIteration[] = [];
 

--- a/src/azure-devops/lib/iterations.ts
+++ b/src/azure-devops/lib/iterations.ts
@@ -2,7 +2,8 @@
  * Iteration (sprint) resolution.
  *
  * Pure logic only: no API calls, no output. The caller fetches the iteration
- * list with `Api.getTeamIterations()` and passes it in.
+ * list with `Api.getTeamIterations()` or `Api.getProjectIterations()` and
+ * passes it in.
  *
  * Why not `@CurrentIteration`: that WIQL macro needs a team context and is
  * resolved server-side, so the CLI cannot tell which iteration it picked. We
@@ -10,8 +11,67 @@
  * predicate in the query instead.
  */
 
-import type { TeamIteration } from "@app/azure-devops/api.types";
+import type { IterationClassificationNode, TeamIteration } from "@app/azure-devops/api.types";
 import { formatLocalDate } from "@genesiscz/utils/date";
+
+/** Which endpoint produced the iteration list the command is working from. */
+export interface IterationSource {
+    kind: "team" | "project";
+    /** The team name for `kind: "team"`, null for the project-wide list. */
+    team: string | null;
+    count: number;
+}
+
+/** One line naming the source, so a row-count difference is never a silent surprise. */
+export function describeIterationSource(source: IterationSource): string {
+    if (source.kind === "team") {
+        return `team "${source.team}" (${source.count} iterations)`;
+    }
+
+    return `project classification nodes (${source.count} iterations)`;
+}
+
+/**
+ * Convert a classification-node path to the `System.IterationPath` form WIQL needs.
+ *
+ * Classification nodes carry a structural path with an `Iteration` segment and a
+ * leading backslash (`\Widgets\Iteration\Sprint 17`). `System.IterationPath` has
+ * neither (`Widgets\Sprint 17`). Strip one leading backslash, then drop the
+ * `\Iteration` segment.
+ */
+export function toIterationPath(nodePath: string): string {
+    return nodePath.replace(/^\\/, "").replace(/\\Iteration(\\|$)/, "$1");
+}
+
+/**
+ * Flatten the iteration classification tree into the shape `getTeamIterations()`
+ * returns. Nodes without a start date are structural containers (the project root,
+ * a release folder) rather than sprints, so they are dropped.
+ */
+export function flattenIterationNodes(root: IterationClassificationNode): TeamIteration[] {
+    const flat: TeamIteration[] = [];
+
+    const walk = (node: IterationClassificationNode): void => {
+        if (node.attributes?.startDate) {
+            flat.push({
+                id: node.identifier,
+                name: node.name,
+                path: toIterationPath(node.path),
+                attributes: {
+                    startDate: node.attributes.startDate,
+                    finishDate: node.attributes.finishDate ?? null,
+                },
+            });
+        }
+
+        for (const child of node.children ?? []) {
+            walk(child);
+        }
+    };
+
+    walk(root);
+    return flat;
+}
 
 export type IterationResolution =
     | { kind: "resolved"; iteration: TeamIteration; matchedBy: "path" | "name" | "substring" | "current" }

--- a/src/azure-devops/lib/team.test.ts
+++ b/src/azure-devops/lib/team.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { NO_TEAM_MESSAGE, resolveTeam } from "@app/azure-devops/lib/team";
+import { resolveTeam } from "@app/azure-devops/lib/team";
 import type { AzureConfig } from "@app/azure-devops/types";
 
 const BASE: AzureConfig = {
@@ -22,12 +22,7 @@ describe("resolveTeam", () => {
         expect(resolveTeam({ ...BASE, team: "Team A" }, "   ")).toEqual({ team: "Team A", source: "config" });
     });
 
-    test("returns null when neither is set", () => {
+    test("returns null when neither is set, which callers treat as 'no narrowing'", () => {
         expect(resolveTeam(BASE, undefined)).toBeNull();
-    });
-
-    test("the failure message names both the flag and configure", () => {
-        expect(NO_TEAM_MESSAGE).toContain("--team");
-        expect(NO_TEAM_MESSAGE).toContain("tools azure-devops configure");
     });
 });

--- a/src/azure-devops/lib/team.ts
+++ b/src/azure-devops/lib/team.ts
@@ -11,7 +11,10 @@ export interface TeamResolution {
 
 /**
  * Resolve the team from an explicit `--team` flag, falling back to config.
- * Returns null when neither is set; the caller prints the fix.
+ *
+ * Returns null when neither is set. A team is never a precondition: it only
+ * narrows an iteration list to the ones that team subscribes to. Callers fall
+ * back to the project-wide classification nodes instead of failing.
  */
 export function resolveTeam(config: AzureConfig, explicit?: string): TeamResolution | null {
     const flag = explicit?.trim();
@@ -28,15 +31,3 @@ export function resolveTeam(config: AzureConfig, explicit?: string): TeamResolut
 
     return null;
 }
-
-/** Message shown when no team is configured and none was passed. */
-export const NO_TEAM_MESSAGE = [
-    "No Azure DevOps team is configured.",
-    "",
-    "This command reads team settings, so it needs a team name. Either:",
-    '  1. Pass it for this run:   tools azure-devops sprint --team "<Your Team>"',
-    "  2. Store it in config:     tools azure-devops configure \\",
-    '       "https://dev.azure.com/{org}/{project}/_backlogs/backlog/{team}/Stories"',
-    "",
-    'Or add "team": "<Your Team>" to .claude/azure/config.json by hand.',
-].join("\n");


### PR DESCRIPTION
## Why

`tools azure-devops iterations` and `tools azure-devops sprint` both exited 1 with "No Azure DevOps team is configured." when no team was set. That precondition was never needed.

Iterations are **project-level classification nodes**. A team only subscribes to a subset of them, and `System.IterationPath` never contains a team segment. The work items a sprint holds therefore do not depend on which team you ask through.

## What changed

**`--team` is now an optional narrowing filter, never a precondition.**

- New `Api.getProjectIterations()` reads `GET {org}/{project}/_apis/wit/classificationnodes/iterations?$depth=3` and flattens the node tree into the shape `getTeamIterations()` already returns. No team segment in the URL.
- New pure helpers in `src/azure-devops/lib/iterations.ts`:
  - `toIterationPath()` converts a classification-node path to `System.IterationPath` form. It strips one leading backslash, then removes the `\Iteration` segment: `\Widgets\Iteration\Sprint 17` becomes `Widgets\Sprint 17`. Nested release folders survive.
  - `flattenIterationNodes()` walks the tree and drops undated container nodes (the project root, release folders), because those are not sprints.
  - `describeIterationSource()` renders the one-line source label.
- With a team (flag or `config.team`), both commands keep using `work/teamsettings/iterations`. Without one they fall back to the project nodes instead of exiting.
- `NO_TEAM_MESSAGE` is deleted. It was the only hard failure path.

**The source is always reported**, so the row-count difference between the two lists is not a silent surprise:

```
source: team "Payments Team" (22 iterations)
source: project classification nodes (26 iterations)
```

It appears in the `ai` header, as a `Source:` line in `md`, and as a `source` field in `json`.

**Breaking change to the `-f json` shape.** Both commands now always emit an object:

- `iterations -f json` emits `{ source, iterations }` instead of a bare array.
- `sprint -f json` emits `{ iteration, source, items }`, plus `totals` with `--totals`. Previously it emitted a bare array without `--totals` and an object with it. The shape is now uniform.

## Identifier scrub

This branch also removes real organisation, project, team, work-item and tenant identifiers from the `azure-devops` surface, ahead of the repo going open source. Examples now use the fictional vocabulary: `contoso` (org), `Widgets` (project), `Payments Team` or `<Your Team>` (team), `Widgets\Sprint 17` (iteration path), invented five-digit work-item ids, and all-zero GUIDs.

The scrub is a separate commit from the feature. Fixture ids in tests were remapped so their relative ordering is preserved, which keeps the `sortByBacklogOrder` assertion meaningful rather than merely passing.

## Verification

- `bun tsgo --noEmit -p tsconfig.json` clean.
- `bun run test src/azure-devops`: 89 pass, 0 fail, 149 expect() calls, 7 files.
- `bunx biome check --write src/azure-devops`: no fixes applied.
- 17 new unit tests cover path normalisation, tree flattening, undated-node dropping, and the source label.

Live, against a real organisation from a config with no `team` key:

- `iterations` with no team: exit 0, 26 dated iterations, exactly one marked current.
- `sprint --mine --totals` with no team: exit 0, Items 17 (Tasks 9), Task CompletedWork 139.75 h, Task RemainingWork 88 h.
- The same command through two different teams: 22 iterations each, and byte-identical work-item id lists, totals and resolved iteration path against the no-team run.

## Docs

`tools azure-devops --readme` gains a "No team required" subsection covering the classification-nodes fallback, the `\Iteration` normalisation rule, and a worked no-team example. The existing "Why not `@CurrentIteration`" section stays. The plugin skill carries the same explanation in short form.
