### PR TITLE
fix(apoptosis): the churn window followed the wall clock, not the scan's now

### DIFF
--- a/src/apoptosis/apoptosis.test.ts
+++ b/src/apoptosis/apoptosis.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { loadCoverageSet } from "./lib/coverage";
-import { churnCountForFile } from "./lib/git";
+import { churnCountForFile, churnCutoff, getChurnCounts } from "./lib/git";
 import { buildInboundImportCounts } from "./lib/imports";
 import { evaluateLifecycle } from "./lib/lifecycle";
 import { renderJson, renderKillScript, renderPrBody } from "./lib/render";
@@ -275,7 +275,12 @@ describe("churnCountForFile", () => {
         git(dir, "add", ".");
         git(dir, "commit", "-qm", "c2");
 
-        const alive = await churnCountForFile(join(dir, "alive.ts"), 365, dir);
+        const alive = await churnCountForFile({
+            file: join(dir, "alive.ts"),
+            churnDays: 365,
+            repoRoot: dir,
+            now: Date.now(),
+        });
         expect(alive).toBe(2);
     });
 
@@ -286,8 +291,79 @@ describe("churnCountForFile", () => {
         git(dir, "commit", "-qm", "c1");
         writeFileSync(join(dir, "untracked.ts"), "x");
 
-        const untracked = await churnCountForFile(join(dir, "untracked.ts"), 365, dir);
+        const untracked = await churnCountForFile({
+            file: join(dir, "untracked.ts"),
+            churnDays: 365,
+            repoRoot: dir,
+            now: Date.now(),
+        });
         expect(untracked).toBe(0);
+    });
+});
+
+/**
+ * Regression test: the churn window used `--since=<n> days ago`, which git
+ * resolves against the SYSTEM clock, while every other date in a scan comes from
+ * the injected `now`. The two agreed until the calendar moved past a fixture's
+ * commit date, and then a test that had passed for 90 days started failing with
+ * no code change (observed 2026-08-28). These pin the window to `now`.
+ */
+describe("churn window is a function of the injected now, not the wall clock", () => {
+    let dir: string;
+    afterEach(() => {
+        if (dir) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it("derives an absolute cutoff from now", () => {
+        expect(churnCutoff(90, Date.parse("2026-06-02T00:00:00.000Z"))).toBe("2026-03-04T00:00:00.000Z");
+    });
+
+    it("counts a commit inside a window that ended years ago", async () => {
+        dir = initRepo();
+        writeFileSync(join(dir, "old.ts"), "export const x = 1;");
+        git(dir, "add", "old.ts");
+        commitAt(dir, "2020-03-01T12:00:00");
+
+        const counts = await getChurnCounts({
+            churnDays: 90,
+            repoRoot: dir,
+            now: Date.parse("2020-03-10T00:00:00.000Z"),
+        });
+
+        expect(counts.get(join(dir, "old.ts"))).toBe(1);
+    });
+
+    it("still excludes a commit that falls outside that window", async () => {
+        dir = initRepo();
+        writeFileSync(join(dir, "old.ts"), "export const x = 1;");
+        git(dir, "add", "old.ts");
+        commitAt(dir, "2020-03-01T12:00:00");
+
+        const counts = await getChurnCounts({
+            churnDays: 90,
+            repoRoot: dir,
+            now: Date.parse("2021-01-01T00:00:00.000Z"),
+        });
+
+        expect(counts.get(join(dir, "old.ts"))).toBeUndefined();
+    });
+
+    it("churnCountForFile honours the same cutoff", async () => {
+        dir = initRepo();
+        writeFileSync(join(dir, "old.ts"), "export const x = 1;");
+        git(dir, "add", "old.ts");
+        commitAt(dir, "2020-03-01T12:00:00");
+
+        const inside = await churnCountForFile({
+            file: join(dir, "old.ts"),
+            churnDays: 90,
+            repoRoot: dir,
+            now: Date.parse("2020-03-10T00:00:00.000Z"),
+        });
+
+        expect(inside).toBe(1);
     });
 });
 

--- a/src/apoptosis/lib/git.ts
+++ b/src/apoptosis/lib/git.ts
@@ -1,12 +1,34 @@
 import { resolve } from "node:path";
 import { logger } from "@genesiscz/utils/logger";
 
+const DAY_MS = 86_400_000;
+
 /**
- * Count commits in the last `days` that touched every file under `repoRoot`, via
+ * The absolute start of a churn window, as an ISO-8601 date git accepts.
+ *
+ * `--since=<n> days ago` makes git resolve the window against the SYSTEM clock,
+ * while every other date in a scan comes from the injected `now`. The two agree
+ * only while the calendar cooperates: a fixture pinning `now` to 2026-06-02 with
+ * a commit at 2026-05-30 and a 90-day window passed for exactly 90 days, then
+ * began failing on 2026-08-28 with no code change. Deriving the cutoff from
+ * `now` makes the window a function of its inputs alone.
+ */
+export function churnCutoff(days: number, now: number): string {
+    return new Date(now - days * DAY_MS).toISOString();
+}
+
+export interface ChurnQuery {
+    churnDays: number;
+    repoRoot: string;
+    now: number;
+}
+
+/**
+ * Count commits in the churn window that touched every file under `repoRoot`, via
  * a single `git log --name-only` invocation. Returns a map of absolute path to
  * commit count; empty outside a repo or on any git failure.
  */
-export async function getChurnCounts(days: number, repoRoot: string): Promise<Map<string, number>> {
+export async function getChurnCounts({ churnDays, repoRoot, now }: ChurnQuery): Promise<Map<string, number>> {
     const counts = new Map<string, number>();
     try {
         const proc = Bun.spawn({
@@ -15,7 +37,7 @@ export async function getChurnCounts(days: number, repoRoot: string): Promise<Ma
                 "-c",
                 "core.quotePath=false",
                 "log",
-                `--since=${days} days ago`,
+                `--since=${churnCutoff(churnDays, now)}`,
                 "--name-only",
                 "--format=",
                 "--",
@@ -46,13 +68,18 @@ export async function getChurnCounts(days: number, repoRoot: string): Promise<Ma
 }
 
 /**
- * Count commits in the last `days` that touched `file`, via `git log`. Returns 0
+ * Count commits in the churn window that touched `file`, via `git log`. Returns 0
  * outside a repo, for untracked files, or on any git failure.
  */
-export async function churnCountForFile(file: string, days: number, repoRoot: string): Promise<number> {
+export async function churnCountForFile({
+    file,
+    churnDays,
+    repoRoot,
+    now,
+}: ChurnQuery & { file: string }): Promise<number> {
     try {
         const proc = Bun.spawn({
-            cmd: ["git", "log", `--since=${days} days ago`, "--format=%H", "--", file],
+            cmd: ["git", "log", `--since=${churnCutoff(churnDays, now)}`, "--format=%H", "--", file],
             cwd: repoRoot,
             stdout: "pipe",
             stderr: "pipe",

--- a/src/apoptosis/lib/scan.ts
+++ b/src/apoptosis/lib/scan.ts
@@ -36,7 +36,7 @@ export async function runScan(opts: ScanOptions): Promise<ScanReport> {
     logger.debug(`apoptosis: scanning ${files.length} files under ${dir}`);
 
     const repoRoot = (await findRepoRoot(dir)) ?? dir;
-    const churnCounts = await getChurnCounts(opts.churnDays, repoRoot);
+    const churnCounts = await getChurnCounts({ churnDays: opts.churnDays, repoRoot, now: opts.now });
     const aliasConfig = loadAliasConfig(dir) ?? undefined;
     const inbound = buildInboundImportCounts(files, aliasConfig);
     const coverage = loadCoverageSet(opts.coveragePath);


### PR DESCRIPTION
`src/apoptosis/apoptosis.test.ts` started failing on **2026-08-28** with no code change, on a clean checkout of `master`.

## Cause

`getChurnCounts` passed `--since=${days} days ago` to git. Git resolves that against the **system clock**, while every other date in a scan comes from the `now` that `runScan` injects. The two agree only while the calendar cooperates.

The fixture pins `now = 2026-06-02`, commits `main.ts` at **2026-05-30**, and uses a 90-day window. 2026-05-30 + 90 days is 2026-08-28. On that day git's window moved past the commit, churn dropped to zero, and `main.ts` — which nothing imports and which was only kept alive by churn — flipped to `dying`.

Reproduced standalone:

```
$ git init -q "$D" && ... GIT_COMMITTER_DATE="2026-05-30T12:00:00" git commit
$ git -C "$D" log --since='90 days ago' --format= --name-only | grep -c main.ts
0
```

CI kept passing because the runner is UTC: the fixture's bare `12:00` is 12:00 UTC there and still inside the boundary, while at UTC+2 it is 10:00 UTC and the boundary had already passed it. So this was going to start failing in CI too, a couple of hours later.

## Fix

One root change: `churnCutoff(days, now)` returns an absolute ISO-8601 date, and both churn queries use it. The window is now a function of its inputs alone. Both helpers take an object (`{ churnDays, repoRoot, now }`) since they went to three-plus parameters.

## Verification

- Full suite **7755 pass / 0 fail** (plus 75/0 serialized), `tsgo --noEmit` clean.
- Four new tests, three of which are date-independent: a commit inside a window that ended in 2020 is counted, one outside it is not, and `churnCountForFile` honours the same cutoff.
- **Mutation check**: putting `` `${days} days ago` `` back fails four tests, including the original `runScan` one.

## Note, not fixed here

`churnCountForFile` has no production caller — only tests reach it. Flagging rather than deleting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy and consistency of churn results by making time-based calculations deterministic.
  - Ensured churn analysis correctly includes commits within the selected timeframe and excludes older commits.
  - Preserved existing handling for empty results and query errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->