### PR TITLE
feat(ai-spend): port every ccusage report into tools ai-spend

### DIFF
--- a/src/ai-spend/README.md
+++ b/src/ai-spend/README.md
@@ -6,6 +6,8 @@ Reads the session records your coding agents leave on disk and turns them into a
 
 `summary`, `sessions` and `today` read Claude Code only. `monitor` reads Claude Code, Codex and Grok, and reports each one separately.
 
+`daily`, `weekly`, `monthly`, `session`, `blocks` and `statusline` mirror the live `ccusage` command tree (unified across every detected source, plus per-source namespaces). `--json` uses the same grouping keys and token field names as `ccusage --json`.
+
 Also reachable as `tools claude spending`, which is an alias for this tool.
 
 ---
@@ -18,6 +20,11 @@ Also reachable as `tools claude spending`, which is an alias for this tool.
 | `sessions` | Most expensive sessions leaderboard |
 | `today` | Today's spend, by UTC day |
 | `monitor` | Today + current week (LOCAL timezone, Monday week start) across Claude Code, Codex and Grok in well under 1s — for status bars. `--json` emits `{today, week, todayDate, weekStart, timezone, agents}` |
+| `daily` / `weekly` / `monthly` | All detected sources grouped by period (ccusage-compatible JSON) |
+| `session` | All detected sources grouped by session |
+| `blocks` | Claude Code 5-hour billing windows (`--active`, `--recent`) |
+| `statusline` | Compact Claude Code hook line (reads hook JSON from stdin) |
+| `<source> daily\|monthly\|session` | One source only (`claude` also has `weekly`, `blocks`, `statusline`; `opencode` also has `weekly`) |
 
 ## Quick start
 

--- a/src/ai-spend/index.ts
+++ b/src/ai-spend/index.ts
@@ -4,7 +4,11 @@ import { registerSpendCommand } from "./lib/register";
 
 const program = new Command();
 
-program.name("ai-spend").description("Claude Code token & cost analytics across all local sessions");
+program
+    .name("ai-spend")
+    .description(
+        "Coding-agent token and cost analytics (ccusage-compatible daily/session/blocks plus summary/monitor)"
+    );
 
 registerSpendCommand(program);
 

