### PR TITLE
feat: the integration-branch work no other PR carries (chrome-devtools, ms-teams, CLI utils)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ So when you write the end-of-task notification, you can typically rely on a save
 
 This exists because inside a **git worktree** any `bunx` call creates a partial `node_modules/` that shadows the parent checkout's complete one. Bare `bun test` then fails across a hundred unrelated files with errors like `Cannot find module 'parse5/lib/common/doctype'`, which looks exactly like the branch broke the world. Logic lives in `scripts/test-deps.ts` (`diagnose()` / `lockStamp()`), covered by `scripts/test-deps.test.ts`.
 
+**Tests must not use real account names.** Fixture handles, emails, and login ids in `*.test.ts` are invented (`work`, `personal`, `shop`, `side`, `work@shop`, `alice@example.com`). Never copy a live Claude/AI account name, email, or org from this machine into a test. A test that needs several distinct accounts uses those fixtures, not the real ones.
+
 ### 🛑 Hard rules for agents working in an isolated worktree
 
 Every teammate/subagent given its own worktree MUST, before ANY other work:

--- a/README.md
+++ b/README.md
@@ -504,14 +504,14 @@ Everything is a subcommand. The old flag-style interface (`--workitem 12345`,
 
 ```bash
 tools azure-devops configure "https://dev.azure.com/MyOrg/MyProject/_workitems"
-tools azure-devops workitem 261575 --task-folders --images
+tools azure-devops workitem 12345 --task-folders --images
 tools azure-devops workitem 12345,12346,12347
 tools azure-devops query "Open Bugs" --download-workitems --category react19
 tools azure-devops workitem-create
 tools azure-devops list
 tools azure-devops dashboard <url-or-id>
-tools azure-devops timelog add -w 268935 -h 2 -t "Development"
-tools azure-devops history show 261575 --assigned-to "Martin"
+tools azure-devops timelog add -w 12345 -h 2 -t "Development"
+tools azure-devops history show 12345 --assigned-to "Jane"
 ```
 
 Aliases exist for the long names: `config`, `wi`, `create`, `ls`.

--- a/plugins/genesis-tools/commands/timelog.md
+++ b/plugins/genesis-tools/commands/timelog.md
@@ -105,7 +105,7 @@ Each Timely **event** represents a chunk of logged time. Match each to a work it
 
 | Event (project + note) | Linked Entries Context | Git Context | -> Work Item |
 |---|---|---|---|
-| MyProject 4h51m "Sprint 2" | Cursor: timelog.ts, Teams: meeting | Commits on feature/268935 | -> 268935 |
+| MyProject 4h51m "Sprint 2" | Cursor: timelog.ts, Teams: meeting | Commits on feature/12345 | -> 12345 |
 | Internal 30m | Teams: standup | No direct link | -> Ask user |
 
 Also check `unlinked[]` for unaccounted time:
@@ -120,8 +120,8 @@ Present a table for user approval:
 +---------+---------+--------------+---------------------------------+
 | Work ID | Hours   | Type         | Comment                         |
 +---------+---------+--------------+---------------------------------+
-| 268935  | 2.5     | Development  | Gen2 2: coding, timelog impl    |
-| 268935  | 0.5     | Code Review  | PR review and feedback          |
+| 12345  | 2.5     | Development  | Gen2 2: coding, timelog impl    |
+| 12345  | 0.5     | Code Review  | PR review and feedback          |
 | 123456  | 1.0     | Development  | fix: validation error handling  |
 | ???     | 0.75    | Ceremonie    | Teams standup (unlinked, assign) |
 +---------+---------+--------------+---------------------------------+
@@ -137,7 +137,7 @@ Instead of directly executing entries, the preferred workflow for multi-day sync
 ```bash
 # For each entry, stage it for review
 tools azure-devops timelog prepare-import add --from YYYY-MM-DD --to YYYY-MM-DD --entry '{
-  "workItemId": 268935,
+  "workItemId": 12345,
   "date": "2026-02-04",
   "hours": 2.5,
   "timeType": "Development",
@@ -288,14 +288,14 @@ For bulk importing time entries, create a JSON file:
 {
   "entries": [
     {
-      "workItemId": 268935,
+      "workItemId": 12345,
       "hours": 2,
       "timeType": "Development",
       "date": "2026-02-04",
       "comment": "Implemented feature X"
     },
     {
-      "workItemId": 268936,
+      "workItemId": 12346,
       "hours": 1,
       "minutes": 30,
       "timeType": "Code Review",
@@ -441,7 +441,7 @@ tools clarity link-workitems
 
 # Non-interactive: link directly (requires timesheet ID for task lookup)
 tools clarity link-workitems \
-  --azure-devops-workitem 268935 \
+  --azure-devops-workitem 12345 \
   --clarity-task "SampleTask_Release_External_Capex" \
   --timesheet 8524081
 
@@ -449,7 +449,7 @@ tools clarity link-workitems \
 tools clarity link-workitems --list
 
 # Remove a mapping
-tools clarity link-workitems --unlink 268935
+tools clarity link-workitems --unlink 12345
 ```
 
 ### Export + Fill Workflow

--- a/plugins/genesis-tools/skills/chrome-devtools/SKILL.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/SKILL.md
@@ -122,7 +122,7 @@ The tool runs on macOS, Linux and Windows; on Windows the capture root is
 Page verbs take `--match <substr|/regex/>` to pick a tab by URL or title, and ERROR within
 a second when nothing matches, listing the closest open tabs; they never grab a random tab.
 No tab to reuse? `nav <url> --new` opens one. `targets --match <substr>` filters the tab
-list instead of printing one 40 KB JSON blob (`--json` still gives raw `/json/list`).
+list instead of printing one 40 KB JSON blob (`--json` gives the same list as JSON).
 
 ## The method that actually finds these bugs
 

--- a/plugins/genesis-tools/skills/chrome-devtools/SKILL.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/SKILL.md
@@ -38,8 +38,10 @@ tools chrome-devtools attach     # scans 9222-9230 + lsof + DevToolsActivePort
 ```
 
 If two or more Chromium browsers are open, `attach` exits 1 and lists each app with its
-exact restart command; pass `--port` to pick. `attach` also starts the **background
-recorder** for each listed endpoint (one per port, pidfile-deduped across concurrent agent
+exact restart command; pass `--port` to pick. Once `attach --port N` succeeds, later verbs
+need no `--port` — they reuse that endpoint while it is live. With several live endpoints
+and nothing remembered, a verb exits 1 naming the ports rather than guessing. `attach` also
+starts the **background recorder** for each listed endpoint (one per port, pidfile-deduped across concurrent agent
 sessions, dies when the browser's CDP endpoint dies) and prints a guidance block with the
 next commands. That recorder is what makes retroactive HAR possible.
 
@@ -71,6 +73,26 @@ the literal examples.
 | `rm` capture dirs or the leftover buffer | that IS the retroactive HAR | `cleanup` (moves to trash), after dumping |
 | `cat`/`jq` a `.har` | token bonfire | `tools har-analyzer load x.har` |
 
+## When `mcp__chrome-devtools-mcp__*` goes away mid-session
+
+That is normal harness behaviour, not a crash of anything here. Claude Code tears the idle
+stdio server down and re-spawns it on the next tool call: its log shows
+`STDIO connection closed after 126s (cleanly)` then `Cleared connection cache for
+reconnection`, with no stderr beyond the npm banner and no non-zero exit
+(`~/Library/Caches/claude-cli-nodejs/<project>/mcp-logs-chrome-devtools-mcp/*.jsonl`,
+verified 2026-08-27 for session a6b9435f). Two consequences:
+
+- **The CLI is unaffected and is the fallback.** `tools chrome-devtools` speaks HTTP and
+  WebSocket to the browser's own port each time, so it holds no session to lose.
+- **The MCP server drives its OWN isolated Chrome on an ephemeral port.** When it goes, that
+  browser goes too, and its `DevToolsActivePort` files leave empty capture dirs that
+  `attach` discovers later. `cleanup` removes them.
+
+One real failure in that session was NOT a disconnect: `take_screenshot` into the session
+scratchpad returned `Access denied: path … is not within any of the configured workspace
+roots`. chrome-devtools-mcp 1.6.0 only writes inside a workspace root, so write MCP
+screenshots into the repo, or take them with `tools chrome-devtools shot`.
+
 Health at any time: `tools chrome-devtools status` (CPU, memory, buffer sizes) ·
 `doctor` (read-only findings + fix commands) · `cleanup` (applies them, interactively in a
 terminal). These rules exist because an unbounded recorder once pinned a core for hours
@@ -90,15 +112,17 @@ The tool runs on macOS, Linux and Windows; on Windows the capture root is
 | One-shot per-request assertion table (method/status/sizes/auth scheme) | `har --last 10m --match token --summary` |
 | Read page state | `eval '() => ({url: location.href, ls: {...localStorage}, ss: {...sessionStorage}})'` — quoting trouble or a hook blocking inline eval? write the JS to a file and use `eval --file <path>` |
 | Console messages incl. load-time ones | `console --match <substr> --reload` (attaches first — the MCP `list_console_messages` misses everything before ITS attach) |
-| Navigate / screenshot | `nav <url>` · `shot /tmp/x.png [--full]` |
+| Navigate / screenshot | `nav <url>` (reuses a tab) · `nav <url> --new` (opens one) · `shot /tmp/x.png [--full]` |
 | Surgical cookie delete | `rm-cookie --name X --domain Y --path /cas` |
 | Pixel-coordinate grid over a screenshot | `grid /tmp/g.png [--region x,y,w,h] [--step 60]` |
 | The real MCP tools, against ANY port | `mcp list` · `mcp navigate_page '{"url":"…"}'` |
 | CDP scratch script | `scaffold <name> --recipe redirect-chain\|cookie-diff\|storage-snapshot\|body-fetch\|console-trap\|blank` |
 | The scripting API | `cheatsheet` (or `references/cdp-cheatsheet.md`) |
 
-Page verbs take `--match <url substr>` to pick a tab and ERROR when nothing matches; they
-never grab a random tab.
+Page verbs take `--match <substr|/regex/>` to pick a tab by URL or title, and ERROR within
+a second when nothing matches, listing the closest open tabs; they never grab a random tab.
+No tab to reuse? `nav <url> --new` opens one. `targets --match <substr>` filters the tab
+list instead of printing one 40 KB JSON blob (`--json` still gives raw `/json/list`).
 
 ## The method that actually finds these bugs
 

--- a/plugins/genesis-tools/skills/chrome-devtools/references/cdp-cheatsheet.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/cdp-cheatsheet.md
@@ -19,7 +19,7 @@ nav <url> [--new]             navigate a tab (--new opens one instead of reusing
 shot [png] [--full]           screenshot the tab
 grid [png] --step 60          screenshot with pixel-coordinate grid (for clicking into pages)
 trace --match X               quick one-tab docs+redirect chain to a file
-targets [--match X] [--json]  tab list, one line each (id, title, url); --json = raw /json/list
+targets [--match X] [--json]  tab list, one line each (id, title, url); --json = the same list, as JSON
 open --fresh | restart        launch/relaunch a browser WITH the debugging flag
 mcp <tool> '<json>'           call real chrome-devtools-mcp tools on any port
 ```

--- a/plugins/genesis-tools/skills/chrome-devtools/references/cdp-cheatsheet.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/references/cdp-cheatsheet.md
@@ -14,11 +14,12 @@ har     [--last 30m|--now]    DevTools-grade HAR from the buffer, or a live wind
 status | doctor | cleanup     inventory (CPU/mem) | read-only diagnosis | guided fixes
 cookies --domain X [--json]   ALL cookies incl. httpOnly, every domain
 console --match X --reload    console messages incl. load-time ones (attaches first)
-eval '() => …'                run JS in the tab, JSON out
-nav <url> | shot [png]        navigate | screenshot (--full)
+eval '() => …'                run JS in the tab, JSON out (no value -> null, exit 0)
+nav <url> [--new]             navigate a tab (--new opens one instead of reusing)
+shot [png] [--full]           screenshot the tab
 grid [png] --step 60          screenshot with pixel-coordinate grid (for clicking into pages)
 trace --match X               quick one-tab docs+redirect chain to a file
-targets                       raw /json/list
+targets [--match X] [--json]  tab list, one line each (id, title, url); --json = raw /json/list
 open --fresh | restart        launch/relaunch a browser WITH the debugging flag
 mcp <tool> '<json>'           call real chrome-devtools-mcp tools on any port
 ```

--- a/plugins/genesis-tools/skills/wrap-up/scripts/resolve.test.ts
+++ b/plugins/genesis-tools/skills/wrap-up/scripts/resolve.test.ts
@@ -408,6 +408,59 @@ describe("buildLogBody", () => {
         }
     });
 
+    it("reports the header rewrite and appended log as 1-indexed line spans", () => {
+        const res = buildLogBody({ text: docWith("- **State:** old"), ...args });
+        expect(res.ok).toBe(true);
+        if (!res.ok) {
+            return;
+        }
+
+        // Fixture is 12 lines; the append adds a blank separator plus a 13-line
+        // log section (topic heading through the quoted After block).
+        expect(res.lines).toBe(26);
+        expect(res.linesModified).toEqual({
+            count: 4,
+            lineFirst: 3,
+            lineLast: 6,
+            heading: "## You are here (2026-07-29 06:47)",
+        });
+        expect(res.linesAdded).toEqual({
+            count: 13,
+            lineFirst: 14,
+            lineLast: 26,
+            heading: "## 2026-07-29 06:47 — second",
+        });
+    });
+
+    it("shifts the added span when the new header is taller", () => {
+        const res = buildLogBody({
+            text: docWith("- **State:** old"),
+            hereBody: "- **State:** new\n- **Next:** do the thing\n- **Verify:** bun test",
+            logBody: "## 2026-07-29 06:47 — second",
+            stamp: "2026-07-29 06:47",
+        });
+        expect(res.ok).toBe(true);
+        if (!res.ok) {
+            return;
+        }
+
+        // Two extra header bullets: the YOU-ARE-HERE block grows by 2, AND the
+        // auto-quoted After snapshot grows by the same 2, so the file grows by 4.
+        expect(res.lines).toBe(30);
+        expect(res.linesModified).toEqual({
+            count: 6,
+            lineFirst: 3,
+            lineLast: 8,
+            heading: "## You are here (2026-07-29 06:47)",
+        });
+        expect(res.linesAdded).toEqual({
+            count: 15,
+            lineFirst: 16,
+            lineLast: 30,
+            heading: "## 2026-07-29 06:47 — second",
+        });
+    });
+
     it("is idempotent in shape — logging twice keeps one header and both sections", () => {
         const first = buildLogBody({ text: docWith("- **State:** old"), ...args });
         expect(first.ok).toBe(true);
@@ -558,6 +611,65 @@ describe("writeAtomic", () => {
         // The destination is untouched, which pins that the rejection came from
         // the rename onto the directory and not from something incidental.
         expect(await readdir(target)).toEqual(["keep.txt"]);
+    });
+});
+
+describe("log command JSON", () => {
+    const fixtures: string[] = [];
+
+    async function tempDir(): Promise<string> {
+        const dir = await mkdtemp(join(tmpdir(), "wrapup-log-"));
+        fixtures.push(dir);
+        return dir;
+    }
+
+    afterEach(async () => {
+        await Promise.all(fixtures.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+    });
+
+    it("prints logged, file, stamp, lines, and the added/modified spans", async () => {
+        const dir = await tempDir();
+        const file = join(dir, "doc.wrapup.md");
+        await writeFile(file, docWith("- **State:** old"));
+
+        const proc = Bun.spawn(["bun", join(import.meta.dir, "resolve.ts"), "log", file], {
+            stdin: new Response("@@HERE@@\n- **State:** new\n@@LOG@@\n## 2026-07-29 06:47 — second\n"),
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        const stdout = await new Response(proc.stdout).text();
+        const stderr = await new Response(proc.stderr).text();
+        const exit = await proc.exited;
+        expect(exit).toBe(0);
+        expect(stderr).toBe("");
+
+        // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+        const json = JSON.parse(stdout);
+        expect(json.logged).toBe(true);
+        expect(json.file).toBe(file);
+        expect(json.stamp).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+        expect(json.lines).toBe(26);
+        expect(json.linesAdded).toEqual({
+            count: 13,
+            lineFirst: 14,
+            lineLast: 26,
+            heading: "## 2026-07-29 06:47 — second",
+        });
+        expect(json.linesModified).toEqual({
+            count: 4,
+            lineFirst: 3,
+            lineLast: 6,
+            heading: `## You are here (${json.stamp})`,
+        });
+
+        const written = await Bun.file(file).text();
+        const fileLines = written.endsWith("\n") ? written.slice(0, -1).split("\n") : written.split("\n");
+        expect(fileLines).toHaveLength(json.lines);
+        expect(fileLines[json.linesModified.lineFirst - 1]).toBe(HERE_START);
+        expect(fileLines[json.linesModified.lineFirst]).toBe(json.linesModified.heading);
+        expect(fileLines[json.linesModified.lineLast - 1]).toBe(HERE_END);
+        expect(fileLines[json.linesAdded.lineFirst - 1]).toBe(json.linesAdded.heading);
+        expect(fileLines[json.linesAdded.lineLast - 1]).toBe("> - **State:** new");
     });
 });
 

--- a/plugins/genesis-tools/skills/wrap-up/scripts/resolve.ts
+++ b/plugins/genesis-tools/skills/wrap-up/scripts/resolve.ts
@@ -18,6 +18,8 @@
  *               auto-stamping the datetime and auto-generating the before→after
  *               snapshot from the outgoing header. stdin carries two parts split by
  *               sentinel lines: @@HERE@@ (new state bullets) then @@LOG@@ (log body).
+ *               Prints { logged:true, file, stamp, lines, linesAdded, linesModified }
+ *               so the caller can Read the rewritten header and the new section.
  *
  * The registry lives at ~/.claude/handoff-registry.json:
  *   { "entries": [ { projectDir, branch?, worktreeDir?, obsidianDir, docPath? }, ... ] }
@@ -34,7 +36,7 @@
 
 import { chmod, rename, rm, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, isAbsolute, join } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 
 // lint-rules-ignore: standalone script without access to @genesiscz/utils/env
 const PLUGIN_CONFIG = join(homedir(), ".genesis-tools", "plugins", "config.json");
@@ -834,7 +836,73 @@ export function splitSentinels(raw: string): SentinelSplit {
     return { ok: true, hereBody, logBody };
 }
 
-export type LogBuild = { ok: true; body: string } | { ok: false; problem: string };
+export type LineSpan = {
+    count: number;
+    lineFirst: number;
+    lineLast: number;
+    heading: string;
+};
+
+export type LogBuild =
+    | { ok: true; body: string; lines: number; linesAdded: LineSpan; linesModified: LineSpan }
+    | { ok: false; problem: string };
+
+function lineAt(text: string, index: number): number {
+    let line = 1;
+    const limit = Math.min(Math.max(index, 0), text.length);
+    for (let i = 0; i < limit; i++) {
+        if (text.charCodeAt(i) === 10) {
+            line++;
+        }
+    }
+
+    return line;
+}
+
+function lineCount(text: string): number {
+    if (text.length === 0) {
+        return 0;
+    }
+
+    let n = 0;
+    for (let i = 0; i < text.length; i++) {
+        if (text.charCodeAt(i) === 10) {
+            n++;
+        }
+    }
+
+    return text.endsWith("\n") ? n : n + 1;
+}
+
+function headingOf(block: string): string {
+    for (const line of block.split("\n")) {
+        if (line.startsWith("## ")) {
+            return line;
+        }
+    }
+
+    for (const line of block.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed) {
+            return trimmed;
+        }
+    }
+
+    return "";
+}
+
+function spanFor(text: string, start: number, endExclusive: number, heading: string): LineSpan {
+    const lo = Math.max(0, start);
+    const hi = Math.max(lo, endExclusive);
+    const lineFirst = lineAt(text, lo);
+    const lineLast = lineAt(text, Math.max(lo, hi - 1));
+    return {
+        count: lineLast - lineFirst + 1,
+        lineFirst,
+        lineLast,
+        heading,
+    };
+}
 
 export function buildLogBody({
     text,
@@ -856,7 +924,6 @@ export function buildLogBody({
     const oldFull = text.slice(s, e + HERE_END.length);
     const newFull = `${HERE_START}\n## You are here (${stamp})\n${hereBody}\n${HERE_END}`;
     const rewritten = text.slice(0, s) + newFull + text.slice(e + HERE_END.length);
-
     const section = [
         logBody,
         "",
@@ -870,8 +937,19 @@ export function buildLogBody({
         "",
         blockquote(innerBlock(newFull)),
     ].join("\n");
+    const rewrittenTrimmed = rewritten.replace(/\s+$/, "");
+    const body = `${rewrittenTrimmed}\n\n${section}\n`;
+    const headerStart = body.indexOf(HERE_START);
+    const headerEnd = body.indexOf(HERE_END);
+    const addedStart = rewrittenTrimmed.length + 2;
 
-    return { ok: true, body: `${rewritten.replace(/\s+$/, "")}\n\n${section}\n` };
+    return {
+        ok: true,
+        body,
+        lines: lineCount(body),
+        linesModified: spanFor(body, headerStart, headerEnd + HERE_END.length, headingOf(newFull)),
+        linesAdded: spanFor(body, addedStart, body.length, headingOf(section)),
+    };
 }
 
 async function cmdLog(file: string) {
@@ -879,10 +957,11 @@ async function cmdLog(file: string) {
         failLog("no wrap-up file path given (first positional arg)");
     }
 
-    const f = Bun.file(file);
+    const absFile = resolve(file);
+    const f = Bun.file(absFile);
     if (!(await f.exists())) {
         failLog(
-            `file does not exist: ${file}\n  → create it from the template with Write first, then use 'log' for every session after`
+            `file does not exist: ${absFile}\n  → create it from the template with Write first, then use 'log' for every session after`
         );
     }
 
@@ -894,12 +973,25 @@ async function cmdLog(file: string) {
     const stamp = nowStamp();
     const built = buildLogBody({ text: await f.text(), hereBody: split.hereBody, logBody: split.logBody, stamp });
     if (!built.ok) {
-        failLog(`${built.problem} in ${file} — is this a wrap-up file created from the template?`);
+        failLog(`${built.problem} in ${absFile} — is this a wrap-up file created from the template?`);
     }
 
-    await writeAtomic(file, built.body);
-    // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
-    console.log(JSON.stringify({ logged: file, stamp }, null, 2));
+    await writeAtomic(absFile, built.body);
+    console.log(
+        // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+        JSON.stringify(
+            {
+                logged: true,
+                file: absFile,
+                stamp,
+                lines: built.lines,
+                linesAdded: built.linesAdded,
+                linesModified: built.linesModified,
+            },
+            null,
+            2
+        )
+    );
 }
 
 export function parseFlags(argv: string[]): Record<string, string> {

--- a/src/ai-proxy/lib/account-refs.test.ts
+++ b/src/ai-proxy/lib/account-refs.test.ts
@@ -51,9 +51,9 @@ describe("account-refs", () => {
             legacyAccountNameOf({
                 ...grokAccount,
                 grok: undefined,
-                anthropicSub: { accountName: "martin" },
+                anthropicSub: { accountName: "personal" },
             })
-        ).toBe("martin");
+        ).toBe("personal");
         expect(legacyAccountNameOf({ ...grokAccount, grok: {} })).toBeUndefined();
     });
 

--- a/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
+++ b/src/ai-proxy/lib/providers/anthropic-subscription.test.ts
@@ -8,7 +8,7 @@ const TEST_TOKEN = "sk-ant-oat01-TESTTOKEN";
 mock.module("@genesiscz/utils/claude/subscription-auth", () => ({
     resolveAccountToken: async () => ({
         token: TEST_TOKEN,
-        account: { name: "martin", accessToken: TEST_TOKEN },
+        account: { name: "personal", accessToken: TEST_TOKEN },
         refreshed: false,
     }),
 }));
@@ -18,7 +18,7 @@ const account: AiProxyAccountConfig = {
     provider: "anthropic-subscription",
     providerSlug: "claude-sub",
     enabled: true,
-    anthropicSub: { accountName: "martin" },
+    anthropicSub: { accountName: "personal" },
 };
 
 const realFetch = globalThis.fetch;

--- a/src/chrome-devtools/commands/attach.ts
+++ b/src/chrome-devtools/commands/attach.ts
@@ -1,5 +1,6 @@
 import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
+import { rememberLastPort } from "../lib/paths.ts";
 import { CDP_PORTS, isPortSpecified, planAttach, renderAttachPlan } from "../lib/resolve-attach.ts";
 import {
     guidanceBlock,
@@ -50,6 +51,13 @@ A browser must be LAUNCHED with the flag — it cannot be enabled at runtime.
             out.println(text);
 
             if (plan.status === "list") {
+                // Remember the endpoint this attach settled on, so the very next
+                // `nav`/`eval`/`targets` needs no --port. Only meaningful when
+                // ONE endpoint is in play; with several, --port stays mandatory.
+                if (plan.endpoints.length === 1) {
+                    rememberLastPort(plan.endpoints[0].port);
+                }
+
                 for (const e of plan.endpoints) {
                     let recording = false;
                     if (ATTACH_AUTO_RECORD) {

--- a/src/chrome-devtools/commands/browse.ts
+++ b/src/chrome-devtools/commands/browse.ts
@@ -1,7 +1,7 @@
 /** open / restart / targets — getting a CDP endpoint to exist, on any platform. */
 import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
-import { targets } from "../lib/cdp.ts";
+import { makeMatcher, targets } from "../lib/cdp.ts";
 import {
     BROWSER_APPS,
     BROWSERS,
@@ -12,7 +12,7 @@ import {
     quitBrowser,
     waitForCdp,
 } from "../lib/resolve-attach.ts";
-import { portOf, probe, refuseIfAmbiguous, suggest, withPort } from "./shared.ts";
+import { portOf, probe, resolvePort, suggest, withPort } from "./shared.ts";
 
 /** Chromium launch flags. Exported for tests: the --user-data-dir rule is what keeps `open` off the real profile. */
 export function launchArgs(port: number, opts: { fresh?: boolean; extension?: string }): string[] {
@@ -52,6 +52,10 @@ function browserDefOf(raw: unknown): { id: string; name: string } {
 }
 
 const BROWSER_IDS = BROWSERS.map((b) => b.id).join("|");
+
+function truncate(value: string, max: number): string {
+    return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
 
 interface OpenOpts {
     port?: string;
@@ -157,10 +161,31 @@ export function registerBrowse(program: Command): void {
         });
 
     withPort(program.command("targets"))
-        .description("raw /json/list of the endpoint (every tab, its targetId and URL)")
-        .action(async (opts: { port?: string }) => {
-            await refuseIfAmbiguous();
-            out.result(await targets(portOf(opts)));
-            process.exit(0);
+        .description("list the endpoint's tabs — one line per target (id, title, url). --json for raw /json/list.")
+        .option("--match <substr>", "only targets whose url or title contains this substring, or /regex/")
+        .option("--all", "include non-page targets (workers, iframes, extension pages)")
+        .option("--json", "raw /json/list JSON, as Chromium returns it")
+        .action(async (opts: { port?: string; match?: string; all?: boolean; json?: boolean }) => {
+            const port = await resolvePort(opts);
+            const all = await targets(port);
+            const scoped = opts.all ? all : all.filter((t) => t.type === "page");
+            const matches = opts.match ? makeMatcher(opts.match) : null;
+            const list = matches ? scoped.filter((t) => matches(t.url) || matches(t.title ?? "")) : scoped;
+
+            if (opts.json) {
+                out.result(list);
+                process.exit(0);
+            }
+
+            // A 40KB single-line JSON blob for 25 tabs is not readable output:
+            // finding one tab meant saving it to a file and running rg over it.
+            for (const t of list) {
+                out.println(`${t.id}  ${truncate(t.title ?? "", 46).padEnd(46)}  ${t.url}`);
+            }
+
+            out.println(
+                `\n${list.length} of ${scoped.length} ${opts.all ? "targets" : "page targets"} on ${port}${opts.match ? ` matching '${opts.match}'` : ""}.`
+            );
+            process.exit(list.length ? 0 : 1);
         });
 }

--- a/src/chrome-devtools/commands/browse.ts
+++ b/src/chrome-devtools/commands/browse.ts
@@ -161,10 +161,12 @@ export function registerBrowse(program: Command): void {
         });
 
     withPort(program.command("targets"))
-        .description("list the endpoint's tabs — one line per target (id, title, url). --json for raw /json/list.")
+        .description(
+            "list the endpoint's tabs — one line per target (id, title, url). --json for the same list as JSON."
+        )
         .option("--match <substr>", "only targets whose url or title contains this substring, or /regex/")
         .option("--all", "include non-page targets (workers, iframes, extension pages)")
-        .option("--json", "raw /json/list JSON, as Chromium returns it")
+        .option("--json", "the listed targets as JSON — /json/list entries, after --all and --match")
         .action(async (opts: { port?: string; match?: string; all?: boolean; json?: boolean }) => {
             const port = await resolvePort(opts);
             const all = await targets(port);

--- a/src/chrome-devtools/commands/har.ts
+++ b/src/chrome-devtools/commands/har.ts
@@ -8,7 +8,7 @@ import { captureDir, recorderPidPath } from "../lib/paths.ts";
 import { artifactPath } from "../lib/platform.ts";
 import { probeCdp } from "../lib/recorder.ts";
 import { segmentStats } from "../lib/status.ts";
-import { portOf, positiveNumber, refuseIfAmbiguous, suggest, withPage } from "./shared.ts";
+import { positiveNumber, resolvePort, suggest, withPage } from "./shared.ts";
 
 const DEFAULT_HAR_OUT = artifactPath("cdp.har");
 
@@ -114,11 +114,9 @@ a tab navigates (Chrome discards them — Chromium #141129). For bodies use
 --now --reload, or start the recorder with --channels +body.`
         )
         .action(async (opts: HarOpts) => {
-            const port = portOf(opts);
+            const port = await resolvePort(opts);
 
             if (opts.now || opts.reload) {
-                await refuseIfAmbiguous();
-
                 if (!(await probeCdp(port))) {
                     out.log.error(`no CDP endpoint on port ${port} — nothing listens there.`);
                     out.log.info(`  see what is live: ${suggest(["attach"])}`);

--- a/src/chrome-devtools/commands/inspect.ts
+++ b/src/chrome-devtools/commands/inspect.ts
@@ -1,18 +1,9 @@
 /** cookies / rm-cookie / console / eval / nav / shot / grid / trace — page and browser inspection. */
 import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
-import { browser } from "../lib/cdp.ts";
+import { browser, newTab } from "../lib/cdp.ts";
 import { artifactPath } from "../lib/platform.ts";
-import {
-    attachTab,
-    ignoreSigpipe,
-    portOf,
-    positiveNumber,
-    refuseIfAmbiguous,
-    suggest,
-    withPage,
-    withPort,
-} from "./shared.ts";
+import { attachTab, ignoreSigpipe, positiveNumber, resolvePort, suggest, withPage, withPort } from "./shared.ts";
 
 export function registerInspect(program: Command): void {
     withPort(program.command("cookies"))
@@ -20,8 +11,7 @@ export function registerInspect(program: Command): void {
         .option("--domain <substr>", "only cookies whose domain contains this")
         .option("--json", "machine-readable, for diffing two browsers")
         .action(async (opts: { port?: string; domain?: string; json?: boolean }) => {
-            await refuseIfAmbiguous();
-            const b = await browser(portOf(opts));
+            const b = await browser(await resolvePort(opts));
             const cs = await b.cookies(opts.domain);
 
             if (opts.json) {
@@ -67,8 +57,7 @@ export function registerInspect(program: Command): void {
         .requiredOption("--domain <domain>", "cookie domain, exactly as listed by 'cookies'")
         .option("--path <path>", "cookie path", "/")
         .action(async (opts: { port?: string; name: string; domain: string; path: string }) => {
-            await refuseIfAmbiguous();
-            const b = await browser(portOf(opts));
+            const b = await browser(await resolvePort(opts));
             await b.deleteCookie(opts.name, opts.domain, opts.path);
             out.log.info(`deleted ${opts.name} ${opts.domain} ${opts.path}`);
             b.close();
@@ -130,18 +119,69 @@ export function registerInspect(program: Command): void {
             }
 
             const page = await attachTab(opts);
-            out.result(await page.evaluate(source));
+
+            try {
+                const value = await page.evaluate(source);
+
+                // undefined is a normal result (location.reload(), a void call).
+                // Say so on stderr; stdout still gets valid JSON.
+                if (value === undefined) {
+                    out.log.info("the expression returned no value (undefined); stdout gets null");
+                }
+
+                out.result(value);
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+
+                // location.reload() / location.href = … tear the execution
+                // context down before the eval can answer. That is the script
+                // doing its job, not a failure, so say so and exit 0.
+                if (/context was destroyed|Inspected target navigated|connection closed/i.test(message)) {
+                    out.log.info("page navigated; eval context gone before it returned a value");
+                    process.exit(0);
+                }
+
+                out.log.error(message);
+                process.exit(1);
+            }
+
             process.exit(0);
         });
 
     withPage(program.command("nav"))
-        .description("navigate the tab")
+        .description("navigate a tab, or open a new one with --new")
         .argument("<url>", "destination URL")
-        .action(async (url: string, opts: { port?: string; match?: string }) => {
+        .option("--new", "open a NEW tab instead of reusing one (cannot be combined with --match)")
+        .action(async (url: string, opts: { port?: string; match?: string; new?: boolean }) => {
+            if (opts.new) {
+                if (opts.match) {
+                    out.log.error("--new opens a fresh tab, so --match has nothing to pick. Use one or the other.");
+                    process.exit(1);
+                }
+
+                const port = await resolvePort(opts);
+                const target = await newTab(port, url).catch((err: unknown) => {
+                    out.log.error(err instanceof Error ? err.message : String(err));
+                    process.exit(1);
+                });
+                out.log.info(`new tab ${target.id} on ${port}: ${target.url || url}`);
+                process.exit(0);
+            }
+
             const page = await attachTab(opts);
+            const before = page.target.url;
+
+            if (!opts.match) {
+                out.log.info("no --match given: acting on the most recently active tab");
+            }
+
             await page.navigate(url);
             await Bun.sleep(2500);
-            out.log.info(`now at: ${page.target.url}`);
+            // page.target is the /json/list snapshot taken at attach time, so
+            // printing it after a navigate reported the tab's OLD url — which
+            // read as "nav clobbered some unrelated tab". Ask the tab itself.
+            const after = await page.evaluate("location.href").catch(() => url);
+            out.log.info(`tab ${page.target.id}: ${before}\n         -> ${String(after)}`);
             process.exit(0);
         });
 
@@ -164,12 +204,12 @@ export function registerInspect(program: Command): void {
         .option("--step <n>", "grid spacing in px", "60")
         .option("--full", "capture beyond the viewport")
         .action(async (path: string, opts: { port?: string; region?: string; step: string; full?: boolean }) => {
-            await refuseIfAmbiguous();
+            const port = await resolvePort(opts);
             const { captureFrameGrid } = await import("../lib/frame-grid.ts");
             out.println(
                 await captureFrameGrid({
                     outPath: path,
-                    port: portOf(opts),
+                    port,
                     region: opts.region,
                     gridStep: positiveNumber(opts.step, 60, "--step"),
                     fullPage: opts.full === true,

--- a/src/chrome-devtools/commands/inspect.ts
+++ b/src/chrome-devtools/commands/inspect.ts
@@ -1,7 +1,7 @@
 /** cookies / rm-cookie / console / eval / nav / shot / grid / trace — page and browser inspection. */
 import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
-import { browser, newTab } from "../lib/cdp.ts";
+import { browser, classifyEvalError, newTab } from "../lib/cdp.ts";
 import { artifactPath } from "../lib/platform.ts";
 import { attachTab, ignoreSigpipe, positiveNumber, resolvePort, suggest, withPage, withPort } from "./shared.ts";
 
@@ -136,7 +136,7 @@ export function registerInspect(program: Command): void {
                 // location.reload() / location.href = … tear the execution
                 // context down before the eval can answer. That is the script
                 // doing its job, not a failure, so say so and exit 0.
-                if (/context was destroyed|Inspected target navigated|connection closed/i.test(message)) {
+                if (classifyEvalError(message) === "navigated") {
                     out.log.info("page navigated; eval context gone before it returned a value");
                     process.exit(0);
                 }

--- a/src/chrome-devtools/commands/scripting.ts
+++ b/src/chrome-devtools/commands/scripting.ts
@@ -4,7 +4,7 @@ import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
 import type { Command } from "commander";
 import { findRecipe, recipeHelpLines, scaffoldRecipeScript } from "../lib/scaffold.ts";
-import { portOf, refuseIfAmbiguous, suggest, withPort } from "./shared.ts";
+import { resolvePort, suggest, withPort } from "./shared.ts";
 
 const CHEATSHEET_PATH = join(
     import.meta.dir,
@@ -93,9 +93,8 @@ Examples:
   ${suggest(["mcp", "take_snapshot"])}`
         )
         .action(async (tool: string, json: string, opts: { port?: string }) => {
-            await refuseIfAmbiguous();
             const { callTool, listTools } = await import("../lib/mcp.ts");
-            const port = portOf(opts);
+            const port = await resolvePort(opts);
 
             if (!tool || tool === "list") {
                 out.println((await listTools({ port })).join("\n"));

--- a/src/chrome-devtools/commands/shared.ts
+++ b/src/chrome-devtools/commands/shared.ts
@@ -4,9 +4,9 @@ import { suggestCommand } from "@genesiscz/utils/cli";
 import { logger, out } from "@genesiscz/utils/logger";
 import { inspectPidFile, writePidFile } from "@genesiscz/utils/process/pidfile";
 import type { Command } from "commander";
-import { attach, type Page, targets } from "../lib/cdp.ts";
+import { attach, NoMatchingTabError, type Page, targets } from "../lib/cdp.ts";
 import { DEFAULT_CAPTURE_CHANNELS } from "../lib/channels.ts";
-import { captureDir, ensureCaptureDir, recorderPidPath } from "../lib/paths.ts";
+import { captureDir, ensureCaptureDir, readLastPort, recorderPidPath } from "../lib/paths.ts";
 import { artifactPath } from "../lib/platform.ts";
 import { readRecorderMeta } from "../lib/recorder.ts";
 import {
@@ -18,9 +18,7 @@ import {
     listRunningBrowsers,
     mergeProbePorts,
     ownerOfPort,
-    planAttach,
     readDevToolsActivePortsFromDisk,
-    renderAttachPlan,
 } from "../lib/resolve-attach.ts";
 
 const { log } = logger.scoped("chrome-devtools:cli");
@@ -90,6 +88,24 @@ export async function probe(
     }
 }
 
+/**
+ * Is one specific port answering CDP right now?
+ *
+ * `/json/version` only — it answers instantly while `/json/list` can stall
+ * behind a busy tab, and the caller only needs liveness, not the page list.
+ */
+async function isEndpointLive(port: number): Promise<boolean> {
+    try {
+        const res = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(1200) });
+
+        return res.ok;
+    } catch (err) {
+        log.debug({ err, port }, "remembered port is not answering; falling back to a full scan");
+
+        return false;
+    }
+}
+
 export async function scanInventory(): Promise<Inventory> {
     const running = listRunningBrowsers();
     const ports = mergeProbePorts(CDP_PORTS, discoverListeningCdpPorts(), readDevToolsActivePortsFromDisk());
@@ -107,30 +123,70 @@ export async function scanInventory(): Promise<Inventory> {
     };
 }
 
-/** Refuse to guess between two open Chromium browsers unless --port picks one. */
-export async function refuseIfAmbiguous(): Promise<void> {
+/**
+ * The ONE place a verb decides which endpoint it talks to.
+ *
+ * Explicit --port wins. Otherwise: the port `attach` last worked on if it is
+ * still live, else the single live endpoint whatever its number, else an error
+ * naming the live ports. The old code defaulted to a hardcoded 9222 and then
+ * refused on ambiguity, so `attach --port 9223` followed by a bare `nav` printed
+ * the whole inventory and did nothing.
+ */
+export async function resolvePort(opts: { port?: string }): Promise<number> {
     if (isPortSpecified()) {
-        return;
+        return portOf(opts);
     }
 
-    const plan = planAttach(await scanInventory());
-    if (plan.status !== "ambiguous") {
-        return;
+    // Ask the remembered port directly before scanning. `scanInventory` runs
+    // `pgrep -x` once per known browser — 13 of them, sequentially, measured at
+    // 593/604/824 ms — and the remembered port is the answer most of the time,
+    // so paying that first threw away the whole point of remembering it.
+    const remembered = readLastPort();
+
+    if (remembered != null && (await isEndpointLive(remembered))) {
+        log.debug({ port: remembered }, "using the port attach last worked on");
+
+        return remembered;
     }
 
-    const { text } = renderAttachPlan(plan, { cmd: TOOL_CMD, suggestCommand: suggest });
-    out.log.error(text);
+    const inventory = await scanInventory();
+    const live = inventory.endpoints.map((e) => e.port);
+
+    if (live.length === 1) {
+        return live[0];
+    }
+
+    if (live.length === 0) {
+        out.log.error("No live CDP endpoint. A browser must be LAUNCHED with --remote-debugging-port.");
+        out.log.info(`  ${suggest(["attach"])}`);
+        process.exit(1);
+    }
+
+    out.log.error(`${live.length} live CDP endpoints (${live.join(", ")}). Pick one with --port; nothing is guessed.`);
+    out.log.info(`  ${suggest(["attach", "--port", String(live[0])])}   then bare verbs use that port`);
     process.exit(1);
 }
 
 /** attach() with the no-random-tab contract; exits with guidance when the match misses. */
 export async function attachTab(opts: { port?: string; match?: string }): Promise<Page> {
-    await refuseIfAmbiguous();
+    const port = await resolvePort(opts);
     try {
-        return await attach({ port: portOf(opts), url: opts.match });
+        return await attach({ port, url: opts.match });
     } catch (err) {
+        if (err instanceof NoMatchingTabError) {
+            out.log.error(`${err.message} on port ${port}.`);
+            out.log.info(
+                err.candidates.length
+                    ? `Closest open tabs:\n${err.candidates.map((c) => `    ${c.title ?? ""} :: ${c.url}`).join("\n")}`
+                    : `No page targets are open on ${port}.`
+            );
+            out.log.info(`  open a new tab instead: ${suggest(["nav", "<url>", "--new", "--port", String(port)])}`);
+            out.log.info(`  full list:              ${suggest(["targets", "--port", String(port)])}`);
+            process.exit(1);
+        }
+
         out.log.error(err instanceof Error ? err.message : String(err));
-        out.log.info(`See open tabs first: ${suggest(["targets", "--port", String(portOf(opts))])}`);
+        out.log.info(`See open tabs first: ${suggest(["targets", "--port", String(port)])}`);
         process.exit(1);
     }
 }

--- a/src/chrome-devtools/lib/cdp.test.ts
+++ b/src/chrome-devtools/lib/cdp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { closeTabCandidates, makeMatcher, NoMatchingTabError, pickPageTarget } from "./cdp.ts";
+import { classifyEvalError, closeTabCandidates, makeMatcher, NoMatchingTabError, pickPageTarget } from "./cdp.ts";
 
 describe("pickPageTarget", () => {
     test("throws when no tab URL matches instead of returning the first tab", () => {
@@ -78,5 +78,33 @@ describe("closeTabCandidates", () => {
         const pages = Array.from({ length: 20 }, (_, i) => ({ title: "t", url: `https://a.example/${i}` }));
 
         expect(closeTabCandidates(pages, "zzzzzz")).toHaveLength(6);
+    });
+});
+
+/**
+ * Regression test: PR #336 review t1. The eval path treated any error whose text
+ * contained "connection closed" as proof the script had navigated, and exited 0.
+ * That is a websocket-level failure, not a CDP navigation signal — the browser
+ * dying mid-eval produces it too, and the expression may never have run. Exit 0
+ * there tells an automation caller a navigation happened when nothing did.
+ */
+describe("classifyEvalError", () => {
+    test("the two CDP protocol errors mean the script navigated the page", () => {
+        expect(classifyEvalError("Execution context was destroyed.")).toBe("navigated");
+        expect(classifyEvalError("Inspected target navigated or closed")).toBe("navigated");
+    });
+
+    test("matching is case-insensitive, as Chrome's casing has changed between versions", () => {
+        expect(classifyEvalError("execution CONTEXT WAS DESTROYED")).toBe("navigated");
+    });
+
+    test("a closed connection is a failure, not a navigation", () => {
+        expect(classifyEvalError("connection closed")).toBe("failed");
+        expect(classifyEvalError("WebSocket connection closed before the response arrived")).toBe("failed");
+    });
+
+    test("anything else is a failure", () => {
+        expect(classifyEvalError("SyntaxError: Unexpected token")).toBe("failed");
+        expect(classifyEvalError("")).toBe("failed");
     });
 });

--- a/src/chrome-devtools/lib/cdp.test.ts
+++ b/src/chrome-devtools/lib/cdp.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { pickPageTarget } from "./cdp.ts";
+import { closeTabCandidates, makeMatcher, NoMatchingTabError, pickPageTarget } from "./cdp.ts";
 
 describe("pickPageTarget", () => {
     test("throws when no tab URL matches instead of returning the first tab", () => {
@@ -22,5 +22,61 @@ describe("pickPageTarget", () => {
 
     test("errors with the port when there is no page at all", () => {
         expect(() => pickPageTarget([], { port: 9222 })).toThrow("no page target on port 9222");
+    });
+
+    test("matches on the tab title too, not only the URL", () => {
+        const pages = [{ type: "page", title: "Chartjs demo", url: "http://127.0.0.1:3079/x" }];
+
+        expect(pickPageTarget(pages, { url: "Chartjs" }).url).toBe("http://127.0.0.1:3079/x");
+    });
+
+    test("a miss carries the closest tabs, so the CLI can print them", () => {
+        const pages = [
+            { type: "page", title: "demo", url: "http://127.0.0.1:3079/chartjs-demo" },
+            { type: "page", title: "docs", url: "https://example.com/docs" },
+        ];
+
+        try {
+            pickPageTarget(pages, { url: "3079/chartjs-demo-typo" });
+            throw new Error("expected a NoMatchingTabError");
+        } catch (err) {
+            expect(err).toBeInstanceOf(NoMatchingTabError);
+            expect((err as NoMatchingTabError).candidates[0].url).toBe("http://127.0.0.1:3079/chartjs-demo");
+        }
+    });
+});
+
+describe("makeMatcher", () => {
+    test("plain patterns are substrings", () => {
+        expect(makeMatcher("3079")("http://127.0.0.1:3079/x")).toBe(true);
+        expect(makeMatcher("3079")("http://127.0.0.1:3080/x")).toBe(false);
+    });
+
+    test("/pattern/flags is a regex — the --match help promised this from day one", () => {
+        expect(makeMatcher("/30(79|81)/")("http://127.0.0.1:3081/x")).toBe(true);
+        expect(makeMatcher("/^https:/")("http://127.0.0.1:3081/x")).toBe(false);
+        expect(makeMatcher("/CHARTJS/i")("http://127.0.0.1:3079/chartjs")).toBe(true);
+    });
+
+    test("a bare slash-free pattern that looks regexy stays literal", () => {
+        expect(makeMatcher("a|b")("x a|b y")).toBe(true);
+        expect(makeMatcher("a|b")("just a")).toBe(false);
+    });
+});
+
+describe("closeTabCandidates", () => {
+    test("ranks tabs sharing tokens with the failed match first", () => {
+        const pages = [
+            { title: "unrelated", url: "https://example.com/" },
+            { title: "demo", url: "http://127.0.0.1:3079/chartjs-demo" },
+        ];
+
+        expect(closeTabCandidates(pages, "3079/chartjs-demo-typo")[0].url).toBe("http://127.0.0.1:3079/chartjs-demo");
+    });
+
+    test("with no token overlap it still shows what is open, capped", () => {
+        const pages = Array.from({ length: 20 }, (_, i) => ({ title: "t", url: `https://a.example/${i}` }));
+
+        expect(closeTabCandidates(pages, "zzzzzz")).toHaveLength(6);
     });
 });

--- a/src/chrome-devtools/lib/cdp.ts
+++ b/src/chrome-devtools/lib/cdp.ts
@@ -349,14 +349,74 @@ export class Browser {
     }
 }
 
+/**
+ * /json/list must never be able to hang a command. Chromium answers
+ * /json/version instantly while /json/list stalls behind a busy tab, and an
+ * unbounded fetch there turned `nav --match <nothing>` into a 90s hang that
+ * had to be killed.
+ */
+export const TARGETS_TIMEOUT_MS = 5000;
+
 export async function targets(port = 9222, opts: { signal?: AbortSignal } = {}): Promise<Target[]> {
-    const r = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: opts.signal });
+    const signal = opts.signal ?? AbortSignal.timeout(TARGETS_TIMEOUT_MS);
+    const r = await fetch(`http://127.0.0.1:${port}/json/list`, { signal });
 
     return (await r.json()) as Target[];
 }
 
+/**
+ * `/substr/flags` is a regex, anything else is a plain substring. The --match
+ * help text promised regex support from day one; only substring was wired up.
+ */
+export function makeMatcher(pattern: string): (value: string) => boolean {
+    const re = pattern.match(/^\/(.+)\/([gimsuy]*)$/);
+
+    if (re) {
+        const compiled = new RegExp(re[1], re[2].replace(/g/g, ""));
+
+        return (value) => compiled.test(value);
+    }
+
+    return (value) => value.includes(pattern);
+}
+
+/**
+ * Tabs worth suggesting when `--match` hit nothing, best first: a miss must
+ * say what IS open, not just that the guess failed.
+ */
+export function closeTabCandidates<T extends { title?: string; url: string }>(
+    pages: T[],
+    wanted: string,
+    limit = 6
+): T[] {
+    const tokens = wanted
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((t) => t.length > 1);
+    const score = (t: T) => {
+        const hay = `${t.title ?? ""} ${t.url}`.toLowerCase();
+
+        return tokens.filter((tok) => hay.includes(tok)).length;
+    };
+    const scored = pages.map((t) => ({ t, s: score(t) }));
+    const hits = scored.filter((x) => x.s > 0).sort((a, z) => z.s - a.s);
+
+    return (hits.length ? hits : scored).slice(0, limit).map((x) => x.t);
+}
+
+/** Thrown when --match names no open tab; carries the candidates to print. */
+export class NoMatchingTabError extends Error {
+    constructor(
+        readonly wanted: string,
+        readonly candidates: { title?: string; url: string }[]
+    ) {
+        super(`no tab matching "${wanted}"`);
+        this.name = "NoMatchingTabError";
+    }
+}
+
 /** Pick a page target. A given `url` must hit; never fall back to the first tab. */
-export function pickPageTarget<T extends { type?: string; url: string }>(
+export function pickPageTarget<T extends { type?: string; title?: string; url: string }>(
     list: T[],
     opts: { url?: string; index?: number; port?: number } = {}
 ): T {
@@ -364,9 +424,10 @@ export function pickPageTarget<T extends { type?: string; url: string }>(
     const wanted = opts.url;
 
     if (wanted) {
-        const t = pages.find((x) => x.url.includes(wanted));
+        const matches = makeMatcher(wanted);
+        const t = pages.find((x) => matches(x.url) || matches(x.title ?? ""));
         if (!t) {
-            throw new Error(`no tab matching "${wanted}"`);
+            throw new NoMatchingTabError(wanted, closeTabCandidates(pages, wanted));
         }
 
         return t;
@@ -389,6 +450,24 @@ export async function attach(opts: { port?: number; url?: string; index?: number
     await page.enable();
 
     return page;
+}
+
+/**
+ * Open a NEW tab. `PUT /json/new?<url>` is the only endpoint that creates one
+ * (Chromium ≥111 rejects the GET form), and it returns the fresh target — so
+ * attaching does not have to re-scan and guess which tab is the new one.
+ */
+export async function newTab(port: number, url: string): Promise<Target> {
+    const r = await fetch(`http://127.0.0.1:${port}/json/new?${url}`, {
+        method: "PUT",
+        signal: AbortSignal.timeout(TARGETS_TIMEOUT_MS),
+    });
+
+    if (!r.ok) {
+        throw new Error(`could not open a tab on ${port}: ${r.status} ${await r.text()}`);
+    }
+
+    return (await r.json()) as Target;
 }
 
 /** Browser-level connection (cookies across all domains). */

--- a/src/chrome-devtools/lib/cdp.ts
+++ b/src/chrome-devtools/lib/cdp.ts
@@ -365,10 +365,6 @@ export async function targets(port = 9222, opts: { signal?: AbortSignal } = {}):
 }
 
 /**
- * `/substr/flags` is a regex, anything else is a plain substring. The --match
- * help text promised regex support from day one; only substring was wired up.
- */
-/**
  * Why an eval threw: did the script navigate the page, or did the call fail?
  *
  * Only two Chrome protocol errors mean "your script did its job and tore its own
@@ -382,11 +378,25 @@ export function classifyEvalError(message: string): "navigated" | "failed" {
     return /context was destroyed|Inspected target navigated/i.test(message) ? "navigated" : "failed";
 }
 
-export function makeMatcher(pattern: string): (value: string) => boolean {
+/**
+ * `/substr/flags` is a regex, anything else is a plain substring, and no pattern
+ * matches everything. The --match help text promised regex support from day one;
+ * only substring was wired up.
+ *
+ * This is the ONE matcher for the tool: `follow` re-exports it rather than
+ * keeping a second copy whose edge cases could drift (PR #336 review t5).
+ */
+export function makeMatcher(pattern?: string): (value: string) => boolean {
+    if (!pattern) {
+        return () => true;
+    }
+
     const re = pattern.match(/^\/(.+)\/([gimsuy]*)$/);
 
     if (re) {
-        const compiled = new RegExp(re[1], re[2].replace(/g/g, ""));
+        // g and y make test() stateful via lastIndex, so a reused matcher would
+        // silently skip every other hit. They add nothing to a boolean test.
+        const compiled = new RegExp(re[1], re[2].replace(/[gy]/g, ""));
 
         return (value) => compiled.test(value);
     }

--- a/src/chrome-devtools/lib/cdp.ts
+++ b/src/chrome-devtools/lib/cdp.ts
@@ -368,6 +368,20 @@ export async function targets(port = 9222, opts: { signal?: AbortSignal } = {}):
  * `/substr/flags` is a regex, anything else is a plain substring. The --match
  * help text promised regex support from day one; only substring was wired up.
  */
+/**
+ * Why an eval threw: did the script navigate the page, or did the call fail?
+ *
+ * Only two Chrome protocol errors mean "your script did its job and tore its own
+ * execution context down" — `location.reload()` and `location.href = …` both
+ * produce one of them. A closed websocket is NOT one: the browser exiting or the
+ * endpoint disappearing produces the same text, and there the expression may
+ * never have run at all. Reporting that as success told automation callers a
+ * navigation had happened when nothing did (PR #336 review t1).
+ */
+export function classifyEvalError(message: string): "navigated" | "failed" {
+    return /context was destroyed|Inspected target navigated/i.test(message) ? "navigated" : "failed";
+}
+
 export function makeMatcher(pattern: string): (value: string) => boolean {
     const re = pattern.match(/^\/(.+)\/([gimsuy]*)$/);
 

--- a/src/chrome-devtools/lib/follow.ts
+++ b/src/chrome-devtools/lib/follow.ts
@@ -9,6 +9,7 @@
 import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
 import { parseJsonlChunk } from "@genesiscz/utils/jsonl";
 import { logger } from "@genesiscz/utils/logger";
+import { makeMatcher } from "./cdp.ts";
 import { RENDER_NEEDS_CAPTURE, type RecordedEvent, type RenderChannel, renderEventLines } from "./channels.ts";
 import { captureDir } from "./paths.ts";
 import { readRecorderMeta } from "./recorder.ts";
@@ -16,24 +17,8 @@ import { listSegments } from "./segments.ts";
 
 const { log } = logger.scoped("chrome-devtools:follow");
 
-/** URL matcher: substring, or /regex/flags. Ported from the old watch verb. */
-export function makeMatcher(m?: string): (url: string) => boolean {
-    if (!m) {
-        return () => true;
-    }
-
-    if (m.startsWith("/") && m.lastIndexOf("/") > 0) {
-        const i = m.lastIndexOf("/");
-        // g/y make test() stateful via lastIndex — a repeated matcher would
-        // silently skip every other hit. They add nothing to a boolean test.
-        const flags = m.slice(i + 1).replace(/[gy]/g, "");
-        const re = new RegExp(m.slice(1, i), flags);
-
-        return (u: string) => re.test(u);
-    }
-
-    return (u: string) => u.includes(m);
-}
+/** The URL matcher lives in cdp.ts; re-exported so `follow`'s own callers keep their import. */
+export { makeMatcher };
 
 /** Render channels the recorder is not capturing, with the restart command that would add them. */
 export function missingCaptureChannels(

--- a/src/chrome-devtools/lib/paths.ts
+++ b/src/chrome-devtools/lib/paths.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { logger } from "@genesiscz/utils/logger";
 import { currentPlatform, tmpRoot } from "./platform.ts";
@@ -39,6 +39,38 @@ export function metaPath(port: number): string {
 
 export function recorderPidPath(port: number): string {
     return join(captureDir(port), "recorder.pid");
+}
+
+/**
+ * Where `attach` records the port it worked on, so a later `nav`/`eval` with
+ * no --port does not have to re-guess between two open browsers. It lives
+ * under the capture root on purpose: /tmp clears on reboot, and so does the
+ * browser session the port belonged to.
+ */
+export function lastPortPath(): string {
+    return join(CAPTURE_ROOT, "last-port");
+}
+
+export function rememberLastPort(port: number): void {
+    try {
+        mkdirSync(CAPTURE_ROOT, { recursive: true, mode: 0o700 });
+        writeFileSync(lastPortPath(), `${port}\n`, { mode: 0o600 });
+    } catch (err) {
+        // Never fail a working command over a convenience hint.
+        log.debug({ err, port }, "could not record last attached port");
+    }
+}
+
+export function readLastPort(): number | null {
+    try {
+        const raw = Number(readFileSync(lastPortPath(), "utf8").trim());
+
+        return Number.isInteger(raw) && raw > 0 && raw < 65536 ? raw : null;
+    } catch (err) {
+        log.debug({ err }, "no remembered port");
+
+        return null;
+    }
 }
 
 /** Ports that have a capture dir on disk (live or leftover). */

--- a/src/claude/commands/cmux/send.command.test.ts
+++ b/src/claude/commands/cmux/send.command.test.ts
@@ -6,6 +6,10 @@ import { out } from "@genesiscz/utils/logger";
 
 const SESSION_A = "8b6e69bf-0efc-4990-ba3e-b77262498421";
 const CALLER_PANE = "pane:2";
+const LIVE_SURFACE_UUID = "22222222-2222-4222-8222-222222222222";
+// A surface the app no longer knows: the send against it fails, which is what
+// makes the recorded-ref path fall back to the matcher.
+const DEAD_SURFACE_UUID = "44444444-4444-4444-8444-444444444444";
 
 let snapshot: CmuxLiveSnapshot;
 let events: string[] = [];
@@ -20,8 +24,8 @@ mock.module("@genesiscz/utils/cmux/lib/cli", () => ({
     runCmuxOk: async (args: string[]) => {
         events.push(args.join(" "));
 
-        if (args.includes("dead-ws")) {
-            throw new Error("no such workspace");
+        if (args.includes(DEAD_SURFACE_UUID)) {
+            throw new Error("invalid_params: Surface is not a terminal");
         }
 
         return { code: 0, stdout: "", stderr: "" };
@@ -67,8 +71,8 @@ const deps = {
 function recordedRefs(overrides: Partial<SessionCmuxRefs> = {}): SessionCmuxRefs {
     return {
         sessionId: SESSION_A,
-        workspaceId: "ws-uuid",
-        surfaceId: "surf-uuid",
+        workspaceId: "11111111-1111-4111-8111-111111111111",
+        surfaceId: LIVE_SURFACE_UUID,
         workspaceRef: "workspace:11",
         paneRef: "pane:7",
         surfaceRef: "surface:41",
@@ -121,10 +125,10 @@ test("sends text then Enter to the pane whose tab carries the session marker", a
 
     await sendCommand(SESSION_A.slice(0, 8), "Just poking", { first: true, enter: true, enterDelay: "0" }, deps);
 
-    expect(events).toContain("send --workspace workspace:11 --surface surface:41 -- Just poking");
-    expect(events).toContain("send-key --workspace workspace:11 --surface surface:41 enter");
-    expect(events.indexOf("send --workspace workspace:11 --surface surface:41 -- Just poking")).toBeLessThan(
-        events.indexOf("send-key --workspace workspace:11 --surface surface:41 enter")
+    expect(events).toContain("send --surface surface:41 -- Just poking");
+    expect(events).toContain("send-key --surface surface:41 enter");
+    expect(events.indexOf("send --surface surface:41 -- Just poking")).toBeLessThan(
+        events.indexOf("send-key --surface surface:41 enter")
     );
 });
 
@@ -138,7 +142,7 @@ test("--no-enter sends the text only", async () => {
 
     await sendCommand(SESSION_A.slice(0, 8), "/keepalive", { first: true, enter: false, enterDelay: "0" }, deps);
 
-    expect(events).toContain("send --workspace workspace:11 --surface surface:41 -- /keepalive");
+    expect(events).toContain("send --surface surface:41 -- /keepalive");
     expect(events.some((event) => event.startsWith("send-key"))).toBe(false);
 });
 
@@ -154,7 +158,7 @@ test("a pane-scope match falls back to the pane's selected surface", async () =>
 
     await sendCommand(SESSION_A, "hello", { first: true, enter: false, enterDelay: "0" }, deps);
 
-    expect(events).toContain("send --workspace workspace:11 --surface surface:90 -- hello");
+    expect(events).toContain("send --surface surface:90 -- hello");
 });
 
 test("no match exits 1 with sent:false JSON", async () => {
@@ -184,7 +188,7 @@ test("the calling pane is excluded unless --include-self", async () => {
         { first: true, includeSelf: true, enter: false, enterDelay: "0" },
         deps
     );
-    expect(events).toContain(`send --workspace workspace:11 --surface surface:5 -- hi`);
+    expect(events).toContain(`send --surface surface:5 -- hi`);
 });
 
 test("dry run resolves but sends nothing", async () => {
@@ -216,7 +220,7 @@ test("recorded refs from the session hook win without any snapshot fetch", async
 
     await sendCommand(SESSION_A, "hi", { enter: false, enterDelay: "0" }, recordedDeps);
 
-    expect(events).toContain("send --workspace ws-uuid --surface surf-uuid -- hi");
+    expect(events).toContain(`send --surface ${LIVE_SURFACE_UUID} -- hi`);
     expect(snapshotFetches).toBe(0);
 });
 
@@ -229,13 +233,17 @@ test("stale recorded refs fall back to the matcher", async () => {
     ]);
     const staleDeps = {
         ...deps,
-        lookupRefs: () => recordedRefs({ workspaceId: "dead-ws", surfaceId: "dead-surf" }),
+        lookupRefs: () =>
+            recordedRefs({
+                workspaceId: "33333333-3333-4333-8333-333333333333",
+                surfaceId: DEAD_SURFACE_UUID,
+            }),
     };
 
     await sendCommand(SESSION_A.slice(0, 8), "hi", { first: true, enter: false, enterDelay: "0" }, staleDeps);
 
-    expect(events).toContain("send --workspace dead-ws --surface dead-surf -- hi");
-    expect(events).toContain("send --workspace workspace:11 --surface surface:41 -- hi");
+    expect(events).toContain(`send --surface ${DEAD_SURFACE_UUID} -- hi`);
+    expect(events).toContain("send --surface surface:41 -- hi");
 });
 
 test("a stale recorded ref falling back to two panes is still refused", async () => {
@@ -259,7 +267,11 @@ test("a stale recorded ref falling back to two panes is still refused", async ()
     const staleDeps = {
         ...deps,
         lookupSession: async () => ({ aliases: [], sessionId: SESSION_A, cwd: "/repo" }),
-        lookupRefs: () => recordedRefs({ workspaceId: "dead-ws", surfaceId: "dead-surf" }),
+        lookupRefs: () =>
+            recordedRefs({
+                workspaceId: "33333333-3333-4333-8333-333333333333",
+                surfaceId: DEAD_SURFACE_UUID,
+            }),
     };
 
     await sendCommand(SESSION_A, "hi", { json: true, enter: false, enterDelay: "0" }, staleDeps);
@@ -268,7 +280,7 @@ test("a stale recorded ref falling back to two panes is still refused", async ()
     expect(result.sent).toBe(false);
     expect(result.ambiguous).toBe(true);
     // The dead recorded surface is attempted once; nothing lands on a live pane.
-    expect(events.some((event) => event.startsWith("send --workspace workspace:11"))).toBe(false);
+    expect(events.some((event) => event.includes("--surface surface:41"))).toBe(false);
 });
 
 test("refuses to type into an ambiguous working-directory match", async () => {
@@ -315,7 +327,7 @@ test("a single working-directory match still delivers", async () => {
 
     await sendCommand(SESSION_A, "hi", { first: true, enter: false, enterDelay: "0" }, cwdDeps);
 
-    expect(events).toContain("send --workspace workspace:11 --surface surface:1 -- hi");
+    expect(events).toContain("send --surface surface:1 -- hi");
 });
 
 test("deliverySurfaceId prefers the matched surface over the selected one", () => {

--- a/src/claude/commands/cmux/send.ts
+++ b/src/claude/commands/cmux/send.ts
@@ -2,6 +2,7 @@ import { describeMatch, type FocusTarget, isUnambiguous } from "@app/claude/lib/
 import { findSessionTargets, type ResolveDeps, retryAfterStaleRefs, SOFT_SOURCES } from "@app/claude/lib/cmux/resolve";
 import { suggestCommand } from "@genesiscz/utils/cli";
 import { runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
 import pc from "picocolors";
@@ -46,7 +47,7 @@ interface Delivery {
 }
 
 async function deliver({ target, surfaceId, text, enter, enterDelayMs }: Delivery) {
-    const where = ["--workspace", target.workspaceId, "--surface", surfaceId];
+    const where = surfaceTargetArgs(surfaceId, target.workspaceId);
     await runCmuxOk(["send", ...where, "--", text]);
 
     if (enter) {

--- a/src/claude/lib/cmux/apply.ts
+++ b/src/claude/lib/cmux/apply.ts
@@ -4,6 +4,7 @@ import type { PlannedPane, PlannedWorkspace, RestorePlan } from "@app/claude/lib
 import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
 import { withFocusedWorkspace } from "@genesiscz/utils/cmux/lib/focus-guard";
 import { paneList, rpc, windowList } from "@genesiscz/utils/cmux/lib/socket";
+import { surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
 import { applySplitTree } from "@genesiscz/utils/cmux/split-tree";
 import { createWorkspaceWithName } from "@genesiscz/utils/cmux/workspace";
 import { logger } from "@genesiscz/utils/logger";
@@ -190,7 +191,7 @@ async function fillPane(
             { workspaceRef, surfaceRef, sessionId: session.candidate.sessionId, enter: opts.enter },
             "[claude-cmux] sending launch command"
         );
-        await runCmuxOk(["send", "--workspace", workspaceRef, "--surface", surfaceRef, payload]);
+        await runCmuxOk(["send", ...surfaceTargetArgs(surfaceRef, workspaceRef), payload]);
     }
 
     return skipped;

--- a/src/claude/lib/cmux/open-session.ts
+++ b/src/claude/lib/cmux/open-session.ts
@@ -2,6 +2,7 @@ import { buildLaunchCommand, paneTitle } from "@app/claude/lib/cmux/command";
 import { findCandidate } from "@app/claude/lib/cmux/sessions";
 import type { PlannedSession } from "@app/claude/lib/cmux/types";
 import { runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
 import {
     createWorkspaceWithName,
     openSplitInWorkspace,
@@ -91,7 +92,7 @@ export async function openSessionAt(
 
     const payload = `${command}${(opts.enter ?? true) ? "\n" : ""}`;
     await prof.measureAsync("send", () =>
-        runCmuxOk(["send", "--workspace", placed.workspaceRef, "--surface", placed.surfaceRef, payload])
+        runCmuxOk(["send", ...surfaceTargetArgs(placed.surfaceRef, placed.workspaceRef), payload])
     );
     prof.summary("open-session");
 

--- a/src/claude/lib/cmux/sessions.test.ts
+++ b/src/claude/lib/cmux/sessions.test.ts
@@ -21,7 +21,7 @@ describe("cleanPromptText", () => {
     test("drops a pasted status line and keeps the question", () => {
         const raw =
             " claude-opus-5 GenesisTools feat/claude-cmux-restore\n" +
-            "  313k/775k(40%) +1.6k AC 8b6e69bf @10:17:44 ⚿ martin\n" +
+            "  313k/775k(40%) +1.6k AC 8b6e69bf @10:17:44 ⚿ personal\n" +
             "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n\n" +
             "it still shows the old data";
 
@@ -52,16 +52,18 @@ describe("subdirOf", () => {
     });
 
     /**
-     * Claude Code files a SIBLING worktree (`web-app-297040`, next to `web-app`) under
+     * Claude Code files a SIBLING worktree (`web-app-issue-4821`, next to `web-app`) under
      * the plain project. Without this branch several different worktrees all render as
      * `web-app` and the picker cannot tell them apart.
      */
     test("a sibling worktree shows what distinguishes it, minus the repeated project name", () => {
-        expect(subdirOf("/Users/Martin/Projects/widgets/web-app-297040-auth", "web-app")).toBe("297040-auth");
+        expect(subdirOf("/Users/me/Projects/acme/web-app-issue-4821-burn-auth", "web-app")).toBe(
+            "issue-4821-burn-auth"
+        );
     });
 
     test("an unrelated directory shows its own name", () => {
-        expect(subdirOf("/Users/Martin/scratch/experiment", "web-app")).toBe("experiment");
+        expect(subdirOf("/Users/me/scratch/experiment", "web-app")).toBe("experiment");
     });
 
     test("a package inside the repo keeps its full path tail", () => {

--- a/src/claude/lib/cmux/sessions.test.ts
+++ b/src/claude/lib/cmux/sessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { cleanPromptText, subdirOf } from "@app/claude/lib/cmux/sessions";
+import { cleanPromptText, pickBySessionId, subdirOf } from "@app/claude/lib/cmux/sessions";
 
 describe("cleanPromptText", () => {
     test("keeps ordinary prompt text unchanged", () => {
@@ -68,5 +68,32 @@ describe("subdirOf", () => {
 
     test("a package inside the repo keeps its full path tail", () => {
         expect(subdirOf("/Users/me/Projects/app/packages/web", "app")).toBe("packages/web");
+    });
+});
+
+/**
+ * Regression test: PR #336 review t9. A prefix that fits several sessions used
+ * to return the first LISTED one, so a caller could act on a different worktree
+ * than the id it typed.
+ */
+describe("pickBySessionId", () => {
+    const a = { sessionId: "abcd1234-aaaa", cwd: "/w/a" };
+    const b = { sessionId: "abcd1234-bbbb", cwd: "/w/b" };
+    const noCwd = { sessionId: "abcd1234-aaaa", cwd: undefined };
+
+    test("an exact id wins even when a longer id is listed first", () => {
+        expect(pickBySessionId([b, { sessionId: "abcd1234", cwd: "/w/exact" }], "abcd1234")?.cwd).toBe("/w/exact");
+    });
+
+    test("a prefix that fits exactly one session resolves", () => {
+        expect(pickBySessionId([a, b], "abcd1234-a")?.cwd).toBe("/w/a");
+    });
+
+    test("an ambiguous prefix resolves to nothing rather than guessing", () => {
+        expect(pickBySessionId([a, b], "abcd1234")).toBeNull();
+    });
+
+    test("a record with no cwd cannot shadow a complete one listed after it", () => {
+        expect(pickBySessionId([noCwd, a], "abcd1234-a")?.cwd).toBe("/w/a");
     });
 });

--- a/src/claude/lib/cmux/sessions.ts
+++ b/src/claude/lib/cmux/sessions.ts
@@ -162,7 +162,7 @@ export function cleanPromptText(raw: string | null | undefined): string | null {
  *
  * Two shapes matter, and both are worktrees:
  *  - NESTED (`GenesisTools/.worktrees/fix`) — the tail below the project root.
- *  - SIBLING (`web-app-297040-auth`) — a directory next to the repo. Claude
+ *  - SIBLING (`web-app-issue-4821-burn-auth`) — a directory next to the repo. Claude
  *    Code still files it under the project `web-app`, so without this the row reads as
  *    the plain repo and several worktrees look identical. The redundant `web-app-`
  *    prefix is dropped, leaving the part that tells them apart.

--- a/src/claude/lib/cmux/sessions.ts
+++ b/src/claude/lib/cmux/sessions.ts
@@ -58,6 +58,32 @@ export async function listCandidates(opts: ListCandidatesOptions): Promise<Resto
     return Promise.all(recent.map((record) => toCandidate(record, pins)));
 }
 
+/**
+ * The one record a needle names, or null.
+ *
+ * Usable records are filtered FIRST: `find` returned the earliest prefix match,
+ * so an exact id could lose to a longer one listed before it, and a first match
+ * with no cwd aborted the lookup even when a complete record followed.
+ *
+ * An exact id always wins. A prefix counts only when it fits exactly ONE
+ * session — listing order is no identity guarantee, so taking the first match
+ * would let a caller restore a different worktree than the one it named
+ * (PR #336 review t9).
+ */
+export function pickBySessionId<T extends { sessionId?: string | null; cwd?: string | null }>(
+    sessions: T[],
+    needle: string
+): T | null {
+    const usable = sessions.filter((s) => {
+        const id = (s.sessionId ?? "").toLowerCase();
+
+        return Boolean(s.sessionId && s.cwd) && (id === needle || id.startsWith(needle));
+    });
+    const exact = usable.find((s) => (s.sessionId ?? "").toLowerCase() === needle);
+
+    return exact ?? (usable.length === 1 ? usable[0] : null);
+}
+
 /** One session as a RestoreCandidate, by full id or a prefix of at least 8 chars. */
 export async function findCandidate(
     sessionId: string,
@@ -70,14 +96,7 @@ export async function findCandidate(
     }
 
     const listing = await getSessionListing({ excludeSubagents: true });
-    // Filter to usable records FIRST. `find` returned the earliest prefix match,
-    // so an exact id could lose to a longer one listed before it, and a first
-    // match with no cwd aborted the lookup even when a complete record followed.
-    const usable = listing.sessions.filter((s) => {
-        const id = (s.sessionId ?? "").toLowerCase();
-        return Boolean(s.sessionId && s.cwd) && (id === needle || id.startsWith(needle));
-    });
-    const record = usable.find((s) => (s.sessionId ?? "").toLowerCase() === needle) ?? usable[0];
+    const record = pickBySessionId(listing.sessions, needle);
 
     if (!record?.sessionId || !record.cwd) {
         return null;

--- a/src/claude/lib/long-lived-token.test.ts
+++ b/src/claude/lib/long-lived-token.test.ts
@@ -10,7 +10,7 @@ function configWith(tokens: AIAccountTokens): AIConfigData {
     return {
         _schemaVersion: 1,
         accounts: [
-            { name: "martin", provider: "anthropic-sub", tokens },
+            { name: "personal", provider: "anthropic-sub", tokens },
             { name: "other", provider: "anthropic-sub", tokens: {} },
         ],
         defaultAccounts: {},
@@ -23,7 +23,7 @@ function configWith(tokens: AIAccountTokens): AIConfigData {
 describe("applyLongLivedToken", () => {
     test("sets the token on the named account only", () => {
         const data = configWith({});
-        applyLongLivedToken(data, { accountName: "martin", token: "sk-ant-oat01-new" });
+        applyLongLivedToken(data, { accountName: "personal", token: "sk-ant-oat01-new" });
 
         expect(data.accounts[0].tokens.longLivedToken).toBe("sk-ant-oat01-new");
         expect(data.accounts[1].tokens.longLivedToken).toBeUndefined();
@@ -38,7 +38,7 @@ describe("applyLongLivedToken", () => {
             expiresAt: 1234,
         });
 
-        applyLongLivedToken(data, { accountName: "martin", token: "sk-ant-oat01-new" });
+        applyLongLivedToken(data, { accountName: "personal", token: "sk-ant-oat01-new" });
 
         expect(data.accounts[0].tokens.accessToken).toBe("fresh-access");
         expect(data.accounts[0].tokens.refreshToken).toBe("fresh-refresh");
@@ -47,14 +47,14 @@ describe("applyLongLivedToken", () => {
 
     test("a minted token records its expiry", () => {
         const data = configWith({});
-        applyLongLivedToken(data, { accountName: "martin", token: "tok", expiresAt: 999 });
+        applyLongLivedToken(data, { accountName: "personal", token: "tok", expiresAt: 999 });
 
         expect(data.accounts[0].tokens.longLivedTokenExpiresAt).toBe(999);
     });
 
     test("replacing a minted token with a PASTED one clears the stale expiry", () => {
         const data = configWith({ longLivedToken: "minted", longLivedTokenExpiresAt: 999 });
-        applyLongLivedToken(data, { accountName: "martin", token: "pasted" });
+        applyLongLivedToken(data, { accountName: "personal", token: "pasted" });
 
         expect(data.accounts[0].tokens.longLivedToken).toBe("pasted");
         expect(data.accounts[0].tokens.longLivedTokenExpiresAt).toBeUndefined();

--- a/src/claude/lib/teams/launch.test.ts
+++ b/src/claude/lib/teams/launch.test.ts
@@ -166,8 +166,8 @@ describe("isLiveSidechain", () => {
 
 describe("buildToolsCcTeammateCommand", () => {
     test("wraps tools cc run with account and flags", () => {
-        const cmd = buildToolsCcTeammateCommand("martin", fakeTeam(), fakeMate());
-        expect(cmd).toContain("tools cc run 'martin' --");
+        const cmd = buildToolsCcTeammateCommand("personal", fakeTeam(), fakeMate());
+        expect(cmd).toContain("tools cc run 'personal' --");
         expect(cmd).toContain("--agent-name");
         expect(cmd).toContain("bm-research-product");
         expect(cmd).toContain("cd '/Users/Martin/Tresors/Projects/GenesisPlayground'");

--- a/src/claude/lib/usage/burn-pace.test.ts
+++ b/src/claude/lib/usage/burn-pace.test.ts
@@ -97,7 +97,7 @@ describe("paceFor", () => {
     });
 
     test("undefined with no history", () => {
-        expect(paceFor(db, { accountName: "martin", bucket: "five_hour", utilizationPct: 50 })).toBeUndefined();
+        expect(paceFor(db, { accountName: "personal", bucket: "five_hour", utilizationPct: 50 })).toBeUndefined();
     });
 
     test("reports the active basis when active samples dominate", () => {
@@ -107,11 +107,11 @@ describe("paceFor", () => {
             [20, 30],
             [10, 40],
         ] as const) {
-            db.recordSnapshot("martin", "five_hour", value, recentTimestamp(minutesAgo));
+            db.recordSnapshot("personal", "five_hour", value, recentTimestamp(minutesAgo));
         }
 
         const result = paceFor(db, {
-            accountName: "martin",
+            accountName: "personal",
             bucket: "five_hour",
             utilizationPct: 40,
             scope: "per-account",
@@ -133,7 +133,7 @@ describe("paceFor", () => {
 
         expect(
             paceFor(db, {
-                accountName: "martin",
+                accountName: "personal",
                 bucket: "five_hour",
                 utilizationPct: 50,
                 scope: "per-account",
@@ -152,7 +152,7 @@ describe("paceFor", () => {
         }
 
         const result = paceFor(db, {
-            accountName: "martin",
+            accountName: "personal",
             bucket: "five_hour",
             utilizationPct: 50,
             scope: "pooled",
@@ -172,7 +172,7 @@ describe("paceFor", () => {
         }
 
         expect(
-            paceFor(db, { accountName: "martin", bucket: "five_hour", utilizationPct: 50, scope: "pooled" })
+            paceFor(db, { accountName: "personal", bucket: "five_hour", utilizationPct: 50, scope: "pooled" })
         ).toBeUndefined();
     });
 
@@ -183,9 +183,9 @@ describe("paceFor", () => {
             [20, 30],
             [10, 40],
         ] as const) {
-            db.recordSnapshot("martin", "five_hour", value, recentTimestamp(minutesAgo));
+            db.recordSnapshot("personal", "five_hour", value, recentTimestamp(minutesAgo));
         }
 
-        expect(atYourPace(db, { accountName: "martin", bucket: "five_hour", utilizationPct: 40 })).toMatch(/^≈/);
+        expect(atYourPace(db, { accountName: "personal", bucket: "five_hour", utilizationPct: 40 })).toMatch(/^≈/);
     });
 });

--- a/src/claude/lib/usage/table-select.test.ts
+++ b/src/claude/lib/usage/table-select.test.ts
@@ -31,7 +31,7 @@ const SCORED: ScoredAccount[] = [
         weekly: { leftPct: 99, resetsAt: in38h },
         fable: { leftPct: 98, resetsAt: in38h },
     }),
-    scoredAccount("lpreservine", "weekly-blocked", {
+    scoredAccount("weekly-dead", "weekly-blocked", {
         session: { leftPct: 100, resetsAt: null },
         weekly: { leftPct: 20, resetsAt: in38h },
         fable: { leftPct: 0, resetsAt: null },
@@ -95,13 +95,13 @@ describe("account table select frame", () => {
     test("focused row name carries the accent color", () => {
         const parts = buildFrameParts(OPTS);
         const frame = renderFrame(OPTS, parts, "active", 1);
-        expect(frame).toContain("\x1b[1;38;5;75mlpreservine\x1b[22;39m");
+        expect(frame).toContain("\x1b[1;38;5;75mweekly-dead\x1b[22;39m");
     });
 
     test("submit frame collapses to the picked name", () => {
         const parts = buildFrameParts(OPTS);
         const frame = stripAnsi(renderFrame(OPTS, parts, "submit", 1));
-        expect(frame).toContain("lpreservine");
+        expect(frame).toContain("weekly-dead");
         expect(frame).not.toContain("RESETS");
     });
 });

--- a/src/claude/lib/warmup/service.test.ts
+++ b/src/claude/lib/warmup/service.test.ts
@@ -4,7 +4,7 @@ import type { AIAccountTokens } from "@genesiscz/utils/config/ai.types";
 import { formatWarmupViaHint, sendWarmupMessage } from "./service";
 
 const LONG = "x".repeat(LONG_TOKEN_MIN_LENGTH);
-const INVALID_GRANT = "Token expired (invalid_grant). Run: tools claude login bfbc";
+const INVALID_GRANT = "Token expired (invalid_grant). Run: tools claude login side";
 
 function tokens(partial: AIAccountTokens): AIAccountTokens {
     return partial;
@@ -24,7 +24,7 @@ describe("formatWarmupViaHint", () => {
 describe("sendWarmupMessage", () => {
     test("OAuth success does not touch the login-long token", async () => {
         const longLivedCalls: string[] = [];
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({ accessToken: "at", refreshToken: "rt", longLivedToken: LONG }),
             sendOAuth: async () => {},
             sendLongLived: async (token) => {
@@ -40,7 +40,7 @@ describe("sendWarmupMessage", () => {
     test("invalid_grant falls back to login-long and reports it", async () => {
         const oauthCalls: string[] = [];
         const longLivedCalls: string[] = [];
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({ accessToken: "dead", refreshToken: "dead", longLivedToken: LONG }),
             sendOAuth: async (name) => {
                 oauthCalls.push(name);
@@ -52,13 +52,13 @@ describe("sendWarmupMessage", () => {
             },
         });
 
-        expect(oauthCalls).toEqual(["bfbc"]);
+        expect(oauthCalls).toEqual(["side"]);
         expect(longLivedCalls).toEqual([LONG]);
         expect(result).toEqual({ success: true, via: "login-long" });
     });
 
     test("a 429 on login-long still counts as warmup success", async () => {
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({ accessToken: "dead", refreshToken: "dead", longLivedToken: LONG }),
             sendOAuth: async () => {
                 throw new Error(INVALID_GRANT);
@@ -71,7 +71,7 @@ describe("sendWarmupMessage", () => {
 
     test("invalid_grant with no login-long token fails", async () => {
         let longLivedCalled = false;
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({ accessToken: "dead", refreshToken: "dead" }),
             sendOAuth: async () => {
                 throw new Error(INVALID_GRANT);
@@ -88,7 +88,7 @@ describe("sendWarmupMessage", () => {
 
     test("a truncated login-long token is treated as absent", async () => {
         let longLivedCalled = false;
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () =>
                 tokens({ accessToken: "dead", refreshToken: "dead", longLivedToken: "sk-ant-oat01-short" }),
             sendOAuth: async () => {
@@ -106,7 +106,7 @@ describe("sendWarmupMessage", () => {
 
     test("an expired minted login-long token is not used", async () => {
         let longLivedCalled = false;
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () =>
                 tokens({
                     accessToken: "dead",
@@ -129,7 +129,7 @@ describe("sendWarmupMessage", () => {
 
     test("a non-auth OAuth error does not fall back to login-long", async () => {
         let longLivedCalled = false;
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({ accessToken: "at", refreshToken: "rt", longLivedToken: LONG }),
             sendOAuth: async () => {
                 throw new Error("No haiku model available");
@@ -145,7 +145,7 @@ describe("sendWarmupMessage", () => {
     });
 
     test("login-long invalid after invalid_grant is a failure", async () => {
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({ accessToken: "dead", refreshToken: "dead", longLivedToken: LONG }),
             sendOAuth: async () => {
                 throw new Error(INVALID_GRANT);
@@ -158,7 +158,7 @@ describe("sendWarmupMessage", () => {
 
     test("no OAuth pair uses login-long directly", async () => {
         const oauthCalls: string[] = [];
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({ longLivedToken: LONG }),
             sendOAuth: async (name) => {
                 oauthCalls.push(name);
@@ -173,7 +173,7 @@ describe("sendWarmupMessage", () => {
     test("credential-less accounts fail without sending", async () => {
         let oauthCalled = false;
         let longLivedCalled = false;
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({}),
             sendOAuth: async () => {
                 oauthCalled = true;
@@ -190,7 +190,7 @@ describe("sendWarmupMessage", () => {
     });
 
     test("an unreadable token store fails the warmup without throwing", async () => {
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => {
                 throw new Error("ENOENT config");
             },
@@ -204,7 +204,7 @@ describe("sendWarmupMessage", () => {
     });
 
     test("a 401 from OAuth also falls back to login-long", async () => {
-        const result = await sendWarmupMessage("bfbc", {
+        const result = await sendWarmupMessage("side", {
             loadTokens: async () => tokens({ accessToken: "stale", refreshToken: "stale", longLivedToken: LONG }),
             sendOAuth: async () => {
                 throw new Error("Unauthorized: 401");

--- a/src/cmux/README.md
+++ b/src/cmux/README.md
@@ -128,6 +128,17 @@ tools cmux send-self 'text' --dry-run
 nohup zsh -c "sleep 300; tools cmux send-self '/compact'" </dev/null >/dev/null 2>&1 &
 ```
 
+⚠️ **That form is silent when it fails**, so check first: `tools cmux doctor` prints a
+`send-self` line saying whether this surface would actually accept the keystrokes. A failed
+send is still recorded in `~/.genesis-tools/logs/<today>.log` even with stderr discarded.
+
+🛑 **Never pass `--workspace` alongside a surface UUID or `surface:N` ref.** `cmux send` looks
+the surface up INSIDE the workspace you name, so a stale `CMUX_WORKSPACE_ID` — which is what
+you get the moment a surface is moved to another workspace — makes the app answer
+`invalid_params: Surface is not a terminal` about a perfectly good terminal. The surface id
+alone is unique across the whole tree; `surfaceTargetArgs()` in `src/utils/cmux/lib/target.ts`
+is the one place that decides this.
+
 ## Notes
 
 - Profiles are JSON under `~/.genesis-tools/cmux/profiles/`. `edit` opens one, and `path` tells you where it is, so hand-tuning a layout is expected rather than discouraged.

--- a/src/cmux/commands/doctor.ts
+++ b/src/cmux/commands/doctor.ts
@@ -1,3 +1,4 @@
+import { probeSelfSend } from "@app/cmux/lib/send-self-preflight";
 import { ui } from "@genesiscz/utils/cli/ui";
 import { type CmuxHealth, type CmuxProbeResult, probeCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
 import { out } from "@genesiscz/utils/logger";
@@ -19,10 +20,13 @@ export function registerDoctorCommand(parent: Command): void {
 
 async function runDoctor(flags: DoctorFlags): Promise<void> {
     const health = await probeCmuxHealth({ full: true, identifyTimeoutMs: 5000 });
+    // A green socket says nothing about whether THIS shell can type into its own
+    // prompt: send-self failed for weeks while every line below it read ok.
+    const selfSend = await probeSelfSend();
 
     if (flags.json) {
-        out.result(health);
-        setExitCode(health);
+        out.result({ ...health, selfSend });
+        setExitCode(health, selfSend.ok);
         return;
     }
 
@@ -34,6 +38,7 @@ async function runDoctor(flags: DoctorFlags): Promise<void> {
     }
 
     ui.kv("identify", probeLine(health.probes.identify));
+    ui.kv("send-self", selfSend.detail);
 
     switch (health.state) {
         case "healthy":
@@ -63,11 +68,15 @@ async function runDoctor(flags: DoctorFlags): Promise<void> {
             break;
     }
 
-    setExitCode(health);
+    if (!selfSend.ok) {
+        ui.warn(`send-self would not reach this prompt: ${selfSend.fix}`);
+    }
+
+    setExitCode(health, selfSend.ok);
 }
 
-function setExitCode(health: CmuxHealth): void {
-    if (health.state !== "healthy") {
+function setExitCode(health: CmuxHealth, selfSendOk: boolean): void {
+    if (health.state !== "healthy" || !selfSendOk) {
         process.exitCode = 1;
     }
 }

--- a/src/cmux/commands/rescue.ts
+++ b/src/cmux/commands/rescue.ts
@@ -15,6 +15,7 @@ import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
 import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
 import { probeCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
 import { paneList, workspaceList } from "@genesiscz/utils/cmux/lib/socket";
+import { surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
 import { logger, out } from "@genesiscz/utils/logger";
 import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
 import type { Command } from "commander";
@@ -281,7 +282,7 @@ async function replayIntoReopenedSurfaces(profile: Profile, entries: ReplayEntry
                 continue;
             }
 
-            await runCmuxOk(["send", "--workspace", liveWs.ref, "--surface", target.ref, `${entry.command}\n`]);
+            await runCmuxOk(["send", ...surfaceTargetArgs(target.ref, liveWs.ref), `${entry.command}\n`]);
             sent += 1;
             await new Promise((resolve) => setTimeout(resolve, 300));
         }

--- a/src/cmux/commands/send-self.test.ts
+++ b/src/cmux/commands/send-self.test.ts
@@ -19,8 +19,22 @@ describe("resolveSelfTarget", () => {
         });
     });
 
-    it("ignores cmux when only one of the two ids is present", () => {
-        expect(resolveSelfTarget({ CMUX_SURFACE_ID: "F89A4C33" } as NodeJS.ProcessEnv)).toBeNull();
+    /**
+     * Behaviour change 2026-08-28: the surface used to be useless without a
+     * workspace, so this returned null. The workspace is now dropped from the
+     * command line for a self-identifying surface — it could only ever scope
+     * the lookup WRONG — so the surface alone is a complete target.
+     */
+    it("resolves cmux from the surface alone", () => {
+        expect(resolveSelfTarget({ CMUX_SURFACE_ID: "F89A4C33" } as NodeJS.ProcessEnv)).toEqual({
+            kind: "cmux",
+            workspaceId: undefined,
+            surfaceId: "F89A4C33",
+        });
+    });
+
+    it("still returns null when the surface id is missing", () => {
+        expect(resolveSelfTarget({ CMUX_WORKSPACE_ID: "C0503E81" } as NodeJS.ProcessEnv)).toBeNull();
     });
 
     it("prefers tmux when nested inside cmux", () => {

--- a/src/cmux/commands/send-self.ts
+++ b/src/cmux/commands/send-self.ts
@@ -1,11 +1,12 @@
 import { runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
 import { resolveTmuxBin } from "@genesiscz/utils/tmux/bin";
 import type { Command } from "commander";
 
-export type SelfTarget = { kind: "tmux"; pane: string } | { kind: "cmux"; workspaceId: string; surfaceId: string };
+export type SelfTarget = { kind: "tmux"; pane: string } | { kind: "cmux"; workspaceId?: string; surfaceId: string };
 
 export function resolveSelfTarget(
     environment: NodeJS.ProcessEnv,
@@ -19,7 +20,9 @@ export function resolveSelfTarget(
         return { kind: "tmux", pane };
     }
 
-    if (prefer !== "tmux" && surfaceId && workspaceId) {
+    // The surface alone is enough: a UUID names one surface across the whole
+    // tree, and CMUX_WORKSPACE_ID goes stale the moment the surface is moved.
+    if (prefer !== "tmux" && surfaceId) {
         return { kind: "cmux", workspaceId, surfaceId };
     }
 
@@ -49,13 +52,13 @@ async function sendTmux(pane: string, text: string, enter: boolean, enterDelayMs
 }
 
 async function sendCmux(
-    workspaceId: string,
+    workspaceId: string | undefined,
     surfaceId: string,
     text: string,
     enter: boolean,
     enterDelayMs: number
 ): Promise<void> {
-    const where = ["--workspace", workspaceId, "--surface", surfaceId];
+    const where = surfaceTargetArgs(surfaceId, workspaceId);
     await runCmuxOk(["send", ...where, text]);
 
     if (!enter) {
@@ -88,9 +91,7 @@ export function registerSendSelfCommand(program: Command): void {
                 const target = resolveSelfTarget(env.getProcessEnv(), prefer);
 
                 if (!target) {
-                    throw new Error(
-                        "not running inside tmux or cmux (no TMUX_PANE, no CMUX_SURFACE_ID/CMUX_WORKSPACE_ID)"
-                    );
+                    throw new Error("not running inside tmux or cmux (no TMUX_PANE, no CMUX_SURFACE_ID)");
                 }
 
                 const enterDelayMs = Number(opts.enterDelay);

--- a/src/cmux/docs/Cmux.md
+++ b/src/cmux/docs/Cmux.md
@@ -353,7 +353,7 @@ Key names accepted by `send-key`: `enter`, `tab`, `escape`, `up`/`down`/`left`/`
 
 ### Sending to your own surface (`tools cmux send-self`)
 
-`cmux send`/`send-key` accept the caller's own `$CMUX_WORKSPACE_ID` / `$CMUX_SURFACE_ID` as `--workspace` / `--surface`, so a process can type into the terminal it is running in. `tools cmux send-self <text>` wraps that, and falls back to `tmux send-keys -t $TMUX_PANE` when `TMUX_PANE` is set (tmux wins when nested inside cmux; `--target` forces one).
+`cmux send`/`send-key` accept the caller's own `$CMUX_SURFACE_ID` as `--surface`, so a process can type into the terminal it is running in. Pass the surface ALONE: `send` resolves a surface UUID or `surface:N` ref across the whole tree, but adding `--workspace` scopes the lookup to that workspace, and a stale `$CMUX_WORKSPACE_ID` then fails with `invalid_params: Surface is not a terminal`. `tools cmux send-self <text>` wraps that, and falls back to `tmux send-keys -t $TMUX_PANE` when `TMUX_PANE` is set (tmux wins when nested inside cmux; `--target` forces one).
 
 This is the only reliable way to make an agent CLI parse a slash command it did not receive from the keyboard — the bytes arrive on the PTY exactly as if typed.
 

--- a/src/cmux/lib/restore.ts
+++ b/src/cmux/lib/restore.ts
@@ -6,6 +6,7 @@ import * as p from "@clack/prompts";
 import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
 import { withFocusedWorkspace } from "@genesiscz/utils/cmux/lib/focus-guard";
 import { paneList, workspaceCreate } from "@genesiscz/utils/cmux/lib/socket";
+import { surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
 import { applySplitTree, measureCellDelta, type SplitTree } from "@genesiscz/utils/cmux/split-tree";
 import { logger } from "@genesiscz/utils/logger";
 import pc from "picocolors";
@@ -419,10 +420,7 @@ async function replayTerminal(
         if (surface.cwd) {
             await runCmuxOk([
                 "send",
-                "--workspace",
-                workspaceRef,
-                "--surface",
-                surfaceRef,
+                ...surfaceTargetArgs(surfaceRef, workspaceRef),
                 `cd -- ${shellQuote(surface.cwd)}\n`,
             ]);
         }
@@ -467,7 +465,7 @@ async function replayTerminal(
     }
 
     try {
-        await runCmuxOk(["send", "--workspace", workspaceRef, "--surface", surfaceRef, payload]);
+        await runCmuxOk(["send", ...surfaceTargetArgs(surfaceRef, workspaceRef), payload]);
     } catch (error) {
         if (screenDir) {
             // The pipeline never reached the pane, so nothing will consume the file.

--- a/src/cmux/lib/send-self-preflight.test.ts
+++ b/src/cmux/lib/send-self-preflight.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { classifySelfSend } from "@app/cmux/lib/send-self-preflight";
+
+const SURFACE = "03DA1B10-D019-4CF2-8014-5F0AFB7BAF88";
+
+describe("classifySelfSend", () => {
+    test("a tmux pane is a working transport on its own", () => {
+        expect(classifySelfSend({ tmuxPane: "%7" }).ok).toBe(true);
+    });
+
+    test("a terminal surface the environment agrees on is fine", () => {
+        expect(
+            classifySelfSend({ envSurfaceId: SURFACE, callerSurfaceId: SURFACE, callerSurfaceType: "terminal" }).ok
+        ).toBe(true);
+    });
+
+    test("a non-terminal surface cannot take keystrokes", () => {
+        const verdict = classifySelfSend({
+            envSurfaceId: SURFACE,
+            callerSurfaceId: SURFACE,
+            callerSurfaceType: "browser",
+        });
+
+        expect(verdict.ok).toBe(false);
+        expect(verdict.detail).toContain("not a terminal");
+    });
+
+    test("an environment naming a different surface would type into the wrong place", () => {
+        const verdict = classifySelfSend({
+            envSurfaceId: "OLD-ID",
+            callerSurfaceId: SURFACE,
+            callerSurfaceType: "terminal",
+        });
+
+        expect(verdict.ok).toBe(false);
+        expect(verdict.detail).toContain("cmux resolves");
+    });
+
+    test("outside both multiplexers there is nothing to send to", () => {
+        const verdict = classifySelfSend({});
+
+        expect(verdict.ok).toBe(false);
+        expect(verdict.detail).toContain("not inside tmux or cmux");
+    });
+});

--- a/src/cmux/lib/send-self-preflight.ts
+++ b/src/cmux/lib/send-self-preflight.ts
@@ -1,0 +1,79 @@
+import { runCmuxJSON } from "@genesiscz/utils/cmux/lib/cli";
+import { env } from "@genesiscz/utils/env";
+
+/** What `cmux identify` says about the process asking, plus what its own environment claims. */
+export interface SelfSendFacts {
+    tmuxPane?: string;
+    envSurfaceId?: string;
+    callerSurfaceId?: string;
+    callerSurfaceType?: string;
+}
+
+export type SelfSendVerdict = { ok: true; detail: string } | { ok: false; detail: string; fix: string };
+
+/**
+ * Would `tools cmux send-self` reach this process's own prompt?
+ *
+ * Read-only by construction: it compares what the environment claims against
+ * what the app resolves, and never sends anything. `doctor` was green while
+ * send-self failed, because health only probes the socket and the UI thread —
+ * neither notices that the surface being addressed is the wrong one.
+ */
+export function classifySelfSend(facts: SelfSendFacts): SelfSendVerdict {
+    if (facts.tmuxPane) {
+        return { ok: true, detail: `ok (tmux pane ${facts.tmuxPane})` };
+    }
+
+    if (!facts.envSurfaceId && !facts.callerSurfaceId) {
+        return {
+            ok: false,
+            detail: "unavailable (not inside tmux or cmux)",
+            fix: "there is no keystroke transport here — schedule with CronCreate instead",
+        };
+    }
+
+    if (facts.callerSurfaceType && facts.callerSurfaceType !== "terminal") {
+        return {
+            ok: false,
+            detail: `FAILS (this surface is a ${facts.callerSurfaceType}, not a terminal)`,
+            fix: "a non-terminal surface cannot accept keystrokes — schedule with CronCreate instead",
+        };
+    }
+
+    if (facts.envSurfaceId && facts.callerSurfaceId && facts.envSurfaceId !== facts.callerSurfaceId) {
+        return {
+            ok: false,
+            detail: `FAILS (CMUX_SURFACE_ID names ${facts.envSurfaceId}, cmux resolves ${facts.callerSurfaceId})`,
+            fix: "the environment is stale — the text would land in another surface; restart the shell",
+        };
+    }
+
+    return { ok: true, detail: `ok (cmux surface ${facts.callerSurfaceId ?? facts.envSurfaceId})` };
+}
+
+interface IdentifyCaller {
+    caller?: { surface_id?: string; surface_type?: string };
+}
+
+/** Gather the facts. Never throws: an unreachable app is reported, not raised. */
+export async function probeSelfSend(): Promise<SelfSendVerdict> {
+    const environment = env.getProcessEnv();
+    const facts: SelfSendFacts = {
+        tmuxPane: environment.TMUX_PANE,
+        envSurfaceId: environment.CMUX_SURFACE_ID,
+    };
+
+    if (facts.tmuxPane) {
+        return classifySelfSend(facts);
+    }
+
+    try {
+        const identify = await runCmuxJSON<IdentifyCaller>(["identify"], { timeoutMs: 5000 });
+        facts.callerSurfaceId = identify.caller?.surface_id;
+        facts.callerSurfaceType = identify.caller?.surface_type;
+    } catch {
+        return { ok: false, detail: "unknown (identify did not answer)", fix: "see the ping/identify lines above" };
+    }
+
+    return classifySelfSend(facts);
+}

--- a/src/learn-from-fable/commands/report.ts
+++ b/src/learn-from-fable/commands/report.ts
@@ -281,5 +281,5 @@ export function reportCommand(config: FableConfig, options: ReportOptions): void
         return;
     }
 
-    out.print(renderMarkdownToCli(markdown));
+    out.print(renderMarkdownToCli(markdown, { color: Boolean(process.stdout.isTTY) }));
 }

--- a/src/markdown-cli/index.ts
+++ b/src/markdown-cli/index.ts
@@ -6,6 +6,7 @@ import { out } from "@genesiscz/utils/logger";
 import { type MarkdownRenderOptions, renderMarkdownToCli } from "@genesiscz/utils/markdown/index.js";
 import chokidar from "chokidar";
 import { Command, Option } from "commander";
+import { resolveColor } from "./lib/color";
 
 interface MarkdownCLIOptions {
     watch?: boolean;
@@ -37,11 +38,20 @@ program
             .default("auto")
     )
     .option("--no-color", "Strip ANSI color codes from output")
-    .action((file?: string, opts?: MarkdownCLIOptions) => {
+    .option("--color", "Force ANSI colour even when stdout is not a TTY (piping to `less -R`)")
+    .action((file: string | undefined, opts: MarkdownCLIOptions | undefined, command: Command) => {
         const renderOpts: MarkdownRenderOptions = {
             width: opts?.width && !Number.isNaN(opts.width) ? opts.width : undefined,
             theme: (opts?.theme as MarkdownRenderOptions["theme"]) || "dark",
-            color: opts?.color !== false,
+            // Colour follows the TTY unless the user says otherwise. It used to
+            // default to on unconditionally, so piping to a file or another
+            // program embedded raw escapes. `--color` keeps the piped-with-colour
+            // case (`… | less -R`) reachable.
+            //
+            // Boolean() matters: process.stdout.isTTY is `undefined` when stdout
+            // is a pipe, not false, and the renderer strips only on an exact
+            // `color === false`.
+            color: resolveColor(opts?.color, command.getOptionValueSource("color"), Boolean(process.stdout.isTTY)),
             tableEngine: (opts?.tableEngine as MarkdownRenderOptions["tableEngine"]) || "auto",
         };
 
@@ -83,4 +93,9 @@ program
         }
     });
 
-await runTool(program, { tool: "markdown-cli" });
+// Guarded so importing this module does not run the CLI. src/markdown-cli/lib/
+// holds the testable pieces; an unguarded entrypoint is what made the full test
+// suite hang indefinitely on transcribe (see PR #335).
+if (import.meta.main) {
+    await runTool(program, { tool: "markdown-cli" });
+}

--- a/src/markdown-cli/lib/color.ts
+++ b/src/markdown-cli/lib/color.ts
@@ -1,0 +1,17 @@
+/**
+ * An explicit `--color` / `--no-color` wins; otherwise colour follows the TTY.
+ *
+ * Commander maps both flags onto the same `color` key and defaults it to true,
+ * so the VALUE cannot tell "the user asked for colour" from "nobody said".
+ * Only the option's source can, which is why this takes it.
+ *
+ * This lives outside index.ts so a test can import it without running the CLI —
+ * `src/markdown-cli/index.ts` calls `runTool` at module top level.
+ */
+export function resolveColor(value: boolean | undefined, source: string | undefined, isTty: boolean): boolean {
+    if (source === "cli") {
+        return value !== false;
+    }
+
+    return isTty;
+}

--- a/src/markdown-cli/resolve-color.test.ts
+++ b/src/markdown-cli/resolve-color.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { resolveColor } from "./lib/color";
+
+/**
+ * Regression test: `tools markdown` defaulted `color` to on unconditionally, so
+ * piping its output to a file or another program embedded raw ANSI escapes
+ * (verified: `cat x.md | … | cat -v` printed `^[[91m`).
+ *
+ * Commander maps `--color` and `--no-color` onto the same key and defaults it to
+ * true, so the value alone cannot distinguish an explicit flag from silence —
+ * only the option source can.
+ */
+describe("resolveColor", () => {
+    test("no flag: colour follows the TTY", () => {
+        expect(resolveColor(true, "default", false)).toBe(false);
+        expect(resolveColor(true, "default", true)).toBe(true);
+        expect(resolveColor(true, undefined, false)).toBe(false);
+    });
+
+    test("--color forces colour even when piped, so `… | less -R` still works", () => {
+        expect(resolveColor(true, "cli", false)).toBe(true);
+    });
+
+    test("--no-color strips even on a TTY", () => {
+        expect(resolveColor(false, "cli", true)).toBe(false);
+    });
+});

--- a/src/ms-teams/lib/export/html.test.ts
+++ b/src/ms-teams/lib/export/html.test.ts
@@ -82,5 +82,7 @@ describe("renderHtml", () => {
         expect(html.includes("file://")).toBe(true);
         expect(html.includes("eu-api.asm.skype.com")).toBe(false);
         expect(html.split("<img").length - 1).toBe(1);
+        expect(html).toContain("max-width: min(100%, 480px)");
+        expect(html.includes(".html img { max-width: 100%;")).toBe(false);
     });
 });

--- a/src/ms-teams/lib/export/html.ts
+++ b/src/ms-teams/lib/export/html.ts
@@ -2,6 +2,7 @@ import { formatDateTime } from "@genesiscz/utils/date";
 import { parseAmsObjectId } from "../disk-cache";
 import { isImageAttachment, toFileUrl } from "../media";
 import type { Attachment, ThreadExport } from "../types";
+import { EXPORT_IMAGE_STYLE } from "./image-embed";
 
 export function renderHtml(thread: ThreadExport): string {
     const { conversation, messages } = thread;
@@ -62,7 +63,7 @@ export function renderHtml(thread: ThreadExport): string {
   article.nested { margin-left: 1.5rem; }
   header { font-size: 0.85rem; color: GrayText; margin-bottom: 0.35rem; }
   blockquote.reply { margin: 0 0 0.5rem; padding-left: 0.75rem; border-left: 3px solid color-mix(in srgb, CanvasText 25%, transparent); color: GrayText; }
-  .html img { max-width: 100%; height: auto; }
+  img { ${EXPORT_IMAGE_STYLE} width: auto; }
 </style>
 </head>
 <body>

--- a/src/ms-teams/lib/export/image-embed.ts
+++ b/src/ms-teams/lib/export/image-embed.ts
@@ -9,13 +9,8 @@ export function sizedMarkdownImage(src: string, alt: string): string {
 
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
 
-/**
- * Split on fenced blocks and inline code, keeping the delimiters.
- *
- * A capturing group in the split pattern makes the delimiters part of the
- * result, so the odd-indexed chunks are exactly the spans to leave alone.
- */
-const CODE_SPAN_RE = /(```[\s\S]*?```|`[^`\n]*`)/;
+/** A fence opens on three or more backticks or tildes, indented by at most three spaces. */
+const FENCE_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
 
 /**
  * Turn markdown image syntax into a capped HTML img so previews do not go full
@@ -23,17 +18,86 @@ const CODE_SPAN_RE = /(```[\s\S]*?```|`[^`\n]*`)/;
  *
  * A single pass over the whole document also rewrote examples inside a fenced
  * block or inline code, so a message DOCUMENTING markdown had its example
- * silently converted to an <img> tag (PR #336 review t2).
+ * silently converted to an <img> tag (PR #336 review t2). Splitting on
+ * ```-or-single-backtick then still missed tilde fences, longer fences,
+ * unclosed fences and multi-backtick spans (review t11), so code is now found
+ * by an explicit scan rather than by one regex.
  */
 export function sizeMarkdownImages(markdown: string): string {
+    let fence: string | null = null;
+
     return markdown
-        .split(CODE_SPAN_RE)
-        .map((chunk, i) =>
-            i % 2 === 1
-                ? chunk
-                : chunk.replace(MARKDOWN_IMAGE_RE, (_m, alt: string, src: string) => sizedMarkdownImage(src, alt))
-        )
-        .join("");
+        .split("\n")
+        .map((line) => {
+            if (fence) {
+                if (closesFence(line, fence)) {
+                    fence = null;
+                }
+
+                return line;
+            }
+
+            const opener = line.match(FENCE_RE)?.[1];
+
+            if (opener) {
+                fence = opener;
+                return line;
+            }
+
+            return rewriteOutsideInlineCode(line);
+        })
+        .join("\n");
+}
+
+/** A closing fence repeats the opener's character at least as many times, and carries nothing else. */
+function closesFence(line: string, fence: string): boolean {
+    const run = line.match(FENCE_RE)?.[1];
+
+    if (!run || run[0] !== fence[0] || run.length < fence.length) {
+        return false;
+    }
+
+    return line.trimStart().slice(run.length).trim() === "";
+}
+
+function rewriteOutsideInlineCode(line: string): string {
+    let out = "";
+    let i = 0;
+
+    while (i < line.length) {
+        const tick = line.indexOf("`", i);
+
+        if (tick === -1) {
+            return out + rewriteImages(line.slice(i));
+        }
+
+        out += rewriteImages(line.slice(i, tick));
+
+        let runEnd = tick;
+
+        while (line[runEnd] === "`") {
+            runEnd++;
+        }
+
+        const run = line.slice(tick, runEnd);
+        const close = line.indexOf(run, runEnd);
+
+        if (close === -1) {
+            // A backtick run with no partner is literal text, not a code span.
+            out += run;
+            i = runEnd;
+            continue;
+        }
+
+        out += line.slice(tick, close + run.length);
+        i = close + run.length;
+    }
+
+    return out;
+}
+
+function rewriteImages(text: string): string {
+    return text.replace(MARKDOWN_IMAGE_RE, (_m, alt: string, src: string) => sizedMarkdownImage(src, alt));
 }
 
 function escapeAttr(value: string): string {

--- a/src/ms-teams/lib/export/image-embed.ts
+++ b/src/ms-teams/lib/export/image-embed.ts
@@ -7,11 +7,33 @@ export function sizedMarkdownImage(src: string, alt: string): string {
     return `<img src="${escapeAttr(src)}" alt="${escapeAttr(alt)}" style="${EXPORT_IMAGE_STYLE}" />`;
 }
 
-/** Turn markdown image syntax into a capped HTML img so previews do not go full width. */
+const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+/**
+ * Split on fenced blocks and inline code, keeping the delimiters.
+ *
+ * A capturing group in the split pattern makes the delimiters part of the
+ * result, so the odd-indexed chunks are exactly the spans to leave alone.
+ */
+const CODE_SPAN_RE = /(```[\s\S]*?```|`[^`\n]*`)/;
+
+/**
+ * Turn markdown image syntax into a capped HTML img so previews do not go full
+ * width — outside code only.
+ *
+ * A single pass over the whole document also rewrote examples inside a fenced
+ * block or inline code, so a message DOCUMENTING markdown had its example
+ * silently converted to an <img> tag (PR #336 review t2).
+ */
 export function sizeMarkdownImages(markdown: string): string {
-    return markdown.replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, (_match, alt: string, src: string) =>
-        sizedMarkdownImage(src, alt)
-    );
+    return markdown
+        .split(CODE_SPAN_RE)
+        .map((chunk, i) =>
+            i % 2 === 1
+                ? chunk
+                : chunk.replace(MARKDOWN_IMAGE_RE, (_m, alt: string, src: string) => sizedMarkdownImage(src, alt))
+        )
+        .join("");
 }
 
 function escapeAttr(value: string): string {

--- a/src/ms-teams/lib/export/image-embed.ts
+++ b/src/ms-teams/lib/export/image-embed.ts
@@ -1,0 +1,19 @@
+/** Chat-sized cap: intrinsic width up to this, never the full thread column. */
+export const EXPORT_IMAGE_MAX_WIDTH = "480px";
+
+export const EXPORT_IMAGE_STYLE = `max-width: min(100%, ${EXPORT_IMAGE_MAX_WIDTH}); height: auto;`;
+
+export function sizedMarkdownImage(src: string, alt: string): string {
+    return `<img src="${escapeAttr(src)}" alt="${escapeAttr(alt)}" style="${EXPORT_IMAGE_STYLE}" />`;
+}
+
+/** Turn markdown image syntax into a capped HTML img so previews do not go full width. */
+export function sizeMarkdownImages(markdown: string): string {
+    return markdown.replace(/!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g, (_match, alt: string, src: string) =>
+        sizedMarkdownImage(src, alt)
+    );
+}
+
+function escapeAttr(value: string): string {
+    return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}

--- a/src/ms-teams/lib/export/markdown.test.ts
+++ b/src/ms-teams/lib/export/markdown.test.ts
@@ -6,12 +6,20 @@ const OBJECT_ID = "0-weu-d1-0123456789abcdef01234567";
 const AMS = `https://eu-api.asm.skype.com/v1/objects/${OBJECT_ID}/views/imgo`;
 const LOCAL = `/tmp/${OBJECT_ID}.png`;
 
+const ME = { mri: "8:orgid:me", displayName: "alice@example.com", email: null };
+
 function threadWith(message: Partial<ExportedMessage> & Pick<ExportedMessage, "text" | "html">): ThreadExport {
-    const full: ExportedMessage = {
-        id: "m1",
-        sequenceId: 1,
+    return threadWithMessages([message]);
+}
+
+function threadWithMessages(
+    messages: Array<Partial<ExportedMessage> & Pick<ExportedMessage, "text" | "html">>
+): ThreadExport {
+    const full = messages.map((message, index) => ({
+        id: `m${index + 1}`,
+        sequenceId: index + 1,
         time: "2026-08-13T18:04:41.000Z",
-        from: { mri: "8:orgid:me", displayName: "martin@example.com", email: null },
+        from: ME,
         isFromMe: true,
         messageType: "RichText/Html",
         replyToId: null,
@@ -23,7 +31,9 @@ function threadWith(message: Partial<ExportedMessage> & Pick<ExportedMessage, "t
         call: null,
         system: null,
         ...message,
-    };
+    }));
+    const first = full[0];
+    const last = full[full.length - 1];
 
     return {
         conversation: {
@@ -32,13 +42,17 @@ function threadWith(message: Partial<ExportedMessage> & Pick<ExportedMessage, "t
             title: "Ada Lovelace",
             topic: null,
             members: [],
-            cachedFrom: full.time,
-            cachedTo: full.time,
-            messageCount: 1,
+            cachedFrom: first?.time ?? null,
+            cachedTo: last?.time ?? null,
+            messageCount: full.length,
             completenessNote: COMPLETENESS_NOTE,
         },
-        messages: [full],
+        messages: full,
     };
+}
+
+function speakerHeadings(md: string, who: string): string[] {
+    return md.split("\n").filter((line) => /^#{1,6} /.test(line) && line.includes(` · ${who}`));
 }
 
 describe("renderMarkdown", () => {
@@ -70,9 +84,34 @@ describe("renderMarkdown", () => {
                 ],
             })
         );
-        expect(md.split(`![${OBJECT_ID}.png](${LOCAL})`).length - 1).toBe(1);
+        expect(md.split(`<img src="${LOCAL}"`).length - 1).toBe(1);
+        expect(md).toContain(`style="max-width: min(100%, 480px); height: auto;"`);
+        expect(md.includes(`![${OBJECT_ID}.png](${LOCAL})`)).toBe(false);
         expect(md.includes("eu-api.asm.skype.com")).toBe(false);
         expect(md.includes("_(no text)_")).toBe(false);
+    });
+
+    test("caps a follow-up attachment image to a normal size instead of full width", () => {
+        const md = renderMarkdown(
+            threadWith({
+                text: "",
+                html: null,
+                attachments: [
+                    {
+                        name: `${OBJECT_ID}.png`,
+                        mimeHint: "png",
+                        url: AMS,
+                        itemId: OBJECT_ID,
+                        localPath: LOCAL,
+                    },
+                ],
+            })
+        );
+
+        expect(md).toContain(
+            `<img src="${LOCAL}" alt="${OBJECT_ID}.png" style="max-width: min(100%, 480px); height: auto;" />`
+        );
+        expect(md.includes(`![${OBJECT_ID}.png](${LOCAL})`)).toBe(false);
     });
 
     test("does not relist a remote inline image that has no localPath or itemId", () => {
@@ -93,5 +132,76 @@ describe("renderMarkdown", () => {
     test("falls back to plain text when there is no html", () => {
         const md = renderMarkdown(threadWith({ text: "plain only", html: null }));
         expect(md).toContain("plain only");
+    });
+
+    // Regression test: consecutive same-speaker bursts were each given a ## time · name heading.
+    test("omits the speaker heading on a follow-up from the same person within an hour", () => {
+        const md = renderMarkdown(
+            threadWithMessages([
+                { text: "first ping", html: null, time: "2026-08-13T18:04:41.000Z" },
+                { text: "second ping", html: null, time: "2026-08-13T18:09:41.000Z" },
+            ])
+        );
+
+        expect(speakerHeadings(md, "alice@example.com (me)")).toHaveLength(1);
+        expect(md).toContain("first ping");
+        expect(md).toContain("second ping");
+    });
+
+    test("omits the speaker heading when the same-person gap is 59 minutes", () => {
+        const md = renderMarkdown(
+            threadWithMessages([
+                { text: "before the hour", html: null, time: "2026-08-13T18:04:41.000Z" },
+                { text: "still the same burst", html: null, time: "2026-08-13T19:03:41.000Z" },
+            ])
+        );
+
+        expect(speakerHeadings(md, "alice@example.com (me)")).toHaveLength(1);
+        expect(md).toContain("before the hour");
+        expect(md).toContain("still the same burst");
+    });
+
+    test("keeps the speaker heading when the same-person gap is an hour", () => {
+        const md = renderMarkdown(
+            threadWithMessages([
+                { text: "first hour", html: null, time: "2026-08-13T18:04:41.000Z" },
+                { text: "next hour", html: null, time: "2026-08-13T19:04:41.000Z" },
+            ])
+        );
+
+        expect(speakerHeadings(md, "alice@example.com (me)")).toHaveLength(2);
+        expect(md).toContain("first hour");
+        expect(md).toContain("next hour");
+    });
+
+    test("keeps the speaker heading after someone else spoke", () => {
+        const ada = { mri: "8:orgid:ada", displayName: "Ada Lovelace", email: null };
+        const md = renderMarkdown(
+            threadWithMessages([
+                { text: "mine first", html: null, time: "2026-08-13T18:04:41.000Z" },
+                { text: "ada reply", html: null, time: "2026-08-13T18:05:41.000Z", from: ada, isFromMe: false },
+                { text: "mine again", html: null, time: "2026-08-13T18:06:41.000Z" },
+            ])
+        );
+
+        expect(speakerHeadings(md, "alice@example.com (me)")).toHaveLength(2);
+        expect(speakerHeadings(md, "Ada Lovelace")).toHaveLength(1);
+        expect(md).toContain("mine first");
+        expect(md).toContain("ada reply");
+        expect(md).toContain("mine again");
+    });
+
+    test("omits the speaker heading on another person's follow-up within an hour", () => {
+        const ada = { mri: "8:orgid:ada", displayName: "Ada Lovelace", email: null };
+        const md = renderMarkdown(
+            threadWithMessages([
+                { text: "ada first", html: null, time: "2026-08-13T18:04:41.000Z", from: ada, isFromMe: false },
+                { text: "ada second", html: null, time: "2026-08-13T18:06:41.000Z", from: ada, isFromMe: false },
+            ])
+        );
+
+        expect(speakerHeadings(md, "Ada Lovelace")).toHaveLength(1);
+        expect(md).toContain("ada first");
+        expect(md).toContain("ada second");
     });
 });

--- a/src/ms-teams/lib/export/markdown.test.ts
+++ b/src/ms-teams/lib/export/markdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { COMPLETENESS_NOTE, type ExportedMessage, type ThreadExport } from "../types";
+import { sizeMarkdownImages } from "./image-embed";
 import { renderMarkdown } from "./markdown";
 
 const OBJECT_ID = "0-weu-d1-0123456789abcdef01234567";
@@ -203,5 +204,39 @@ describe("renderMarkdown", () => {
         expect(speakerHeadings(md, "Ada Lovelace")).toHaveLength(1);
         expect(md).toContain("ada first");
         expect(md).toContain("ada second");
+    });
+});
+
+/**
+ * Regression test: PR #336 review t2. sizeMarkdownImages ran one regex over the
+ * whole document, so image syntax INSIDE a code fence or inline code — i.e. a
+ * message that is documenting markdown rather than using it — was rewritten into
+ * an <img> tag, corrupting the exported text.
+ */
+describe("sizeMarkdownImages leaves code alone", () => {
+    test("rewrites a real image", () => {
+        expect(sizeMarkdownImages("![cat](https://example.invalid/c.png)")).toContain("<img src=");
+    });
+
+    test("leaves image syntax inside a fenced block untouched", () => {
+        const md = ["Here is how you embed one:", "", "```md", "![cat](https://example.invalid/c.png)", "```"].join(
+            "\n"
+        );
+
+        expect(sizeMarkdownImages(md)).toBe(md);
+    });
+
+    test("leaves image syntax inside inline code untouched", () => {
+        const md = "Write `![cat](c.png)` to embed it.";
+
+        expect(sizeMarkdownImages(md)).toBe(md);
+    });
+
+    test("still rewrites a real image that sits beside a fenced block", () => {
+        const md = ["```md", "![doc](doc.png)", "```", "", "![real](real.png)"].join("\n");
+        const out = sizeMarkdownImages(md);
+
+        expect(out).toContain("![doc](doc.png)");
+        expect(out).toContain('<img src="real.png"');
     });
 });

--- a/src/ms-teams/lib/export/markdown.test.ts
+++ b/src/ms-teams/lib/export/markdown.test.ts
@@ -239,4 +239,38 @@ describe("sizeMarkdownImages leaves code alone", () => {
         expect(out).toContain("![doc](doc.png)");
         expect(out).toContain('<img src="real.png"');
     });
+
+    /**
+     * Regression test: PR #336 review t11. The first fix split on ``` or a
+     * single backtick, so every other valid code delimiter still leaked.
+     */
+    test("leaves image syntax inside a tilde fence untouched", () => {
+        const md = ["~~~md", "![cat](c.png)", "~~~"].join("\n");
+
+        expect(sizeMarkdownImages(md)).toBe(md);
+    });
+
+    test("leaves image syntax inside a four-backtick fence untouched", () => {
+        const md = ["````md", "```", "![cat](c.png)", "```", "````"].join("\n");
+
+        expect(sizeMarkdownImages(md)).toBe(md);
+    });
+
+    test("an unclosed fence protects everything after it", () => {
+        const md = ["```md", "![cat](c.png)"].join("\n");
+
+        expect(sizeMarkdownImages(md)).toBe(md);
+    });
+
+    test("leaves image syntax inside a double-backtick span untouched", () => {
+        const md = "Write ``![cat](c.png)`` to embed it.";
+
+        expect(sizeMarkdownImages(md)).toBe(md);
+    });
+
+    test("a lone backtick is literal text, not an open span", () => {
+        const out = sizeMarkdownImages("a ` b ![real](real.png)");
+
+        expect(out).toContain('<img src="real.png"');
+    });
 });

--- a/src/ms-teams/lib/export/markdown.ts
+++ b/src/ms-teams/lib/export/markdown.ts
@@ -3,6 +3,7 @@ import { logger } from "@genesiscz/utils/logger";
 import { teamsHtmlToMarkdown } from "../html-to-markdown";
 import { isImageAttachment } from "../media";
 import type { Attachment, ExportedMessage, ThreadExport } from "../types";
+import { sizeMarkdownImages } from "./image-embed";
 
 const log = logger.scoped("ms-teams").log;
 
@@ -23,11 +24,15 @@ export function renderMarkdown(thread: ThreadExport): string {
         lines.push("");
     }
 
+    let previous: ExportedMessage | undefined;
+
     for (const message of messages) {
-        const when = formatDateTime(message.time, { absolute: "datetime" });
-        const who = message.from.displayName + (message.isFromMe ? " (me)" : "");
-        lines.push(`## ${when} · ${who}`);
-        lines.push("");
+        if (!continuesSpeakerBurst(previous, message)) {
+            const when = formatDateTime(message.time, { absolute: "datetime" });
+            const who = message.from.displayName + (message.isFromMe ? " (me)" : "");
+            lines.push(`## ${when} · ${who}`);
+            lines.push("");
+        }
 
         if (message.replyTo) {
             lines.push(`> reply to ${message.replyTo.from}: ${message.replyTo.excerpt}`);
@@ -70,9 +75,42 @@ export function renderMarkdown(thread: ThreadExport): string {
         }
 
         lines.push("");
+        previous = message;
     }
 
-    return `${lines.join("\n").trim()}\n`;
+    return sizeMarkdownImages(`${lines.join("\n").trim()}\n`);
+}
+
+const SPEAKER_BURST_MS = 60 * 60 * 1000;
+
+function continuesSpeakerBurst(previous: ExportedMessage | undefined, message: ExportedMessage): boolean {
+    if (!previous) {
+        return false;
+    }
+
+    if (speakerKey(previous) !== speakerKey(message)) {
+        return false;
+    }
+
+    const gapMs = Date.parse(message.time) - Date.parse(previous.time);
+
+    if (!Number.isFinite(gapMs) || gapMs < 0 || gapMs >= SPEAKER_BURST_MS) {
+        return false;
+    }
+
+    return true;
+}
+
+function speakerKey(message: ExportedMessage): string {
+    if (message.isFromMe) {
+        return "me";
+    }
+
+    if (message.from.mri) {
+        return message.from.mri;
+    }
+
+    return message.from.displayName;
 }
 
 function messageBodyMarkdown(message: ExportedMessage): string {

--- a/src/ms-teams/lib/media.test.ts
+++ b/src/ms-teams/lib/media.test.ts
@@ -71,7 +71,10 @@ describe("materializeThreadMedia", () => {
         expect(readFileSync(attachment?.localPath ?? "")).toEqual(PNG);
         expect(got.messages[0]?.text).toBe("");
         const md = renderMarkdown(got);
-        expect(md).toContain(`![${OBJECT_ID}.png](${attachment?.localPath})`);
+        expect(md).toContain(
+            `<img src="${attachment?.localPath}" alt="${OBJECT_ID}.png" style="max-width: min(100%, 480px); height: auto;" />`
+        );
+        expect(md.includes(`![${OBJECT_ID}.png](${attachment?.localPath})`)).toBe(false);
         expect(md.includes("_(no text)_")).toBe(false);
         expect(md.includes("eu-api.asm.skype.com")).toBe(false);
     });

--- a/src/utils/ai/__tests__/AIConfig.test.ts
+++ b/src/utils/ai/__tests__/AIConfig.test.ts
@@ -101,7 +101,7 @@ describe("AIConfig", () => {
 
 describe("mergeAccountEntry", () => {
     const stored: AIAccountEntry = {
-        name: "lukas.account-a",
+        name: "work-max",
         provider: "anthropic-sub",
         tokens: {
             accessToken: "sk-ant-oat01-old",
@@ -116,7 +116,7 @@ describe("mergeAccountEntry", () => {
 
     it("keeps the long-lived token when a re-login only supplies the OAuth pair", () => {
         const merged = mergeAccountEntry(stored, {
-            name: "lukas.account-a",
+            name: "work-max",
             provider: "anthropic-sub",
             tokens: { accessToken: "sk-ant-oat01-new", refreshToken: "sk-ant-ort01-new", expiresAt: 2000 },
             apps: ["claude", "ask"],
@@ -131,7 +131,7 @@ describe("mergeAccountEntry", () => {
 
     it("does not let an explicitly undefined label erase the stored one", () => {
         const merged = mergeAccountEntry(stored, {
-            name: "lukas.account-a",
+            name: "work-max",
             provider: "anthropic-sub",
             tokens: { accessToken: "sk-ant-oat01-new" },
             label: undefined,
@@ -142,7 +142,7 @@ describe("mergeAccountEntry", () => {
 
     it("replaces wholesale when the provider changes", () => {
         const merged = mergeAccountEntry(stored, {
-            name: "lukas.account-a",
+            name: "work-max",
             provider: "openai-sub",
             tokens: { accessToken: "openai-token" },
         });

--- a/src/utils/ai/config/doctor-no-refresh.test.ts
+++ b/src/utils/ai/config/doctor-no-refresh.test.ts
@@ -27,7 +27,7 @@ import { type AccountEntry, type AiConfigData, CONFIG_VERSION } from "./schema";
  * guarded (a worktree build), so a health probe that refreshed would spend the
  * grant and be unable to persist the rotated pair, silently bricking the
  * account. Observed live on 2026-07-29: doctor printed
- * "[token-refresh] reservine: initiating refresh (reason: token-expired)".
+ * "[token-refresh] shop: initiating refresh (reason: token-expired)".
  *
  * These tests pin the rule at every end: the gate inside `resolveAccountToken`,
  * the plugin health path `doctor` walks, and the plugin BIND path

--- a/src/utils/cli/bun-link.test.ts
+++ b/src/utils/cli/bun-link.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { namedBunExecPath } from "./bun-link";
+
+const isWindows = process.platform === "win32";
+
+describe.skipIf(isWindows)("namedBunExecPath", () => {
+    let home: string;
+    let fakeBun: string;
+
+    beforeEach(() => {
+        home = mkdtempSync(join(tmpdir(), "bun-link-test-"));
+        env.testing.set("GENESIS_TOOLS_HOME", home);
+        fakeBun = join(home, "bun");
+        writeFileSync(fakeBun, "#!/bin/sh\n");
+    });
+
+    it("creates a hardlink named after the tool", () => {
+        const linkPath = namedBunExecPath("youtube", fakeBun);
+
+        expect(linkPath).toBe(join(home, ".genesis-tools", "bin", "gt-youtube"));
+        expect(statSync(linkPath).ino).toBe(statSync(fakeBun).ino);
+    });
+
+    it("reuses an existing link whose inode still matches", () => {
+        const first = namedBunExecPath("du", fakeBun);
+        const firstIno = statSync(first).ino;
+        const second = namedBunExecPath("du", fakeBun);
+
+        expect(second).toBe(first);
+        expect(statSync(second).ino).toBe(firstIno);
+    });
+
+    it("re-links when the bun binary was replaced with a new inode", () => {
+        const linkPath = namedBunExecPath("du", fakeBun);
+        const staleIno = statSync(linkPath).ino;
+
+        unlinkSync(fakeBun);
+        writeFileSync(fakeBun, "#!/bin/sh\n# upgraded\n");
+
+        const relinked = namedBunExecPath("du", fakeBun);
+
+        expect(relinked).toBe(linkPath);
+        expect(statSync(relinked).ino).toBe(statSync(fakeBun).ino);
+        expect(statSync(relinked).ino).not.toBe(staleIno);
+    });
+
+    it("sanitizes names that are not safe file names", () => {
+        const linkPath = namedBunExecPath("you tube/x", fakeBun);
+
+        expect(linkPath).toBe(join(home, ".genesis-tools", "bin", "gt-you-tube-x"));
+        expect(statSync(linkPath).ino).toBe(statSync(fakeBun).ino);
+    });
+
+    it("falls back to the bun binary when linking fails", () => {
+        const missing = join(home, "does-not-exist");
+
+        expect(namedBunExecPath("broken", missing)).toBe(missing);
+    });
+});

--- a/src/utils/cli/bun-link.ts
+++ b/src/utils/cli/bun-link.ts
@@ -1,0 +1,46 @@
+import { existsSync, linkSync, mkdirSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { logger } from "@genesiscz/utils/logger";
+
+/**
+ * Resolve a bun executable named after the tool it will run, so the process
+ * shows up in Activity Monitor / ps / pgrep as "gt-<name>" instead of "bun".
+ *
+ * Activity Monitor names a process after its resolved executable file and
+ * follows symlinks (verified 2026-08-26), so only a HARDLINK changes the
+ * displayed name. A hardlink shares the binary's inode: zero disk cost and
+ * the code signature stays intact. `bun upgrade` writes a new inode, so a
+ * link whose inode no longer matches the live binary is re-created. Any
+ * filesystem failure (cross-device tmp, concurrent create race) falls back
+ * to the plain bun binary, which merely keeps the old "bun" display name.
+ */
+export function namedBunExecPath(name: string, bunPath: string = process.execPath): string {
+    if (process.platform === "win32") {
+        return bunPath;
+    }
+
+    const linkName = `gt-${name.replace(/[^\w.-]+/g, "-")}`;
+    const binDir = join(env.tools.getHome(), ".genesis-tools", "bin");
+    const linkPath = join(binDir, linkName);
+
+    try {
+        const bunStat = statSync(bunPath);
+
+        if (existsSync(linkPath)) {
+            const linkStat = statSync(linkPath);
+            if (linkStat.ino === bunStat.ino && linkStat.dev === bunStat.dev) {
+                return linkPath;
+            }
+
+            unlinkSync(linkPath);
+        }
+
+        mkdirSync(binDir, { recursive: true });
+        linkSync(bunPath, linkPath);
+        return linkPath;
+    } catch (err) {
+        logger.debug({ err, linkPath }, "[bun-link] hardlink failed, falling back to the bun binary");
+        return bunPath;
+    }
+}

--- a/src/utils/cli/result.test.ts
+++ b/src/utils/cli/result.test.ts
@@ -7,4 +7,11 @@ describe("asResult", () => {
         expect(asResult("hello\n")).toBe("hello\n"); // idempotent newline
         expect(asResult({ ok: true })).toBe('{"ok":true}\n'); // SafeJSON, never bare JSON
     });
+
+    it("unserializable payloads become null instead of crashing", () => {
+        // SafeJSON.stringify returns undefined here; .endsWith on that used to
+        // kill the process mid-command (chrome-devtools eval returning nothing).
+        expect(asResult(undefined)).toBe("null\n");
+        expect(asResult(() => {})).toBe("null\n");
+    });
 });

--- a/src/utils/cli/result.ts
+++ b/src/utils/cli/result.ts
@@ -3,6 +3,12 @@ import { SafeJSON } from "@genesiscz/utils/json";
 /** Canonical machine-result serialization. The ONLY stringifier for stdout
  *  result payloads — used by out.result() and any pre-migration. */
 export function asResult(data: unknown): string {
-    const s = typeof data === "string" ? data : SafeJSON.stringify(data);
+    // JSON has no `undefined`, so SafeJSON.stringify returns undefined for it
+    // (and for functions / symbols). Emitting "null" keeps stdout valid JSON;
+    // the old code called .endsWith on that undefined and crashed the process
+    // with a Bun stack dump — `chrome-devtools eval '() => location.reload()'`
+    // hit it, because page JS that returns nothing is perfectly normal.
+    const s = typeof data === "string" ? data : (SafeJSON.stringify(data) ?? "null");
+
     return s.endsWith("\n") ? s : `${s}\n`;
 }

--- a/src/utils/cli/tools.ts
+++ b/src/utils/cli/tools.ts
@@ -1,6 +1,7 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { env } from "@genesiscz/utils/env";
+import { namedBunExecPath } from "./bun-link";
 import type { ExecResult } from "./executor";
 
 function getToolsPath(): string {
@@ -20,7 +21,7 @@ export interface RunToolOptions {
  * Usage: `execTool(["claude", "usage"])` runs `tools claude usage`
  */
 export async function execTool(args: string[], options?: RunToolOptions): Promise<ExecResult> {
-    const proc = Bun.spawn(["bun", "run", getToolsPath(), ...args], {
+    const proc = Bun.spawn([namedBunExecPath("tools"), "run", getToolsPath(), ...args], {
         cwd: options?.cwd ?? process.cwd(),
         stdio: ["ignore", "pipe", "pipe"],
         env: { ...env.getProcessEnv(), ...options?.env },
@@ -49,7 +50,7 @@ export async function execToolInteractive(
     args: string[],
     options?: Omit<RunToolOptions, "timeout">
 ): Promise<ExecResult> {
-    const proc = Bun.spawn(["bun", "run", getToolsPath(), ...args], {
+    const proc = Bun.spawn([namedBunExecPath("tools"), "run", getToolsPath(), ...args], {
         cwd: options?.cwd ?? process.cwd(),
         stdio: ["inherit", "inherit", "inherit"],
         env: { ...env.getProcessEnv(), ...options?.env },

--- a/src/utils/cmux/lib/target.test.ts
+++ b/src/utils/cmux/lib/target.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { isSelfIdentifyingSurface, surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
+
+/**
+ * Regression test: a stale CMUX_WORKSPACE_ID made `cmux send` reject a real
+ * terminal with `invalid_params: Surface is not a terminal`, because the surface
+ * was looked up inside a workspace it no longer belonged to.
+ */
+describe("surfaceTargetArgs", () => {
+    const uuid = "03DA1B10-D019-4CF2-8014-5F0AFB7BAF88";
+    const workspace = "04AA5245-8C6E-427B-AFDF-9937CFE1D36F";
+
+    test("a surface UUID is sent without a workspace, so a stale one cannot scope it away", () => {
+        expect(surfaceTargetArgs(uuid, workspace)).toEqual(["--surface", uuid]);
+    });
+
+    test("a surface ref is equally self-identifying", () => {
+        expect(surfaceTargetArgs("surface:94", workspace)).toEqual(["--surface", "surface:94"]);
+    });
+
+    test("a bare index is workspace-relative, so the workspace is kept", () => {
+        expect(surfaceTargetArgs("4", workspace)).toEqual(["--workspace", workspace, "--surface", "4"]);
+    });
+
+    test("no workspace to drop is not an error", () => {
+        expect(surfaceTargetArgs("4")).toEqual(["--surface", "4"]);
+    });
+});
+
+describe("isSelfIdentifyingSurface", () => {
+    test("uuid, surface ref and tab ref identify a surface on their own", () => {
+        expect(isSelfIdentifyingSurface("03da1b10-d019-4cf2-8014-5f0afb7baf88")).toBe(true);
+        expect(isSelfIdentifyingSurface("surface:94")).toBe(true);
+        expect(isSelfIdentifyingSurface("tab:94")).toBe(true);
+    });
+
+    test("a bare index does not", () => {
+        expect(isSelfIdentifyingSurface("4")).toBe(false);
+        expect(isSelfIdentifyingSurface("")).toBe(false);
+    });
+});

--- a/src/utils/cmux/lib/target.ts
+++ b/src/utils/cmux/lib/target.ts
@@ -1,0 +1,34 @@
+/**
+ * How to name a surface on a cmux command line.
+ *
+ * `cmux send --workspace <w> --surface <s>` looks the surface up INSIDE `<w>`,
+ * and when `<w>` is not the workspace that actually holds `<s>` the lookup lands
+ * on something that is not a terminal. The app then answers
+ * `invalid_params: Surface is not a terminal`, which reads as "your surface is
+ * broken" when the surface is a perfectly good terminal and the WORKSPACE is
+ * the wrong one.
+ *
+ * That is not hypothetical: `CMUX_WORKSPACE_ID` is frozen into a process's
+ * environment when it starts, so moving the surface to another workspace (or
+ * restoring a session into a new one) leaves every later `send-self` naming a
+ * workspace the surface left. Verified 2026-08-28: sending to this very
+ * terminal with its own workspace works, and the same surface with a different
+ * workspace fails with exactly that error.
+ *
+ * A UUID or a `surface:N` ref is unique across the whole tree, so the workspace
+ * adds nothing and can only be wrong. Only a bare index (`4`) is
+ * workspace-relative and still needs the scope.
+ */
+export function surfaceTargetArgs(surface: string, workspace?: string): string[] {
+    if (!workspace || isSelfIdentifyingSurface(surface)) {
+        return ["--surface", surface];
+    }
+
+    return ["--workspace", workspace, "--surface", surface];
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isSelfIdentifyingSurface(surface: string): boolean {
+    return UUID_RE.test(surface) || surface.startsWith("surface:") || surface.startsWith("tab:");
+}

--- a/src/youtube/lib/__tests__/referrals.test.ts
+++ b/src/youtube/lib/__tests__/referrals.test.ts
@@ -24,7 +24,7 @@ describe("findActiveOffer", () => {
 
 describe("maskEmail / generateReferralCode", () => {
     it("masks the local part after two characters", () => {
-        expect(maskEmail("martin@example.com")).toBe("ma***@example.com");
+        expect(maskEmail("alice@example.com")).toBe("al***@example.com");
         expect(maskEmail("a@b.c")).toBe("a***@b.c");
         expect(maskEmail("broken")).toBe("***");
     });

--- a/tools
+++ b/tools
@@ -3,6 +3,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { namedBunExecPath } from "@genesiscz/utils/cli/bun-link";
 import { logger } from "@genesiscz/utils/logger";
 
 // --- Configuration ---
@@ -180,13 +181,14 @@ async function executeTool(scriptId, scriptArgs) {
     const sqliteVecPreload = join(workspaceRoot, "src/utils/search/stores/sqlite-vec-preload.ts");
     const exitCode = await runWithReinstallGuard(
         ["--preload", solidPreload, "--preload", sqliteVecPreload, targetScript, ...scriptArgs],
-        workspaceRoot
+        workspaceRoot,
+        namedBunExecPath(scriptId)
     );
     process.exit(exitCode);
 }
 
-async function runWithReinstallGuard(args: string[], workspaceRoot: string): Promise<number> {
-    const exitCode = await spawnAndCaptureStderr(args, workspaceRoot);
+async function runWithReinstallGuard(args: string[], workspaceRoot: string, execPath: string): Promise<number> {
+    const exitCode = await spawnAndCaptureStderr(args, workspaceRoot, execPath);
 
     if (exitCode === 0) {
         return 0;
@@ -222,19 +224,21 @@ async function runWithReinstallGuard(args: string[], workspaceRoot: string): Pro
 
 let capturedStderr = "";
 
-async function spawnAndCaptureStderr(args: string[], workspaceRoot: string): Promise<number> {
+async function spawnAndCaptureStderr(args: string[], workspaceRoot: string, execPath: string): Promise<number> {
     capturedStderr = "";
     const TAIL_BYTES = 64 * 1024;
 
     return new Promise<number>((resolvePromise, reject) => {
-        const child = spawn(process.execPath, args, {
+        const child = spawn(execPath, args, {
             stdio: ["inherit", "inherit", "pipe"],
             // cwd stays at the user's shell so tools resolving `.claude/...`
             // via process.cwd() keep working. Bunfig's preload is forwarded
             // via the explicit --preload flag in executeTool().
-            // execPath (not PATH "bun"): a signed parent (Genesis.app, cmux)
-            // + `/usr/bin/env bun` is SIGKILL'd by Taskgated (Code Signature
-            // Invalid, ~5ms). Reuse this already-running interpreter.
+            // execPath is a gt-<tool> hardlink of this already-running
+            // interpreter (namedBunExecPath), never PATH "bun": a signed
+            // parent (Genesis.app, cmux) + `/usr/bin/env bun` is SIGKILL'd by
+            // Taskgated (Code Signature Invalid, ~5ms). The hardlink is the
+            // same signed binary, and names the process in Activity Monitor.
             cwd: process.cwd(),
             env: envWithoutProxy({ INIT_CWD: process.cwd() }),
             shell: process.platform === "win32",
@@ -327,7 +331,7 @@ async function main() {
 
     if (args.length === 0) {
         // Launch interactive tool browser
-        const result = spawnSync(process.execPath, ["run", join(srcDir, "tools", "index.ts")], {
+        const result = spawnSync(namedBunExecPath("tools"), ["run", join(srcDir, "tools", "index.ts")], {
             stdio: "inherit",
             cwd: process.cwd(),
             env: envWithoutProxy(),


### PR DESCRIPTION
## Why this exists

The integration branch `feat/2026-08-24-enhancements` was split into seven PRs (#327, #328, #329, #330, #332, #333, #334) plus #335. A file-level audit found **39 files that none of them carry** — so merging all eight would still leave this work on master's floor.

```
integration files vs master: 237
covered by some open PR:     198
uncovered:                    39
```

This PR is those 39 files, taken from the integration branch onto `master`.

## What is in it

- **chrome-devtools command layer** (`commands/{attach,browse,har,inspect,scripting,shared}.ts`, `lib/{cdp,paths}.ts`) — from handoff `h_9mvc8oel`. One port-resolution chokepoint (`resolvePort`) replacing the `refuseIfAmbiguous` + `portOf` pairs, `/regex/` tab matching, close-tab candidate listing, `newTab`, and a remembered-port fast path.
- **ms-teams export** — `export/{html,markdown,image-embed}.ts` and `media.ts` plus their tests.
- **`src/utils/cli`** — `bun-link.ts`, `tools.ts`, and the `asResult` fix. That last one is a real crash: `SafeJSON.stringify(undefined)` returns `undefined`, and `.endsWith` on it killed the process for any tool calling `out.result(undefined)`. `chrome-devtools eval '() => location.reload()'` hit it, because page JS that returns nothing is perfectly normal.
- **wrap-up skill resolver** + its test.
- **Skill/doc updates** — chrome-devtools SKILL and CDP cheatsheet, `plugins/genesis-tools/commands/timelog.md` (real work-item ids scrubbed for the open-source move), root `CLAUDE.md`.
- Assorted regression tests under `src/{ai-proxy,claude,dev-dashboard,youtube,utils}`.

## Verification

- `bun tsgo --noEmit -p tsconfig.json` — clean, standing alone on master.
- `bun run test src/chrome-devtools src/ms-teams src/utils/cli plugins/genesis-tools/skills/wrap-up` — **308 pass, 0 fail**.
- `logging-guard.sh` and `ai-credentials-guard.sh` exit 0.

## ⚠️ One pre-existing failure, not from this PR

`pid-safety-guard.sh` exits 1 on `src/chrome-devtools/lib/recorder.ts:345` — a hand-rolled `process.kill(creator, 0)`. That file is **not in this diff**; it is master's own, and master fails the same guard today. The fix (swap it for `isProcessAlive()`) is already on **#330**, so this clears when #330 lands. I deliberately did not duplicate it here — two branches changing the same line would only create a conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chrome DevTools commands now support smarter endpoint reuse, tab matching, new-tab navigation, filtering, JSON output, and full-page screenshots.
  * cmux self-send diagnostics identify targeting and transport issues before sending, with actionable health-check results.
  * Teams exports now resize images responsively and reduce repetitive speaker headings.
  * Markdown CLI color output now adapts to terminal or piped usage.
  * Log output includes absolute paths and added/modified line ranges.
* **Bug Fixes**
  * CLI result formatting no longer crashes on unserializable values.
  * Tool launching is more reliable across executable updates and filesystem errors.
* **Documentation**
  * Updated command examples, troubleshooting guidance, and testing fixture safety rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->