### PR TITLE
fix: preserve Codex MCP HTTP headers

### DIFF
--- a/src/mcp-manager/commands/__tests__/codex-provider.test.ts
+++ b/src/mcp-manager/commands/__tests__/codex-provider.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setGlobalOptions } from "@app/mcp-manager/utils/config.utils.js";
+import { CodexProvider } from "@app/mcp-manager/utils/providers/codex.js";
+import { env } from "@genesiscz/utils/env";
+import * as TOML from "@iarna/toml";
+
+describe("CodexProvider remote HTTP authentication", () => {
+    let homeDir: string;
+    let previousHome: string | undefined;
+
+    beforeEach(() => {
+        previousHome = env.get("HOME");
+        homeDir = mkdtempSync(join(tmpdir(), "mcp-codex-provider-"));
+        env.testing.set("HOME", homeDir);
+        setGlobalOptions({ yes: true });
+    });
+
+    afterEach(() => {
+        if (previousHome) {
+            env.testing.set("HOME", previousHome);
+        } else {
+            env.testing.unset("HOME");
+        }
+        setGlobalOptions({});
+        rmSync(homeDir, { recursive: true, force: true });
+    });
+
+    it("writes unified HTTP headers using Codex's supported table", async () => {
+        // Regression test: user report 2026-09-02 — mcp-manager emitted `headers`, which Codex ignored.
+        const provider = new CodexProvider();
+
+        await provider.syncServers({
+            jina: {
+                type: "http",
+                url: "https://mcp.jina.ai/v1",
+                headers: { Authorization: "Bearer test-jina-key" },
+                _meta: { enabled: { codex: true } },
+            },
+        });
+
+        const config = TOML.parse(readFileSync(join(homeDir, ".codex", "config.toml"), "utf-8")) as {
+            mcp_servers?: Record<string, unknown>;
+        };
+        expect(config.mcp_servers?.jina).toEqual({
+            type: "http",
+            url: "https://mcp.jina.ai/v1",
+            http_headers: { Authorization: "Bearer test-jina-key" },
+        });
+    });
+
+    it("reads Codex HTTP headers into the unified configuration", async () => {
+        // Regression test: user report 2026-09-02 — sync could not recover authentication from Codex.
+        mkdirSync(join(homeDir, ".codex"), { recursive: true });
+        writeFileSync(
+            join(homeDir, ".codex", "config.toml"),
+            `[mcp_servers.jina]
+url = "https://mcp.jina.ai/v1"
+
+[mcp_servers.jina.http_headers]
+Authorization = "Bearer test-jina-key"
+`
+        );
+        const provider = new CodexProvider();
+
+        const config = await provider.getServerConfig("jina");
+
+        expect(config?.headers).toEqual({ Authorization: "Bearer test-jina-key" });
+    });
+});

--- a/src/mcp-manager/commands/__tests__/codex-provider.test.ts
+++ b/src/mcp-manager/commands/__tests__/codex-provider.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setGlobalOptions } from "@app/mcp-manager/utils/config.utils.js";
@@ -19,7 +19,7 @@ describe("CodexProvider remote HTTP authentication", () => {
     });
 
     afterEach(() => {
-        if (previousHome) {
+        if (previousHome !== undefined) {
             env.testing.set("HOME", previousHome);
         } else {
             env.testing.unset("HOME");
@@ -54,7 +54,7 @@ describe("CodexProvider remote HTTP authentication", () => {
     it("reads Codex HTTP headers into the unified configuration", async () => {
         // Regression test: user report 2026-09-02 — sync could not recover authentication from Codex.
         mkdirSync(join(homeDir, ".codex"), { recursive: true });
-        writeFileSync(
+        await Bun.write(
             join(homeDir, ".codex", "config.toml"),
             `[mcp_servers.jina]
 url = "https://mcp.jina.ai/v1"

--- a/src/mcp-manager/utils/providers/codex.ts
+++ b/src/mcp-manager/utils/providers/codex.ts
@@ -253,7 +253,7 @@ export class CodexProvider extends MCPProvider {
             args: codex.args,
             env: codex.env,
             url: codex.url as string | undefined,
-            headers: codex.headers as Record<string, string> | undefined,
+            headers: (codex.http_headers ?? codex.headers) as Record<string, string> | undefined,
         };
     }
 
@@ -264,7 +264,7 @@ export class CodexProvider extends MCPProvider {
             args: unified.args,
             env: unified.env,
             url: unified.url,
-            headers: unified.headers,
+            http_headers: unified.headers,
         };
     }
 }


### PR DESCRIPTION
## Summary

- map unified remote MCP headers to the Codex http_headers table
- read Codex http_headers back into the unified manager representation
- add regression coverage for both sync directions

## Verification

- bun scripts/test.ts src/mcp-manager/commands/__tests__/ — 89 passed, 0 failed
- bun run tsgo — passed
- pre-push CI mirror — Biome, lint rules, dashboard lint, and typecheck:all passed
- live Jina MCP probe — healthy, 8 tools discovered

## Full-suite note

The full serial repository suite is currently red outside the touched MCP-manager area: 7,696 passed, 237 failed, 189 skipped, and 2 errors in its main phase. The complete MCP-manager suite is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex remote HTTP authentication compatibility by reading headers from both current and legacy configuration formats.
  * Unified HTTP headers are now saved using Codex’s supported configuration field, ensuring authentication settings are preserved correctly.

* **Tests**
  * Added coverage for reading and writing Codex remote HTTP authentication headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->