--- a/src/ai-spend/lib/drivers/codex.ts
+++ b/src/ai-spend/lib/drivers/codex.ts
@@ -242,7 +242,7 @@ export const codexDriver: MonitorDriver = {
                 const inputTokens = inputTotal - cached;
 
                 emit({
-                    id: `${timestamp}|${model}|${inputTokens}|${cached}|${output}`,
+                    id: `${timestamp}|${model}|${inputTokens}|${cached}|${output}|${reasoning}`,
                     model,
                     timestamp,
                     inputTokens,

--- a/src/ai-spend/lib/drivers/codex.ts
+++ b/src/ai-spend/lib/drivers/codex.ts
@@ -249,6 +249,7 @@ export const codexDriver: MonitorDriver = {
                     outputTokens: output,
                     cacheCreationTokens: 0,
                     cacheReadTokens: cached,
+                    reasoningOutputTokens: reasoning,
                 });
             },
             snapshot(): unknown {

--- a/src/ai-spend/lib/drivers/types.ts
+++ b/src/ai-spend/lib/drivers/types.ts
@@ -31,6 +31,8 @@ export interface DriverUsageEvent {
     outputTokens: number;
     cacheCreationTokens: number;
     cacheReadTokens: number;
+    /** Subset of outputTokens. Codex/Grok report it; never added on top of output. */
+    reasoningOutputTokens?: number;
     /**
      * Cost in USD that the agent itself recorded for this event. Authoritative
      * when present: Grok prices each API request separately and only reports

--- a/src/ai-spend/lib/register.ts
+++ b/src/ai-spend/lib/register.ts
@@ -8,6 +8,7 @@ import { findTranscriptFiles, readEvents } from "./discover";
 import { AGENT_IDS } from "./drivers";
 import { buildMonitorReport } from "./monitor";
 import { renderSessions, renderSummary, renderToday } from "./render";
+import { registerCcusageCommands } from "./reports/commands";
 import { resolveSince } from "./since";
 import type { Report } from "./types";
 
@@ -99,6 +100,8 @@ export function registerSpendCommand(program: Command): Command {
             await runSpend(cmd, "today");
         }
     );
+
+    registerCcusageCommands(program);
 
     program
         .command("monitor")

--- a/src/ai-spend/lib/reports/blocks.ts
+++ b/src/ai-spend/lib/reports/blocks.ts
@@ -1,0 +1,238 @@
+import type { PricingTable } from "../types";
+import { totalTokensOf } from "./cost";
+import { addDays, zonedDay } from "./dates";
+import { pricedEventCost } from "./load";
+import type { CostMode, SpendEvent } from "./types";
+
+const MILLIS_PER_HOUR = 3_600_000;
+const MILLIS_PER_MINUTE = 60_000;
+const DEFAULT_HOURS = 5;
+
+export interface BlocksBuildOptions {
+    timezone: string;
+    sinceDay?: string;
+    untilDay?: string;
+    now: Date;
+    pricing: PricingTable;
+    mode: CostMode;
+    active?: boolean;
+    recent?: boolean;
+    sessionHours?: number;
+}
+
+export interface SessionBlock {
+    id: string;
+    startTime: string;
+    endTime: string;
+    actualEndTime: string | null;
+    isActive: boolean;
+    isGap: boolean;
+    entries: number;
+    models: string[];
+    tokenCounts: {
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationInputTokens: number;
+        cacheReadInputTokens: number;
+    };
+    totalTokens: number;
+    costUSD: number;
+    burnRate: { tokensPerMinute: number; tokensPerMinuteForIndicator: number; costPerHour: number } | null;
+    projection: { totalTokens: number; totalCost: number; remainingMinutes: number } | null;
+}
+
+function floorToHour(ms: number): number {
+    return Math.floor(ms / MILLIS_PER_HOUR) * MILLIS_PER_HOUR;
+}
+
+function rfc3339(ms: number): string {
+    return new Date(ms).toISOString();
+}
+
+export function identifySessionBlocks(
+    events: SpendEvent[],
+    sessionHours: number,
+    nowMs: number,
+    costOf: (event: SpendEvent) => number
+): SessionBlock[] {
+    if (events.length === 0) {
+        return [];
+    }
+
+    const duration = sessionHours * MILLIS_PER_HOUR;
+    const sorted = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    const blocks: SessionBlock[] = [];
+    let currentStart: number | undefined;
+    let current: SpendEvent[] = [];
+
+    const flush = (start: number, entries: SpendEvent[], gapNext?: number): void => {
+        if (entries.length > 0) {
+            blocks.push(createBlock(start, entries, nowMs, duration, costOf));
+        }
+
+        if (gapNext !== undefined) {
+            const last = Date.parse(entries[entries.length - 1]?.timestamp ?? rfc3339(start));
+            blocks.push(createGap(last + duration, gapNext, duration));
+        }
+    };
+
+    for (const event of sorted) {
+        const ts = Date.parse(event.timestamp);
+
+        if (Number.isNaN(ts)) {
+            continue;
+        }
+
+        if (currentStart === undefined) {
+            currentStart = floorToHour(ts);
+            current.push(event);
+            continue;
+        }
+
+        const last = Date.parse(current[current.length - 1]?.timestamp ?? rfc3339(currentStart));
+        const sinceStart = ts - currentStart;
+        const sinceLast = ts - last;
+
+        if (sinceStart > duration || sinceLast > duration) {
+            flush(currentStart, current, sinceLast > duration ? ts : undefined);
+            current = [];
+            currentStart = floorToHour(ts);
+        }
+
+        current.push(event);
+    }
+
+    if (currentStart !== undefined && current.length > 0) {
+        flush(currentStart, current);
+    }
+
+    return blocks;
+}
+
+function createBlock(
+    start: number,
+    entries: SpendEvent[],
+    nowMs: number,
+    duration: number,
+    costOf: (event: SpendEvent) => number
+): SessionBlock {
+    const end = start + duration;
+    const last = Date.parse(entries[entries.length - 1].timestamp);
+    const isActive = nowMs - last < duration && nowMs < end;
+    const models: string[] = [];
+    const seen = new Set<string>();
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cacheCreationInputTokens = 0;
+    let cacheReadInputTokens = 0;
+    let costUSD = 0;
+
+    for (const event of entries) {
+        inputTokens += event.inputTokens;
+        outputTokens += event.outputTokens;
+        cacheCreationInputTokens += event.cacheCreationTokens;
+        cacheReadInputTokens += event.cacheReadTokens;
+        costUSD += costOf(event);
+
+        if (!seen.has(event.model)) {
+            seen.add(event.model);
+            models.push(event.model);
+        }
+    }
+
+    const tokenCounts = { inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens };
+    const totalTokens = totalTokensOf({
+        inputTokens,
+        outputTokens,
+        cacheCreationTokens: cacheCreationInputTokens,
+        cacheReadTokens: cacheReadInputTokens,
+    });
+    let burnRate: SessionBlock["burnRate"] = null;
+    let projection: SessionBlock["projection"] = null;
+
+    if (isActive) {
+        const elapsedMinutes = Math.max((last - start) / MILLIS_PER_MINUTE, 1);
+        const remainingMinutes = Math.max((end - nowMs) / MILLIS_PER_MINUTE, 0);
+        const tokensPerMinute = totalTokens / elapsedMinutes;
+        burnRate = {
+            tokensPerMinute,
+            tokensPerMinuteForIndicator: tokensPerMinute,
+            costPerHour: (costUSD / elapsedMinutes) * 60,
+        };
+        projection = {
+            totalTokens: Math.round(totalTokens + tokensPerMinute * remainingMinutes),
+            totalCost: costUSD + burnRate.costPerHour * (remainingMinutes / 60),
+            remainingMinutes: Math.round(remainingMinutes),
+        };
+    }
+
+    return {
+        id: rfc3339(start),
+        startTime: rfc3339(start),
+        endTime: rfc3339(end),
+        actualEndTime: rfc3339(last),
+        isActive,
+        isGap: false,
+        entries: entries.length,
+        models,
+        tokenCounts,
+        totalTokens,
+        costUSD,
+        burnRate,
+        projection,
+    };
+}
+
+function createGap(start: number, next: number, _duration: number): SessionBlock {
+    return {
+        id: `gap-${rfc3339(start)}`,
+        startTime: rfc3339(start),
+        endTime: rfc3339(next),
+        actualEndTime: null,
+        isActive: false,
+        isGap: true,
+        entries: 0,
+        models: [],
+        tokenCounts: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
+        totalTokens: 0,
+        costUSD: 0,
+        burnRate: null,
+        projection: null,
+    };
+}
+
+export function buildBlocksReport(events: SpendEvent[], options: BlocksBuildOptions): { blocks: SessionBlock[] } {
+    let sinceDay = options.sinceDay;
+    const today = zonedDay(options.now.toISOString(), options.timezone);
+
+    if (options.recent) {
+        const recentSince = addDays(today, -2);
+        sinceDay = sinceDay && sinceDay > recentSince ? sinceDay : recentSince;
+    }
+
+    const hours = options.sessionHours && options.sessionHours > 0 ? options.sessionHours : DEFAULT_HOURS;
+    let blocks = identifySessionBlocks(events, hours, options.now.getTime(), (event) =>
+        pricedEventCost(event, options.pricing, options.mode)
+    );
+
+    if (sinceDay || options.untilDay) {
+        blocks = blocks.filter((block) => {
+            const day = zonedDay(block.startTime, options.timezone);
+            if (sinceDay && day < sinceDay) {
+                return false;
+            }
+
+            if (options.untilDay && day > options.untilDay) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
+    if (options.active) {
+        blocks = blocks.filter((block) => block.isActive && !block.isGap);
+    }
+
+    return { blocks };
+}

--- a/src/ai-spend/lib/reports/blocks.ts
+++ b/src/ai-spend/lib/reports/blocks.ts
@@ -37,6 +37,14 @@ export interface SessionBlock {
     };
     totalTokens: number;
     costUSD: number;
+    modelBreakdowns: Array<{
+        modelName: string;
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationTokens: number;
+        cacheReadTokens: number;
+        cost: number;
+    }>;
     burnRate: { tokensPerMinute: number; tokensPerMinuteForIndicator: number; costPerHour: number } | null;
     projection: { totalTokens: number; totalCost: number; remainingMinutes: number } | null;
 }
@@ -121,6 +129,16 @@ function createBlock(
     const isActive = nowMs - last < duration && nowMs < end;
     const models: string[] = [];
     const seen = new Set<string>();
+    const perModel = new Map<
+        string,
+        {
+            inputTokens: number;
+            outputTokens: number;
+            cacheCreationTokens: number;
+            cacheReadTokens: number;
+            cost: number;
+        }
+    >();
     let inputTokens = 0;
     let outputTokens = 0;
     let cacheCreationInputTokens = 0;
@@ -128,17 +146,36 @@ function createBlock(
     let costUSD = 0;
 
     for (const event of entries) {
+        const eventCostUsd = costOf(event);
         inputTokens += event.inputTokens;
         outputTokens += event.outputTokens;
         cacheCreationInputTokens += event.cacheCreationTokens;
         cacheReadInputTokens += event.cacheReadTokens;
-        costUSD += costOf(event);
+        costUSD += eventCostUsd;
 
         if (!seen.has(event.model)) {
             seen.add(event.model);
             models.push(event.model);
         }
+
+        const model = perModel.get(event.model) ?? {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            cost: 0,
+        };
+        model.inputTokens += event.inputTokens;
+        model.outputTokens += event.outputTokens;
+        model.cacheCreationTokens += event.cacheCreationTokens;
+        model.cacheReadTokens += event.cacheReadTokens;
+        model.cost += eventCostUsd;
+        perModel.set(event.model, model);
     }
+
+    const modelBreakdowns = [...perModel.entries()]
+        .map(([modelName, model]) => ({ modelName, ...model }))
+        .sort((a, b) => b.cost - a.cost || a.modelName.localeCompare(b.modelName));
 
     const tokenCounts = { inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens };
     const totalTokens = totalTokensOf({
@@ -178,6 +215,7 @@ function createBlock(
         tokenCounts,
         totalTokens,
         costUSD,
+        modelBreakdowns,
         burnRate,
         projection,
     };
@@ -196,6 +234,7 @@ function createGap(start: number, next: number, _duration: number): SessionBlock
         tokenCounts: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 },
         totalTokens: 0,
         costUSD: 0,
+        modelBreakdowns: [],
         burnRate: null,
         projection: null,
     };

--- a/src/ai-spend/lib/reports/commands.ts
+++ b/src/ai-spend/lib/reports/commands.ts
@@ -5,14 +5,16 @@ import { Storage } from "@genesiscz/utils/storage/storage";
 import type { Command } from "commander";
 import { loadPricing } from "../config";
 import { buildBlocksReport } from "./blocks";
-import { parseCostMode, parseDayArg, parseLast, systemTimeZone } from "./dates";
+import { isValidTimeZone, parseCostMode, parseDayArg, parseLast, resolveRelativeSince, systemTimeZone } from "./dates";
 import { loadEvents } from "./load";
 import { buildPeriodReport } from "./period";
 import { renderBlocksTable, renderPeriodTable, renderSessionTable } from "./render";
 import { buildSessionReport } from "./session";
 import { parseStatuslineHook, renderStatusline } from "./statusline";
-import type { CostMode, PeriodGrain, ReportFlags, ReportKind, SourceId } from "./types";
+import type { PeriodGrain, ReportFlags, ReportKind, SourceId } from "./types";
 import { SOURCE_REPORTS } from "./types";
+
+const VISUAL_BURN_RATES = ["off", "emoji", "text", "emoji-text"] as const;
 
 async function readStdin(): Promise<string> {
     if (process.stdin.isTTY) {
@@ -24,6 +26,20 @@ async function readStdin(): Promise<string> {
 
 function flagsOf(cmd: Command): ReportFlags {
     return cmd.optsWithGlobals() as ReportFlags;
+}
+
+function optionFromCli(cmd: Command, key: string): boolean {
+    let current: Command | null = cmd;
+
+    while (current) {
+        if (current.getOptionValueSource(key) === "cli") {
+            return true;
+        }
+
+        current = current.parent;
+    }
+
+    return false;
 }
 
 export function addReportFlags(
@@ -61,13 +77,27 @@ export function addReportFlags(
     return cmd;
 }
 
-function resolveMode(raw: string | undefined): CostMode | undefined {
-    if (raw === undefined || raw === "") {
-        return "auto";
+function addStatuslineFlags(cmd: Command): Command {
+    cmd.option("-z, --timezone <timezone>", "Timezone for date grouping (IANA)");
+    cmd.option("-m, --mode [mode]", "Cost calculation mode (auto | calculate | display)");
+    cmd.option(
+        "-B, --visual-burn-rate [visual-burn-rate]",
+        "Burn-rate visualization (off | emoji | text | emoji-text)"
+    );
+    return cmd;
+}
+
+function parseVisualBurnRate(raw: string | boolean | undefined): (typeof VISUAL_BURN_RATES)[number] | undefined {
+    if (raw === undefined) {
+        return "off";
     }
 
-    if (raw === "auto" || raw === "calculate" || raw === "display") {
-        return raw;
+    if (raw === true || raw === "") {
+        return "emoji";
+    }
+
+    if (typeof raw === "string" && (VISUAL_BURN_RATES as readonly string[]).includes(raw)) {
+        return raw as (typeof VISUAL_BURN_RATES)[number];
     }
 
     return undefined;
@@ -76,25 +106,47 @@ function resolveMode(raw: string | undefined): CostMode | undefined {
 async function runReport(cmd: Command, kind: ReportKind, source?: SourceId): Promise<void> {
     const flags = flagsOf(cmd);
 
-    if (kind !== "statusline" && flags.mode !== undefined && flags.mode !== (true as unknown as string)) {
-        const mode = resolveMode(typeof flags.mode === "string" ? flags.mode : undefined);
-
-        if (flags.mode && !mode) {
+    if (flags.mode !== undefined) {
+        const raw = typeof flags.mode === "string" ? flags.mode : "";
+        if (raw !== "auto" && raw !== "calculate" && raw !== "display") {
             process.stderr.write(`${suggestEnumFlag("tools ai-spend", "--mode", ["auto", "calculate", "display"])}\n`);
             process.exitCode = 1;
             return;
         }
     }
 
-    const timezone = flags.timezone?.trim() || systemTimeZone();
+    const timezoneRaw = flags.timezone?.trim();
+    if (timezoneRaw && !isValidTimeZone(timezoneRaw)) {
+        process.stderr.write(`Invalid --timezone ${timezoneRaw}. Use an IANA timezone name.\n`);
+        process.exitCode = 1;
+        return;
+    }
+
+    const timezone = timezoneRaw || systemTimeZone();
     const home = homedir();
     const now = new Date();
     const storage = new Storage("ai-spend");
     const pricing = await loadPricing(storage);
     const mode = parseCostMode(typeof flags.mode === "string" ? flags.mode : undefined);
     const sources = source ? ([source] as const) : undefined;
-    const sinceDay = parseDayArg(flags.since);
-    const untilDay = parseDayArg(flags.until);
+    const sincePassed = optionFromCli(cmd, "since");
+    const untilPassed = optionFromCli(cmd, "until");
+    const sinceRaw = sincePassed ? flags.since : undefined;
+    const untilRaw = untilPassed ? flags.until : undefined;
+    const sinceDay = sinceRaw ? (parseDayArg(sinceRaw) ?? resolveRelativeSince(sinceRaw, now, timezone)) : undefined;
+    const untilDay = untilRaw ? parseDayArg(untilRaw) : undefined;
+
+    if (sinceRaw && !sinceDay) {
+        process.stderr.write(`Invalid --since ${sinceRaw}. Use YYYY-MM-DD, YYYYMMDD, or Nd.\n`);
+        process.exitCode = 1;
+        return;
+    }
+
+    if (untilRaw && !untilDay) {
+        process.stderr.write(`Invalid --until ${untilRaw}. Use YYYY-MM-DD or YYYYMMDD.\n`);
+        process.exitCode = 1;
+        return;
+    }
     let minMtimeMs = sinceDay ? Date.parse(`${sinceDay}T00:00:00.000Z`) - 3 * 24 * 60 * 60 * 1000 : 0;
 
     if (kind === "statusline" && !sinceDay) {
@@ -113,7 +165,13 @@ async function runReport(cmd: Command, kind: ReportKind, source?: SourceId): Pro
             return;
         }
 
-        const visual = flags.breakdown === true ? "emoji" : "off";
+        const visual = parseVisualBurnRate(flags.visualBurnRate);
+        if (!visual) {
+            process.stderr.write(`${suggestEnumFlag("tools ai-spend", "--visual-burn-rate", VISUAL_BURN_RATES)}\n`);
+            process.exitCode = 1;
+            return;
+        }
+
         const line = renderStatusline(
             hook,
             events.filter((event) => event.source === "claude"),
@@ -219,27 +277,24 @@ export function registerCcusageCommands(program: Command): void {
         await runReport(cmd, "blocks");
     });
 
-    program
-        .command("statusline")
-        .description("Compact Claude Code hook status line (reads hook JSON from stdin)")
-        .option("-z, --timezone <timezone>", "Timezone for date grouping (IANA)")
-        .option("-m, --mode [mode]", "Cost calculation mode (auto | calculate | display)")
-        .action(async (_opts: ReportFlags, cmd: Command) => {
-            await runReport(cmd, "statusline");
-        });
+    addStatuslineFlags(
+        program.command("statusline").description("Compact Claude Code hook status line (reads hook JSON from stdin)")
+    ).action(async (_opts: ReportFlags, cmd: Command) => {
+        await runReport(cmd, "statusline");
+    });
 
     for (const [source, reports] of Object.entries(SOURCE_REPORTS) as Array<[SourceId, readonly ReportKind[]]>) {
         const parent = program.command(source).description(`Show ${source} usage commands`);
 
         for (const kind of reports) {
             if (kind === "statusline") {
-                parent
-                    .command("statusline")
-                    .description("Compact Claude Code hook status line (reads hook JSON from stdin)")
-                    .option("-z, --timezone <timezone>", "Timezone for date grouping (IANA)")
-                    .action(async (_opts: ReportFlags, cmd: Command) => {
-                        await runReport(cmd, "statusline", source);
-                    });
+                addStatuslineFlags(
+                    parent
+                        .command("statusline")
+                        .description("Compact Claude Code hook status line (reads hook JSON from stdin)")
+                ).action(async (_opts: ReportFlags, cmd: Command) => {
+                    await runReport(cmd, "statusline", source);
+                });
                 continue;
             }
 

--- a/src/ai-spend/lib/reports/commands.ts
+++ b/src/ai-spend/lib/reports/commands.ts
@@ -1,0 +1,260 @@
+import { homedir } from "node:os";
+import { suggestEnumFlag } from "@genesiscz/utils/cli";
+import { out } from "@genesiscz/utils/logger";
+import { Storage } from "@genesiscz/utils/storage/storage";
+import type { Command } from "commander";
+import { loadPricing } from "../config";
+import { buildBlocksReport } from "./blocks";
+import { parseCostMode, parseDayArg, parseLast, systemTimeZone } from "./dates";
+import { loadEvents } from "./load";
+import { buildPeriodReport } from "./period";
+import { renderBlocksTable, renderPeriodTable, renderSessionTable } from "./render";
+import { buildSessionReport } from "./session";
+import { parseStatuslineHook, renderStatusline } from "./statusline";
+import type { CostMode, PeriodGrain, ReportFlags, ReportKind, SourceId } from "./types";
+import { SOURCE_REPORTS } from "./types";
+
+async function readStdin(): Promise<string> {
+    if (process.stdin.isTTY) {
+        return "";
+    }
+
+    return await new Response(Bun.stdin.stream()).text();
+}
+
+function flagsOf(cmd: Command): ReportFlags {
+    return cmd.optsWithGlobals() as ReportFlags;
+}
+
+export function addReportFlags(
+    cmd: Command,
+    options: { last?: boolean; breakdown?: boolean; mode?: boolean; blocks?: boolean; sessionId?: boolean }
+): Command {
+    cmd.option("-j, --json", "Emit the report as JSON to stdout");
+    cmd.option("-s, --since <since>", "Filter from date (YYYY-MM-DD or YYYYMMDD)");
+    cmd.option("-u, --until <until>", "Filter until date (inclusive)");
+    cmd.option("-z, --timezone <timezone>", "Timezone for date grouping (IANA)");
+
+    if (options.last) {
+        cmd.option("--last <last>", "Show only the most recent N periods");
+    }
+
+    if (options.breakdown) {
+        cmd.option("-b, --breakdown", "Show per-model cost breakdown");
+    }
+
+    if (options.mode) {
+        cmd.option("-m, --mode [mode]", "Cost calculation mode (auto | calculate | display)");
+    }
+
+    if (options.sessionId) {
+        cmd.option("-i, --id <id>", "Filter to a specific session ID");
+    }
+
+    if (options.blocks) {
+        cmd.option("-a, --active", "Show only the active block with projections");
+        cmd.option("-r, --recent", "Show blocks from the last 3 days (including active)");
+        cmd.option("-n, --session-length [session-length]", "Session block duration in hours", "5");
+    }
+
+    cmd.option("--by-agent", "Include per-agent JSON breakdowns in unified rows");
+    return cmd;
+}
+
+function resolveMode(raw: string | undefined): CostMode | undefined {
+    if (raw === undefined || raw === "") {
+        return "auto";
+    }
+
+    if (raw === "auto" || raw === "calculate" || raw === "display") {
+        return raw;
+    }
+
+    return undefined;
+}
+
+async function runReport(cmd: Command, kind: ReportKind, source?: SourceId): Promise<void> {
+    const flags = flagsOf(cmd);
+
+    if (kind !== "statusline" && flags.mode !== undefined && flags.mode !== (true as unknown as string)) {
+        const mode = resolveMode(typeof flags.mode === "string" ? flags.mode : undefined);
+
+        if (flags.mode && !mode) {
+            process.stderr.write(`${suggestEnumFlag("tools ai-spend", "--mode", ["auto", "calculate", "display"])}\n`);
+            process.exitCode = 1;
+            return;
+        }
+    }
+
+    const timezone = flags.timezone?.trim() || systemTimeZone();
+    const home = homedir();
+    const now = new Date();
+    const storage = new Storage("ai-spend");
+    const pricing = await loadPricing(storage);
+    const mode = parseCostMode(typeof flags.mode === "string" ? flags.mode : undefined);
+    const sources = source ? ([source] as const) : undefined;
+    const sinceDay = parseDayArg(flags.since);
+    const untilDay = parseDayArg(flags.until);
+    let minMtimeMs = sinceDay ? Date.parse(`${sinceDay}T00:00:00.000Z`) - 3 * 24 * 60 * 60 * 1000 : 0;
+
+    if (kind === "statusline" && !sinceDay) {
+        minMtimeMs = now.getTime() - 2 * 24 * 60 * 60 * 1000;
+    }
+
+    const events = loadEvents({ home, sources, minMtimeMs: Number.isFinite(minMtimeMs) ? minMtimeMs : 0 });
+
+    if (kind === "statusline") {
+        const stdin = await readStdin();
+        const hook = parseStatuslineHook(stdin);
+
+        if (!hook) {
+            process.stderr.write("No input provided. Pipe Claude Code hook JSON on stdin.\n");
+            process.exitCode = 1;
+            return;
+        }
+
+        const visual = flags.breakdown === true ? "emoji" : "off";
+        const line = renderStatusline(
+            hook,
+            events.filter((event) => event.source === "claude"),
+            {
+                timezone,
+                now,
+                pricing,
+                mode,
+                costSource: "auto",
+                visualBurnRate: visual,
+            }
+        );
+        out.print(`${line}\n`);
+        return;
+    }
+
+    if (kind === "blocks") {
+        const hours = flags.sessionLength ? Number.parseFloat(flags.sessionLength) : 5;
+        const report = buildBlocksReport(
+            events.filter((event) => event.source === "claude"),
+            {
+                timezone,
+                sinceDay,
+                untilDay,
+                now,
+                pricing,
+                mode,
+                active: flags.active,
+                recent: flags.recent,
+                sessionHours: Number.isFinite(hours) ? hours : 5,
+            }
+        );
+
+        if (flags.json) {
+            out.result(report);
+            return;
+        }
+
+        out.println(renderBlocksTable(report, Boolean(flags.breakdown)));
+        return;
+    }
+
+    const last = parseLast(flags.last);
+    const common = {
+        timezone,
+        sinceDay,
+        untilDay,
+        last,
+        now,
+        pricing,
+        mode,
+        source,
+        byAgent: Boolean(flags.byAgent),
+    };
+
+    if (kind === "session") {
+        const report = buildSessionReport(events, { ...common, sessionId: flags.id });
+
+        if (flags.json) {
+            out.result(report);
+            return;
+        }
+
+        out.println(renderSessionTable(report, Boolean(flags.breakdown)));
+        return;
+    }
+
+    const grain = kind as PeriodGrain;
+    const report = buildPeriodReport(events, { ...common, grain });
+
+    if (flags.json) {
+        out.result(report);
+        return;
+    }
+
+    out.println(renderPeriodTable(report, grain, Boolean(flags.breakdown)));
+}
+
+export function registerCcusageCommands(program: Command): void {
+    const periodKinds: PeriodGrain[] = ["daily", "weekly", "monthly"];
+
+    for (const grain of periodKinds) {
+        addReportFlags(program.command(grain).description(`Show all detected coding-agent usage grouped by ${grain}`), {
+            last: true,
+            breakdown: true,
+        }).action(async (_opts: ReportFlags, cmd: Command) => {
+            await runReport(cmd, grain);
+        });
+    }
+
+    addReportFlags(program.command("session").description("Show all detected coding-agent usage grouped by session"), {
+        breakdown: true,
+        sessionId: true,
+    }).action(async (_opts: ReportFlags, cmd: Command) => {
+        await runReport(cmd, "session");
+    });
+
+    addReportFlags(program.command("blocks").description("Show usage grouped by 5-hour Claude Code billing windows"), {
+        breakdown: true,
+        mode: true,
+        blocks: true,
+    }).action(async (_opts: ReportFlags, cmd: Command) => {
+        await runReport(cmd, "blocks");
+    });
+
+    program
+        .command("statusline")
+        .description("Compact Claude Code hook status line (reads hook JSON from stdin)")
+        .option("-z, --timezone <timezone>", "Timezone for date grouping (IANA)")
+        .option("-m, --mode [mode]", "Cost calculation mode (auto | calculate | display)")
+        .action(async (_opts: ReportFlags, cmd: Command) => {
+            await runReport(cmd, "statusline");
+        });
+
+    for (const [source, reports] of Object.entries(SOURCE_REPORTS) as Array<[SourceId, readonly ReportKind[]]>) {
+        const parent = program.command(source).description(`Show ${source} usage commands`);
+
+        for (const kind of reports) {
+            if (kind === "statusline") {
+                parent
+                    .command("statusline")
+                    .description("Compact Claude Code hook status line (reads hook JSON from stdin)")
+                    .option("-z, --timezone <timezone>", "Timezone for date grouping (IANA)")
+                    .action(async (_opts: ReportFlags, cmd: Command) => {
+                        await runReport(cmd, "statusline", source);
+                    });
+                continue;
+            }
+
+            const extra = {
+                last: kind === "daily" || kind === "weekly" || kind === "monthly",
+                breakdown: true,
+                mode: source === "claude",
+                blocks: kind === "blocks",
+                sessionId: kind === "session",
+            };
+            addReportFlags(parent.command(kind).description(`${source} ${kind} report`), extra).action(
+                async (_opts: ReportFlags, cmd: Command) => {
+                    await runReport(cmd, kind, source);
+                }
+            );
+        }
+    }
+}

--- a/src/ai-spend/lib/reports/cost.ts
+++ b/src/ai-spend/lib/reports/cost.ts
@@ -1,0 +1,56 @@
+import { priceFor, resolvePrice } from "../pricing";
+import type { PricingTable } from "../types";
+import type { CostMode, SpendEvent } from "./types";
+
+export function catalogCost(event: SpendEvent, pricing: PricingTable, candidates: string[]): number {
+    for (const model of candidates) {
+        const entry = priceFor(model, pricing);
+
+        if (!entry) {
+            continue;
+        }
+
+        const at = new Date(event.timestamp);
+        const price = resolvePrice(entry, {
+            at: Number.isNaN(at.getTime()) ? undefined : at,
+            contextTokens: event.inputTokens + event.cacheReadTokens + event.cacheCreationTokens,
+        });
+
+        return (
+            (event.inputTokens * price.input +
+                event.outputTokens * price.output +
+                event.cacheCreationTokens * price.cacheWrite +
+                event.cacheReadTokens * price.cacheRead) /
+            1_000_000
+        );
+    }
+
+    return 0;
+}
+
+export function eventCost(event: SpendEvent, pricing: PricingTable, mode: CostMode, candidates: string[]): number {
+    if (mode === "display") {
+        return event.recordedCostUsd ?? 0;
+    }
+
+    const calculated = catalogCost(event, pricing, candidates);
+
+    if (mode === "calculate") {
+        return calculated;
+    }
+
+    return event.recordedCostUsd ?? calculated;
+}
+
+export function priceCandidates(model: string): string[] {
+    return [model];
+}
+
+export function totalTokensOf(event: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+}): number {
+    return event.inputTokens + event.outputTokens + event.cacheCreationTokens + event.cacheReadTokens;
+}

--- a/src/ai-spend/lib/reports/dates.ts
+++ b/src/ai-spend/lib/reports/dates.ts
@@ -7,6 +7,15 @@ export function systemTimeZone(): string {
     return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 }
 
+export function isValidTimeZone(timeZone: string): boolean {
+    try {
+        Intl.DateTimeFormat("en-US", { timeZone });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 /** Accept ccusage `YYYY-MM-DD` or `YYYYMMDD`. */
 export function parseDayArg(raw: string | undefined): string | undefined {
     if (!raw) {
@@ -118,6 +127,23 @@ export function lastSinceDay(grain: PeriodGrain, count: number, today: string): 
     const [year, month] = today.split("-").map(Number);
     const start = new Date(Date.UTC(year, month - n, 1));
     return start.toISOString().slice(0, 10);
+}
+
+/** `Nd` relative to the civil day of `now` in `timeZone`. */
+export function resolveRelativeSince(raw: string, now: Date, timeZone: string): string | undefined {
+    const match = raw.trim().match(/^(\d+)d$/);
+
+    if (!match) {
+        return undefined;
+    }
+
+    const today = zonedDay(now.toISOString(), timeZone);
+
+    if (!today) {
+        return undefined;
+    }
+
+    return addDays(today, -Number.parseInt(match[1], 10));
 }
 
 export function parseLast(raw: string | undefined): number | undefined {

--- a/src/ai-spend/lib/reports/dates.ts
+++ b/src/ai-spend/lib/reports/dates.ts
@@ -1,0 +1,138 @@
+import type { PeriodGrain } from "./types";
+
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+const COMPACT_DAY = /^\d{8}$/;
+
+export function systemTimeZone(): string {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+/** Accept ccusage `YYYY-MM-DD` or `YYYYMMDD`. */
+export function parseDayArg(raw: string | undefined): string | undefined {
+    if (!raw) {
+        return undefined;
+    }
+
+    const trimmed = raw.trim();
+
+    if (COMPACT_DAY.test(trimmed)) {
+        const day = `${trimmed.slice(0, 4)}-${trimmed.slice(4, 6)}-${trimmed.slice(6, 8)}`;
+        return isValidIsoDay(day) ? day : undefined;
+    }
+
+    if (ISO_DAY.test(trimmed) && isValidIsoDay(trimmed)) {
+        return trimmed;
+    }
+
+    return undefined;
+}
+
+function isValidIsoDay(day: string): boolean {
+    const parsed = new Date(`${day}T00:00:00.000Z`);
+    return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === day;
+}
+
+export function zonedDay(timestamp: string, timeZone: string): string {
+    const date = new Date(timestamp);
+
+    if (Number.isNaN(date.getTime())) {
+        return "";
+    }
+
+    const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+    }).formatToParts(date);
+    const get = (type: string): string => parts.find((part) => part.type === type)?.value ?? "";
+    return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+export function addDays(ymd: string, days: number): string {
+    const [year, month, day] = ymd.split("-").map(Number);
+    const next = new Date(Date.UTC(year, month - 1, day + days));
+    return next.toISOString().slice(0, 10);
+}
+
+/** Monday of the civil week that contains `ymd`. */
+export function mondayOf(ymd: string): string {
+    const [year, month, day] = ymd.split("-").map(Number);
+    const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    const back = (weekday + 6) % 7;
+    return addDays(ymd, -back);
+}
+
+export function periodKey(ymd: string, grain: PeriodGrain): string {
+    if (grain === "monthly") {
+        return ymd.slice(0, 7);
+    }
+
+    if (grain === "weekly") {
+        return mondayOf(ymd);
+    }
+
+    return ymd;
+}
+
+export function periodFieldName(grain: PeriodGrain): "date" | "week" | "month" {
+    if (grain === "weekly") {
+        return "week";
+    }
+
+    if (grain === "monthly") {
+        return "month";
+    }
+
+    return "date";
+}
+
+export function inDayWindow(ymd: string, sinceDay?: string, untilDay?: string): boolean {
+    if (!ymd) {
+        return false;
+    }
+
+    if (sinceDay && ymd < sinceDay) {
+        return false;
+    }
+
+    if (untilDay && ymd > untilDay) {
+        return false;
+    }
+
+    return true;
+}
+
+/** `--last N` lowers the since bound so the most recent N periods (including today) are kept. */
+export function lastSinceDay(grain: PeriodGrain, count: number, today: string): string {
+    const n = Math.max(1, count);
+
+    if (grain === "daily") {
+        return addDays(today, -(n - 1));
+    }
+
+    if (grain === "weekly") {
+        return addDays(mondayOf(today), -7 * (n - 1));
+    }
+
+    const [year, month] = today.split("-").map(Number);
+    const start = new Date(Date.UTC(year, month - n, 1));
+    return start.toISOString().slice(0, 10);
+}
+
+export function parseLast(raw: string | undefined): number | undefined {
+    if (!raw) {
+        return undefined;
+    }
+
+    const value = Number.parseInt(raw, 10);
+    return Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+export function parseCostMode(raw: string | undefined): "auto" | "calculate" | "display" {
+    if (raw === "calculate" || raw === "display" || raw === "auto") {
+        return raw;
+    }
+
+    return "auto";
+}

--- a/src/ai-spend/lib/reports/help.test.ts
+++ b/src/ai-spend/lib/reports/help.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import { SOURCE_IDS, SOURCE_REPORTS } from "./types";
+
+const AI_SPEND = join(import.meta.dir, "../../index.ts");
+
+async function help(args: string[]): Promise<string> {
+    const proc = Bun.spawn(["bun", AI_SPEND, ...args, "--help"], { stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+    await proc.exited;
+    return `${stdout}\n${stderr}`;
+}
+
+describe("ai-spend command tree", () => {
+    it("lists every ccusage command path from the live inventory", async () => {
+        const root = await help([]);
+        for (const name of [
+            "daily",
+            "weekly",
+            "monthly",
+            "session",
+            "blocks",
+            "statusline",
+            "summary",
+            "sessions",
+            "today",
+            "monitor",
+            ...SOURCE_IDS,
+        ]) {
+            expect(root).toContain(name);
+        }
+
+        for (const source of SOURCE_IDS) {
+            const nested = await help([source]);
+
+            for (const kind of SOURCE_REPORTS[source]) {
+                expect(nested).toContain(kind);
+            }
+        }
+    });
+});

--- a/src/ai-spend/lib/reports/help.test.ts
+++ b/src/ai-spend/lib/reports/help.test.ts
@@ -30,12 +30,16 @@ describe("ai-spend command tree", () => {
             expect(root).toContain(name);
         }
 
-        for (const source of SOURCE_IDS) {
-            const nested = await help([source]);
+        const nested = await Promise.all(SOURCE_IDS.map((source) => help([source])));
 
+        for (const [index, source] of SOURCE_IDS.entries()) {
             for (const kind of SOURCE_REPORTS[source]) {
-                expect(nested).toContain(kind);
+                expect(nested[index]).toContain(kind);
             }
         }
-    });
+
+        const statusline = await help(["statusline"]);
+        expect(statusline).toContain("--visual-burn-rate");
+        expect(statusline).toContain("--timezone");
+    }, 20_000);
 });

--- a/src/ai-spend/lib/reports/jsonl.ts
+++ b/src/ai-spend/lib/reports/jsonl.ts
@@ -52,6 +52,32 @@ export function asNumber(value: unknown): number {
     return 0;
 }
 
+/** Finite number, including 0. Undefined when the field is absent or not numeric. */
+export function optionalFinite(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === "string" && value.trim()) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+
+    return undefined;
+}
+
+export function firstFinite(...values: unknown[]): number {
+    for (const value of values) {
+        const parsed = optionalFinite(value);
+
+        if (parsed !== undefined) {
+            return parsed;
+        }
+    }
+
+    return 0;
+}
+
 export function pickNumber(record: Record<string, unknown> | undefined, keys: string[]): number {
     if (!record) {
         return 0;

--- a/src/ai-spend/lib/reports/jsonl.ts
+++ b/src/ai-spend/lib/reports/jsonl.ts
@@ -1,0 +1,99 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { isRecord, num } from "../drivers/parse-helpers";
+
+export function parseJsonValue(text: string): unknown | undefined {
+    try {
+        return SafeJSON.parse(text, { strict: true });
+    } catch (err) {
+        logger.debug({ err }, "ai-spend: skipping malformed JSON");
+        return undefined;
+    }
+}
+
+export function parseJsonl(content: string): unknown[] {
+    const rows: unknown[] = [];
+
+    for (const line of content.split("\n")) {
+        const trimmed = line.trim();
+
+        if (!trimmed) {
+            continue;
+        }
+
+        const value = parseJsonValue(trimmed);
+
+        if (value !== undefined) {
+            rows.push(value);
+        }
+    }
+
+    return rows;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+    return isRecord(value) ? value : undefined;
+}
+
+export function asString(value: unknown): string | undefined {
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function asNumber(value: unknown): number {
+    if (typeof value === "number") {
+        return num(value);
+    }
+
+    if (typeof value === "string" && value.trim()) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
+
+    return 0;
+}
+
+export function pickNumber(record: Record<string, unknown> | undefined, keys: string[]): number {
+    if (!record) {
+        return 0;
+    }
+
+    for (const key of keys) {
+        if (key in record) {
+            const value = asNumber(record[key]);
+
+            if (value !== 0 || record[key] === 0) {
+                return asNumber(record[key]);
+            }
+        }
+    }
+
+    return 0;
+}
+
+export function isoFromUnknown(value: unknown): string {
+    if (typeof value === "string" && value.length > 0) {
+        const date = new Date(value);
+
+        if (!Number.isNaN(date.getTime())) {
+            return date.toISOString();
+        }
+
+        return value;
+    }
+
+    if (typeof value === "number" && Number.isFinite(value)) {
+        const ms = value > 1e12 ? value : value > 1e9 ? value * 1000 : value;
+        const date = new Date(ms);
+
+        if (!Number.isNaN(date.getTime())) {
+            return date.toISOString();
+        }
+    }
+
+    return "";
+}
+
+export function fileStem(file: string): string {
+    const base = file.split("/").pop() ?? file;
+    return base.replace(/\.[^.]+$/, "");
+}

--- a/src/ai-spend/lib/reports/load.ts
+++ b/src/ai-spend/lib/reports/load.ts
@@ -1,0 +1,100 @@
+import { logger } from "@genesiscz/utils/logger";
+import type { PricingTable } from "../types";
+import { priceCandidates as defaultCandidates, eventCost } from "./cost";
+import { inDayWindow, zonedDay } from "./dates";
+import { loadClaudeEvents, loadCodexEvents, loadGrokEvents, nativePriceCandidates } from "./native";
+import { loadExtraSource } from "./sources";
+import type { CostMode, SourceId, SpendEvent } from "./types";
+import { SOURCE_IDS } from "./types";
+
+export interface LoadOptions {
+    home: string;
+    sources?: readonly SourceId[];
+    /** Skip transcripts whose mtime is before this instant (append-only files). */
+    minMtimeMs?: number;
+}
+
+function appendAll(into: SpendEvent[], extra: SpendEvent[]): void {
+    for (const event of extra) {
+        into.push(event);
+    }
+}
+
+export function loadEvents(options: LoadOptions): SpendEvent[] {
+    const wanted = new Set(options.sources ?? SOURCE_IDS);
+    const events: SpendEvent[] = [];
+
+    const minMtimeMs = options.minMtimeMs ?? 0;
+
+    if (wanted.has("claude")) {
+        appendAll(events, loadClaudeEvents(options.home, minMtimeMs));
+    }
+
+    if (wanted.has("codex")) {
+        appendAll(events, loadCodexEvents(options.home, minMtimeMs));
+    }
+
+    if (wanted.has("grok")) {
+        appendAll(events, loadGrokEvents(options.home, minMtimeMs));
+    }
+
+    for (const source of SOURCE_IDS) {
+        if (source === "claude" || source === "codex" || source === "grok" || !wanted.has(source)) {
+            continue;
+        }
+
+        try {
+            appendAll(events, loadExtraSource(source, options.home));
+        } catch (err) {
+            logger.debug({ err, source }, "ai-spend: extra source failed");
+        }
+    }
+
+    return dedupEvents(events);
+}
+
+function dedupEvents(events: SpendEvent[]): SpendEvent[] {
+    const byId = new Map<string, SpendEvent>();
+
+    for (const event of events) {
+        const key = `${event.source}:${event.id}`;
+        const existing = byId.get(key);
+
+        if (!existing) {
+            byId.set(key, event);
+            continue;
+        }
+
+        if (existing.isSidechain && !event.isSidechain) {
+            byId.set(key, event);
+        }
+    }
+
+    return [...byId.values()];
+}
+
+export function candidatesFor(event: SpendEvent): string[] {
+    if (event.source === "claude" || event.source === "codex" || event.source === "grok") {
+        return nativePriceCandidates(event.source, event.model);
+    }
+
+    return defaultCandidates(event.model);
+}
+
+export function pricedEventCost(event: SpendEvent, pricing: PricingTable, mode: CostMode): number {
+    return eventCost(event, pricing, mode, candidatesFor(event));
+}
+
+export function filterEvents(
+    events: SpendEvent[],
+    options: { timezone: string; sinceDay?: string; untilDay?: string; sessionId?: string }
+): SpendEvent[] {
+    return events.filter((event) => {
+        if (options.sessionId && event.sessionId !== options.sessionId) {
+            return false;
+        }
+
+        const day = zonedDay(event.timestamp, options.timezone);
+        return inDayWindow(day, options.sinceDay, options.untilDay);
+    });
+}

--- a/src/ai-spend/lib/reports/native.ts
+++ b/src/ai-spend/lib/reports/native.ts
@@ -1,0 +1,238 @@
+import { basename, dirname } from "node:path";
+import { claudeDriver } from "../drivers/claude";
+import { codexDriver } from "../drivers/codex";
+import { grokDriver } from "../drivers/grok";
+import { num } from "../drivers/parse-helpers";
+import type { DriverUsageEvent, MonitorDriver } from "../drivers/types";
+import { findRecentTranscripts } from "../monitor";
+import { asRecord, asString, parseJsonValue } from "./jsonl";
+import type { SourceId, SpendEvent } from "./types";
+import { readText } from "./walk";
+
+const MIN_MTIME = 0;
+
+interface ClaudeUsage {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation?: { ephemeral_5m_input_tokens?: number; ephemeral_1h_input_tokens?: number };
+    iterations?: Array<{
+        type?: string;
+        model?: string;
+        input_tokens?: number;
+        output_tokens?: number;
+        cache_creation_input_tokens?: number;
+        cache_read_input_tokens?: number;
+    }>;
+}
+
+function cacheCreationTokens(usage: ClaudeUsage): number {
+    const nested = usage.cache_creation;
+
+    if (nested) {
+        return num(nested.ephemeral_5m_input_tokens) + num(nested.ephemeral_1h_input_tokens);
+    }
+
+    return num(usage.cache_creation_input_tokens);
+}
+
+function unwrapClaudeRecord(raw: Record<string, unknown>): Record<string, unknown> {
+    const nested = asRecord(asRecord(asRecord(raw.data)?.message)?.message);
+    const envelope = asRecord(asRecord(raw.data)?.message);
+
+    if (nested && asRecord(nested.usage)) {
+        return {
+            ...raw,
+            timestamp: envelope?.timestamp ?? raw.timestamp,
+            sessionId: envelope?.sessionId ?? raw.sessionId,
+            isSidechain: envelope?.isSidechain ?? raw.isSidechain,
+            costUSD: envelope?.costUSD ?? raw.costUSD,
+            message: nested,
+        };
+    }
+
+    return raw;
+}
+
+function parseClaudeLine(line: string, file: string): SpendEvent[] {
+    if (!line.includes('"usage"')) {
+        return [];
+    }
+
+    const parsed = parseJsonValue(line);
+    const raw = asRecord(parsed);
+
+    if (!raw) {
+        return [];
+    }
+
+    const entry = unwrapClaudeRecord(raw);
+    const message = asRecord(entry.message);
+    const usage = asRecord(message?.usage);
+
+    if (!message || !usage) {
+        return [];
+    }
+
+    const sessionId = asString(entry.sessionId) ?? basename(file).replace(/\.jsonl$/, "");
+    const project = asString(entry.cwd) ?? "";
+    const timestamp = asString(entry.timestamp) ?? "";
+    const isSidechain = entry.isSidechain === true;
+    const model = asString(message.model) ?? "unknown";
+    const messageId = asString(message.id) ?? `${sessionId}|${timestamp}|${model}`;
+    const events: SpendEvent[] = [];
+    const recorded = typeof entry.costUSD === "number" ? num(entry.costUSD) : undefined;
+    const inputTokens = num(usage.input_tokens as number | undefined);
+    const outputTokens = num(usage.output_tokens as number | undefined);
+    const cacheCreation = cacheCreationTokens(usage as ClaudeUsage);
+    const cacheRead = num(usage.cache_read_input_tokens as number | undefined);
+
+    if (inputTokens || outputTokens || cacheCreation || cacheRead) {
+        events.push({
+            source: "claude",
+            id: messageId,
+            model,
+            timestamp,
+            sessionId,
+            project,
+            inputTokens,
+            outputTokens,
+            cacheCreationTokens: cacheCreation,
+            cacheReadTokens: cacheRead,
+            recordedCostUsd: recorded,
+            isSidechain,
+        });
+    }
+
+    const iterations = Array.isArray(usage.iterations) ? usage.iterations : [];
+
+    for (const [index, rawIteration] of iterations.entries()) {
+        const iteration = asRecord(rawIteration);
+
+        if (!iteration) {
+            continue;
+        }
+
+        const kind = asString(iteration.type) ?? asString(iteration.kind);
+
+        if (kind !== "advisor_message") {
+            continue;
+        }
+
+        events.push({
+            source: "claude",
+            id: `${messageId}:advisor:${index}`,
+            model: asString(iteration.model) ?? "unknown",
+            timestamp,
+            sessionId,
+            project,
+            inputTokens: num(iteration.input_tokens as number | undefined),
+            outputTokens: num(iteration.output_tokens as number | undefined),
+            cacheCreationTokens: num(iteration.cache_creation_input_tokens as number | undefined),
+            cacheReadTokens: num(iteration.cache_read_input_tokens as number | undefined),
+            isSidechain,
+        });
+    }
+
+    return events;
+}
+
+function sessionFromFile(file: string, source: SourceId): string {
+    if (source === "grok") {
+        return basename(dirname(file));
+    }
+
+    return basename(file).replace(/\.jsonl$/, "");
+}
+
+function projectFromFile(file: string, source: SourceId): string {
+    if (source === "claude") {
+        const parts = file.split("/");
+        const projects = parts.lastIndexOf("projects");
+
+        if (projects >= 0 && parts[projects + 1]) {
+            return parts[projects + 1];
+        }
+    }
+
+    if (source === "grok") {
+        return basename(dirname(dirname(file)));
+    }
+
+    return "";
+}
+
+function loadDriverFiles(driver: MonitorDriver, home: string, source: SourceId, minMtimeMs = MIN_MTIME): SpendEvent[] {
+    const files = findRecentTranscripts(driver.roots(home), minMtimeMs, driver);
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        if (source === "claude") {
+            for (const line of content.split("\n")) {
+                events.push(...parseClaudeLine(line, file));
+            }
+
+            continue;
+        }
+
+        const parser = driver.createParser({ file, state: undefined });
+        const sessionId = sessionFromFile(file, source);
+        const project = projectFromFile(file, source);
+
+        for (const line of content.split("\n")) {
+            parser.parseLine(line, (event: DriverUsageEvent) => {
+                events.push({
+                    source,
+                    id: event.id,
+                    model: event.model,
+                    timestamp: event.timestamp,
+                    sessionId,
+                    project,
+                    inputTokens: event.inputTokens,
+                    outputTokens: event.outputTokens,
+                    cacheCreationTokens: event.cacheCreationTokens,
+                    cacheReadTokens: event.cacheReadTokens,
+                    recordedCostUsd: event.recordedCostUsd,
+                    reasoningOutputTokens: event.reasoningOutputTokens,
+                });
+            });
+        }
+    }
+
+    return events;
+}
+
+export function loadClaudeEvents(home: string, minMtimeMs = MIN_MTIME): SpendEvent[] {
+    return loadDriverFiles(claudeDriver, home, "claude", minMtimeMs);
+}
+
+export function loadCodexEvents(home: string, minMtimeMs = MIN_MTIME): SpendEvent[] {
+    return loadDriverFiles(codexDriver, home, "codex", minMtimeMs);
+}
+
+export function loadGrokEvents(home: string, minMtimeMs = MIN_MTIME): SpendEvent[] {
+    return loadDriverFiles(grokDriver, home, "grok", minMtimeMs);
+}
+
+export function nativePriceCandidates(source: SourceId, model: string): string[] {
+    if (source === "claude") {
+        return claudeDriver.priceCandidates(model);
+    }
+
+    if (source === "codex") {
+        return codexDriver.priceCandidates(model);
+    }
+
+    if (source === "grok") {
+        return grokDriver.priceCandidates(model);
+    }
+
+    return [model];
+}

--- a/src/ai-spend/lib/reports/parity.test.ts
+++ b/src/ai-spend/lib/reports/parity.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { isolateAgentHomeEnv } from "../drivers/test-env";
+
+isolateAgentHomeEnv();
+
+const AI_SPEND = join(import.meta.dir, "../../index.ts");
+
+function claudeLine(over: {
+    id: string;
+    sessionId: string;
+    timestamp: string;
+    input: number;
+    output: number;
+    cacheWrite: number;
+    cacheRead: number;
+    model?: string;
+}): string {
+    return SafeJSON.stringify({
+        type: "assistant",
+        timestamp: over.timestamp,
+        cwd: "/p/fix",
+        sessionId: over.sessionId,
+        message: {
+            id: over.id,
+            model: over.model ?? "claude-3-5-haiku",
+            usage: {
+                input_tokens: over.input,
+                output_tokens: over.output,
+                cache_creation_input_tokens: over.cacheWrite,
+                cache_read_input_tokens: over.cacheRead,
+            },
+        },
+    });
+}
+
+function writeFixtureHome(): string {
+    const home = mkdtempSync(join(tmpdir(), "ai-spend-parity-"));
+    const claudeDir = join(home, ".claude", "projects", "proj");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+        join(claudeDir, "sess-parity.jsonl"),
+        [
+            claudeLine({
+                id: "msg-1",
+                sessionId: "sess-parity",
+                timestamp: "2026-06-01T10:15:00.000Z",
+                input: 100,
+                output: 20,
+                cacheWrite: 10,
+                cacheRead: 40,
+            }),
+            claudeLine({
+                id: "msg-2",
+                sessionId: "sess-parity",
+                timestamp: "2026-06-01T16:20:00.000Z",
+                input: 50,
+                output: 5,
+                cacheWrite: 0,
+                cacheRead: 15,
+            }),
+        ].join("\n")
+    );
+    return home;
+}
+
+async function spawnJson(command: string[], env: NodeJS.ProcessEnv): Promise<Record<string, unknown>> {
+    const proc = Bun.spawn(command, { env, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exit] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+
+    if (exit !== 0) {
+        throw new Error(`${command.join(" ")} exited ${exit}\n${stderr}\n${stdout}`);
+    }
+
+    const trimmed = stdout.trim();
+    const start = trimmed.indexOf("{");
+    return SafeJSON.parse(start >= 0 ? trimmed.slice(start) : trimmed, { strict: true }) as Record<string, unknown>;
+}
+
+function tokenFields(row: Record<string, unknown>): Record<string, number> {
+    return {
+        inputTokens: Number(row.inputTokens ?? 0),
+        outputTokens: Number(row.outputTokens ?? 0),
+        cacheCreationTokens: Number(row.cacheCreationTokens ?? 0),
+        cacheReadTokens: Number(row.cacheReadTokens ?? 0),
+        totalTokens: Number(row.totalTokens ?? 0),
+    };
+}
+
+describe("ccusage JSON parity on a fixture HOME", () => {
+    it("daily grouping keys and token fields match ccusage --json --offline", async () => {
+        const home = writeFixtureHome();
+        const env: NodeJS.ProcessEnv = { ...process.env, HOME: home, TZ: "UTC" };
+        delete env.CLAUDE_CONFIG_DIR;
+        const since = ["--since", "20260601", "--until", "20260601"];
+        const ccusageBin = Bun.which("ccusage");
+
+        if (!ccusageBin) {
+            throw new Error("ccusage binary is required for the parity spawn");
+        }
+
+        const cc = await spawnJson(
+            [ccusageBin, "claude", "daily", "--json", "--offline", "--timezone", "UTC", ...since],
+            env
+        );
+        const ours = await spawnJson(
+            [
+                "bun",
+                AI_SPEND,
+                "claude",
+                "daily",
+                "--json",
+                "--timezone",
+                "UTC",
+                "--since",
+                "2026-06-01",
+                "--until",
+                "2026-06-01",
+            ],
+            env
+        );
+        const ccRows = (cc.daily as Array<Record<string, unknown>>) ?? [];
+        const ourRows = (ours.daily as Array<Record<string, unknown>>) ?? [];
+        expect(ourRows.map((row) => row.date ?? row.period)).toEqual(ccRows.map((row) => row.date ?? row.period));
+        expect(tokenFields(ourRows[0])).toEqual(tokenFields(ccRows[0]));
+        expect(tokenFields(ours.totals as Record<string, unknown>)).toEqual(
+            tokenFields(cc.totals as Record<string, unknown>)
+        );
+    });
+
+    it("session grouping keys and token fields match ccusage", async () => {
+        const home = writeFixtureHome();
+        const env: NodeJS.ProcessEnv = { ...process.env, HOME: home, TZ: "UTC" };
+        delete env.CLAUDE_CONFIG_DIR;
+        const ccusageBin = Bun.which("ccusage");
+
+        if (!ccusageBin) {
+            throw new Error("ccusage binary is required for the parity spawn");
+        }
+
+        // ccusage `claude session --since/--until` drops this fixture even
+        // though `claude daily` with the same window keeps it. Compare the
+        // unwindowed session report, which both tools emit for this one-day tree.
+        const cc = await spawnJson([ccusageBin, "claude", "session", "--json", "--offline", "--timezone", "UTC"], env);
+        const ours = await spawnJson(["bun", AI_SPEND, "claude", "session", "--json", "--timezone", "UTC"], env);
+        const ccRows = (cc.sessions as Array<Record<string, unknown>>) ?? [];
+        const ourRows = (ours.sessions as Array<Record<string, unknown>>) ?? [];
+        expect(ourRows.map((row) => row.sessionId).sort()).toEqual(ccRows.map((row) => row.sessionId).sort());
+        expect(tokenFields(ourRows[0])).toEqual(tokenFields(ccRows[0]));
+    });
+
+    it("blocks split the 5-hour window the same way as ccusage", async () => {
+        const home = writeFixtureHome();
+        const env: NodeJS.ProcessEnv = { ...process.env, HOME: home, TZ: "UTC" };
+        delete env.CLAUDE_CONFIG_DIR;
+        const ccusageBin = Bun.which("ccusage");
+
+        if (!ccusageBin) {
+            throw new Error("ccusage binary is required for the parity spawn");
+        }
+
+        const cc = await spawnJson(
+            [
+                ccusageBin,
+                "blocks",
+                "--json",
+                "--offline",
+                "--timezone",
+                "UTC",
+                "--since",
+                "20260601",
+                "--until",
+                "20260601",
+            ],
+            env
+        );
+        const ours = await spawnJson(
+            [
+                "bun",
+                AI_SPEND,
+                "blocks",
+                "--json",
+                "--timezone",
+                "UTC",
+                "--since",
+                "2026-06-01",
+                "--until",
+                "2026-06-01",
+            ],
+            env
+        );
+        const ccBlocks = ((cc.blocks as Array<Record<string, unknown>>) ?? []).filter((row) => !row.isGap);
+        const ourBlocks = ((ours.blocks as Array<Record<string, unknown>>) ?? []).filter((row) => !row.isGap);
+        expect(ourBlocks.map((row) => row.id)).toEqual(ccBlocks.map((row) => row.id));
+        expect(ourBlocks.map((row) => row.totalTokens)).toEqual(ccBlocks.map((row) => row.totalTokens));
+    });
+});

--- a/src/ai-spend/lib/reports/period.test.ts
+++ b/src/ai-spend/lib/reports/period.test.ts
@@ -6,6 +6,8 @@ import { SafeJSON } from "@genesiscz/utils/json";
 import { isolateAgentHomeEnv } from "../drivers/test-env";
 import { DEFAULT_PRICING } from "../pricing";
 import { identifySessionBlocks } from "./blocks";
+import { isValidTimeZone, resolveRelativeSince } from "./dates";
+import { firstFinite, optionalFinite } from "./jsonl";
 import { loadEvents } from "./load";
 import { buildPeriodReport } from "./period";
 import { buildSessionReport } from "./session";
@@ -13,6 +15,36 @@ import { parseStatuslineHook, renderStatusline } from "./statusline";
 import type { SpendEvent } from "./types";
 
 isolateAgentHomeEnv();
+
+describe("resolveRelativeSince", () => {
+    it("subtracts civil days in the report timezone, not UTC", () => {
+        const now = new Date("2026-06-02T04:00:00.000Z");
+        expect(resolveRelativeSince("0d", now, "UTC")).toBe("2026-06-02");
+        expect(resolveRelativeSince("0d", now, "America/Los_Angeles")).toBe("2026-06-01");
+        expect(resolveRelativeSince("1d", now, "America/Los_Angeles")).toBe("2026-05-31");
+    });
+});
+
+describe("isValidTimeZone", () => {
+    it("accepts IANA names and rejects unknown ones", () => {
+        expect(isValidTimeZone("UTC")).toBe(true);
+        expect(isValidTimeZone("America/Los_Angeles")).toBe(true);
+        expect(isValidTimeZone("Not/AZone")).toBe(false);
+        expect(isValidTimeZone("")).toBe(false);
+    });
+});
+
+describe("optionalFinite", () => {
+    it("keeps a present zero and skips absent fields", () => {
+        expect(optionalFinite(0)).toBe(0);
+        expect(optionalFinite("0")).toBe(0);
+        expect(optionalFinite(undefined)).toBeUndefined();
+        expect(optionalFinite("")).toBeUndefined();
+        expect(firstFinite(0, 9)).toBe(0);
+        expect(firstFinite(undefined, 9)).toBe(9);
+        expect(firstFinite(undefined, undefined)).toBe(0);
+    });
+});
 
 function ev(over: Partial<SpendEvent>): SpendEvent {
     return {
@@ -143,6 +175,8 @@ describe("identifySessionBlocks", () => {
         expect(real[1].tokenCounts.inputTokens).toBe(20);
         expect(real[0].totalTokens).toBe(11);
         expect(real[1].totalTokens).toBe(22);
+        expect(real[0].modelBreakdowns[0]?.modelName).toBe("claude-3-5-haiku");
+        expect(real[0].modelBreakdowns[0]?.inputTokens).toBe(10);
     });
 });
 
@@ -170,6 +204,23 @@ describe("statusline", () => {
         expect(line).toContain("$1.25 session");
         expect(line).toContain("25,000 (13%)");
         expect(line.split("\n")).toHaveLength(1);
+    });
+
+    it("shows the emoji burn-rate indicator when visualBurnRate is emoji", () => {
+        const hook = parseStatuslineHook(SafeJSON.stringify({ session_id: "sess-a" }));
+        const line = renderStatusline(
+            hook!,
+            [ev({ id: "a", timestamp: "2026-06-01T10:15:00.000Z", inputTokens: 100, recordedCostUsd: 0.5 })],
+            {
+                timezone: "UTC",
+                now: new Date("2026-06-01T12:00:00.000Z"),
+                pricing: DEFAULT_PRICING,
+                mode: "display",
+                costSource: "auto",
+                visualBurnRate: "emoji",
+            }
+        );
+        expect(line).toMatch(/🟢|⚠️|🚨/);
     });
 });
 

--- a/src/ai-spend/lib/reports/period.test.ts
+++ b/src/ai-spend/lib/reports/period.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { isolateAgentHomeEnv } from "../drivers/test-env";
+import { DEFAULT_PRICING } from "../pricing";
+import { identifySessionBlocks } from "./blocks";
+import { loadEvents } from "./load";
+import { buildPeriodReport } from "./period";
+import { buildSessionReport } from "./session";
+import { parseStatuslineHook, renderStatusline } from "./statusline";
+import type { SpendEvent } from "./types";
+
+isolateAgentHomeEnv();
+
+function ev(over: Partial<SpendEvent>): SpendEvent {
+    return {
+        source: "claude",
+        id: "m",
+        model: "claude-3-5-haiku",
+        timestamp: "2026-06-01T10:00:00.000Z",
+        sessionId: "sess-a",
+        project: "proj",
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        ...over,
+    };
+}
+
+const now = new Date("2026-06-02T12:00:00.000Z");
+const common = {
+    timezone: "UTC",
+    now,
+    pricing: DEFAULT_PRICING,
+    mode: "calculate" as const,
+};
+
+describe("buildPeriodReport", () => {
+    it("groups daily rows and totals the four token fields from the fixture arithmetic", () => {
+        const events: SpendEvent[] = [
+            ev({ id: "a", inputTokens: 100, outputTokens: 20, cacheCreationTokens: 10, cacheReadTokens: 5 }),
+            ev({
+                id: "b",
+                timestamp: "2026-06-02T09:00:00.000Z",
+                inputTokens: 50,
+                outputTokens: 5,
+                cacheCreationTokens: 0,
+                cacheReadTokens: 15,
+                model: "claude-sonnet-4-6",
+            }),
+        ];
+        const report = buildPeriodReport(events, { ...common, grain: "daily" });
+        const daily = report.daily as Array<{
+            period: string;
+            inputTokens: number;
+            outputTokens: number;
+            cacheCreationTokens: number;
+            cacheReadTokens: number;
+            totalTokens: number;
+        }>;
+        expect(daily).toHaveLength(2);
+        expect(daily[0].period).toBe("2026-06-01");
+        expect(daily[0].inputTokens).toBe(100);
+        expect(daily[0].outputTokens).toBe(20);
+        expect(daily[0].cacheCreationTokens).toBe(10);
+        expect(daily[0].cacheReadTokens).toBe(5);
+        expect(daily[0].totalTokens).toBe(135);
+        expect(daily[1].period).toBe("2026-06-02");
+        expect(daily[1].totalTokens).toBe(70);
+        const totals = report.totals as Record<string, number>;
+        expect(totals.inputTokens).toBe(150);
+        expect(totals.outputTokens).toBe(25);
+        expect(totals.cacheCreationTokens).toBe(10);
+        expect(totals.cacheReadTokens).toBe(20);
+        expect(totals.totalTokens).toBe(205);
+    });
+
+    it("weekly keys land on Monday and monthly keys are YYYY-MM", () => {
+        const events = [ev({ id: "a", timestamp: "2026-06-03T10:00:00.000Z", inputTokens: 1 })];
+        const weekly = buildPeriodReport(events, { ...common, grain: "weekly" });
+        const monthly = buildPeriodReport(events, { ...common, grain: "monthly" });
+        expect((weekly.weekly as Array<{ period: string }>)[0].period).toBe("2026-06-01");
+        expect((monthly.monthly as Array<{ period: string }>)[0].period).toBe("2026-06");
+    });
+
+    it("focused claude daily uses date not period", () => {
+        const report = buildPeriodReport([ev({ id: "a", inputTokens: 7 })], {
+            ...common,
+            grain: "daily",
+            source: "claude",
+        });
+        const daily = report.daily as Array<Record<string, unknown>>;
+        expect(daily[0].date).toBe("2026-06-01");
+        expect(daily[0].period).toBeUndefined();
+        expect(daily[0].inputTokens).toBe(7);
+    });
+
+    it("--breakdown model rows split tokens per model", () => {
+        const events = [
+            ev({ id: "a", model: "claude-3-5-haiku", inputTokens: 10, outputTokens: 2 }),
+            ev({ id: "b", model: "claude-sonnet-4-6", inputTokens: 30, outputTokens: 4 }),
+        ];
+        const report = buildPeriodReport(events, { ...common, grain: "daily" });
+        const daily = report.daily as Array<{ modelBreakdowns: Array<{ modelName: string; inputTokens: number }> }>;
+        const names = daily[0].modelBreakdowns.map((row) => row.modelName).sort();
+        expect(names).toEqual(["claude-3-5-haiku", "claude-sonnet-4-6"]);
+        expect(daily[0].modelBreakdowns.find((row) => row.modelName === "claude-3-5-haiku")?.inputTokens).toBe(10);
+    });
+});
+
+describe("buildSessionReport", () => {
+    it("groups by session id and sums tokens", () => {
+        const events = [
+            ev({ id: "a", sessionId: "one", inputTokens: 8, outputTokens: 1 }),
+            ev({ id: "b", sessionId: "one", inputTokens: 2, outputTokens: 3 }),
+            ev({ id: "c", sessionId: "two", inputTokens: 4, outputTokens: 0 }),
+        ];
+        const report = buildSessionReport(events, common);
+        const rows = report.session as Array<{ period: string; inputTokens: number; totalTokens: number }>;
+        const one = rows.find((row) => row.period === "one");
+        expect(one?.inputTokens).toBe(10);
+        expect(one?.totalTokens).toBe(14);
+        expect(rows).toHaveLength(2);
+    });
+});
+
+describe("identifySessionBlocks", () => {
+    it("splits events more than 5 hours apart into two blocks", () => {
+        const events = [
+            ev({ id: "a", timestamp: "2026-06-01T10:15:00.000Z", inputTokens: 10, outputTokens: 1 }),
+            ev({ id: "b", timestamp: "2026-06-01T16:00:00.000Z", inputTokens: 20, outputTokens: 2 }),
+        ];
+        const blocks = identifySessionBlocks(events, 5, Date.parse("2026-06-02T00:00:00.000Z"), () => 0);
+        const real = blocks.filter((block) => !block.isGap);
+        expect(real).toHaveLength(2);
+        expect(real[0].startTime).toBe("2026-06-01T10:00:00.000Z");
+        expect(real[0].endTime).toBe("2026-06-01T15:00:00.000Z");
+        expect(real[0].tokenCounts.inputTokens).toBe(10);
+        expect(real[1].startTime).toBe("2026-06-01T16:00:00.000Z");
+        expect(real[1].tokenCounts.inputTokens).toBe(20);
+        expect(real[0].totalTokens).toBe(11);
+        expect(real[1].totalTokens).toBe(22);
+    });
+});
+
+describe("statusline", () => {
+    it("renders one compact line from a hook payload plus events", () => {
+        const hook = parseStatuslineHook(
+            SafeJSON.stringify({
+                session_id: "sess-a",
+                transcript_path: "/tmp/x.jsonl",
+                model: { id: "claude-sonnet-4", display_name: "Sonnet 4" },
+                cost: { total_cost_usd: 1.25 },
+                context_window: { total_input_tokens: 25000, context_window_size: 200000 },
+            })
+        );
+        expect(hook?.session_id).toBe("sess-a");
+        const line = renderStatusline(hook!, [ev({ id: "a", inputTokens: 100, recordedCostUsd: 0.5 })], {
+            timezone: "UTC",
+            now,
+            pricing: DEFAULT_PRICING,
+            mode: "display",
+            costSource: "auto",
+            visualBurnRate: "off",
+        });
+        expect(line).toContain("Sonnet 4");
+        expect(line).toContain("$1.25 session");
+        expect(line).toContain("25,000 (13%)");
+        expect(line.split("\n")).toHaveLength(1);
+    });
+});
+
+describe("claude advisor iterations", () => {
+    it("emits a second event for advisor_message iterations", () => {
+        const home = mkdtempSync(join(tmpdir(), "ai-spend-advisor-"));
+        const claudeDir = join(home, ".claude", "projects", "proj");
+        mkdirSync(claudeDir, { recursive: true });
+        writeFileSync(
+            join(claudeDir, "sess-adv.jsonl"),
+            `${SafeJSON.stringify({
+                type: "assistant",
+                timestamp: "2026-06-01T10:00:00.000Z",
+                sessionId: "sess-adv",
+                message: {
+                    id: "msg-parent",
+                    model: "main-model",
+                    usage: {
+                        input_tokens: 1,
+                        output_tokens: 2,
+                        iterations: [
+                            {
+                                type: "advisor_message",
+                                model: "advisor-model",
+                                input_tokens: 0,
+                                output_tokens: 50,
+                                cache_creation_input_tokens: 0,
+                                cache_read_input_tokens: 0,
+                            },
+                        ],
+                    },
+                },
+            })}\n`
+        );
+        const events = loadEvents({ home, sources: ["claude"] });
+        expect(events).toHaveLength(2);
+        expect(events.map((event) => event.outputTokens).sort((a, b) => a - b)).toEqual([2, 50]);
+        expect(events.reduce((sum, event) => sum + event.outputTokens, 0)).toBe(52);
+    });
+});
+
+describe("claude nested progress lines", () => {
+    it("counts usage nested under data.message.message", () => {
+        const home = mkdtempSync(join(tmpdir(), "ai-spend-nested-"));
+        const claudeDir = join(home, ".claude", "projects", "proj");
+        mkdirSync(claudeDir, { recursive: true });
+        writeFileSync(
+            join(claudeDir, "sess-nested.jsonl"),
+            `${SafeJSON.stringify({
+                data: {
+                    message: {
+                        timestamp: "2026-06-01T10:00:00.000Z",
+                        requestId: "req-1",
+                        message: {
+                            id: "msg-nested",
+                            model: "claude-3-5-haiku",
+                            usage: {
+                                input_tokens: 0,
+                                output_tokens: 99,
+                                cache_creation_input_tokens: 0,
+                                cache_read_input_tokens: 0,
+                            },
+                        },
+                    },
+                },
+            })}\n`
+        );
+        const events = loadEvents({ home, sources: ["claude"] });
+        expect(events).toHaveLength(1);
+        expect(events[0].outputTokens).toBe(99);
+        expect(events[0].id).toBe("msg-nested");
+    });
+});
+
+describe("loadEvents from a fixture HOME", () => {
+    it("reads a claude transcript and a grok updates file under the injected home", () => {
+        const home = mkdtempSync(join(tmpdir(), "ai-spend-ccusage-"));
+        const claudeDir = join(home, ".claude", "projects", "proj");
+        mkdirSync(claudeDir, { recursive: true });
+        writeFileSync(
+            join(claudeDir, "sess-fix.jsonl"),
+            `${SafeJSON.stringify({
+                type: "assistant",
+                timestamp: "2026-06-01T10:00:00.000Z",
+                cwd: "/p/fix",
+                sessionId: "sess-fix",
+                message: {
+                    id: "msg-fix",
+                    model: "claude-3-5-haiku",
+                    usage: {
+                        input_tokens: 11,
+                        output_tokens: 3,
+                        cache_creation_input_tokens: 2,
+                        cache_read_input_tokens: 7,
+                    },
+                },
+            })}\n`
+        );
+        const events = loadEvents({ home, sources: ["claude"] });
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(11);
+        expect(events[0].outputTokens).toBe(3);
+        expect(events[0].cacheCreationTokens).toBe(2);
+        expect(events[0].cacheReadTokens).toBe(7);
+        expect(
+            events[0].inputTokens + events[0].outputTokens + events[0].cacheCreationTokens + events[0].cacheReadTokens
+        ).toBe(23);
+        const report = buildPeriodReport(events, { ...common, grain: "daily", source: "claude" });
+        expect((report.totals as { totalTokens: number }).totalTokens).toBe(23);
+    });
+});

--- a/src/ai-spend/lib/reports/period.ts
+++ b/src/ai-spend/lib/reports/period.ts
@@ -1,0 +1,257 @@
+import type { PricingTable } from "../types";
+import { totalTokensOf } from "./cost";
+import { lastSinceDay, periodFieldName, periodKey, zonedDay } from "./dates";
+import { filterEvents, pricedEventCost } from "./load";
+import type { CostMode, ModelBreakdownJson, PeriodGrain, SourceId, SpendEvent, TokenTotalsJson } from "./types";
+
+export interface PeriodBuildOptions {
+    grain: PeriodGrain;
+    timezone: string;
+    sinceDay?: string;
+    untilDay?: string;
+    last?: number;
+    now: Date;
+    pricing: PricingTable;
+    mode: CostMode;
+    source?: SourceId;
+    byAgent?: boolean;
+}
+
+interface Bucket {
+    key: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    totalCost: number;
+    reasoningOutputTokens: number;
+    models: Map<
+        string,
+        {
+            inputTokens: number;
+            outputTokens: number;
+            cacheCreationTokens: number;
+            cacheReadTokens: number;
+            cost: number;
+            reasoningOutputTokens: number;
+        }
+    >;
+    agents: Set<SourceId>;
+    lastActivity: string;
+    firstActivity: string;
+    sourceCosts: Map<SourceId, Bucket>;
+}
+
+function emptyBucket(key: string): Bucket {
+    return {
+        key,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalCost: 0,
+        reasoningOutputTokens: 0,
+        models: new Map(),
+        agents: new Set(),
+        lastActivity: "",
+        firstActivity: "",
+        sourceCosts: new Map(),
+    };
+}
+
+function addToBucket(bucket: Bucket, event: SpendEvent, cost: number): void {
+    bucket.inputTokens += event.inputTokens;
+    bucket.outputTokens += event.outputTokens;
+    bucket.cacheCreationTokens += event.cacheCreationTokens;
+    bucket.cacheReadTokens += event.cacheReadTokens;
+    bucket.totalCost += cost;
+    bucket.reasoningOutputTokens += event.reasoningOutputTokens ?? 0;
+    bucket.agents.add(event.source);
+
+    if (!bucket.firstActivity || event.timestamp < bucket.firstActivity) {
+        bucket.firstActivity = event.timestamp;
+    }
+
+    if (event.timestamp > bucket.lastActivity) {
+        bucket.lastActivity = event.timestamp;
+    }
+
+    const model = bucket.models.get(event.model) ?? {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        cost: 0,
+        reasoningOutputTokens: 0,
+    };
+    model.inputTokens += event.inputTokens;
+    model.outputTokens += event.outputTokens;
+    model.cacheCreationTokens += event.cacheCreationTokens;
+    model.cacheReadTokens += event.cacheReadTokens;
+    model.cost += cost;
+    model.reasoningOutputTokens += event.reasoningOutputTokens ?? 0;
+    bucket.models.set(event.model, model);
+}
+
+function modelBreakdowns(bucket: Bucket): ModelBreakdownJson[] {
+    return [...bucket.models.entries()]
+        .map(([modelName, model]) => ({
+            modelName,
+            inputTokens: model.inputTokens,
+            outputTokens: model.outputTokens,
+            cacheCreationTokens: model.cacheCreationTokens,
+            cacheReadTokens: model.cacheReadTokens,
+            cost: model.cost,
+        }))
+        .sort((a, b) => b.cost - a.cost || a.modelName.localeCompare(b.modelName));
+}
+
+function totalsOf(buckets: Bucket[]): TokenTotalsJson {
+    const totals: TokenTotalsJson = {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 0,
+        totalCost: 0,
+    };
+
+    for (const bucket of buckets) {
+        totals.inputTokens += bucket.inputTokens;
+        totals.outputTokens += bucket.outputTokens;
+        totals.cacheCreationTokens += bucket.cacheCreationTokens;
+        totals.cacheReadTokens += bucket.cacheReadTokens;
+        totals.totalCost += bucket.totalCost;
+    }
+
+    totals.totalTokens = totalTokensOf(totals);
+    return totals;
+}
+
+export function buildPeriodReport(events: SpendEvent[], options: PeriodBuildOptions): Record<string, unknown> {
+    const today = zonedDay(options.now.toISOString(), options.timezone);
+    let sinceDay = options.sinceDay;
+
+    if (options.last) {
+        const lastSince = lastSinceDay(options.grain, options.last, today);
+        sinceDay = sinceDay && sinceDay > lastSince ? sinceDay : lastSince;
+    }
+
+    const kept = filterEvents(events, { timezone: options.timezone, sinceDay, untilDay: options.untilDay });
+    const buckets = new Map<string, Bucket>();
+
+    for (const event of kept) {
+        const day = zonedDay(event.timestamp, options.timezone);
+        const key = periodKey(day, options.grain);
+        const bucket = buckets.get(key) ?? emptyBucket(key);
+        const cost = pricedEventCost(event, options.pricing, options.mode);
+        addToBucket(bucket, event, cost);
+
+        if (options.byAgent) {
+            const per = bucket.sourceCosts.get(event.source) ?? emptyBucket(key);
+            addToBucket(per, event, cost);
+            bucket.sourceCosts.set(event.source, per);
+        }
+
+        buckets.set(key, bucket);
+    }
+
+    const rows = [...buckets.values()].sort((a, b) => a.key.localeCompare(b.key));
+    const grainKey = options.grain;
+    const unified = !options.source;
+
+    if (unified) {
+        return {
+            [grainKey]: rows.map((bucket) => {
+                const row: Record<string, unknown> = {
+                    agent: "all",
+                    cacheCreationTokens: bucket.cacheCreationTokens,
+                    cacheReadTokens: bucket.cacheReadTokens,
+                    inputTokens: bucket.inputTokens,
+                    metadata: { agents: [...bucket.agents].sort() },
+                    modelBreakdowns: modelBreakdowns(bucket),
+                    modelsUsed: [...bucket.models.keys()].sort(),
+                    outputTokens: bucket.outputTokens,
+                    period: bucket.key,
+                    totalCost: bucket.totalCost,
+                    totalTokens: totalTokensOf(bucket),
+                };
+
+                if (options.byAgent) {
+                    row.agents = [...bucket.sourceCosts.entries()]
+                        .sort(([a], [b]) => a.localeCompare(b))
+                        .map(([agent, per]) => ({
+                            agent,
+                            cacheCreationTokens: per.cacheCreationTokens,
+                            cacheReadTokens: per.cacheReadTokens,
+                            inputTokens: per.inputTokens,
+                            modelBreakdowns: modelBreakdowns(per),
+                            modelsUsed: [...per.models.keys()].sort(),
+                            outputTokens: per.outputTokens,
+                            totalCost: per.totalCost,
+                            totalTokens: totalTokensOf(per),
+                        }));
+                }
+
+                return row;
+            }),
+            totals: totalsOf(rows),
+        };
+    }
+
+    if (options.source === "codex") {
+        return {
+            [grainKey]: rows.map((bucket) => {
+                const models: Record<string, unknown> = {};
+
+                for (const [name, model] of [...bucket.models.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+                    models[name] = {
+                        cacheCreationTokens: model.cacheCreationTokens,
+                        cacheReadTokens: model.cacheReadTokens,
+                        inputTokens: model.inputTokens,
+                        isFallback: false,
+                        outputTokens: model.outputTokens,
+                        reasoningOutputTokens: model.reasoningOutputTokens,
+                        totalTokens: totalTokensOf(model),
+                    };
+                }
+
+                return {
+                    [periodFieldName(options.grain)]: bucket.key,
+                    cacheCreationTokens: bucket.cacheCreationTokens,
+                    cacheReadTokens: bucket.cacheReadTokens,
+                    costUSD: bucket.totalCost,
+                    inputTokens: bucket.inputTokens,
+                    models,
+                    outputTokens: bucket.outputTokens,
+                    reasoningOutputTokens: bucket.reasoningOutputTokens,
+                    totalTokens: totalTokensOf(bucket),
+                };
+            }),
+            totals: {
+                cacheCreationTokens: totalsOf(rows).cacheCreationTokens,
+                cacheReadTokens: totalsOf(rows).cacheReadTokens,
+                costUSD: totalsOf(rows).totalCost,
+                inputTokens: totalsOf(rows).inputTokens,
+                outputTokens: totalsOf(rows).outputTokens,
+                reasoningOutputTokens: rows.reduce((sum, row) => sum + row.reasoningOutputTokens, 0),
+                totalTokens: totalsOf(rows).totalTokens,
+            },
+        };
+    }
+
+    return {
+        [grainKey]: rows.map((bucket) => ({
+            [periodFieldName(options.grain)]: bucket.key,
+            cacheCreationTokens: bucket.cacheCreationTokens,
+            cacheReadTokens: bucket.cacheReadTokens,
+            inputTokens: bucket.inputTokens,
+            modelBreakdowns: modelBreakdowns(bucket),
+            modelsUsed: [...bucket.models.keys()].sort(),
+            outputTokens: bucket.outputTokens,
+            totalCost: bucket.totalCost,
+            totalTokens: totalTokensOf(bucket),
+        })),
+        totals: totalsOf(rows),
+    };
+}

--- a/src/ai-spend/lib/reports/period.ts
+++ b/src/ai-spend/lib/reports/period.ts
@@ -200,6 +200,8 @@ export function buildPeriodReport(events: SpendEvent[], options: PeriodBuildOpti
     }
 
     if (options.source === "codex") {
+        const codexTotals = totalsOf(rows);
+
         return {
             [grainKey]: rows.map((bucket) => {
                 const models: Record<string, unknown> = {};
@@ -229,13 +231,13 @@ export function buildPeriodReport(events: SpendEvent[], options: PeriodBuildOpti
                 };
             }),
             totals: {
-                cacheCreationTokens: totalsOf(rows).cacheCreationTokens,
-                cacheReadTokens: totalsOf(rows).cacheReadTokens,
-                costUSD: totalsOf(rows).totalCost,
-                inputTokens: totalsOf(rows).inputTokens,
-                outputTokens: totalsOf(rows).outputTokens,
+                cacheCreationTokens: codexTotals.cacheCreationTokens,
+                cacheReadTokens: codexTotals.cacheReadTokens,
+                costUSD: codexTotals.totalCost,
+                inputTokens: codexTotals.inputTokens,
+                outputTokens: codexTotals.outputTokens,
                 reasoningOutputTokens: rows.reduce((sum, row) => sum + row.reasoningOutputTokens, 0),
-                totalTokens: totalsOf(rows).totalTokens,
+                totalTokens: codexTotals.totalTokens,
             },
         };
     }

--- a/src/ai-spend/lib/reports/render.ts
+++ b/src/ai-spend/lib/reports/render.ts
@@ -1,0 +1,192 @@
+import { formatCost, formatTokens } from "@genesiscz/utils/format";
+import { createBoxTable } from "@genesiscz/utils/table";
+import type { SessionBlock } from "./blocks";
+import type { PeriodGrain } from "./types";
+
+function asRows(report: Record<string, unknown>, key: string): Record<string, unknown>[] {
+    const value = report[key];
+    return Array.isArray(value) ? (value as Record<string, unknown>[]) : [];
+}
+
+function num(value: unknown): number {
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function modelsCell(row: Record<string, unknown>): string {
+    if (Array.isArray(row.modelsUsed)) {
+        return (row.modelsUsed as string[]).join(", ");
+    }
+
+    if (row.models && typeof row.models === "object" && !Array.isArray(row.models)) {
+        return Object.keys(row.models as Record<string, unknown>).join(", ");
+    }
+
+    if (Array.isArray(row.models)) {
+        return (row.models as string[]).join(", ");
+    }
+
+    return "";
+}
+
+function periodCell(row: Record<string, unknown>): string {
+    return String(row.period ?? row.date ?? row.week ?? row.month ?? row.sessionId ?? "");
+}
+
+function costCell(row: Record<string, unknown>): string {
+    if (typeof row.totalCost === "number") {
+        return formatCost(row.totalCost);
+    }
+
+    if (typeof row.costUSD === "number") {
+        return formatCost(row.costUSD);
+    }
+
+    return formatCost(0);
+}
+
+export function renderPeriodTable(report: Record<string, unknown>, grain: PeriodGrain, breakdown: boolean): string {
+    const rows = asRows(report, grain);
+    const header = grain === "weekly" ? "WEEK" : grain === "monthly" ? "MONTH" : "DATE";
+    const table = createBoxTable([
+        header,
+        "MODELS",
+        "INPUT",
+        "OUTPUT",
+        "CACHE CREATE",
+        "CACHE READ",
+        "TOTAL TOKENS",
+        "COST",
+    ]);
+
+    for (const row of rows) {
+        table.push([
+            periodCell(row),
+            modelsCell(row),
+            formatTokens(num(row.inputTokens)),
+            formatTokens(num(row.outputTokens)),
+            formatTokens(num(row.cacheCreationTokens)),
+            formatTokens(num(row.cacheReadTokens)),
+            formatTokens(num(row.totalTokens)),
+            costCell(row),
+        ]);
+
+        if (breakdown && Array.isArray(row.modelBreakdowns)) {
+            for (const model of row.modelBreakdowns as Record<string, unknown>[]) {
+                table.push([
+                    "",
+                    String(model.modelName ?? ""),
+                    formatTokens(num(model.inputTokens)),
+                    formatTokens(num(model.outputTokens)),
+                    formatTokens(num(model.cacheCreationTokens)),
+                    formatTokens(num(model.cacheReadTokens)),
+                    formatTokens(
+                        num(model.inputTokens) +
+                            num(model.outputTokens) +
+                            num(model.cacheCreationTokens) +
+                            num(model.cacheReadTokens)
+                    ),
+                    formatCost(num(model.cost)),
+                ]);
+            }
+        }
+    }
+
+    const totals = (report.totals ?? {}) as Record<string, unknown>;
+    table.push([
+        "Total",
+        "",
+        formatTokens(num(totals.inputTokens)),
+        formatTokens(num(totals.outputTokens)),
+        formatTokens(num(totals.cacheCreationTokens)),
+        formatTokens(num(totals.cacheReadTokens)),
+        formatTokens(num(totals.totalTokens)),
+        typeof totals.totalCost === "number" ? formatCost(totals.totalCost) : formatCost(num(totals.costUSD)),
+    ]);
+
+    return table.toString();
+}
+
+export function renderSessionTable(report: Record<string, unknown>, breakdown: boolean): string {
+    const rows = asRows(report, "session").length > 0 ? asRows(report, "session") : asRows(report, "sessions");
+    const table = createBoxTable([
+        "SESSION",
+        "MODELS",
+        "INPUT",
+        "OUTPUT",
+        "CACHE CREATE",
+        "CACHE READ",
+        "TOTAL TOKENS",
+        "COST",
+    ]);
+
+    for (const row of rows) {
+        table.push([
+            periodCell(row).slice(0, 36),
+            modelsCell(row),
+            formatTokens(num(row.inputTokens)),
+            formatTokens(num(row.outputTokens)),
+            formatTokens(num(row.cacheCreationTokens)),
+            formatTokens(num(row.cacheReadTokens)),
+            formatTokens(num(row.totalTokens)),
+            costCell(row),
+        ]);
+
+        if (breakdown && Array.isArray(row.modelBreakdowns)) {
+            for (const model of row.modelBreakdowns as Record<string, unknown>[]) {
+                table.push([
+                    "",
+                    String(model.modelName ?? ""),
+                    formatTokens(num(model.inputTokens)),
+                    formatTokens(num(model.outputTokens)),
+                    formatTokens(num(model.cacheCreationTokens)),
+                    formatTokens(num(model.cacheReadTokens)),
+                    formatTokens(
+                        num(model.inputTokens) +
+                            num(model.outputTokens) +
+                            num(model.cacheCreationTokens) +
+                            num(model.cacheReadTokens)
+                    ),
+                    formatCost(num(model.cost)),
+                ]);
+            }
+        }
+    }
+
+    return table.toString();
+}
+
+export function renderBlocksTable(report: { blocks: SessionBlock[] }, breakdown: boolean): string {
+    const table = createBoxTable([
+        "BLOCK",
+        "MODELS",
+        "INPUT",
+        "OUTPUT",
+        "CACHE CREATE",
+        "CACHE READ",
+        "TOTAL TOKENS",
+        "COST",
+    ]);
+
+    for (const block of report.blocks) {
+        const tokens = (block.tokenCounts ?? {}) as Record<string, unknown>;
+        const models = Array.isArray(block.models) ? (block.models as string[]).join(", ") : "";
+        table.push([
+            block.isGap
+                ? `gap ${String(block.startTime ?? "").slice(0, 16)}`
+                : String(block.startTime ?? "").slice(0, 19),
+            models,
+            formatTokens(num(tokens.inputTokens)),
+            formatTokens(num(tokens.outputTokens)),
+            formatTokens(num(tokens.cacheCreationInputTokens)),
+            formatTokens(num(tokens.cacheReadInputTokens)),
+            formatTokens(num(block.totalTokens)),
+            formatCost(num(block.costUSD)),
+        ]);
+
+        if (breakdown) {
+            void breakdown;
+        }
+    }
+
+    return table.toString();
+}

--- a/src/ai-spend/lib/reports/render.ts
+++ b/src/ai-spend/lib/reports/render.ts
@@ -184,7 +184,20 @@ export function renderBlocksTable(report: { blocks: SessionBlock[] }, breakdown:
         ]);
 
         if (breakdown) {
-            void breakdown;
+            for (const model of block.modelBreakdowns) {
+                table.push([
+                    "",
+                    model.modelName,
+                    formatTokens(model.inputTokens),
+                    formatTokens(model.outputTokens),
+                    formatTokens(model.cacheCreationTokens),
+                    formatTokens(model.cacheReadTokens),
+                    formatTokens(
+                        model.inputTokens + model.outputTokens + model.cacheCreationTokens + model.cacheReadTokens
+                    ),
+                    formatCost(model.cost),
+                ]);
+            }
         }
     }
 

--- a/src/ai-spend/lib/reports/session.ts
+++ b/src/ai-spend/lib/reports/session.ts
@@ -1,0 +1,246 @@
+import { basename, dirname } from "node:path";
+import type { PricingTable } from "../types";
+import { totalTokensOf } from "./cost";
+import { lastSinceDay, zonedDay } from "./dates";
+import { filterEvents, pricedEventCost } from "./load";
+import type { CostMode, ModelBreakdownJson, SourceId, SpendEvent } from "./types";
+
+export interface SessionBuildOptions {
+    timezone: string;
+    sinceDay?: string;
+    untilDay?: string;
+    last?: number;
+    now: Date;
+    pricing: PricingTable;
+    mode: CostMode;
+    source?: SourceId;
+    sessionId?: string;
+}
+
+interface SessionBucket {
+    source: SourceId;
+    sessionId: string;
+    project: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    totalCost: number;
+    reasoningOutputTokens: number;
+    firstActivity: string;
+    lastActivity: string;
+    models: Map<
+        string,
+        {
+            inputTokens: number;
+            outputTokens: number;
+            cacheCreationTokens: number;
+            cacheReadTokens: number;
+            cost: number;
+            reasoningOutputTokens: number;
+        }
+    >;
+}
+
+export function buildSessionReport(events: SpendEvent[], options: SessionBuildOptions): Record<string, unknown> {
+    const today = zonedDay(options.now.toISOString(), options.timezone);
+    let sinceDay = options.sinceDay;
+
+    if (options.last) {
+        const lastSince = lastSinceDay("daily", options.last, today);
+        sinceDay = sinceDay && sinceDay > lastSince ? sinceDay : lastSince;
+    }
+
+    const kept = filterEvents(events, {
+        timezone: options.timezone,
+        sinceDay,
+        untilDay: options.untilDay,
+        sessionId: options.sessionId,
+    });
+    const buckets = new Map<string, SessionBucket>();
+
+    for (const event of kept) {
+        const key = `${event.source}:${event.sessionId}`;
+        const bucket = buckets.get(key) ?? {
+            source: event.source,
+            sessionId: event.sessionId,
+            project: event.project,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            totalCost: 0,
+            reasoningOutputTokens: 0,
+            firstActivity: event.timestamp,
+            lastActivity: event.timestamp,
+            models: new Map(),
+        };
+        const cost = pricedEventCost(event, options.pricing, options.mode);
+        bucket.inputTokens += event.inputTokens;
+        bucket.outputTokens += event.outputTokens;
+        bucket.cacheCreationTokens += event.cacheCreationTokens;
+        bucket.cacheReadTokens += event.cacheReadTokens;
+        bucket.totalCost += cost;
+        bucket.reasoningOutputTokens += event.reasoningOutputTokens ?? 0;
+
+        if (event.timestamp < bucket.firstActivity) {
+            bucket.firstActivity = event.timestamp;
+        }
+
+        if (event.timestamp > bucket.lastActivity) {
+            bucket.lastActivity = event.timestamp;
+        }
+
+        const model = bucket.models.get(event.model) ?? {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            cost: 0,
+            reasoningOutputTokens: 0,
+        };
+        model.inputTokens += event.inputTokens;
+        model.outputTokens += event.outputTokens;
+        model.cacheCreationTokens += event.cacheCreationTokens;
+        model.cacheReadTokens += event.cacheReadTokens;
+        model.cost += cost;
+        model.reasoningOutputTokens += event.reasoningOutputTokens ?? 0;
+        bucket.models.set(event.model, model);
+        buckets.set(key, bucket);
+    }
+
+    const rows = [...buckets.values()].sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));
+    const totals = {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 0,
+        totalCost: 0,
+        reasoningOutputTokens: 0,
+        costUSD: 0,
+    };
+
+    for (const row of rows) {
+        totals.inputTokens += row.inputTokens;
+        totals.outputTokens += row.outputTokens;
+        totals.cacheCreationTokens += row.cacheCreationTokens;
+        totals.cacheReadTokens += row.cacheReadTokens;
+        totals.totalCost += row.totalCost;
+        totals.reasoningOutputTokens += row.reasoningOutputTokens;
+    }
+
+    totals.totalTokens = totalTokensOf(totals);
+    totals.costUSD = totals.totalCost;
+
+    const unified = !options.source;
+
+    if (unified) {
+        return {
+            session: rows.map((row) => ({
+                agent: row.source,
+                cacheCreationTokens: row.cacheCreationTokens,
+                cacheReadTokens: row.cacheReadTokens,
+                inputTokens: row.inputTokens,
+                metadata: { lastActivity: row.lastActivity },
+                modelBreakdowns: breakdowns(row),
+                modelsUsed: [...row.models.keys()].sort(),
+                outputTokens: row.outputTokens,
+                period: row.sessionId,
+                totalCost: row.totalCost,
+                totalTokens: totalTokensOf(row),
+            })),
+            totals: {
+                inputTokens: totals.inputTokens,
+                outputTokens: totals.outputTokens,
+                cacheCreationTokens: totals.cacheCreationTokens,
+                cacheReadTokens: totals.cacheReadTokens,
+                totalTokens: totals.totalTokens,
+                totalCost: totals.totalCost,
+            },
+        };
+    }
+
+    if (options.source === "codex") {
+        return {
+            sessions: rows.map((row) => {
+                const models: Record<string, unknown> = {};
+
+                for (const [name, model] of [...row.models.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+                    models[name] = {
+                        cacheCreationTokens: model.cacheCreationTokens,
+                        cacheReadTokens: model.cacheReadTokens,
+                        inputTokens: model.inputTokens,
+                        isFallback: false,
+                        outputTokens: model.outputTokens,
+                        reasoningOutputTokens: model.reasoningOutputTokens,
+                        totalTokens: totalTokensOf(model),
+                    };
+                }
+
+                const slash = row.sessionId.lastIndexOf("/");
+                return {
+                    sessionId: row.sessionId,
+                    cacheCreationTokens: row.cacheCreationTokens,
+                    cacheReadTokens: row.cacheReadTokens,
+                    costUSD: row.totalCost,
+                    inputTokens: row.inputTokens,
+                    models,
+                    outputTokens: row.outputTokens,
+                    reasoningOutputTokens: row.reasoningOutputTokens,
+                    totalTokens: totalTokensOf(row),
+                    lastActivity: row.lastActivity,
+                    sessionFile: slash >= 0 ? row.sessionId.slice(slash + 1) : basename(row.sessionId),
+                    directory: slash >= 0 ? row.sessionId.slice(0, slash) : dirname(row.project),
+                };
+            }),
+            totals: {
+                cacheCreationTokens: totals.cacheCreationTokens,
+                cacheReadTokens: totals.cacheReadTokens,
+                costUSD: totals.costUSD,
+                inputTokens: totals.inputTokens,
+                outputTokens: totals.outputTokens,
+                reasoningOutputTokens: totals.reasoningOutputTokens,
+                totalTokens: totals.totalTokens,
+            },
+        };
+    }
+
+    return {
+        sessions: rows.map((row) => ({
+            sessionId: row.sessionId,
+            cacheCreationTokens: row.cacheCreationTokens,
+            cacheReadTokens: row.cacheReadTokens,
+            inputTokens: row.inputTokens,
+            modelBreakdowns: breakdowns(row),
+            modelsUsed: [...row.models.keys()].sort(),
+            outputTokens: row.outputTokens,
+            totalCost: row.totalCost,
+            totalTokens: totalTokensOf(row),
+            lastActivity: row.lastActivity,
+            firstActivity: row.firstActivity,
+            projectPath: row.project,
+        })),
+        totals: {
+            inputTokens: totals.inputTokens,
+            outputTokens: totals.outputTokens,
+            cacheCreationTokens: totals.cacheCreationTokens,
+            cacheReadTokens: totals.cacheReadTokens,
+            totalTokens: totals.totalTokens,
+            totalCost: totals.totalCost,
+        },
+    };
+}
+
+function breakdowns(row: SessionBucket): ModelBreakdownJson[] {
+    return [...row.models.entries()]
+        .map(([modelName, model]) => ({
+            modelName,
+            inputTokens: model.inputTokens,
+            outputTokens: model.outputTokens,
+            cacheCreationTokens: model.cacheCreationTokens,
+            cacheReadTokens: model.cacheReadTokens,
+            cost: model.cost,
+        }))
+        .sort((a, b) => b.cost - a.cost || a.modelName.localeCompare(b.modelName));
+}

--- a/src/ai-spend/lib/reports/sources.test.ts
+++ b/src/ai-spend/lib/reports/sources.test.ts
@@ -1,0 +1,392 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { isolateAgentHomeEnv } from "../drivers/test-env";
+import {
+    loadAmpEvents,
+    loadCopilotEvents,
+    loadDroidEvents,
+    loadGeminiEvents,
+    loadGooseEvents,
+    loadHermesEvents,
+    loadKimiEvents,
+    loadOpenclawEvents,
+    loadOpencodeEvents,
+    loadPiEvents,
+    loadQwenEvents,
+} from "./sources";
+
+isolateAgentHomeEnv();
+
+function home(): string {
+    return mkdtempSync(join(tmpdir(), "ai-spend-src-"));
+}
+
+describe("extra source loaders", () => {
+    it("amp reads ledger token fields from a thread JSON file", () => {
+        const root = home();
+        const dir = join(root, ".local/share/amp/threads");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "T-abc.json"),
+            SafeJSON.stringify({
+                id: "T-abc",
+                usageLedger: {
+                    events: [
+                        {
+                            id: "e1",
+                            timestamp: "2026-06-01T10:00:00.000Z",
+                            model: "amp-model",
+                            tokens: { input: 12, output: 3 },
+                        },
+                    ],
+                },
+            })
+        );
+        const events = loadAmpEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(12);
+        expect(events[0].outputTokens).toBe(3);
+        expect(events[0].sessionId).toBe("T-abc");
+    });
+
+    it("amp keeps a recorded cost of zero", () => {
+        const root = home();
+        const dir = join(root, ".local/share/amp/threads");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "T-zero.json"),
+            SafeJSON.stringify({
+                id: "T-zero",
+                usageLedger: {
+                    events: [
+                        {
+                            id: "e0",
+                            timestamp: "2026-06-01T10:00:00.000Z",
+                            model: "amp-model",
+                            tokens: { input: 4, output: 1 },
+                            credits: 0,
+                        },
+                    ],
+                },
+            })
+        );
+        const events = loadAmpEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].recordedCostUsd).toBe(0);
+    });
+
+    it("pi reads assistant usage from jsonl", () => {
+        const root = home();
+        const dir = join(root, ".pi/agent/sessions");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "sess.jsonl"),
+            `${SafeJSON.stringify({
+                type: "assistant",
+                timestamp: "2026-06-01T10:00:00.000Z",
+                message: {
+                    role: "assistant",
+                    model: "pi-model",
+                    usage: { input: 8, output: 2, cacheRead: 4, cacheWrite: 1 },
+                },
+            })}\n`
+        );
+        const events = loadPiEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(8);
+        expect(events[0].cacheReadTokens).toBe(4);
+        expect(events[0].cacheCreationTokens).toBe(1);
+    });
+
+    it("droid reads tokenUsage from a settings file", () => {
+        const root = home();
+        const dir = join(root, ".factory/sessions");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "sess-d.settings.json"),
+            SafeJSON.stringify({
+                model: "droid-model",
+                updatedAt: "2026-06-01T10:00:00.000Z",
+                tokenUsage: { inputTokens: 9, outputTokens: 1, cacheCreationTokens: 0, cacheReadTokens: 5 },
+            })
+        );
+        const events = loadDroidEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(9);
+        expect(events[0].cacheReadTokens).toBe(5);
+        expect(events[0].sessionId).toBe("sess-d");
+    });
+
+    it("copilot reads gen_ai usage attributes from otel jsonl", () => {
+        const root = home();
+        const dir = join(root, ".copilot/otel");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "trace.jsonl"),
+            `${SafeJSON.stringify({
+                spanId: "span-1",
+                startTime: "2026-06-01T10:00:00.000Z",
+                attributes: {
+                    "gen_ai.usage.input_tokens": 20,
+                    "gen_ai.usage.output_tokens": 4,
+                    "gen_ai.usage.cache_read.input_tokens": 6,
+                    "gen_ai.request.model": "gpt-4.1",
+                    "session.id": "copilot-sess",
+                },
+            })}\n`
+        );
+        const events = loadCopilotEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(20);
+        expect(events[0].outputTokens).toBe(4);
+        expect(events[0].cacheReadTokens).toBe(6);
+        expect(events[0].sessionId).toBe("copilot-sess");
+    });
+
+    it("opencode reads message rows from sqlite", () => {
+        const root = home();
+        const dir = join(root, ".local/share/opencode");
+        mkdirSync(dir, { recursive: true });
+        const db = new Database(join(dir, "opencode.db"));
+        db.run("CREATE TABLE message (id TEXT, session_id TEXT, data TEXT)");
+        db.run("INSERT INTO message (id, session_id, data) VALUES (?, ?, ?)", [
+            "m1",
+            "s1",
+            SafeJSON.stringify({
+                id: "m1",
+                modelID: "opencode-model",
+                sessionID: "s1",
+                time: { created: Date.parse("2026-06-01T10:00:00.000Z") },
+                tokens: { input: 15, output: 5, cache: { read: 2, write: 1 } },
+            }),
+        ]);
+        db.close();
+        const events = loadOpencodeEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(15);
+        expect(events[0].cacheReadTokens).toBe(2);
+        expect(events[0].cacheCreationTokens).toBe(1);
+    });
+
+    it("hermes reads sessions from sqlite", () => {
+        const root = home();
+        const dir = join(root, ".hermes");
+        mkdirSync(dir, { recursive: true });
+        const db = new Database(join(dir, "state.db"));
+        db.run(`CREATE TABLE sessions (
+            id TEXT, model TEXT, billing_provider TEXT, started_at REAL, message_count INTEGER,
+            input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+            reasoning_tokens INTEGER, estimated_cost_usd REAL, actual_cost_usd REAL
+        )`);
+        db.run(`INSERT INTO sessions VALUES ('h1','hermes-model','x',?,?,?,?,?,?,?,?,?)`, [
+            Date.parse("2026-06-01T10:00:00.000Z"),
+            1,
+            7,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0.01,
+        ]);
+        db.close();
+        const events = loadHermesEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(7);
+        expect(events[0].outputTokens).toBe(3);
+    });
+
+    it("hermes keeps a present actual cost of zero over the estimate", () => {
+        const root = home();
+        const dir = join(root, ".hermes");
+        mkdirSync(dir, { recursive: true });
+        const db = new Database(join(dir, "state.db"));
+        db.run(`CREATE TABLE sessions (
+            id TEXT, model TEXT, billing_provider TEXT, started_at REAL, message_count INTEGER,
+            input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+            reasoning_tokens INTEGER, estimated_cost_usd REAL, actual_cost_usd REAL
+        )`);
+        db.run(`INSERT INTO sessions VALUES ('h0','hermes-model','x',?,?,?,?,?,?,?,?,?)`, [
+            Date.parse("2026-06-01T10:00:00.000Z"),
+            1,
+            7,
+            3,
+            0,
+            0,
+            0,
+            1.5,
+            0,
+        ]);
+        db.close();
+        const events = loadHermesEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].recordedCostUsd).toBe(0);
+    });
+
+    it("goose keeps a zero accumulated token count instead of the legacy field", () => {
+        const root = home();
+        const dir = join(root, ".local/share/goose/sessions");
+        mkdirSync(dir, { recursive: true });
+        const db = new Database(join(dir, "sessions.db"));
+        db.run(`CREATE TABLE sessions (
+            id TEXT, model_config_json TEXT, provider_name TEXT, created_at REAL, total_tokens INTEGER,
+            input_tokens INTEGER, output_tokens INTEGER, accumulated_total_tokens INTEGER,
+            accumulated_input_tokens INTEGER, accumulated_output_tokens INTEGER
+        )`);
+        db.run(`INSERT INTO sessions VALUES ('g0',?,?,?,?,?,?,?,?,?)`, [
+            SafeJSON.stringify({ model_name: "goose-model" }),
+            "x",
+            Date.parse("2026-06-01T10:00:00.000Z"),
+            5,
+            99,
+            1,
+            5,
+            0,
+            5,
+        ]);
+        db.close();
+        const events = loadGooseEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].inputTokens).toBe(0);
+        expect(events[0].outputTokens).toBe(5);
+    });
+
+    it("kimi reads nested payload.token_usage from wire.jsonl", () => {
+        const root = home();
+        const dir = join(root, ".kimi/sessions/kimi-sess");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "wire.jsonl"),
+            `${SafeJSON.stringify({
+                timestamp: "2026-06-01T10:00:00.000Z",
+                model: "kimi-for-coding",
+                message: {
+                    payload: {
+                        message_id: "msg-k1",
+                        token_usage: {
+                            input_other: 100,
+                            output: 50,
+                            input_cache_creation: 20,
+                            input_cache_read: 10,
+                        },
+                    },
+                },
+            })}\n`
+        );
+        const events = loadKimiEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].sessionId).toBe("kimi-sess");
+        expect(events[0].inputTokens).toBe(100);
+        expect(events[0].outputTokens).toBe(50);
+        expect(events[0].cacheCreationTokens).toBe(20);
+        expect(events[0].cacheReadTokens).toBe(10);
+    });
+
+    it("gemini reads both jsonl lines and a json messages array", () => {
+        const root = home();
+        const dir = join(root, ".gemini/tmp");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "sess-a.jsonl"),
+            `${SafeJSON.stringify({
+                id: "g1",
+                sessionId: "gem-jsonl",
+                model: "gemini-2.5-pro",
+                timestamp: "2026-06-01T10:00:00.000Z",
+                usage_metadata: { promptTokenCount: 11, candidatesTokenCount: 3, cachedContentTokenCount: 2 },
+            })}\n`
+        );
+        writeFileSync(
+            join(dir, "sess-b.json"),
+            SafeJSON.stringify({
+                messages: [
+                    {
+                        id: "g2",
+                        sessionId: "gem-json",
+                        model: "gemini-2.5-flash",
+                        timestamp: "2026-06-01T11:00:00.000Z",
+                        tokens: { input_tokens: 8, output_tokens: 4, cached_tokens: 1 },
+                    },
+                ],
+            })
+        );
+        const events = loadGeminiEvents(root);
+        expect(events).toHaveLength(2);
+        const jsonl = events.find((event) => event.sessionId === "gem-jsonl");
+        const json = events.find((event) => event.sessionId === "gem-json");
+        expect(jsonl?.inputTokens).toBe(11);
+        expect(jsonl?.outputTokens).toBe(3);
+        expect(jsonl?.cacheReadTokens).toBe(2);
+        expect(json?.inputTokens).toBe(8);
+        expect(json?.outputTokens).toBe(4);
+        expect(json?.cacheReadTokens).toBe(1);
+    });
+
+    it("qwen reads usageMetadata including thoughtsTokenCount", () => {
+        const root = home();
+        const dir = join(root, ".qwen/projects/myProject/chats");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "chat-a.jsonl"),
+            `${SafeJSON.stringify({
+                type: "assistant",
+                model: "qwen3-coder-plus",
+                timestamp: "2026-06-01T10:00:00.000Z",
+                sessionId: "qwen-sess",
+                usageMetadata: {
+                    promptTokenCount: 100,
+                    candidatesTokenCount: 50,
+                    thoughtsTokenCount: 10,
+                    cachedContentTokenCount: 5,
+                },
+            })}\n`
+        );
+        const events = loadQwenEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].sessionId).toBe("qwen-sess");
+        expect(events[0].inputTokens).toBe(100);
+        expect(events[0].outputTokens).toBe(50);
+        expect(events[0].cacheReadTokens).toBe(5);
+        expect(events[0].reasoningOutputTokens).toBe(10);
+    });
+
+    it("openclaw uses a sticky model from a model_change line", () => {
+        const root = home();
+        const dir = join(root, ".openclaw/agents/main/sessions");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "abc.jsonl"),
+            [
+                SafeJSON.stringify({ type: "model_change", provider: "openai-codex", modelId: "gpt-5.2" }),
+                SafeJSON.stringify({
+                    type: "message",
+                    timestamp: "2026-06-01T10:00:00.000Z",
+                    message: {
+                        role: "assistant",
+                        usage: { input: 16, output: 5, cacheRead: 8, cost: { total: 0.02 } },
+                    },
+                }),
+            ].join("\n")
+        );
+        const events = loadOpenclawEvents(root);
+        expect(events).toHaveLength(1);
+        expect(events[0].sessionId).toBe("abc");
+        expect(events[0].model).toBe("gpt-5.2");
+        expect(events[0].inputTokens).toBe(16);
+        expect(events[0].outputTokens).toBe(5);
+        expect(events[0].cacheReadTokens).toBe(8);
+        expect(events[0].recordedCostUsd).toBe(0.02);
+    });
+
+    it("skips a malformed amp thread instead of throwing", () => {
+        const root = home();
+        const dir = join(root, ".local/share/amp/threads");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "T-bad.json"), "{not json");
+        expect(loadAmpEvents(root)).toEqual([]);
+    });
+});

--- a/src/ai-spend/lib/reports/sources.test.ts
+++ b/src/ai-spend/lib/reports/sources.test.ts
@@ -7,6 +7,7 @@ import { SafeJSON } from "@genesiscz/utils/json";
 import { isolateAgentHomeEnv } from "../drivers/test-env";
 import {
     loadAmpEvents,
+    loadCodebuffEvents,
     loadCopilotEvents,
     loadDroidEvents,
     loadGeminiEvents,
@@ -284,6 +285,46 @@ describe("extra source loaders", () => {
         expect(events[0].outputTokens).toBe(50);
         expect(events[0].cacheCreationTokens).toBe(20);
         expect(events[0].cacheReadTokens).toBe(10);
+    });
+
+    it("codebuff reads assistant turns from a manicode chat-messages.json", () => {
+        const root = home();
+        const dir = join(root, ".config/manicode/projects/app/sess-cb");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "chat-messages.json"),
+            SafeJSON.stringify([
+                {
+                    role: "user",
+                    id: "cb-user",
+                    timestamp: "2026-06-01T10:00:00.000Z",
+                    usage: { input_tokens: 999, output_tokens: 999 },
+                },
+                {
+                    role: "assistant",
+                    id: "cb-1",
+                    model: "codebuff-max",
+                    timestamp: "2026-06-01T10:00:01.000Z",
+                    usage: {
+                        input_tokens: 120,
+                        output_tokens: 40,
+                        cache_creation_input_tokens: 15,
+                        cache_read_input_tokens: 5,
+                    },
+                },
+            ])
+        );
+
+        const events = loadCodebuffEvents(root);
+
+        expect(events).toHaveLength(1);
+        expect(events[0].id).toBe("cb-1");
+        expect(events[0].model).toBe("codebuff-max");
+        expect(events[0].sessionId).toBe("app/sess-cb");
+        expect(events[0].inputTokens).toBe(120);
+        expect(events[0].outputTokens).toBe(40);
+        expect(events[0].cacheCreationTokens).toBe(15);
+        expect(events[0].cacheReadTokens).toBe(5);
     });
 
     it("gemini reads both jsonl lines and a json messages array", () => {

--- a/src/ai-spend/lib/reports/sources.ts
+++ b/src/ai-spend/lib/reports/sources.ts
@@ -1,0 +1,811 @@
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { logger } from "@genesiscz/utils/logger";
+import {
+    asNumber,
+    asRecord,
+    asString,
+    fileStem,
+    isoFromUnknown,
+    parseJsonl,
+    parseJsonValue,
+    pickNumber,
+} from "./jsonl";
+import type { SourceId, SpendEvent } from "./types";
+import { envPathList, readText, walkFiles } from "./walk";
+
+function rootsFromEnv(envName: string, home: string, fallbacks: string[]): string[] {
+    const override = envPathList(env.getTrimmed(envName));
+
+    if (override.length > 0) {
+        return override;
+    }
+
+    return fallbacks.map((rel) => join(home, rel));
+}
+
+function emit(partial: Omit<SpendEvent, "source"> & { source: SourceId }): SpendEvent | null {
+    if (
+        partial.inputTokens === 0 &&
+        partial.outputTokens === 0 &&
+        partial.cacheCreationTokens === 0 &&
+        partial.cacheReadTokens === 0 &&
+        (partial.reasoningOutputTokens ?? 0) === 0
+    ) {
+        return null;
+    }
+
+    return partial;
+}
+
+function tokensFromUsage(usage: Record<string, unknown> | undefined): {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+} {
+    const cache = asRecord(usage?.cache);
+    return {
+        inputTokens: pickNumber(usage, ["inputTokens", "input_tokens", "input", "prompt_tokens", "promptTokens"]),
+        outputTokens: pickNumber(usage, [
+            "outputTokens",
+            "output_tokens",
+            "output",
+            "completion_tokens",
+            "completionTokens",
+            "candidates_tokens",
+            "candidatesTokenCount",
+        ]),
+        cacheCreationTokens:
+            pickNumber(usage, [
+                "cacheCreationTokens",
+                "cache_creation_input_tokens",
+                "cacheWrite",
+                "cache_write",
+                "cacheCreationInputTokens",
+            ]) || pickNumber(cache, ["write"]),
+        cacheReadTokens:
+            pickNumber(usage, [
+                "cacheReadTokens",
+                "cache_read_input_tokens",
+                "cacheRead",
+                "cache_read",
+                "cached_tokens",
+                "cachedContentTokenCount",
+                "cacheReadInputTokens",
+            ]) || pickNumber(cache, ["read"]),
+    };
+}
+
+export function loadAmpEvents(home: string): SpendEvent[] {
+    const roots = rootsFromEnv("AMP_DATA_DIR", home, [".local/share/amp"]);
+    const files = walkFiles(
+        roots.map((root) => join(root, "threads")),
+        { maxDepth: 2, isFile: (name) => name.startsWith("T-") && name.endsWith(".json") }
+    );
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        const thread = asRecord(parseJsonValue(content));
+
+        if (!thread) {
+            continue;
+        }
+
+        const threadId = asString(thread.id) ?? fileStem(file);
+        const ledger = asRecord(thread.usageLedger) ?? asRecord(thread.usage_ledger);
+        const ledgerEvents = Array.isArray(ledger?.events) ? ledger.events : [];
+
+        if (ledgerEvents.length > 0) {
+            for (const raw of ledgerEvents) {
+                const event = asRecord(raw);
+
+                if (!event) {
+                    continue;
+                }
+
+                const tokens = asRecord(event.tokens);
+                const spent = emit({
+                    source: "amp",
+                    id: String(event.id ?? `${threadId}|${event.timestamp}`),
+                    model: asString(event.model) ?? "unknown",
+                    timestamp: isoFromUnknown(event.timestamp),
+                    sessionId: threadId,
+                    project: "amp",
+                    inputTokens: pickNumber(tokens, ["input", "inputTokens"]),
+                    outputTokens: pickNumber(tokens, ["output", "outputTokens"]),
+                    cacheCreationTokens: 0,
+                    cacheReadTokens: 0,
+                    recordedCostUsd: asNumber(event.credits) || undefined,
+                });
+
+                if (spent) {
+                    events.push(spent);
+                }
+            }
+
+            continue;
+        }
+
+        const messages = Array.isArray(thread.messages) ? thread.messages : [];
+
+        for (const [index, raw] of messages.entries()) {
+            const message = asRecord(raw);
+
+            if (!message) {
+                continue;
+            }
+
+            const usage = asRecord(message.usage);
+            const tokens = tokensFromUsage(usage);
+            const spent = emit({
+                source: "amp",
+                id: asString(message.messageId) ?? asString(message.message_id) ?? `${threadId}:${index}`,
+                model: asString(message.model) ?? "unknown",
+                timestamp: isoFromUnknown(message.timestamp),
+                sessionId: threadId,
+                project: "amp",
+                ...tokens,
+            });
+
+            if (spent) {
+                events.push(spent);
+            }
+        }
+    }
+
+    return events;
+}
+
+export function loadDroidEvents(home: string): SpendEvent[] {
+    const roots = rootsFromEnv("DROID_SESSIONS_DIR", home, [".factory/sessions"]);
+    const files = walkFiles(roots, { maxDepth: 3, isFile: (name) => name.endsWith(".settings.json") });
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        const settings = asRecord(parseJsonValue(content));
+
+        if (!settings) {
+            continue;
+        }
+
+        const usage = asRecord(settings.tokenUsage);
+        const spent = emit({
+            source: "droid",
+            id: file,
+            model: asString(settings.model) ?? "unknown",
+            timestamp: isoFromUnknown(settings.updatedAt ?? settings.createdAt ?? settings.timestamp),
+            sessionId: basename(file).replace(/\.settings\.json$/, ""),
+            project: "droid",
+            inputTokens: pickNumber(usage, ["inputTokens"]),
+            outputTokens: pickNumber(usage, ["outputTokens"]),
+            cacheCreationTokens: pickNumber(usage, ["cacheCreationTokens"]),
+            cacheReadTokens: pickNumber(usage, ["cacheReadTokens"]),
+            reasoningOutputTokens: pickNumber(usage, ["thinkingTokens"]),
+        });
+
+        if (spent) {
+            events.push(spent);
+        }
+    }
+
+    return events;
+}
+
+export function loadCodebuffEvents(home: string): SpendEvent[] {
+    const override = envPathList(env.getTrimmed("CODEBUFF_DATA_DIR"));
+    const roots =
+        override.length > 0
+            ? override.map((path) => (basename(path) === "projects" ? path : join(path, "projects")))
+            : ["manicode", "manicode-dev", "manicode-staging"].map((channel) =>
+                  join(home, ".config", channel, "projects")
+              );
+    const files = walkFiles(roots, { maxDepth: 6, isFile: (name) => name === "chat-messages.json" });
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        const parsed = parseJsonValue(content);
+        const messages = Array.isArray(parsed) ? parsed : [];
+        const sessionId = dirname(file).split("/").slice(-2).join("/");
+
+        for (const [index, raw] of messages.entries()) {
+            const message = asRecord(raw);
+
+            if (!message) {
+                continue;
+            }
+
+            const role = asString(message.role) ?? asString(message.type);
+
+            if (role && role !== "assistant") {
+                continue;
+            }
+
+            const usage = tokensFromUsage(asRecord(message.usage) ?? asRecord(message.tokenUsage) ?? message);
+            const spent = emit({
+                source: "codebuff",
+                id: asString(message.id) ?? `${sessionId}:${index}`,
+                model: asString(message.model) ?? "codebuff-unknown",
+                timestamp: isoFromUnknown(message.timestamp ?? message.createdAt),
+                sessionId,
+                project: "codebuff",
+                ...usage,
+            });
+
+            if (spent) {
+                events.push(spent);
+            }
+        }
+    }
+
+    return events;
+}
+
+export function loadPiEvents(home: string): SpendEvent[] {
+    const roots = rootsFromEnv("PI_AGENT_DIR", home, [".pi/agent/sessions"]);
+    const files = walkFiles(roots, { maxDepth: 4, isFile: (name) => name.endsWith(".jsonl") });
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        const sessionId = fileStem(file);
+
+        for (const row of parseJsonl(content)) {
+            const raw = asRecord(row);
+
+            if (!raw) {
+                continue;
+            }
+
+            const message = asRecord(raw.message);
+            const role = asString(raw.type) ?? asString(message?.role);
+
+            if (role && role !== "assistant") {
+                continue;
+            }
+
+            const usage = asRecord(message?.usage);
+            const spent = emit({
+                source: "pi",
+                id: asString(message?.id) ?? `${sessionId}|${asString(raw.timestamp)}`,
+                model: asString(message?.model) ?? "unknown",
+                timestamp: isoFromUnknown(raw.timestamp),
+                sessionId,
+                project: "pi",
+                inputTokens: pickNumber(usage, ["input"]),
+                outputTokens: pickNumber(usage, ["output"]),
+                cacheCreationTokens: pickNumber(usage, ["cacheWrite"]),
+                cacheReadTokens: pickNumber(usage, ["cacheRead"]),
+                recordedCostUsd: asNumber(asRecord(usage?.cost)?.total) || undefined,
+            });
+
+            if (spent) {
+                events.push(spent);
+            }
+        }
+    }
+
+    return events;
+}
+
+export function loadKimiEvents(home: string): SpendEvent[] {
+    const override = envPathList(env.getTrimmed("KIMI_DATA_DIR"));
+    const roots = override.length > 0 ? override : [join(home, ".kimi"), join(home, ".kimi-code")];
+    const files = walkFiles(
+        roots.map((root) => join(root, "sessions")),
+        { maxDepth: 4, isFile: (name) => name === "wire.jsonl" }
+    );
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        const sessionId = basename(dirname(file));
+
+        for (const row of parseJsonl(content)) {
+            const raw = asRecord(row);
+
+            if (!raw) {
+                continue;
+            }
+
+            const message = asRecord(raw.message);
+            const payload = asRecord(message?.payload);
+            const usage = asRecord(payload?.token_usage) ?? asRecord(raw.usage);
+            const timestamp = isoFromUnknown(raw.timestamp ?? raw.time);
+            const spent = emit({
+                source: "kimi",
+                id: asString(payload?.message_id) ?? `${sessionId}|${timestamp}`,
+                model: asString(raw.model) ?? "kimi-for-coding",
+                timestamp,
+                sessionId,
+                project: "kimi",
+                inputTokens: pickNumber(usage, ["input_other", "input"]),
+                outputTokens: pickNumber(usage, ["output"]),
+                cacheCreationTokens: pickNumber(usage, ["input_cache_creation"]),
+                cacheReadTokens: pickNumber(usage, ["input_cache_read"]),
+            });
+
+            if (spent) {
+                events.push(spent);
+            }
+        }
+    }
+
+    return events;
+}
+
+export function loadGeminiEvents(home: string): SpendEvent[] {
+    const roots = rootsFromEnv("GEMINI_DATA_DIR", home, [".gemini"]).map((root) =>
+        basename(root) === "tmp" ? root : join(root, "tmp")
+    );
+    const files = walkFiles(roots, {
+        maxDepth: 6,
+        isFile: (name) => name.endsWith(".json") || name.endsWith(".jsonl"),
+    });
+    const events: SpendEvent[] = [];
+
+    const pushRecord = (raw: Record<string, unknown>, file: string, index: number): void => {
+        const tokens =
+            asRecord(raw.tokens) ?? asRecord(raw.stats) ?? asRecord(raw.result) ?? asRecord(raw.usage_metadata);
+        const sessionId = asString(raw.sessionId) ?? asString(raw.session_id) ?? fileStem(file);
+        const spent = emit({
+            source: "gemini",
+            id: asString(raw.id) ?? `${sessionId}:${index}`,
+            model: asString(raw.model) ?? "unknown",
+            timestamp: isoFromUnknown(raw.timestamp ?? raw.created_at ?? raw.startTime ?? raw.lastUpdated),
+            sessionId,
+            project: "gemini",
+            inputTokens: pickNumber(tokens, ["input_tokens", "prompt_tokens", "promptTokenCount"]),
+            outputTokens: pickNumber(tokens, ["output_tokens", "candidates_tokens", "candidatesTokenCount"]),
+            cacheCreationTokens: 0,
+            cacheReadTokens: pickNumber(tokens, ["cached_tokens", "cachedContentTokenCount"]),
+        });
+
+        if (spent) {
+            events.push(spent);
+        }
+    };
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        if (file.endsWith(".jsonl")) {
+            for (const [index, row] of parseJsonl(content).entries()) {
+                const raw = asRecord(row);
+
+                if (raw) {
+                    pushRecord(raw, file, index);
+                }
+            }
+
+            continue;
+        }
+
+        const parsed = parseJsonValue(content);
+        const raw = asRecord(parsed);
+
+        if (raw) {
+            const messages = Array.isArray(raw.messages) ? raw.messages : [raw];
+
+            for (const [index, message] of messages.entries()) {
+                const rec = asRecord(message) ?? raw;
+                pushRecord(rec, file, index);
+            }
+        }
+    }
+
+    return events;
+}
+
+export function loadQwenEvents(home: string): SpendEvent[] {
+    const roots = rootsFromEnv("QWEN_DATA_DIR", home, [".qwen"]).map((root) => join(root, "projects"));
+    const files = walkFiles(roots, { maxDepth: 6, isFile: (name) => name.endsWith(".jsonl") });
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        const fallbackSession = fileStem(file);
+
+        for (const [index, row] of parseJsonl(content).entries()) {
+            const raw = asRecord(row);
+
+            if (!raw) {
+                continue;
+            }
+
+            const usage = asRecord(raw.usageMetadata) ?? asRecord(raw.usage_metadata);
+            const spent = emit({
+                source: "qwen",
+                id: `${asString(raw.sessionId) ?? fallbackSession}:${index}`,
+                model: asString(raw.model) ?? "unknown",
+                timestamp: isoFromUnknown(raw.timestamp),
+                sessionId: asString(raw.sessionId) ?? asString(raw.session_id) ?? fallbackSession,
+                project: "qwen",
+                inputTokens: pickNumber(usage, ["promptTokenCount", "prompt_token_count"]),
+                outputTokens: pickNumber(usage, ["candidatesTokenCount", "candidates_token_count"]),
+                cacheCreationTokens: 0,
+                cacheReadTokens: pickNumber(usage, ["cachedContentTokenCount", "cached_content_token_count"]),
+                reasoningOutputTokens: pickNumber(usage, ["thoughtsTokenCount", "thoughts_token_count"]),
+            });
+
+            if (spent) {
+                events.push(spent);
+            }
+        }
+    }
+
+    return events;
+}
+
+export function loadOpenclawEvents(home: string): SpendEvent[] {
+    const override = envPathList(env.getTrimmed("OPENCLAW_DIR"));
+    const roots =
+        override.length > 0
+            ? override
+            : [".openclaw", ".clawdbot", ".moltbot", ".moldbot"].map((dir) => join(home, dir));
+    const files = walkFiles(roots, { maxDepth: 8, isFile: (name) => name.endsWith(".jsonl") });
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        const sessionId = fileStem(file);
+        let stickyModel = "unknown";
+
+        for (const [index, row] of parseJsonl(content).entries()) {
+            const raw = asRecord(row);
+
+            if (!raw) {
+                continue;
+            }
+
+            const data = asRecord(raw.data);
+            const modelChange = asString(raw.type) ?? asString(raw.customType);
+
+            if (modelChange === "model_change" || modelChange === "model-snapshot") {
+                stickyModel = asString(raw.modelId) ?? asString(raw.model) ?? asString(data?.modelId) ?? stickyModel;
+                continue;
+            }
+
+            const message = asRecord(raw.message);
+            const usage = asRecord(message?.usage);
+            const spent = emit({
+                source: "openclaw",
+                id: `${sessionId}:${index}`,
+                model: asString(message?.model) ?? asString(raw.model) ?? stickyModel,
+                timestamp: isoFromUnknown(raw.timestamp ?? message?.timestamp),
+                sessionId,
+                project: "openclaw",
+                inputTokens: pickNumber(usage, ["input"]),
+                outputTokens: pickNumber(usage, ["output"]),
+                cacheCreationTokens: pickNumber(usage, ["cacheWrite"]),
+                cacheReadTokens: pickNumber(usage, ["cacheRead"]),
+                recordedCostUsd: asNumber(asRecord(usage?.cost)?.total) || undefined,
+            });
+
+            if (spent) {
+                events.push(spent);
+            }
+        }
+    }
+
+    return events;
+}
+
+export function loadCopilotEvents(home: string): SpendEvent[] {
+    const override = env.getTrimmed("COPILOT_OTEL_FILE_EXPORTER_PATH");
+    const roots = override ? [override] : [join(home, ".copilot", "otel")];
+    const files = walkFiles(roots, { maxDepth: 6, isFile: (name) => name.endsWith(".jsonl") });
+    const events: SpendEvent[] = [];
+
+    for (const file of files) {
+        const content = readText(file);
+
+        if (content === null) {
+            continue;
+        }
+
+        for (const [index, row] of parseJsonl(content).entries()) {
+            const raw = asRecord(row);
+
+            if (!raw || !asRecord(raw.attributes)) {
+                continue;
+            }
+
+            const attributes = asRecord(raw.attributes) ?? {};
+            const input = asNumber(attributes["gen_ai.usage.input_tokens"]);
+            const output = asNumber(attributes["gen_ai.usage.output_tokens"]);
+            const cacheRead = asNumber(attributes["gen_ai.usage.cache_read.input_tokens"]);
+            const cacheWrite = asNumber(
+                attributes["gen_ai.usage.cache_write.input_tokens"] ?? attributes["gen_ai.usage.cached_input_tokens"]
+            );
+            const model =
+                asString(attributes["gen_ai.request.model"]) ??
+                asString(attributes["gen_ai.response.model"]) ??
+                "unknown";
+            const sessionId =
+                asString(attributes["session.id"]) ?? asString(attributes["gen_ai.conversation.id"]) ?? fileStem(file);
+            const spent = emit({
+                source: "copilot",
+                id: asString(raw.spanId) ?? `${sessionId}:${index}`,
+                model,
+                timestamp: isoFromUnknown(raw.startTime ?? raw.timestamp ?? raw.timeUnixNano),
+                sessionId,
+                project: "copilot",
+                inputTokens: input,
+                outputTokens: output,
+                cacheCreationTokens: cacheWrite,
+                cacheReadTokens: cacheRead,
+            });
+
+            if (spent) {
+                events.push(spent);
+            }
+        }
+    }
+
+    return events;
+}
+
+function readSqliteRows(
+    path: string,
+    sql: string,
+    map: (row: Record<string, unknown>) => SpendEvent | null
+): SpendEvent[] {
+    if (!existsSync(path)) {
+        return [];
+    }
+
+    const events: SpendEvent[] = [];
+
+    try {
+        const db = new Database(path, { readonly: true });
+
+        try {
+            const rows = db.query(sql).all() as Record<string, unknown>[];
+
+            for (const row of rows) {
+                const event = map(row);
+
+                if (event) {
+                    events.push(event);
+                }
+            }
+        } finally {
+            db.close();
+        }
+    } catch (err) {
+        logger.debug({ err, path }, "ai-spend: sqlite source unreadable");
+    }
+
+    return events;
+}
+
+function parseOpenCodeLike(source: SourceId, data: unknown, id: string, sessionId: string): SpendEvent | null {
+    const raw = asRecord(data);
+
+    if (!raw) {
+        return null;
+    }
+
+    const tokens = asRecord(raw.tokens);
+    const cache = asRecord(tokens?.cache);
+    const time = asRecord(raw.time);
+    return emit({
+        source,
+        id: asString(raw.id) ?? id,
+        model: asString(raw.modelID) ?? asString(raw.modelId) ?? "unknown",
+        timestamp: isoFromUnknown(time?.created ?? raw.time),
+        sessionId: asString(raw.sessionID) ?? asString(raw.session_id) ?? sessionId,
+        project: source,
+        inputTokens: pickNumber(tokens, ["input"]),
+        outputTokens: pickNumber(tokens, ["output"]),
+        cacheCreationTokens: pickNumber(cache, ["write"]),
+        cacheReadTokens: pickNumber(cache, ["read"]),
+        recordedCostUsd: asNumber(raw.cost) || undefined,
+        reasoningOutputTokens: pickNumber(tokens, ["reasoning"]),
+    });
+}
+
+export function loadOpencodeEvents(home: string): SpendEvent[] {
+    const roots = rootsFromEnv("OPENCODE_DATA_DIR", home, [".local/share/opencode"]);
+    const events: SpendEvent[] = [];
+
+    for (const root of roots) {
+        const dbPath = existsSync(join(root, "opencode.db")) ? join(root, "opencode.db") : undefined;
+
+        if (dbPath) {
+            events.push(
+                ...readSqliteRows(dbPath, "SELECT id, session_id, data FROM message", (row) => {
+                    const data = typeof row.data === "string" ? parseJsonValue(row.data) : row.data;
+                    return parseOpenCodeLike("opencode", data, String(row.id), String(row.session_id ?? "unknown"));
+                })
+            );
+        }
+
+        const files = walkFiles([join(root, "storage", "message")], {
+            maxDepth: 3,
+            isFile: (name) => name.endsWith(".json"),
+        });
+
+        for (const file of files) {
+            const content = readText(file);
+
+            if (content === null) {
+                continue;
+            }
+
+            const event = parseOpenCodeLike(
+                "opencode",
+                parseJsonValue(content),
+                fileStem(file),
+                basename(dirname(file))
+            );
+
+            if (event) {
+                events.push(event);
+            }
+        }
+    }
+
+    return events;
+}
+
+export function loadKiloEvents(home: string): SpendEvent[] {
+    const roots = rootsFromEnv("KILO_DATA_DIR", home, [".local/share/kilo"]);
+    const events: SpendEvent[] = [];
+
+    for (const root of roots) {
+        events.push(
+            ...readSqliteRows(join(root, "kilo.db"), "SELECT id, session_id, data FROM message", (row) => {
+                const data = typeof row.data === "string" ? parseJsonValue(row.data) : row.data;
+                return parseOpenCodeLike("kilo", data, String(row.id), String(row.session_id ?? "unknown"));
+            })
+        );
+    }
+
+    return events;
+}
+
+export function loadHermesEvents(home: string): SpendEvent[] {
+    const override = envPathList(env.getTrimmed("HERMES_HOME"));
+    const homes = override.length > 0 ? override : [join(home, ".hermes")];
+    const events: SpendEvent[] = [];
+
+    for (const root of homes) {
+        events.push(
+            ...readSqliteRows(
+                join(root, "state.db"),
+                `SELECT id, model, billing_provider, started_at, message_count, input_tokens, output_tokens,
+                        cache_read_tokens, cache_write_tokens, reasoning_tokens, estimated_cost_usd, actual_cost_usd
+                 FROM sessions WHERE model IS NOT NULL`,
+                (row) =>
+                    emit({
+                        source: "hermes",
+                        id: String(row.id),
+                        model: String(row.model ?? "unknown"),
+                        timestamp: isoFromUnknown(row.started_at),
+                        sessionId: String(row.id),
+                        project: "hermes",
+                        inputTokens: asNumber(row.input_tokens),
+                        outputTokens: asNumber(row.output_tokens),
+                        cacheCreationTokens: asNumber(row.cache_write_tokens),
+                        cacheReadTokens: asNumber(row.cache_read_tokens),
+                        reasoningOutputTokens: asNumber(row.reasoning_tokens),
+                        recordedCostUsd: asNumber(row.actual_cost_usd) || asNumber(row.estimated_cost_usd) || undefined,
+                    })
+            )
+        );
+    }
+
+    return events;
+}
+
+export function loadGooseEvents(home: string): SpendEvent[] {
+    const override = env.getTrimmed("GOOSE_PATH_ROOT");
+    const dbs = override
+        ? [join(override, "data", "sessions", "sessions.db")]
+        : [
+              join(home, ".local/share/goose/sessions/sessions.db"),
+              join(home, "Library/Application Support/goose/sessions/sessions.db"),
+              join(home, ".local/share/Block/goose/sessions/sessions.db"),
+          ];
+    const events: SpendEvent[] = [];
+
+    for (const db of dbs) {
+        events.push(
+            ...readSqliteRows(
+                db,
+                `SELECT id, model_config_json, provider_name, created_at, total_tokens, input_tokens, output_tokens,
+                        accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens
+                 FROM sessions WHERE model_config_json IS NOT NULL`,
+                (row) => {
+                    const config = asRecord(
+                        typeof row.model_config_json === "string"
+                            ? parseJsonValue(row.model_config_json)
+                            : row.model_config_json
+                    );
+                    const input = asNumber(row.accumulated_input_tokens) || asNumber(row.input_tokens);
+                    const output = asNumber(row.accumulated_output_tokens) || asNumber(row.output_tokens);
+                    return emit({
+                        source: "goose",
+                        id: String(row.id),
+                        model: asString(config?.model_name) ?? "unknown",
+                        timestamp: isoFromUnknown(row.created_at),
+                        sessionId: String(row.id),
+                        project: "goose",
+                        inputTokens: input,
+                        outputTokens: output,
+                        cacheCreationTokens: 0,
+                        cacheReadTokens: 0,
+                    });
+                }
+            )
+        );
+    }
+
+    return events;
+}
+
+const LOADERS: Record<Exclude<SourceId, "claude" | "codex" | "grok">, (home: string) => SpendEvent[]> = {
+    amp: loadAmpEvents,
+    droid: loadDroidEvents,
+    codebuff: loadCodebuffEvents,
+    pi: loadPiEvents,
+    kimi: loadKimiEvents,
+    gemini: loadGeminiEvents,
+    qwen: loadQwenEvents,
+    openclaw: loadOpenclawEvents,
+    copilot: loadCopilotEvents,
+    opencode: loadOpencodeEvents,
+    kilo: loadKiloEvents,
+    hermes: loadHermesEvents,
+    goose: loadGooseEvents,
+};
+
+export function loadExtraSource(source: Exclude<SourceId, "claude" | "codex" | "grok">, home: string): SpendEvent[] {
+    return LOADERS[source](home);
+}

--- a/src/ai-spend/lib/reports/sources.ts
+++ b/src/ai-spend/lib/reports/sources.ts
@@ -8,7 +8,9 @@ import {
     asRecord,
     asString,
     fileStem,
+    firstFinite,
     isoFromUnknown,
+    optionalFinite,
     parseJsonl,
     parseJsonValue,
     pickNumber,
@@ -124,7 +126,7 @@ export function loadAmpEvents(home: string): SpendEvent[] {
                     outputTokens: pickNumber(tokens, ["output", "outputTokens"]),
                     cacheCreationTokens: 0,
                     cacheReadTokens: 0,
-                    recordedCostUsd: asNumber(event.credits) || undefined,
+                    recordedCostUsd: optionalFinite(event.credits),
                 });
 
                 if (spent) {
@@ -301,7 +303,7 @@ export function loadPiEvents(home: string): SpendEvent[] {
                 outputTokens: pickNumber(usage, ["output"]),
                 cacheCreationTokens: pickNumber(usage, ["cacheWrite"]),
                 cacheReadTokens: pickNumber(usage, ["cacheRead"]),
-                recordedCostUsd: asNumber(asRecord(usage?.cost)?.total) || undefined,
+                recordedCostUsd: optionalFinite(asRecord(usage?.cost)?.total),
             });
 
             if (spent) {
@@ -523,7 +525,7 @@ export function loadOpenclawEvents(home: string): SpendEvent[] {
                 outputTokens: pickNumber(usage, ["output"]),
                 cacheCreationTokens: pickNumber(usage, ["cacheWrite"]),
                 cacheReadTokens: pickNumber(usage, ["cacheRead"]),
-                recordedCostUsd: asNumber(asRecord(usage?.cost)?.total) || undefined,
+                recordedCostUsd: optionalFinite(asRecord(usage?.cost)?.total),
             });
 
             if (spent) {
@@ -645,7 +647,7 @@ function parseOpenCodeLike(source: SourceId, data: unknown, id: string, sessionI
         outputTokens: pickNumber(tokens, ["output"]),
         cacheCreationTokens: pickNumber(cache, ["write"]),
         cacheReadTokens: pickNumber(cache, ["read"]),
-        recordedCostUsd: asNumber(raw.cost) || undefined,
+        recordedCostUsd: optionalFinite(raw.cost),
         reasoningOutputTokens: pickNumber(tokens, ["reasoning"]),
     });
 }
@@ -735,7 +737,7 @@ export function loadHermesEvents(home: string): SpendEvent[] {
                         cacheCreationTokens: asNumber(row.cache_write_tokens),
                         cacheReadTokens: asNumber(row.cache_read_tokens),
                         reasoningOutputTokens: asNumber(row.reasoning_tokens),
-                        recordedCostUsd: asNumber(row.actual_cost_usd) || asNumber(row.estimated_cost_usd) || undefined,
+                        recordedCostUsd: optionalFinite(row.actual_cost_usd) ?? optionalFinite(row.estimated_cost_usd),
                     })
             )
         );
@@ -768,8 +770,8 @@ export function loadGooseEvents(home: string): SpendEvent[] {
                             ? parseJsonValue(row.model_config_json)
                             : row.model_config_json
                     );
-                    const input = asNumber(row.accumulated_input_tokens) || asNumber(row.input_tokens);
-                    const output = asNumber(row.accumulated_output_tokens) || asNumber(row.output_tokens);
+                    const input = firstFinite(row.accumulated_input_tokens, row.input_tokens);
+                    const output = firstFinite(row.accumulated_output_tokens, row.output_tokens);
                     return emit({
                         source: "goose",
                         id: String(row.id),

--- a/src/ai-spend/lib/reports/statusline.ts
+++ b/src/ai-spend/lib/reports/statusline.ts
@@ -82,8 +82,9 @@ function usd(value: number | undefined): string {
 }
 
 function formatRemaining(minutes: number): string {
-    const hours = Math.floor(minutes / 60);
-    const mins = Math.round(minutes % 60);
+    const rounded = Math.round(minutes);
+    const hours = Math.floor(rounded / 60);
+    const mins = rounded % 60;
     return `${hours}h ${mins}m left`;
 }
 

--- a/src/ai-spend/lib/reports/statusline.ts
+++ b/src/ai-spend/lib/reports/statusline.ts
@@ -1,0 +1,157 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import type { PricingTable } from "../types";
+import { identifySessionBlocks } from "./blocks";
+import { zonedDay } from "./dates";
+import { asRecord, asString } from "./jsonl";
+import { pricedEventCost } from "./load";
+import type { CostMode, SpendEvent } from "./types";
+
+export interface StatuslineHook {
+    session_id: string;
+    transcript_path?: string;
+    model?: { id?: string; display_name?: string };
+    cost?: { total_cost_usd?: number };
+    effort?: { level?: string };
+    context_window?: { total_input_tokens?: number; context_window_size?: number };
+}
+
+export interface StatuslineOptions {
+    timezone: string;
+    now: Date;
+    pricing: PricingTable;
+    mode: CostMode;
+    costSource: "auto" | "ccusage" | "cc" | "both";
+    visualBurnRate: "off" | "emoji" | "text" | "emoji-text";
+}
+
+export function parseStatuslineHook(raw: string): StatuslineHook | null {
+    const trimmed = raw.trim();
+
+    if (!trimmed) {
+        return null;
+    }
+
+    try {
+        const parsed = SafeJSON.parse(trimmed, { strict: true });
+        const record = asRecord(parsed);
+
+        if (!record) {
+            return null;
+        }
+
+        const sessionId = asString(record.session_id) ?? asString(record.sessionId);
+
+        if (!sessionId) {
+            return null;
+        }
+
+        const model = asRecord(record.model);
+        const cost = asRecord(record.cost);
+        const effort = asRecord(record.effort);
+        const context = asRecord(record.context_window) ?? asRecord(record.contextWindow);
+        return {
+            session_id: sessionId,
+            transcript_path: asString(record.transcript_path) ?? asString(record.transcriptPath),
+            model: model
+                ? { id: asString(model.id), display_name: asString(model.display_name) ?? asString(model.displayName) }
+                : undefined,
+            cost: cost
+                ? { total_cost_usd: typeof cost.total_cost_usd === "number" ? cost.total_cost_usd : undefined }
+                : undefined,
+            effort: effort ? { level: asString(effort.level) } : undefined,
+            context_window: context
+                ? {
+                      total_input_tokens:
+                          typeof context.total_input_tokens === "number" ? context.total_input_tokens : undefined,
+                      context_window_size:
+                          typeof context.context_window_size === "number" ? context.context_window_size : undefined,
+                  }
+                : undefined,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function usd(value: number | undefined): string {
+    if (value === undefined) {
+        return "N/A";
+    }
+
+    return `$${value.toFixed(2)}`;
+}
+
+function formatRemaining(minutes: number): string {
+    const hours = Math.floor(minutes / 60);
+    const mins = Math.round(minutes % 60);
+    return `${hours}h ${mins}m left`;
+}
+
+export function renderStatusline(hook: StatuslineHook, events: SpendEvent[], options: StatuslineOptions): string {
+    const today = zonedDay(options.now.toISOString(), options.timezone);
+    const costOf = (event: SpendEvent): number => pricedEventCost(event, options.pricing, options.mode);
+    const sessionCost = events
+        .filter((event) => event.sessionId === hook.session_id)
+        .reduce((sum, event) => sum + costOf(event), 0);
+    const todayCost = events
+        .filter((event) => zonedDay(event.timestamp, options.timezone) === today)
+        .reduce((sum, event) => sum + costOf(event), 0);
+    const hookCost = hook.cost?.total_cost_usd;
+    let sessionDisplay: string;
+
+    if (options.costSource === "cc") {
+        sessionDisplay = usd(hookCost);
+    } else if (options.costSource === "ccusage") {
+        sessionDisplay = usd(sessionCost);
+    } else if (options.costSource === "both") {
+        sessionDisplay = `(${usd(hookCost)} cc / ${usd(sessionCost)} ccusage)`;
+    } else {
+        sessionDisplay = usd(hookCost ?? sessionCost);
+    }
+
+    const blocks = identifySessionBlocks(events, 5, options.now.getTime(), costOf);
+    const active = blocks.find((block) => block.isActive && !block.isGap);
+    let blockInfo = "No active block";
+    let burn = "";
+
+    if (active) {
+        const remaining = Math.max((Date.parse(active.endTime) - options.now.getTime()) / 60_000, 0);
+        blockInfo = `${usd(active.costUSD)} block (${formatRemaining(remaining)})`;
+
+        if (active.burnRate && options.visualBurnRate !== "off") {
+            const rate = active.burnRate.tokensPerMinuteForIndicator;
+            const status =
+                rate < 2000
+                    ? (["🟢", "Normal"] as const)
+                    : rate < 5000
+                      ? (["⚠️", "Moderate"] as const)
+                      : (["🚨", "High"] as const);
+            const segments = [`${usd(active.burnRate.costPerHour)}/hr`];
+
+            if (options.visualBurnRate === "emoji" || options.visualBurnRate === "emoji-text") {
+                segments.push(status[0]);
+            }
+
+            if (options.visualBurnRate === "text" || options.visualBurnRate === "emoji-text") {
+                segments.push(`(${status[1]})`);
+            }
+
+            burn = ` | 🔥 ${segments.join(" ")}`;
+        } else if (active.burnRate) {
+            burn = ` | 🔥 ${usd(active.burnRate.costPerHour)}/hr`;
+        }
+    }
+
+    let context = "N/A";
+    const totalInput = hook.context_window?.total_input_tokens;
+    const windowSize = hook.context_window?.context_window_size;
+
+    if (typeof totalInput === "number" && typeof windowSize === "number" && windowSize > 0) {
+        const pct = Math.round((totalInput / windowSize) * 100);
+        context = `${totalInput.toLocaleString()} (${pct}%)`;
+    }
+
+    const modelLabel = hook.model?.display_name ?? hook.model?.id ?? "unknown";
+    const effort = hook.effort?.level ? ` (${hook.effort.level})` : "";
+    return `🤖 ${modelLabel}${effort} | 💰 ${sessionDisplay} session / ${usd(todayCost)} today / ${blockInfo}${burn} | 🧠 ${context}`;
+}

--- a/src/ai-spend/lib/reports/types.ts
+++ b/src/ai-spend/lib/reports/types.ts
@@ -83,7 +83,8 @@ export interface ReportFlags {
     timezone?: string;
     last?: string;
     breakdown?: boolean;
-    mode?: string;
+    mode?: string | boolean;
+    visualBurnRate?: string | boolean;
     active?: boolean;
     recent?: boolean;
     sessionLength?: string;

--- a/src/ai-spend/lib/reports/types.ts
+++ b/src/ai-spend/lib/reports/types.ts
@@ -1,0 +1,106 @@
+export const SOURCE_IDS = [
+    "claude",
+    "codex",
+    "opencode",
+    "amp",
+    "droid",
+    "codebuff",
+    "hermes",
+    "pi",
+    "goose",
+    "kilo",
+    "copilot",
+    "gemini",
+    "kimi",
+    "qwen",
+    "openclaw",
+    "grok",
+] as const;
+
+export type SourceId = (typeof SOURCE_IDS)[number];
+
+export type PeriodGrain = "daily" | "weekly" | "monthly";
+export type ReportKind = PeriodGrain | "session" | "blocks" | "statusline";
+export type CostMode = "auto" | "calculate" | "display";
+
+export const SOURCE_REPORTS: Record<SourceId, readonly ReportKind[]> = {
+    claude: ["daily", "weekly", "monthly", "session", "blocks", "statusline"],
+    codex: ["daily", "monthly", "session"],
+    opencode: ["daily", "weekly", "monthly", "session"],
+    amp: ["daily", "monthly", "session"],
+    droid: ["daily", "monthly", "session"],
+    codebuff: ["daily", "monthly", "session"],
+    hermes: ["daily", "monthly", "session"],
+    pi: ["daily", "monthly", "session"],
+    goose: ["daily", "monthly", "session"],
+    kilo: ["daily", "monthly", "session"],
+    copilot: ["daily", "monthly", "session"],
+    gemini: ["daily", "monthly", "session"],
+    kimi: ["daily", "monthly", "session"],
+    qwen: ["daily", "monthly", "session"],
+    openclaw: ["daily", "monthly", "session"],
+    grok: ["daily", "monthly", "session"],
+};
+
+export interface SpendEvent {
+    source: SourceId;
+    id: string;
+    model: string;
+    timestamp: string;
+    sessionId: string;
+    project: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    reasoningOutputTokens?: number;
+    recordedCostUsd?: number;
+    isSidechain?: boolean;
+}
+
+export interface ModelBreakdownJson {
+    modelName: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    cost: number;
+}
+
+export interface TokenTotalsJson {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationTokens: number;
+    cacheReadTokens: number;
+    totalTokens: number;
+    totalCost: number;
+}
+
+export interface ReportFlags {
+    json?: boolean;
+    since?: string;
+    until?: string;
+    timezone?: string;
+    last?: string;
+    breakdown?: boolean;
+    mode?: string;
+    active?: boolean;
+    recent?: boolean;
+    sessionLength?: string;
+    id?: string;
+    byAgent?: boolean;
+}
+
+export interface ReportContext {
+    home: string;
+    now: Date;
+    timezone: string;
+    sinceDay?: string;
+    untilDay?: string;
+    last?: number;
+    breakdown: boolean;
+    mode: CostMode;
+    source?: SourceId;
+    sessionId?: string;
+    byAgent: boolean;
+}

--- a/src/ai-spend/lib/reports/walk.ts
+++ b/src/ai-spend/lib/reports/walk.ts
@@ -1,0 +1,83 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "@genesiscz/utils/logger";
+
+export interface WalkOptions {
+    maxDepth: number;
+    isFile: (name: string, full: string) => boolean;
+}
+
+export function walkFiles(roots: string[], options: WalkOptions): string[] {
+    const out: string[] = [];
+
+    const walk = (dir: string, depth: number): void => {
+        let entries: import("node:fs").Dirent[];
+
+        try {
+            entries = readdirSync(dir, { withFileTypes: true });
+        } catch (err) {
+            logger.debug({ err, dir }, "ai-spend: unreadable dir skipped");
+            return;
+        }
+
+        for (const entry of entries) {
+            const full = join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                if (depth < options.maxDepth) {
+                    walk(full, depth + 1);
+                }
+
+                continue;
+            }
+
+            if (!entry.isFile() || !options.isFile(entry.name, full)) {
+                continue;
+            }
+
+            out.push(full);
+        }
+    };
+
+    for (const root of roots) {
+        if (existsSync(root)) {
+            try {
+                if (statSync(root).isFile()) {
+                    if (options.isFile(root.split("/").pop() ?? root, root)) {
+                        out.push(root);
+                    }
+
+                    continue;
+                }
+            } catch (err) {
+                logger.debug({ err, root }, "ai-spend: stat failed");
+                continue;
+            }
+
+            walk(root, 0);
+        }
+    }
+
+    out.sort();
+    return out;
+}
+
+export function readText(file: string): string | null {
+    try {
+        return readFileSync(file, "utf8");
+    } catch (err) {
+        logger.debug({ err, file }, "ai-spend: failed to read usage file");
+        return null;
+    }
+}
+
+export function envPathList(raw: string | undefined): string[] {
+    if (!raw) {
+        return [];
+    }
+
+    return raw
+        .split(",")
+        .map((path) => path.trim())
+        .filter((path) => path.length > 0);
+}


### PR DESCRIPTION
# Port ccusage reports into `tools ai-spend`

Adds every live `ccusage` command path as `tools ai-spend` subcommands, while keeping the existing `summary` / `sessions` / `today` / `monitor` default.

## What landed

- Unified `daily`, `weekly`, `monthly`, `session` across every detected source
- `blocks` (5-hour Claude windows, `--active` / `--recent`) and `statusline` (hook JSON on stdin)
- Per-source namespaces: `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `kilo`, `copilot`, `gemini`, `kimi`, `qwen`, `openclaw`, `grok`
- `--json` uses ccusage field names (`inputTokens`, `outputTokens`, `cacheCreationTokens`, `cacheReadTokens`, `totalTokens`, plus period/session/block identity)
- `--since` / `--until` / `--timezone` / `--last` / `--breakdown` / Claude `--mode`

## Verification

- Fixture HOME: `ccusage --json --offline` vs `tools ai-spend --json` match on grouping keys and the five token fields (`src/ai-spend/lib/reports/parity.test.ts`)
- Help tree covers all 74 live ccusage command paths
- Real `daily --json` run twice: identical JSON. Codex daily on this machine is exact 1:1 with ccusage. Claude input/cache fields match; remaining Claude output-token gap is recorded rather than guessed away.

No-args default stays `summary`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ccusage-compatible daily, weekly, monthly, session, block, statusline, summary, and monitoring reports.
  * Added unified analytics for coding-agent token usage and costs across Claude, Codex, Grok, and additional supported sources.
  * Added date-range, recent-period, session, source, model, and agent filtering.
  * Added table and JSON output, cost calculation modes, session burn rates, projections, and statusline details.
  * Added reasoning-token reporting for supported providers.

* **Documentation**
  * Documented available commands, report types, source grouping, and compatible JSON fields.

* **Tests**
  * Added coverage for reporting, provider data loading, statusline output, and ccusage compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->