### PR TITLE
feat(cmux,grok,claude): restore-after-restart, grok history/resume, claude --tmux

### DIFF
--- a/src/claude/README.md
+++ b/src/claude/README.md
@@ -33,7 +33,13 @@ tools claude migrate-to codex
 
 # Reopen recent sessions as cmux panes
 tools claude cmux
+
+# Anthropic start inside tmux (alias: run). On --resume <query>, the tmux
+# session is named from the conversation title. A bound ttyd is renamed too.
+tools claude start work --tmux --resume "auth callback"
 ```
+
+`--tmux` applies to `tools claude start` / `run` for Anthropic accounts. A slash target (`account/provider`) still goes to `proxy` and ignores `--tmux`. If you are already inside tmux, this renames the current session instead of nesting a new one.
 
 ---
 

--- a/src/claude/commands/start.tmux.test.ts
+++ b/src/claude/commands/start.tmux.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { tmuxKeychainPrintConflict } from "./start";
+
+describe("tmuxKeychainPrintConflict", () => {
+    test("rejects --tmux --keychain --print", () => {
+        expect(tmuxKeychainPrintConflict(true, true, ["--print"])).toBe(true);
+        expect(tmuxKeychainPrintConflict(true, true, ["-p"])).toBe(true);
+        expect(tmuxKeychainPrintConflict(true, true, [])).toBe(false);
+        expect(tmuxKeychainPrintConflict(true, false, ["--print"])).toBe(false);
+    });
+});

--- a/src/claude/commands/start.ts
+++ b/src/claude/commands/start.ts
@@ -51,6 +51,7 @@ interface StartOptions {
     continue?: boolean;
     keychain?: boolean;
     cmux?: boolean;
+    tmux?: boolean;
 }
 
 /** Same bound findClaudeCommand uses — an rc file that blocks must not hang the launch. */
@@ -150,8 +151,17 @@ export function buildLaunchArgs(input: {
 }
 
 /** Headless launch (`-p`/`--print`): claude prints a result and exits, no TUI. */
-function isHeadlessPassthrough(passthrough: string[]): boolean {
+export function isHeadlessPassthrough(passthrough: string[]): boolean {
     return passthrough.some((arg) => arg === "-p" || arg === "--print");
+}
+
+/** Detached `--tmux` returns before Claude reads the injected keychain. */
+export function tmuxKeychainPrintConflict(
+    tmux: boolean | undefined,
+    keychain: boolean | undefined,
+    passthrough: string[]
+): boolean {
+    return Boolean(tmux && keychain && isHeadlessPassthrough(passthrough));
 }
 
 /**
@@ -769,17 +779,20 @@ async function offerLimitKilledResume(): Promise<string[]> {
     return picked ? ["--resume", picked] : [];
 }
 
-async function resolveResumeArgs(opts: StartOptions, passthrough: string[]): Promise<string[]> {
+async function resolveResumeArgs(
+    opts: StartOptions,
+    passthrough: string[]
+): Promise<{ args: string[]; title?: string }> {
     if (opts.continue) {
         if (opts.resume) {
             out.printlnErr(pc.dim("Both --continue and --resume given; using --continue."));
         }
 
-        return ["--continue"];
+        return { args: ["--continue"] };
     }
 
     if (opts.resume === true) {
-        return ["--resume"];
+        return { args: ["--resume"] };
     }
 
     if (typeof opts.resume === "string") {
@@ -788,16 +801,16 @@ async function resolveResumeArgs(opts: StartOptions, passthrough: string[]): Pro
             throw new Error(`Invalid session ID: ${session.sessionId}`);
         }
 
-        return ["--resume", session.sessionId];
+        return { args: ["--resume", session.sessionId], title: session.name };
     }
 
     // The user said nothing about sessions. Offer the limit-killed one, if the
     // passthrough has not already told claude what to open.
     if (!passthroughHandlesSession(passthrough)) {
-        return offerLimitKilledResume();
+        return { args: await offerLimitKilledResume() };
     }
 
-    return [];
+    return { args: [] };
 }
 
 async function main(nameArg: string | undefined, opts: StartOptions, passthrough: string[]): Promise<never> {
@@ -830,7 +843,7 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
     // --model always wins.
     const modelId =
         explicitModelId ??
-        (alias === "opus" ? "claude-opus-5[1m]" : alias === "fable" ? "claude-fable-5[1m]" : undefined);
+        (alias === "opus" ? "claude-opus-5[1m]" : alias === "fable" ? FABLE_MODEL_OPTION : undefined);
 
     let accountName: string;
 
@@ -852,12 +865,21 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
         await warnKeychainLimits(accountName, aiConfig, modelId);
     }
 
-    const resumeArgs = await resolveResumeArgs(opts, passthrough);
+    const resume = await resolveResumeArgs(opts, passthrough);
+    const resumeArgs = resume.args;
 
     await guardFableHeadroom(accountName, modelId, resumeArgs.length > 0);
 
     let injectedUuid: string | undefined;
     let foreignBackupPath: string | undefined;
+
+    if (tmuxKeychainPrintConflict(opts.tmux, opts.keychain, passthrough)) {
+        out.error(
+            "--tmux --keychain cannot be combined with --print/-p. The detached tmux session would race keychain restore."
+        );
+        await out.flush();
+        process.exit(1);
+    }
 
     if (opts.keychain) {
         const { preSync, foreign } = await inspectKeychainBeforeInject(aiConfig);
@@ -929,7 +951,10 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
         out.printlnErr(pc.dim(`Starting Claude as ${pc.cyan(accountName)} (${mode})${detail ? ` ${detail}` : ""}...`));
     }
 
-    logger.debug({ cmd, accountName, modelId, resumeArgs, passthrough, extraArgs, mode, headless }, "Spawning claude");
+    logger.debug(
+        { cmd, accountName, modelId, resumeArgs, passthrough, extraArgs, mode, headless, tmux: opts.tmux },
+        "Spawning claude"
+    );
 
     let launchEnv: Record<string, string | undefined>;
 
@@ -978,17 +1003,58 @@ async function main(nameArg: string | undefined, opts: StartOptions, passthrough
     let exitCode: number;
 
     try {
-        const proc = Bun.spawn({
-            cmd: [shell, "-ic", `exec ${cmd}${suffix}`],
-            stdio: ["inherit", "inherit", headless ? "pipe" : "inherit"],
-            env: launchEnv,
-        });
+        if (opts.tmux) {
+            const {
+                currentTmuxSessionName,
+                launchCommandInTmux,
+                renameTargetForCurrentSession,
+                renameTmuxAndBoundTtyd,
+                tmuxNameFromResumeTitle,
+            } = await import("../lib/tmux-launch");
+            const desiredName = tmuxNameFromResumeTitle(resume.title, `claude-${accountName}`);
+            const currentName = await currentTmuxSessionName();
 
-        const stderrPump = headless && proc.stderr ? forwardStderrDroppingZleNoise(proc.stderr) : null;
+            if (currentName) {
+                const target = await renameTargetForCurrentSession(currentName, desiredName);
+                await renameTmuxAndBoundTtyd(currentName, target);
+                const proc = Bun.spawn({
+                    cmd: [shell, "-ic", `exec ${cmd}${suffix}`],
+                    stdio: ["inherit", "inherit", headless ? "pipe" : "inherit"],
+                    env: launchEnv,
+                });
+                const stderrPump = headless && proc.stderr ? forwardStderrDroppingZleNoise(proc.stderr) : null;
+                exitCode = await proc.exited;
+                if (stderrPump) {
+                    await stderrPump;
+                }
+            } else {
+                const launched = await launchCommandInTmux({
+                    sessionName: desiredName,
+                    cwd: process.cwd(),
+                    argv: [shell, "-ic", `exec ${cmd}${suffix}`],
+                    env: launchEnv,
+                    attach: !headless,
+                });
+                if (launched.name !== desiredName && resume.title) {
+                    await renameTmuxAndBoundTtyd(launched.name, desiredName).catch((error) => {
+                        logger.debug({ error, from: launched.name, to: desiredName }, "[start] tmux rename skipped");
+                    });
+                }
+                exitCode = launched.exitCode;
+            }
+        } else {
+            const proc = Bun.spawn({
+                cmd: [shell, "-ic", `exec ${cmd}${suffix}`],
+                stdio: ["inherit", "inherit", headless ? "pipe" : "inherit"],
+                env: launchEnv,
+            });
 
-        exitCode = await proc.exited;
-        if (stderrPump) {
-            await stderrPump;
+            const stderrPump = headless && proc.stderr ? forwardStderrDroppingZleNoise(proc.stderr) : null;
+
+            exitCode = await proc.exited;
+            if (stderrPump) {
+                await stderrPump;
+            }
         }
 
         if (opts.keychain) {
@@ -1043,6 +1109,11 @@ export function registerStartCommand(program: Command): void {
                 "Claude's tmux calls become cmux splits); all other args forward unchanged. Adds " +
                 "--dangerously-skip-permissions to match the shell wrapper cmux bypasses, unless you pass " +
                 "your own permission flag"
+        )
+        .option(
+            "--tmux",
+            "Create a tmux session and launch Claude inside it. Already inside tmux (ttyd): rename " +
+                "that session (and the bound ttyd tab) from the resumed session title, then launch here."
         )
         .action(async (name: string | undefined, opts: StartOptions, command: Command) => {
             const operands = command.args;

--- a/src/claude/lib/tmux-launch.test.ts
+++ b/src/claude/lib/tmux-launch.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { resetTmuxBinCache, setTmuxBinForTests } from "@genesiscz/utils/tmux/bin";
+import { setTmuxSpawnSyncForTests } from "@genesiscz/utils/tmux/sessions";
+import { renameTargetForCurrentSession, tmuxNameFromResumeTitle } from "./tmux-launch";
+
+describe("tmuxNameFromResumeTitle", () => {
+    test("sanitizes a resume title for tmux", () => {
+        expect(tmuxNameFromResumeTitle("Fix v1.2 bug", "claude")).toBe("Fix v1-2 bug");
+    });
+
+    test("falls back when the title is empty", () => {
+        expect(tmuxNameFromResumeTitle("  ", "claude-work")).toBe("claude-work");
+        expect(tmuxNameFromResumeTitle(undefined, "claude-work")).toBe("claude-work");
+    });
+});
+
+describe("renameTargetForCurrentSession", () => {
+    afterEach(() => {
+        setTmuxSpawnSyncForTests(null);
+        setTmuxBinForTests(null);
+        resetTmuxBinCache();
+    });
+
+    test("keeps the current name when it already matches", async () => {
+        expect(await renameTargetForCurrentSession("claude-work", "claude-work")).toBe("claude-work");
+    });
+
+    test("suffixes -2 when the desired name is taken by another session", async () => {
+        setTmuxBinForTests("/mock/tmux");
+        setTmuxSpawnSyncForTests((cmd) => {
+            if (cmd.includes("list-sessions")) {
+                return {
+                    exitCode: 0,
+                    stdout: `\x1e${["taken", "1", "1", "claude", "/tmp", "1", "1", "t"].join("\x1f")}\n`,
+                };
+            }
+
+            return { exitCode: 0, stdout: "" };
+        });
+
+        expect(await renameTargetForCurrentSession("current", "taken")).toBe("taken-2");
+    });
+});

--- a/src/claude/lib/tmux-launch.ts
+++ b/src/claude/lib/tmux-launch.ts
@@ -1,0 +1,100 @@
+import { tmuxSessionNameFromTopic } from "@app/dev-dashboard/lib/tmux/claude-pane-title";
+import { listTtyd, renameTtyd } from "@app/dev-dashboard/lib/ttyd/manager";
+import { env } from "@genesiscz/utils/env";
+import { logger } from "@genesiscz/utils/logger";
+import { resolveTmuxBin } from "@genesiscz/utils/tmux/bin";
+import {
+    attachTmuxSession,
+    createTmuxSessionRunning,
+    currentTmuxSessionName,
+    renameTmuxSession,
+    sessionExists,
+} from "@genesiscz/utils/tmux/sessions";
+
+/**
+ * Name to rename the *current* tmux session to. If we already have `desired`,
+ * keep it. Otherwise pick a free name so rename-session does not throw.
+ */
+export async function renameTargetForCurrentSession(currentName: string, desiredName: string): Promise<string> {
+    if (!desiredName || desiredName === currentName) {
+        return currentName;
+    }
+
+    return uniqueTmuxSessionName(desiredName);
+}
+
+export async function uniqueTmuxSessionName(desired: string): Promise<string> {
+    const base = tmuxSessionNameFromTopic(desired) || "claude";
+    if (!(await sessionExists(base))) {
+        return base;
+    }
+
+    for (let i = 2; i < 50; i++) {
+        const candidate = `${base}-${i}`;
+        if (!(await sessionExists(candidate))) {
+            return candidate;
+        }
+    }
+
+    return `${base}-${Date.now()}`;
+}
+
+/**
+ * Rename the tmux session and, if a ttyd tab is bound to it, the ttyd display
+ * name too (dev-dashboard Session Hub). Prefer renameTtyd when a binding
+ * exists — it retargets the ttyd attach argv in the same step.
+ */
+export async function renameTmuxAndBoundTtyd(fromName: string, toName: string): Promise<string> {
+    const trimmed = tmuxSessionNameFromTopic(toName) || toName.trim();
+    if (!trimmed || trimmed === fromName) {
+        return fromName;
+    }
+
+    const ttydSessions = await listTtyd();
+    const bound = ttydSessions.find((session) => session.tmuxSessionName === fromName);
+    if (bound) {
+        await renameTtyd(bound.id, trimmed);
+        return trimmed;
+    }
+
+    await renameTmuxSession(fromName, trimmed);
+    return trimmed;
+}
+
+export async function launchCommandInTmux(opts: {
+    sessionName: string;
+    cwd: string;
+    argv: string[];
+    env: Record<string, string | undefined>;
+    attach: boolean;
+}): Promise<{ name: string; exitCode: number }> {
+    const name = await uniqueTmuxSessionName(opts.sessionName);
+    await createTmuxSessionRunning(name, opts.cwd, opts.argv, opts.env);
+
+    const tmuxBin = resolveTmuxBin();
+    const insideTmux = Boolean(env.get("TMUX"));
+    if (!opts.attach) {
+        logger.info({ name }, "[tmux-launch] created detached session");
+        return { name, exitCode: 0 };
+    }
+
+    if (insideTmux) {
+        const result = Bun.spawnSync([tmuxBin, "switch-client", "-t", name], {
+            stdio: ["inherit", "inherit", "inherit"],
+        });
+        return { name, exitCode: result.exitCode ?? 1 };
+    }
+
+    attachTmuxSession(name);
+    return { name, exitCode: 0 };
+}
+
+export function tmuxNameFromResumeTitle(title: string | undefined, fallback: string): string {
+    if (title?.trim()) {
+        return tmuxSessionNameFromTopic(title.trim()) || fallback;
+    }
+
+    return fallback;
+}
+
+export { currentTmuxSessionName };

--- a/src/cmux/README.md
+++ b/src/cmux/README.md
@@ -11,6 +11,7 @@ Crash recovery and repeatable layouts for cmux. A profile captures the workspace
 | Command | Description |
 |---------|-------------|
 | `profiles` | Manage saved workspace profiles |
+| `restore-after-restart` | Guided (or `--source`/`--list`/`--dry-run`) restore of the pre-restart layout with Claude, Grok, and Codex resume commands |
 | `doctor` | Read-only health probe: is cmux running, does its socket answer, is the UI thread starved |
 | `rescue [name]` | Guided recovery from a livelocked cmux — offline capture, confirmed kill, clean relaunch, command replay |
 | `send-self <text>` | Type text into the terminal surface this process is running in, then press Enter |
@@ -71,6 +72,30 @@ Three capture behaviours are **on by default**, and they are what makes a restor
 Pre-typing rather than auto-running is deliberate. Restoring a layout should not silently re-execute commands.
 
 `restore` is always non-destructive: it creates workspaces, it never closes yours.
+
+## `restore-after-restart`
+
+After a cmux app restart, rebuild the previous panes as new workspaces and pre-type Claude, Grok, and Codex resume commands. Always non-destructive. Default workspace prefix is `restart-`.
+
+```bash
+tools cmux restore-after-restart --source previous --dry-run
+tools cmux restore-after-restart --source previous --agents grok,claude --enter -y
+tools cmux restore-after-restart --list --source previous
+```
+
+| Flag | Description |
+|------|-------------|
+| `--source [source]` | `previous` (autosave `*-previous.json`), `live` (socket, then current autosave), or `profile` |
+| `--profile <name>` | Named profile. Required with `--source profile` off TTY |
+| `--agents [list]` | `claude`, `grok`, `codex`. Default is all three |
+| `--enter` | Press Enter after typing each resume command |
+| `--no-replay` | Only `cd` into cwd |
+| `--prefix <str>` | Workspace name prefix (default `restart-`) |
+| `--list` | Print the layout and inferred commands, then exit |
+| `--dry-run` | Print the restore plan without modifying cmux |
+| `-y, --yes` | Skip confirmation. Required off TTY |
+
+`previous` is the file cmux renamed aside on last launch, not the live layout.
 
 `restore --enter` opts into **executing** each captured command instead of pre-typing it.
 That reverses the safe default above, so it is opt-in and never implied.

--- a/src/cmux/commands/profiles/restore.ts
+++ b/src/cmux/commands/profiles/restore.ts
@@ -1,3 +1,4 @@
+import { prepareProfileForRestore } from "@app/cmux/lib/agent-replay";
 import { renderProfileCommandDetail } from "@app/cmux/lib/format";
 import { buildPlan, type RestoreOptions, reportWaitingPrompts, restoreProfile } from "@app/cmux/lib/restore";
 import { ProfileNotFoundError, ProfileStore } from "@app/cmux/lib/store";
@@ -58,7 +59,8 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
         out.log.warn("--enter has no effect with --no-replay; commands are not typed at all.");
     }
 
-    const plan = buildPlan(profile, opts);
+    const playable = await prepareProfileForRestore(profile);
+    const plan = buildPlan(playable, opts);
 
     p.intro(pc.bgCyan(pc.black(" cmux profiles restore ")));
     const planLines = plan.workspaces.map((ws) => {
@@ -66,7 +68,7 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
     });
     p.note(planLines.join("\n") || "(empty profile)", `Restore plan for ${pc.cyan(name)}`);
 
-    const detail = renderProfileCommandDetail(profile);
+    const detail = renderProfileCommandDetail(playable);
     if (detail.length > 0) {
         p.note(detail.join("\n"), "Panes · commands · drift");
     }
@@ -100,7 +102,7 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
     const startedAt = Date.now();
 
     try {
-        const outcome = await restoreProfile(profile, opts, {
+        const outcome = await restoreProfile(playable, opts, {
             onWorkspaceStart: ({ title, index, total }) => {
                 spinner.message(`Restoring ${index}/${total}: ${title}`);
             },

--- a/src/cmux/commands/restore-after-restart.ts
+++ b/src/cmux/commands/restore-after-restart.ts
@@ -1,0 +1,303 @@
+import { prepareProfileForRestore } from "@app/cmux/lib/agent-replay";
+import { readAutosaveSession, readPreviousAutosaveSession } from "@app/cmux/lib/autosave";
+import { renderProfileCommandDetail, renderProfileTree } from "@app/cmux/lib/format";
+import { buildOfflineProfile } from "@app/cmux/lib/offline-snapshot";
+import { buildPlan, type RestoreOptions, reportWaitingPrompts, restoreProfile } from "@app/cmux/lib/restore";
+import {
+    ALL_RESTORE_AGENTS,
+    filterReplayByAgents,
+    isMissingEnumFlag,
+    parseAgentList,
+    parseRestoreSource,
+    type RestoreRestartSource,
+} from "@app/cmux/lib/restore-after-restart";
+import { captureProfile, getCmuxVersion } from "@app/cmux/lib/snapshot";
+import { ProfileNotFoundError, ProfileStore } from "@app/cmux/lib/store";
+import type { Profile } from "@app/cmux/lib/types";
+import * as p from "@clack/prompts";
+import { isInteractive, suggestCommand, suggestEnumFlag } from "@genesiscz/utils/cli";
+import { ensureCmuxResponsive } from "@genesiscz/utils/cmux/lib/health";
+import { logger, out } from "@genesiscz/utils/logger";
+import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+interface RestartFlags {
+    source?: string | true;
+    profile?: string;
+    agents?: string | true;
+    enter?: boolean;
+    replay?: boolean;
+    prefix?: string;
+    list?: boolean;
+    dryRun?: boolean;
+    yes?: boolean;
+}
+
+const SOURCES: RestoreRestartSource[] = ["previous", "live", "profile"];
+
+async function captureLiveProfile(): Promise<Profile> {
+    try {
+        return await captureProfile({
+            name: "restart-live",
+            scope: "all",
+            captureCwd: true,
+            captureScreen: true,
+            captureHistory: true,
+            note: "live capture for restore-after-restart",
+            cmuxVersion: await getCmuxVersion(),
+        });
+    } catch (error) {
+        logger.warn({ error }, "[restore-after-restart] live capture failed, using current autosave");
+        const session = readAutosaveSession();
+        return buildOfflineProfile(
+            session,
+            { ttyCommands: new Map(), surfaceSessions: new Map() },
+            { name: "restart-live", note: "autosave fallback for restore-after-restart" }
+        );
+    }
+}
+
+function capturePreviousProfile(): Profile {
+    const session = readPreviousAutosaveSession();
+    return buildOfflineProfile(
+        session,
+        { ttyCommands: new Map(), surfaceSessions: new Map() },
+        { name: "restart-previous", note: "previous autosave (pre-restart)" }
+    );
+}
+
+async function resolveSource(
+    flags: RestartFlags
+): Promise<{ source: RestoreRestartSource; profileName?: string } | undefined> {
+    const sourceRaw = typeof flags.source === "string" ? flags.source : undefined;
+    let source = parseRestoreSource(sourceRaw);
+    if (!source) {
+        if (!isInteractive()) {
+            out.error(
+                suggestEnumFlag("tools cmux restore-after-restart", "--source", SOURCES, {
+                    given: isMissingEnumFlag(flags.source) ? undefined : sourceRaw,
+                })
+            );
+            process.exitCode = 1;
+            return undefined;
+        }
+
+        source = await withCancel(
+            p.select({
+                message: "Restore from which layout?",
+                options: [
+                    { value: "previous", label: "previous autosave (what cmux had before last launch)" },
+                    { value: "live", label: "live cmux (current panes)" },
+                    { value: "profile", label: "a named saved profile" },
+                ],
+                initialValue: "previous",
+            })
+        );
+    }
+
+    if (source !== "profile") {
+        return { source };
+    }
+
+    let profileName = flags.profile?.trim();
+    if (!profileName) {
+        if (!isInteractive()) {
+            out.error(
+                `--source profile needs --profile <name>. ${suggestCommand("tools cmux restore-after-restart --source profile --profile crash-20260902-1238")}`
+            );
+            process.exitCode = 1;
+            return undefined;
+        }
+
+        const names = new ProfileStore().list().map((row) => row.name);
+        if (names.length === 0) {
+            throw new Error("No saved profiles.");
+        }
+
+        profileName = await withCancel(
+            p.select({
+                message: "Which profile?",
+                options: names.map((name) => ({ value: name, label: name })),
+            })
+        );
+    }
+
+    return { source, profileName };
+}
+
+async function loadProfile(source: RestoreRestartSource, profileName?: string): Promise<Profile> {
+    if (source === "previous") {
+        return capturePreviousProfile();
+    }
+
+    if (source === "live") {
+        return captureLiveProfile();
+    }
+
+    const store = new ProfileStore();
+    try {
+        return store.read(profileName ?? "");
+    } catch (error) {
+        if (error instanceof ProfileNotFoundError) {
+            throw new Error(error.message);
+        }
+
+        throw error;
+    }
+}
+
+export function registerRestoreAfterRestartCommand(program: Command): void {
+    program
+        .command("restore-after-restart")
+        .description(
+            "Restore cmux panes after a restart: previous autosave, live capture, or a named profile, with Claude/Grok/Codex resume inference"
+        )
+        .option("--source [source]", "previous | live | profile")
+        .option("--profile <name>", "Named profile (with --source profile)")
+        .option("--agents [list]", "Comma list: claude,grok,codex (default all)")
+        .option("--enter", "Press Enter after typing each resume command")
+        .option("--no-replay", "Only cd into cwd, do not type resume commands")
+        .option("--prefix <str>", "Workspace name prefix (default restart-)")
+        .option("--list", "Print the layout and inferred commands, then exit")
+        .option("--dry-run", "Print the restore plan without modifying cmux")
+        .option("-y, --yes", "Do not ask for confirmation")
+        .action(async (flags: RestartFlags) => {
+            await runRestoreAfterRestart(flags);
+        });
+}
+
+async function runRestoreAfterRestart(flags: RestartFlags): Promise<void> {
+    p.intro(pc.bgCyan(pc.black(" cmux restore-after-restart ")));
+
+    const resolved = await resolveSource(flags);
+    if (!resolved) {
+        return;
+    }
+    const { source, profileName } = resolved;
+    if (isMissingEnumFlag(flags.agents)) {
+        if (!isInteractive()) {
+            out.error(suggestEnumFlag("tools cmux restore-after-restart", "--agents", ALL_RESTORE_AGENTS));
+            process.exitCode = 1;
+            return;
+        }
+        flags.agents = undefined;
+    }
+
+    let agents = [...ALL_RESTORE_AGENTS];
+    if (typeof flags.agents === "string") {
+        try {
+            agents = parseAgentList(flags.agents);
+        } catch {
+            out.error(
+                suggestEnumFlag("tools cmux restore-after-restart", "--agents", ALL_RESTORE_AGENTS, {
+                    given: flags.agents,
+                })
+            );
+            process.exitCode = 1;
+            return;
+        }
+    }
+
+    if (isInteractive() && !flags.agents && !flags.yes && !flags.list && !flags.dryRun) {
+        agents = await withCancel(
+            p.multiselect({
+                message: "Which agents should get resume commands?",
+                options: [
+                    { value: "claude", label: "Claude Code" },
+                    { value: "grok", label: "Grok" },
+                    { value: "codex", label: "Codex" },
+                ],
+                initialValues: ["claude", "grok", "codex"],
+                required: true,
+            })
+        );
+    }
+
+    let enter = Boolean(flags.enter);
+    if (isInteractive() && flags.enter === undefined && !flags.yes && !flags.list && !flags.dryRun) {
+        enter = await withCancel(p.confirm({ message: "Execute resume commands now (--enter)?", initialValue: false }));
+    }
+
+    const raw = await loadProfile(source, profileName);
+    const inferred = filterReplayByAgents(await prepareProfileForRestore(raw), agents);
+
+    if (flags.list) {
+        out.println(renderProfileTree(inferred));
+        const detail = renderProfileCommandDetail(inferred);
+        if (detail.length > 0) {
+            p.note(detail.join("\n"), "Panes · commands · drift");
+        }
+        p.outro(pc.dim("List only — nothing changed."));
+        return;
+    }
+
+    const opts: RestoreOptions = {
+        prefix: flags.prefix !== undefined ? flags.prefix : "restart-",
+        replay: flags.replay !== false,
+        enter: enter && flags.replay !== false,
+        yes: Boolean(flags.yes),
+        dryRun: Boolean(flags.dryRun),
+    };
+
+    const plan = buildPlan(inferred, opts);
+    const planLines = plan.workspaces.map(
+        (ws) => `  ${pc.cyan(ws.targetTitle)} ${pc.dim(`(${ws.paneCount} pane(s), ${ws.surfaceCount} surface(s))`)}`
+    );
+    p.note(
+        planLines.join("\n") || "(empty profile)",
+        `Restore plan (${source}${profileName ? `: ${profileName}` : ""})`
+    );
+    const detail = renderProfileCommandDetail(inferred);
+    if (detail.length > 0) {
+        p.note(detail.join("\n"), "Panes · commands · drift");
+    }
+
+    if (opts.dryRun) {
+        p.outro(pc.dim("Dry run — nothing changed."));
+        return;
+    }
+
+    if (!opts.yes) {
+        if (!isInteractive()) {
+            out.error(
+                `Pass --yes to skip confirmation. ${suggestCommand("tools cmux restore-after-restart --source previous --yes")}`
+            );
+            process.exitCode = 1;
+            return;
+        }
+
+        const proceed = await withCancel(
+            p.confirm({ message: `Create ${plan.workspaces.length} workspace(s)?`, initialValue: true })
+        );
+        if (!proceed) {
+            p.cancel("Aborted.");
+            return;
+        }
+    }
+
+    await ensureCmuxResponsive("restore-after-restart");
+    const spinner = p.spinner();
+    spinner.start("Recreating workspaces…");
+    const startedAt = Date.now();
+
+    try {
+        const outcome = await restoreProfile(inferred, opts, {
+            onWorkspaceStart: ({ title, index, total }) => {
+                spinner.message(`Restoring ${index}/${total}: ${title}`);
+            },
+        });
+        spinner.stop(`Restored ${outcome.workspaces.length} workspace(s) in ${Date.now() - startedAt} ms`);
+        p.outro(pc.green("Done."));
+        if (opts.enter) {
+            await reportWaitingPrompts(
+                outcome.workspaces.map((w) => w.ref),
+                "Restore"
+            );
+        }
+    } catch (error) {
+        spinner.stop("Restore failed.");
+        logger.error({ error }, "[restore-after-restart] failed");
+        throw error;
+    }
+}

--- a/src/cmux/index.ts
+++ b/src/cmux/index.ts
@@ -17,6 +17,7 @@
 import { registerDoctorCommand } from "@app/cmux/commands/doctor";
 import { registerProfilesCommand } from "@app/cmux/commands/profiles";
 import { registerRescueCommand } from "@app/cmux/commands/rescue";
+import { registerRestoreAfterRestartCommand } from "@app/cmux/commands/restore-after-restart";
 import { registerSendSelfCommand } from "@app/cmux/commands/send-self";
 import { enhanceHelp, runTool } from "@genesiscz/utils/cli";
 import { out } from "@genesiscz/utils/logger";
@@ -35,6 +36,7 @@ program
     .option("-v, --verbose", "Enable debug logging");
 
 registerProfilesCommand(program);
+registerRestoreAfterRestartCommand(program);
 registerSendSelfCommand(program);
 registerDoctorCommand(program);
 registerRescueCommand(program);

--- a/src/cmux/lib/agent-replay.test.ts
+++ b/src/cmux/lib/agent-replay.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, test } from "bun:test";
+import {
+    inferLauncherFromTitle,
+    matchGrokSession,
+    type ReplayCatalog,
+    type ReplayCatalogSession,
+    replayCommandForSurface,
+    withInferredReplayCommands,
+} from "@app/cmux/lib/agent-replay";
+import type { Profile, TerminalSurface } from "@app/cmux/lib/types";
+import { PROFILE_VERSION } from "@app/cmux/lib/types";
+
+const GROK_ID = "01a05cc5-0ecf-7d40-945e-977e45b3f935";
+const CLAUDE_ID = "6bdfb457-cee9-4202-8105-21be8a801757";
+
+function grokSession(overrides: Partial<ReplayCatalogSession> = {}): ReplayCatalogSession {
+    return {
+        kind: "grok",
+        sessionId: GROK_ID,
+        cwd: "/Users/me/Projects/col-fe",
+        title: "PRs merged into release/2026-09-03",
+        ...overrides,
+    };
+}
+
+function claudeSession(overrides: Partial<ReplayCatalogSession> = {}): ReplayCatalogSession {
+    return {
+        kind: "claude",
+        sessionId: CLAUDE_ID,
+        cwd: "/Users/me/Projects/App",
+        title: "Continue",
+        account: "foltyn",
+        ...overrides,
+    };
+}
+
+function catalog(sessions: ReplayCatalogSession[]): ReplayCatalog {
+    return { sessions };
+}
+
+function terminal(title: string, extra: Partial<TerminalSurface> = {}): TerminalSurface {
+    return {
+        type: "terminal",
+        title,
+        cwd: extra.cwd ?? "/Users/me/Projects/col-fe",
+        ...extra,
+    };
+}
+
+describe("inferLauncherFromTitle", () => {
+    test("detects a grok tab even when the live title has a spinner prefix", () => {
+        expect(inferLauncherFromTitle("PRs merged into release/2026-09-03 - grok")).toBe("grok");
+        expect(inferLauncherFromTitle("lukas-messages - grok · 33a9c763")).toBe("grok");
+        expect(inferLauncherFromTitle("⠙ - Waiting for response… - Restore cmux surfaces - grok")).toBe("grok");
+    });
+
+    test("detects Claude Code tabs from the working/idle glyphs", () => {
+        expect(inferLauncherFromTitle("✳ Continue")).toBe("claude");
+        expect(inferLauncherFromTitle("⠐ Task list h_szhk85zs")).toBe("claude");
+        expect(inferLauncherFromTitle("✳ col-297040-burn-auth-callback · 46768bb6")).toBe("claude");
+    });
+
+    test("detects a codex tab from the same suffix shape as grok", () => {
+        expect(inferLauncherFromTitle("Fix mcp login - codex")).toBe("codex");
+        expect(inferLauncherFromTitle("review-auth - codex · a1523c66")).toBe("codex");
+    });
+
+    test("leaves idle shells and other tools alone", () => {
+        expect(inferLauncherFromTitle("Martin@MacBook-Pro:~/Tresors/Projects/App")).toBeUndefined();
+        expect(inferLauncherFromTitle("ncdu /root/security/")).toBeUndefined();
+        expect(inferLauncherFromTitle("tail -f /tmp/*.log")).toBeUndefined();
+    });
+});
+
+describe("matchGrokSession", () => {
+    const sessions = [
+        grokSession(),
+        grokSession({
+            sessionId: "01a05d17-c512-7dd2-abb6-e62d8c7d612a",
+            title: "Worktree bun installs: Skia copy costs 1.4GB",
+        }),
+        grokSession({ sessionId: "01a03d56-e4fe-7cd1-aee4-dbe54aaf53b3", title: "aws-costs", cwd: "/other" }),
+    ];
+
+    test("matches an exact generated title in the same cwd", () => {
+        const hit = matchGrokSession(
+            "PRs merged into release/2026-09-03 - grok",
+            "/Users/me/Projects/col-fe",
+            sessions
+        );
+        expect(hit?.sessionId).toBe(GROK_ID);
+    });
+
+    test("matches a truncated cmux title against the longer generated title", () => {
+        const hit = matchGrokSession(
+            "Worktree bun installs: Skia copy costs 1… - grok",
+            "/Users/me/Projects/col-fe",
+            sessions
+        );
+        expect(hit?.sessionId).toBe("01a05d17-c512-7dd2-abb6-e62d8c7d612a");
+    });
+
+    test("falls back to a globally unique title when cwd differs", () => {
+        const hit = matchGrokSession("aws-costs - grok", "/Users/me/Projects/App", sessions);
+        expect(hit?.sessionId).toBe("01a03d56-e4fe-7cd1-aee4-dbe54aaf53b3");
+    });
+
+    test("returns nothing for an idle shell title", () => {
+        expect(
+            matchGrokSession("Martin@MacBook-Pro:~/Tresors/Projects/col-fe", "/Users/me/Projects/col-fe", sessions)
+        ).toBeUndefined();
+    });
+});
+
+describe("replayCommandForSurface", () => {
+    test("infers grok -r when the profile only saved a cwd (crash offline capture)", () => {
+        // Regression test: 2026-09-02 — tools cmux profiles restore crash-20260902-1238
+        // only typed `cd` because 30/35 surfaces had no command field.
+        const result = replayCommandForSurface(
+            terminal("PRs merged into release/2026-09-03 - grok"),
+            catalog([grokSession()])
+        );
+        expect(result?.command).toBe(`grok -r ${GROK_ID}`);
+    });
+
+    test("replaces a stale process-table grok -r that belongs to another pane", () => {
+        const result = replayCommandForSurface(
+            terminal("PRs merged into release/2026-09-03 - grok", {
+                command: "grok -r 01a04405-9168-7040-b6e1-3944ff63a604",
+            }),
+            catalog([grokSession()])
+        );
+        expect(result?.command).toBe(`grok -r ${GROK_ID}`);
+    });
+
+    test("enriches a bare grok capture with the session that matches the tab title", () => {
+        const result = replayCommandForSurface(
+            terminal("PRs merged into release/2026-09-03 - grok", { command: "grok" }),
+            catalog([grokSession()])
+        );
+        expect(result?.command).toBe(`grok -r ${GROK_ID}`);
+    });
+
+    test("infers a Claude resume from an ✳ tab with no saved command", () => {
+        const result = replayCommandForSurface(
+            terminal("✳ Continue", { cwd: "/Users/me/Projects/App" }),
+            catalog([claudeSession()])
+        );
+        expect(result?.command).toContain("--resume");
+        expect(result?.command).toContain(CLAUDE_ID);
+        expect(result?.command).not.toMatch(/^cd /);
+    });
+
+    test("matches a Claude tab to the session whose first prompt contains the title phrase", () => {
+        const result = replayCommandForSurface(
+            terminal("✳ Task list h_szhk85zs", { cwd: "/Users/me/Projects/App" }),
+            catalog([
+                claudeSession({
+                    title: "230b3ad0",
+                    prompt: "You have been handed a task list. Call the genesis-tools MCP tool",
+                    sessionId: "230b3ad0-e4a3-48de-ab54-6f97130aa351",
+                }),
+            ])
+        );
+        expect(result?.command).toContain("230b3ad0-e4a3-48de-ab54-6f97130aa351");
+    });
+
+    test("does not invent a command for ncdu, ssh, or an idle shell", () => {
+        const sessions = catalog([grokSession(), claudeSession()]);
+        expect(replayCommandForSurface(terminal("ncdu /root/security/"), sessions)?.command).toBeUndefined();
+        expect(
+            replayCommandForSurface(terminal("Martin@MacBook-Pro:~/Tresors/Projects/col-fe"), sessions)?.command
+        ).toBeUndefined();
+        expect(
+            replayCommandForSurface(terminal("-=*[ROOT]*=- | root@de:~ | 125x25 | pts/0"), sessions)?.command
+        ).toBeUndefined();
+    });
+
+    test("discards a stale grok capture on a Claude tab and infers the Claude resume", () => {
+        const result = replayCommandForSurface(
+            terminal("✳ Task list h_szhk85zs", {
+                cwd: "/Users/me/Projects/App",
+                command: "grok",
+            }),
+            catalog([claudeSession({ title: "Task list h_szhk85zs" })])
+        );
+        expect(result?.command).toContain(CLAUDE_ID);
+        expect(result?.command).toContain("claude");
+        expect(result?.command).not.toMatch(/^grok\b/);
+    });
+
+    test("does not type grok into a Claude tab when no session matches", () => {
+        const result = replayCommandForSurface(
+            terminal("✳ Task list h_szhk85zs", { cwd: "/Users/me/Projects/App", command: "grok" }),
+            catalog([])
+        );
+        expect(result?.command).toBeUndefined();
+    });
+
+    test("infers a Codex resume from a - codex tab with no saved command", () => {
+        const result = replayCommandForSurface(
+            terminal("Fix mcp login - codex", { cwd: "/Users/me/Projects/shop" }),
+            catalog([
+                {
+                    kind: "codex",
+                    sessionId: "01a067d4-d2b0-7532-8f59-9af2a29c2d0e",
+                    cwd: "/Users/me/Projects/shop",
+                    title: "Fix mcp login",
+                },
+            ])
+        );
+        expect(result?.command).toBe("codex resume 01a067d4-d2b0-7532-8f59-9af2a29c2d0e");
+    });
+
+    test("a journal entry never resurrects an agent on a pane that is now a plain shell", () => {
+        // The surface ran a Claude session days ago; it is an idle shell now, so
+        // there is no agent evidence and nothing may be typed into it.
+        const result = replayCommandForSurface(
+            terminal("alice@host:~/Projects/shop"),
+            catalog([]),
+            claudeSession({ title: "alice@host:~/Projects/shop", cwd: "/Users/me/Projects/shop" })
+        );
+        expect(result.command).toBeUndefined();
+    });
+
+    test("the journal's own session id beats a fuzzy title match on another session", () => {
+        // Journal says A; an older session B in the same cwd carries the same
+        // customTitle under a different account. B used to win, so restore
+        // resumed the wrong session under the wrong account.
+        const journal = claudeSession({
+            sessionId: "aaaaaaaa-1111-4111-8111-111111111111",
+            account: "work",
+            title: "✳ fix the snapshot bug",
+            cwd: "/Users/me/Projects/App",
+        });
+        const result = replayCommandForSurface(
+            terminal("✳ fix the snapshot bug", { cwd: "/Users/me/Projects/App" }),
+            catalog([
+                claudeSession({
+                    sessionId: "bbbbbbbb-2222-4222-8222-222222222222",
+                    account: "personal",
+                    title: "fix the snapshot bug",
+                    cwd: "/Users/me/Projects/App",
+                }),
+            ]),
+            journal
+        );
+        expect(result.command).toContain("aaaaaaaa-1111-4111-8111-111111111111");
+        expect(result.command).toContain("work");
+        expect(result.drift.some((d) => d.includes("journal"))).toBe(true);
+    });
+
+    test("a Claude journal id is never typed into a grok tab", () => {
+        // `refactor the cache layer - grok` is a grok tab; the only session on
+        // hand is a Claude one from the surface journal, so nothing is typed.
+        const result = replayCommandForSurface(
+            terminal("refactor the cache layer - grok"),
+            catalog([]),
+            claudeSession({ title: "refactor the cache layer - grok" })
+        );
+        expect(result.command).toBeUndefined();
+    });
+
+    test("keeps a non-agent command that was actually captured", () => {
+        const result = replayCommandForSurface(
+            terminal("vim notes.md", { command: "vim notes.md", command_source: "foreground" }),
+            catalog([grokSession()])
+        );
+        expect(result?.command).toBe("vim notes.md");
+    });
+});
+
+function profileWith(surfaces: TerminalSurface[]): Profile {
+    return {
+        version: PROFILE_VERSION,
+        name: "crash",
+        scope: "all",
+        captured_at: "2026-09-02T10:38:00.000Z",
+        cmux_version: "offline",
+        windows: [
+            {
+                ref: "window:1",
+                title: "Window 1",
+                container_frame: { width: 100, height: 100 },
+                workspaces: [
+                    {
+                        ref: "workspace:1",
+                        title: "ws",
+                        selected: true,
+                        panes: [
+                            {
+                                ref: "pane:1",
+                                index: 0,
+                                columns: 80,
+                                rows: 24,
+                                pixel_frame: { x: 0, y: 0, width: 80, height: 24 },
+                                selected_surface_index: 0,
+                                surfaces,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+describe("withInferredReplayCommands", () => {
+    test("fills missing commands on a saved profile without rewriting non-agent panes", () => {
+        const profile = profileWith([
+            terminal("PRs merged into release/2026-09-03 - grok"),
+            terminal("ncdu /root/security/"),
+            terminal("✳ Continue", { cwd: "/Users/me/Projects/App" }),
+        ]);
+
+        const enriched = withInferredReplayCommands(profile, catalog([grokSession(), claudeSession()]));
+        const surfaces = enriched.windows[0].workspaces[0].panes[0].surfaces;
+        const grok = surfaces[0];
+        const ncdu = surfaces[1];
+        const claude = surfaces[2];
+
+        expect(grok.type).toBe("terminal");
+        if (grok.type === "terminal") {
+            expect(grok.command).toBe(`grok -r ${GROK_ID}`);
+            expect(grok.command_source).toBe("inferred");
+        }
+
+        expect(ncdu.type).toBe("terminal");
+        if (ncdu.type === "terminal") {
+            expect(ncdu.command).toBeUndefined();
+        }
+
+        expect(claude.type).toBe("terminal");
+        if (claude.type === "terminal") {
+            expect(claude.command).toContain(CLAUDE_ID);
+            expect(claude.command_source).toBe("inferred");
+        }
+    });
+
+    test("keeps the session id the saved command already pins over a fuzzy title match", () => {
+        // Snapshot pinned session A from the surface journal. Session B carries
+        // the same title in the same cwd, so the fuzzy matcher picks B and used
+        // to splice B's id into the pane restore types.
+        const pinned = "aaaaaaaa-1111-4111-8111-111111111111";
+        const decoy = "bbbbbbbb-2222-4222-8222-222222222222";
+        const profile = profileWith([
+            terminal("✳ fix the snapshot bug", {
+                cwd: "/Users/me/Projects/App",
+                command: `claude --resume ${pinned}`,
+                command_source: "foreground",
+            }),
+        ]);
+
+        const enriched = withInferredReplayCommands(
+            profile,
+            catalog([
+                claudeSession({
+                    sessionId: decoy,
+                    title: "fix the snapshot bug",
+                    cwd: "/Users/me/Projects/App",
+                    account: "personal",
+                }),
+            ])
+        );
+        const surface = enriched.windows[0].workspaces[0].panes[0].surfaces[0];
+
+        expect(surface.type).toBe("terminal");
+        if (surface.type === "terminal") {
+            expect(surface.command).toBe(`claude --resume ${pinned}`);
+            expect(surface.command).not.toContain(decoy);
+            expect(surface.command_original).toBeUndefined();
+        }
+    });
+});

--- a/src/cmux/lib/agent-replay.ts
+++ b/src/cmux/lib/agent-replay.ts
@@ -1,0 +1,431 @@
+import { homedir } from "node:os";
+import { loadPins } from "@app/claude/lib/cmux/pins";
+import { getSessionListing } from "@app/claude/lib/history/search";
+import {
+    agentKindFromLauncher,
+    deriveReplayCommand,
+    isAgentLauncher,
+    resumeTargetFromCommand,
+} from "@app/cmux/lib/command-capture";
+import type { Profile, TerminalSurface } from "@app/cmux/lib/types";
+import { listCodexSessionsFromRoots } from "@genesiscz/utils/agent-sessions/codex-sessions";
+import { grokSessionsRoot, listGrokSessionsFromRoot } from "@genesiscz/utils/agent-sessions/grok-sessions";
+import { resumeCommandLine } from "@genesiscz/utils/agent-sessions/resume-argv";
+import type { AgentKind } from "@genesiscz/utils/agent-sessions/types";
+import { nativeSessionRoots } from "@genesiscz/utils/providers/session-paths";
+
+export type { AgentKind };
+
+export interface ReplayCatalogSession {
+    kind: AgentKind;
+    sessionId: string;
+    cwd: string;
+    title: string;
+    account?: string | null;
+    /** First user prompt; used when Claude Code never stored a customTitle. */
+    prompt?: string | null;
+}
+
+export interface ReplayCatalog {
+    sessions: ReplayCatalogSession[];
+}
+
+const SPINNER_PREFIX = /^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✳⠐●○]\s*/u;
+
+export function inferLauncherFromTitle(title: string): AgentKind | undefined {
+    if (/\s-\s+grok\b/i.test(title) || /\bgrok\s*$/i.test(title.trim())) {
+        return "grok";
+    }
+
+    if (/\s-\s+codex\b/i.test(title) || /\bcodex\s*$/i.test(title.trim())) {
+        return "codex";
+    }
+
+    if (/^[✳⠐]/.test(title.trim())) {
+        return "claude";
+    }
+
+    return undefined;
+}
+
+function stripGrokSuffix(title: string): string {
+    return title.replace(/\s+-\s+grok(?:\s+·\s+[0-9a-f]{7,8})?\s*$/i, "").trim();
+}
+
+function stripCodexSuffix(title: string): string {
+    return title.replace(/\s+-\s+codex(?:\s+·\s+[0-9a-f]{7,8})?\s*$/i, "").trim();
+}
+
+function stripClaudeGlyph(title: string): string {
+    return title
+        .replace(SPINNER_PREFIX, "")
+        .replace(/\s+·\s+[0-9a-f]{7,8}\s*$/i, "")
+        .trim();
+}
+
+function stripEllipsis(value: string): string {
+    return value.replace(/(\u2026|\.{2,}|…)+$/u, "").trim();
+}
+
+/** Keys to try against a generated session title, most specific first. */
+export function titleMatchKeys(title: string, kind: AgentKind): string[] {
+    const base =
+        kind === "grok" ? stripGrokSuffix(title) : kind === "codex" ? stripCodexSuffix(title) : stripClaudeGlyph(title);
+    const stripped = stripEllipsis(base.replace(SPINNER_PREFIX, "").trim());
+    const parts = stripped
+        .split(/\s+-\s+/)
+        .map((part) => stripEllipsis(part).toLowerCase())
+        .filter((part) => part.length >= 4);
+    const full = stripped.toLowerCase();
+    const keys = [...parts].reverse();
+
+    if (full.length >= 4) {
+        keys.push(full);
+    }
+
+    return [...new Set(keys)];
+}
+
+function sessionMatchesKey(session: ReplayCatalogSession, key: string): boolean {
+    const title = session.title.trim().toLowerCase();
+    if (!key) {
+        return false;
+    }
+
+    if (title === key) {
+        return true;
+    }
+
+    if (key.length >= 12 && title.startsWith(key)) {
+        return true;
+    }
+
+    const prompt = session.prompt?.toLowerCase() ?? "";
+    if (!prompt) {
+        return false;
+    }
+
+    const words = key.split(/\s+/).filter((word) => word.length >= 4);
+    if (words.length < 2) {
+        return false;
+    }
+
+    return prompt.includes(words.slice(0, 2).join(" "));
+}
+
+function pickUnique(hits: ReplayCatalogSession[]): ReplayCatalogSession | undefined {
+    if (hits.length === 1) {
+        return hits[0];
+    }
+
+    if (hits.length === 0) {
+        return undefined;
+    }
+
+    const ids = new Set(hits.map((hit) => hit.sessionId));
+    if (ids.size === 1) {
+        return hits[0];
+    }
+
+    return undefined;
+}
+
+export function matchGrokSession(
+    title: string,
+    cwd: string | undefined,
+    sessions: ReplayCatalogSession[]
+): ReplayCatalogSession | undefined {
+    return matchAgentSession("grok", title, cwd, sessions);
+}
+
+export function matchClaudeSession(
+    title: string,
+    cwd: string | undefined,
+    sessions: ReplayCatalogSession[]
+): ReplayCatalogSession | undefined {
+    return matchAgentSession("claude", title, cwd, sessions);
+}
+
+export function matchCodexSession(
+    title: string,
+    cwd: string | undefined,
+    sessions: ReplayCatalogSession[]
+): ReplayCatalogSession | undefined {
+    return matchAgentSession("codex", title, cwd, sessions);
+}
+
+function matchAgentSession(
+    kind: AgentKind,
+    title: string,
+    cwd: string | undefined,
+    sessions: ReplayCatalogSession[]
+): ReplayCatalogSession | undefined {
+    if (inferLauncherFromTitle(title) !== kind) {
+        return undefined;
+    }
+
+    const keys = titleMatchKeys(title, kind);
+    const pool = sessions.filter((session) => session.kind === kind);
+    const inCwd = cwd ? pool.filter((session) => session.cwd === cwd) : pool;
+
+    for (const key of keys) {
+        const local = pickUnique(inCwd.filter((session) => sessionMatchesKey(session, key)));
+        if (local) {
+            return local;
+        }
+    }
+
+    if (cwd) {
+        for (const key of keys) {
+            const global = pickUnique(pool.filter((session) => sessionMatchesKey(session, key)));
+            if (global) {
+                return global;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+function inferredResumeCommand(hit: ReplayCatalogSession): string {
+    return resumeCommandLine(hit.kind, hit.sessionId, hit.account);
+}
+
+/**
+ * The session the saved command already resumes, as a catalog entry.
+ *
+ * Snapshot resolves each pane's session from the cmux surface journal and pins
+ * it into the command. Restore reads a profile file, which stores no surface
+ * uuid, so that pinned id is the only journal evidence left for the pane.
+ * Without it every restore fell back to fuzzy title/prompt matching and could
+ * splice a different session's id into the terminal.
+ */
+function pinnedSessionForSurface(
+    surface: Pick<TerminalSurface, "title" | "cwd" | "command">
+): ReplayCatalogSession | undefined {
+    const command = surface.command?.trim();
+
+    if (!command) {
+        return undefined;
+    }
+
+    const kind = agentKindFromLauncher(command);
+    const sessionId = resumeTargetFromCommand(command);
+
+    if (!kind || !sessionId) {
+        return undefined;
+    }
+
+    return { kind, sessionId, cwd: surface.cwd ?? "", title: surface.title };
+}
+
+export function replayCommandForSurface(
+    surface: Pick<TerminalSurface, "title" | "cwd" | "command">,
+    catalog: ReplayCatalog,
+    preferred?: ReplayCatalogSession
+): { command?: string; drift: string[] } {
+    const captured = surface.command?.trim();
+    const launcher = inferLauncherFromTitle(surface.title);
+    const capturedKind = captured ? agentKindFromLauncher(captured) : undefined;
+    // A crash capture often attributes the surviving grok tty to a Claude tab.
+    // The tab title is the identity; a mismatched launcher is discarded.
+    const original = captured && capturedKind && launcher && capturedKind !== launcher ? undefined : captured;
+
+    if (original && !isAgentLauncher(original)) {
+        return { command: original, drift: [] };
+    }
+
+    // What kind of agent this pane actually shows. With neither an agent title
+    // nor an agent launcher on the tty there is no evidence any agent runs here,
+    // and `preferred` (a journal entry that can be a week old) must not
+    // synthesise a resume command for what is now a plain shell.
+    const kind = launcher ?? capturedKind;
+
+    // The journal knows THIS surface's own session id, so it beats a fuzzy
+    // title/prompt match against every session on the machine. It is trusted
+    // only for the kind of agent the pane shows: a claude journal id typed into
+    // `grok -r` names a session grok has never seen.
+    const journal = kind && preferred?.kind === kind ? preferred : undefined;
+    const hit =
+        journal ??
+        (kind === "grok" ? matchGrokSession(surface.title, surface.cwd, catalog.sessions) : undefined) ??
+        (kind === "claude" ? matchClaudeSession(surface.title, surface.cwd, catalog.sessions) : undefined) ??
+        (kind === "codex" ? matchCodexSession(surface.title, surface.cwd, catalog.sessions) : undefined);
+
+    if (!hit) {
+        if (original) {
+            return { command: original, drift: [] };
+        }
+
+        return { command: undefined, drift: [] };
+    }
+
+    if (original && isAgentLauncher(original)) {
+        return deriveReplayCommand({ original, sessionId: hit.sessionId, account: hit.account ?? undefined });
+    }
+
+    if (hit.kind === "grok" || hit.kind === "codex") {
+        return deriveReplayCommand({ original: hit.kind, sessionId: hit.sessionId });
+    }
+
+    const source = hit === journal ? "the session journal for this pane" : `tab title "${hit.title}"`;
+
+    return {
+        command: inferredResumeCommand(hit),
+        drift: [`inferred ${hit.kind} resume ${hit.sessionId} from ${source}`],
+    };
+}
+
+export function withInferredReplayCommands(profile: Profile, catalog: ReplayCatalog): Profile {
+    return {
+        ...profile,
+        windows: profile.windows.map((window) => ({
+            ...window,
+            workspaces: window.workspaces.map((workspace) => ({
+                ...workspace,
+                panes: workspace.panes.map((pane) => ({
+                    ...pane,
+                    surfaces: pane.surfaces.map((surface) => {
+                        if (surface.type !== "terminal") {
+                            return surface;
+                        }
+
+                        const resolved = replayCommandForSurface(surface, catalog, pinnedSessionForSurface(surface));
+                        if (!resolved.command) {
+                            const launcher = inferLauncherFromTitle(surface.title);
+                            const saved = surface.command?.trim();
+                            if (launcher && saved && isAgentLauncher(saved)) {
+                                const savedKind = agentKindFromLauncher(saved);
+                                if (savedKind !== launcher) {
+                                    return {
+                                        ...surface,
+                                        command: undefined,
+                                        command_original: saved,
+                                        command_source: undefined,
+                                        drift: [`discarded stale ${savedKind} capture on a ${launcher} tab`],
+                                    };
+                                }
+                            }
+
+                            return surface;
+                        }
+
+                        if (resolved.command === surface.command) {
+                            return surface;
+                        }
+
+                        return {
+                            ...surface,
+                            command: resolved.command,
+                            command_source: surface.command ? surface.command_source : "inferred",
+                            command_original: surface.command,
+                            drift: resolved.drift.length > 0 ? resolved.drift : surface.drift,
+                        };
+                    }),
+                })),
+            })),
+        })),
+    };
+}
+
+export function grokSessionsDir(): string {
+    return grokSessionsRoot();
+}
+
+export function loadGrokCatalog(cwds: string[], sessionsRoot: string = grokSessionsDir()): ReplayCatalogSession[] {
+    const unique = new Set(cwds.filter((cwd) => cwd.length > 0));
+    if (unique.size === 0) {
+        return [];
+    }
+
+    return listGrokSessionsFromRoot(sessionsRoot)
+        .filter((session) => unique.has(session.cwd))
+        .map((session) => ({
+            kind: "grok" as const,
+            sessionId: session.sessionId,
+            cwd: session.cwd,
+            title: session.title,
+            prompt: session.prompt,
+        }));
+}
+
+export function loadCodexCatalog(
+    cwds: string[],
+    roots: string[] = nativeSessionRoots("codex", homedir())
+): ReplayCatalogSession[] {
+    const unique = new Set(cwds.filter((cwd) => cwd.length > 0));
+    if (unique.size === 0) {
+        return [];
+    }
+
+    return listCodexSessionsFromRoots(roots)
+        .filter((session) => unique.has(session.cwd))
+        .map((session) => ({
+            kind: "codex" as const,
+            sessionId: session.sessionId,
+            cwd: session.cwd,
+            title: session.title,
+            prompt: session.prompt,
+        }));
+}
+
+export async function loadClaudeCatalog(): Promise<ReplayCatalogSession[]> {
+    const listing = await getSessionListing({ excludeSubagents: true });
+    const pins = await loadPins({ readOnly: true });
+    const out: ReplayCatalogSession[] = [];
+
+    for (const record of listing.sessions) {
+        if (!record.sessionId || !record.cwd) {
+            continue;
+        }
+
+        const pin = pins.get(record.sessionId);
+        const title = record.customTitle || record.summary || "";
+        out.push({
+            kind: "claude",
+            sessionId: record.sessionId,
+            cwd: record.cwd,
+            title: title || record.sessionId.slice(0, 8),
+            account: pin?.account ?? undefined,
+            prompt: record.firstPrompt ?? undefined,
+        });
+    }
+
+    return out;
+}
+
+export function collectProfileCwds(profile: Profile): string[] {
+    const cwds: string[] = [];
+
+    for (const window of profile.windows) {
+        for (const workspace of window.workspaces) {
+            if (workspace.current_directory) {
+                cwds.push(workspace.current_directory);
+            }
+
+            for (const pane of workspace.panes) {
+                for (const surface of pane.surfaces) {
+                    if (surface.type === "terminal" && surface.cwd) {
+                        cwds.push(surface.cwd);
+                    }
+                }
+            }
+        }
+    }
+
+    return cwds;
+}
+
+export async function loadReplayCatalog(profile: Profile): Promise<ReplayCatalog> {
+    const cwds = collectProfileCwds(profile);
+    const grok = loadGrokCatalog(cwds);
+    const claude = await loadClaudeCatalog();
+    const codex = loadCodexCatalog(cwds);
+
+    return { sessions: [...grok, ...claude, ...codex] };
+}
+
+export async function prepareProfileForRestore(profile: Profile): Promise<Profile> {
+    const catalog = await loadReplayCatalog(profile);
+    return withInferredReplayCommands(profile, catalog);
+}

--- a/src/cmux/lib/autosave.previous.test.ts
+++ b/src/cmux/lib/autosave.previous.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { listAutosaveFiles, readAutosaveFile, readPreviousAutosaveSession } from "./autosave";
+
+describe("listAutosaveFiles", () => {
+    test("splits current vs previous session files", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "cmux-autosave-"));
+        mkdirSync(dir, { recursive: true });
+        await Bun.write(join(dir, "session-app.json"), SafeJSON.stringify({ windows: [] }));
+        await Bun.write(
+            join(dir, "session-app-previous.json"),
+            SafeJSON.stringify({ windows: [{ tabManager: { workspaces: [] } }] })
+        );
+        await Bun.write(join(dir, "session-app-previous-backup.json"), SafeJSON.stringify({ windows: [] }));
+
+        const current = listAutosaveFiles(dir, "current").map((f) => f.path.split("/").pop());
+        const previous = listAutosaveFiles(dir, "previous").map((f) => f.path.split("/").pop());
+        expect(current).toContain("session-app.json");
+        expect(current).toContain("session-app-previous-backup.json");
+        expect(previous).toEqual(["session-app-previous.json"]);
+        expect(readPreviousAutosaveSession(dir).windows).toHaveLength(1);
+    });
+
+    test("readAutosaveFile treats null JSON as empty windows", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "cmux-autosave-"));
+        const path = join(dir, "session-app.json");
+        await Bun.write(path, "null");
+        expect(readAutosaveFile(path).windows).toEqual([]);
+    });
+});

--- a/src/cmux/lib/autosave.ts
+++ b/src/cmux/lib/autosave.ts
@@ -65,25 +65,56 @@ export function autosaveDir(): string {
     return join(homedir(), "Library", "Application Support", "cmux");
 }
 
-/** Newest `session-*.json` in the autosave dir, parsed. Throws when none exists. */
-export function readAutosaveSession(dir: string = autosaveDir()): AutosaveSession {
-    const candidates = readdirSync(dir)
-        .filter((name) => name.startsWith("session-") && name.endsWith(".json") && !name.includes("-previous"))
+export function listAutosaveFiles(
+    dir: string = autosaveDir(),
+    which: "current" | "previous"
+): Array<{ path: string; mtimeMs: number }> {
+    return readdirSync(dir)
+        .filter((name) => name.startsWith("session-") && name.endsWith(".json"))
+        .filter((name) => {
+            const previous = name.endsWith("-previous.json");
+            return which === "previous" ? previous : !previous;
+        })
         .map((name) => {
             const path = join(dir, name);
             return { path, mtimeMs: statSync(path).mtimeMs };
         })
         .sort((a, b) => b.mtimeMs - a.mtimeMs);
+}
 
-    const newest = candidates[0];
+export function readAutosaveFile(path: string, mtimeMs?: number): AutosaveSession {
+    const raw = SafeJSON.parse(readFileSync(path, "utf8"), { strict: true });
+    const savedAtMs = mtimeMs ?? statSync(path).mtimeMs;
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+        logger.warn({ path }, "[cmux-autosave] ignored non-object autosave");
+        return { path, savedAtMs, windows: [] };
+    }
+
+    const windows = Array.isArray((raw as { windows?: unknown }).windows)
+        ? (raw as { windows: AutosaveWindow[] }).windows
+        : [];
+    logger.debug({ path, windows: windows.length }, "[cmux-autosave] loaded");
+    return { path, savedAtMs, windows };
+}
+
+/** Newest `session-*.json` in the autosave dir, parsed. Throws when none exists. */
+export function readAutosaveSession(dir: string = autosaveDir()): AutosaveSession {
+    const newest = listAutosaveFiles(dir, "current")[0];
     if (!newest) {
         throw new Error(`No cmux autosave session file found in ${dir}`);
     }
 
-    const raw = SafeJSON.parse(readFileSync(newest.path, "utf8"), { strict: true }) as { windows?: AutosaveWindow[] };
-    const windows = raw.windows ?? [];
-    logger.debug({ path: newest.path, windows: windows.length }, "[cmux-autosave] loaded");
-    return { path: newest.path, savedAtMs: newest.mtimeMs, windows };
+    return readAutosaveFile(newest.path, newest.mtimeMs);
+}
+
+/** The file cmux renamed aside on last launch (`*-previous.json`). */
+export function readPreviousAutosaveSession(dir: string = autosaveDir()): AutosaveSession {
+    const newest = listAutosaveFiles(dir, "previous")[0];
+    if (!newest) {
+        throw new Error(`No cmux previous-autosave file found in ${dir}`);
+    }
+
+    return readAutosaveFile(newest.path, newest.mtimeMs);
 }
 
 /** panel id (== live surface uuid == CMUX_SURFACE_ID) → panel, across all windows/workspaces. */

--- a/src/cmux/lib/command-capture.test.ts
+++ b/src/cmux/lib/command-capture.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { cleanLaunchCommand, deriveReplayCommand } from "@app/cmux/lib/command-capture";
+import {
+    agentKindFromLauncher,
+    cleanLaunchCommand,
+    deriveReplayCommand,
+    isAgentLauncher,
+} from "@app/cmux/lib/command-capture";
 
 describe("cleanLaunchCommand", () => {
     test("strips the bun wrapper down to `tools`", () => {
-        expect(cleanLaunchCommand("bun /Users/Martin/Projects/GenesisTools/tools cc run martin --resume burn")).toBe(
-            "tools cc run martin --resume burn"
+        expect(cleanLaunchCommand("bun /Users/x/Projects/GenesisTools/tools cc run a --resume burn")).toBe(
+            "tools cc run a --resume burn"
         );
         expect(cleanLaunchCommand("/Users/x/.bun/bin/bun run /repo/tools cc run a")).toBe("tools cc run a");
     });
@@ -21,9 +26,34 @@ describe("cleanLaunchCommand", () => {
 describe("deriveReplayCommand", () => {
     const sessionId = "aa45fee8-9a3b-4745-83d2-89a4445092b7";
 
-    test("non-claude commands pass through with no drift", () => {
-        const result = deriveReplayCommand({ original: "grok --resume", sessionId, account: "work" });
-        expect(result.command).toBe("grok --resume");
+    test("vim and other non-agent commands pass through with no drift", () => {
+        // Regression test: 2026-09-02 — grok used to be in this bucket, so restore
+        // typed `grok` (or nothing) instead of `grok -r <session>`.
+        const result = deriveReplayCommand({ original: "vim notes.md", sessionId, account: "work" });
+        expect(result.command).toBe("vim notes.md");
+        expect(result.drift).toEqual([]);
+    });
+
+    test("bare grok gets -r <session> so restore resumes the same conversation", () => {
+        const result = deriveReplayCommand({ original: "grok", sessionId });
+        expect(result.command).toBe(`grok -r ${sessionId}`);
+        expect(result.drift.some((d) => d.includes(sessionId))).toBe(true);
+    });
+
+    test("grok --resume without an id is pinned to the session that ran here", () => {
+        const result = deriveReplayCommand({ original: "grok --resume", sessionId });
+        expect(result.command).toBe(`grok --resume ${sessionId}`);
+    });
+
+    test("grok -r with the wrong id is replaced", () => {
+        const result = deriveReplayCommand({ original: "grok -r old-session", sessionId });
+        expect(result.command).toBe(`grok -r ${sessionId}`);
+        expect(result.drift.some((d) => d.includes("old-session"))).toBe(true);
+    });
+
+    test("grok already resuming the right session passes through with no drift", () => {
+        const result = deriveReplayCommand({ original: `grok -r ${sessionId}`, sessionId });
+        expect(result.command).toBe(`grok -r ${sessionId}`);
         expect(result.drift).toEqual([]);
     });
 
@@ -50,7 +80,7 @@ describe("deriveReplayCommand", () => {
         expect(result.drift.some((d) => d.includes("account"))).toBe(false);
     });
 
-    test("`tools claude run` keeps its explicit account, same as `tools cc run`", () => {
+    test("`tools claude run` keeps its explicit account and its own launcher spelling", () => {
         // The launcher test accepted both spellings while the account parser only
         // matched `tools cc run`, so `tools claude run personal` silently replayed
         // under the journal account and the drift line claimed there had been none.
@@ -59,8 +89,61 @@ describe("deriveReplayCommand", () => {
             sessionId,
             account: "work",
         });
-        expect(result.command).toBe(`tools cc run personal -- --resume ${sessionId}`);
+        expect(result.command).toBe(`tools claude run personal -- --resume ${sessionId}`);
         expect(result.drift.some((d) => d.includes("account"))).toBe(false);
+    });
+
+    test("every other flag the user typed survives the replay", () => {
+        // `tools cc run work --model opus --verbose` used to restore as
+        // `tools cc run work -- --resume <id>`: the model and the verbosity were
+        // gone, and the only drift note said the command had been "rewritten".
+        const result = deriveReplayCommand({
+            original: "tools cc run work --model opus --verbose",
+            sessionId,
+            account: "work",
+        });
+
+        expect(result.command).toBe(`tools cc run work --model opus --verbose -- --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes("rewritten"))).toBe(false);
+    });
+
+    test("an existing passthrough tail is kept and the resume joins it", () => {
+        const result = deriveReplayCommand({
+            original: "tools cc run work -- --dangerously-skip-permissions",
+            sessionId,
+            account: "work",
+        });
+
+        expect(result.command).toBe(`tools cc run work -- --dangerously-skip-permissions --resume ${sessionId}`);
+    });
+
+    test("a resume already after -- is pinned in place, and the right one is left alone", () => {
+        expect(
+            deriveReplayCommand({
+                original: "tools cc run work --model opus -- --resume burn",
+                sessionId,
+                account: "work",
+            }).command
+        ).toBe(`tools cc run work --model opus -- --resume ${sessionId}`);
+
+        const unchanged = deriveReplayCommand({
+            original: `tools cc run work --model opus -- --resume ${sessionId}`,
+            sessionId,
+            account: "work",
+        });
+        expect(unchanged.command).toBe(`tools cc run work --model opus -- --resume ${sessionId}`);
+        expect(unchanged.drift).toEqual([]);
+    });
+
+    test("the pinned account is spliced in without losing the flags around it", () => {
+        const result = deriveReplayCommand({
+            original: "tools cc run --model opus",
+            sessionId,
+            account: "work",
+        });
+
+        expect(result.command).toBe(`tools cc run work --model opus -- --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes('account "work" added'))).toBe(true);
     });
 
     test("flags a bare --resume picker being replaced", () => {
@@ -95,6 +178,113 @@ describe("deriveReplayCommand", () => {
         const result = deriveReplayCommand({ original: "tools cc run", sessionId });
         expect(result.command).toBe(`tools cc run -- --resume ${sessionId}`);
         expect(result.drift.some((d) => d.includes("no account recorded"))).toBe(true);
+    });
+
+    test("a -r inside a quoted prompt is left alone, not rewritten mid-string", () => {
+        // The regex matched the flag anywhere after whitespace, so restore typed
+        // `grok -p "explain the -r <uuid>` — an unterminated quote — into the pane.
+        const result = deriveReplayCommand({ original: 'grok -p "explain the -r flag"', sessionId });
+        expect(result.command).toBe(`grok -p "explain the -r flag" -r ${sessionId}`);
+        expect(result.drift.some((d) => d.includes("added"))).toBe(true);
+    });
+
+    test("a --resume mentioned inside a quoted prompt does not count as a resume target", () => {
+        const result = deriveReplayCommand({ original: 'grok --model x -p "use -r or --resume"', sessionId });
+        expect(result.command).toBe(`grok --model x -p "use -r or --resume" -r ${sessionId}`);
+    });
+
+    test("a claude prompt quoting --resume still gets its own flag appended", () => {
+        const result = deriveReplayCommand({ original: 'claude -p "what does --resume do"', sessionId });
+        expect(result.command).toBe(`claude -p "what does --resume do" --resume ${sessionId}`);
+    });
+});
+
+describe("isAgentLauncher", () => {
+    test("recognises the `tools claude start` form this module's own replay emits", () => {
+        // While it did not, a saved `tools claude start … --resume <old>` was
+        // returned verbatim forever: never re-pinned, never discarded.
+        expect(isAgentLauncher("tools claude start work -- --resume abc")).toBe(true);
+        expect(isAgentLauncher("tools cc start work")).toBe(true);
+    });
+
+    test("still refuses a launcher that is only mentioned inside another command", () => {
+        expect(isAgentLauncher("echo tools claude start")).toBe(false);
+    });
+
+    test("recognises grok and codex launchers", () => {
+        expect(isAgentLauncher("grok -r abc")).toBe(true);
+        expect(isAgentLauncher("codex resume abc")).toBe(true);
+        expect(isAgentLauncher("echo grok")).toBe(false);
+    });
+});
+
+describe("deriveReplayCommand on a `tools claude start` original", () => {
+    const sessionId = "aa45fee8-9a3b-4745-83d2-89a4445092b7";
+
+    test("re-pins the resume target and keeps the launcher and account", () => {
+        const result = deriveReplayCommand({
+            original: "tools claude start 'work' -- --resume 'OLD'",
+            sessionId,
+            account: "work",
+        });
+        expect(result.command).toBe(`tools claude start 'work' -- --resume ${sessionId}`);
+        expect(result.drift.some((d) => d.includes("replaced"))).toBe(true);
+    });
+});
+
+describe("deriveReplayCommand for codex", () => {
+    const sessionId = "01a067d4-d2b0-7532-8f59-9af2a29c2d0e";
+
+    test("rewrites a bare codex capture to codex resume <id>", () => {
+        const result = deriveReplayCommand({ original: "codex", sessionId });
+        expect(result.command).toBe(`codex resume ${sessionId}`);
+    });
+
+    test("keeps every flag and splices the resume subcommand in", () => {
+        // The whole command used to be discarded: model, cwd and sandbox mode
+        // all vanished from the restored pane.
+        const result = deriveReplayCommand({ original: "codex --model gpt-5.6 --cd /repo --full-auto", sessionId });
+        expect(result.command).toBe(`codex resume ${sessionId} --model gpt-5.6 --cd /repo --full-auto`);
+    });
+
+    test("re-pins an existing resume target in place", () => {
+        const result = deriveReplayCommand({ original: "codex resume OLD --model gpt-5.6", sessionId });
+        expect(result.command).toBe(`codex resume ${sessionId} --model gpt-5.6`);
+        expect(result.drift.some((entry) => entry.includes("replaced"))).toBe(true);
+    });
+
+    test("fills a bare resume that would open the picker", () => {
+        const result = deriveReplayCommand({ original: "codex resume --model gpt-5.6", sessionId });
+        expect(result.command).toBe(`codex resume ${sessionId} --model gpt-5.6`);
+    });
+
+    test("leaves an already-pinned command untouched", () => {
+        const result = deriveReplayCommand({ original: `codex resume ${sessionId}`, sessionId });
+        expect(result.command).toBe(`codex resume ${sessionId}`);
+        expect(result.drift).toEqual([]);
+    });
+});
+
+describe("agent launchers do not match a hyphenated neighbour", () => {
+    test("codex-gateway is not codex", () => {
+        // `\b` sits between "x" and "-", so `codex-gateway serve` was treated as
+        // a codex launcher and rewritten to `codex resume <uuid>` on restore.
+        expect(isAgentLauncher("codex-gateway serve")).toBe(false);
+        expect(agentKindFromLauncher("codex-gateway serve")).toBeUndefined();
+    });
+
+    test("grok-proxy is not grok", () => {
+        expect(isAgentLauncher("grok-proxy up")).toBe(false);
+    });
+
+    test("claude-monitor is not claude", () => {
+        expect(isAgentLauncher("claude-monitor --watch")).toBe(false);
+    });
+
+    test("the real launchers still match", () => {
+        expect(agentKindFromLauncher("codex resume abc")).toBe("codex");
+        expect(agentKindFromLauncher("grok -r abc")).toBe("grok");
+        expect(agentKindFromLauncher("claude --resume abc")).toBe("claude");
     });
 });
 

--- a/src/cmux/lib/command-capture.ts
+++ b/src/cmux/lib/command-capture.ts
@@ -138,8 +138,141 @@ export interface ReplayDerivation {
 // `tools cc run -- --resume <id>` and the original command was lost. The policy
 // is that a non-Claude command replays verbatim, so an embedded mention is not
 // a launcher.
-const CLAUDE_LAUNCHER = /^(tools cc run|tools claude run|claude)\b/;
-const CC_RUN_LAUNCHER = /^tools (?:cc|claude) run\b/;
+// `tools claude start` is here because agent-replay emits exactly that form for
+// an account-pinned Claude resume. While it was missing, isAgentLauncher said
+// false for a command this code had itself written, so the saved command was
+// returned verbatim forever: never re-pinned to the session that ran there
+// later, and never discarded when the tab turned into a grok tab.
+// `(?![\w-])` rather than `\b`: a word boundary sits between "x" and "-", so
+// `/^codex\b/` also matched `codex-gateway serve`, and that pane was then
+// rewritten into `codex resume <uuid>` on restore.
+const CLAUDE_LAUNCHER = /^(tools cc run|tools claude run|tools (?:cc|claude) start|claude)(?![\w-])/;
+const CC_RUN_LAUNCHER = /^tools (?:cc|claude) run(?![\w-])/;
+const GROK_LAUNCHER = /^grok(?![\w-])/;
+const CODEX_LAUNCHER = /^codex(?![\w-])/;
+
+export function isAgentLauncher(command: string): boolean {
+    const trimmed = command.trim();
+
+    return CLAUDE_LAUNCHER.test(trimmed) || GROK_LAUNCHER.test(trimmed) || CODEX_LAUNCHER.test(trimmed);
+}
+
+export function agentKindFromLauncher(command: string): "claude" | "grok" | "codex" | undefined {
+    const trimmed = command.trim();
+    if (GROK_LAUNCHER.test(trimmed)) {
+        return "grok";
+    }
+    if (CODEX_LAUNCHER.test(trimmed)) {
+        return "codex";
+    }
+    if (CLAUDE_LAUNCHER.test(trimmed)) {
+        return "claude";
+    }
+
+    return undefined;
+}
+
+interface CommandToken {
+    value: string;
+    start: number;
+    end: number;
+}
+
+/**
+ * Split a command line on top-level whitespace, treating a quoted span as one
+ * opaque unit. Quotes are kept in the token so a rewrite can splice the exact
+ * original bytes back.
+ */
+export function tokenizeCommand(command: string): CommandToken[] {
+    const tokens: CommandToken[] = [];
+    let index = 0;
+
+    while (index < command.length) {
+        while (index < command.length && /\s/.test(command[index])) {
+            index++;
+        }
+
+        if (index >= command.length) {
+            break;
+        }
+
+        const start = index;
+        let quote: string | undefined;
+
+        while (index < command.length) {
+            const char = command[index];
+
+            if (quote) {
+                if (char === quote) {
+                    quote = undefined;
+                }
+
+                index++;
+                continue;
+            }
+
+            if (char === '"' || char === "'") {
+                quote = char;
+                index++;
+                continue;
+            }
+
+            if (/\s/.test(char)) {
+                break;
+            }
+
+            index++;
+        }
+
+        tokens.push({ value: command.slice(start, index), start, end: index });
+    }
+
+    return tokens;
+}
+
+interface ResumeFlagMatch {
+    flag: string;
+    /** The value exactly as written, quotes included. Undefined for a bare flag. */
+    value?: string;
+    start: number;
+    end: number;
+}
+
+/**
+ * Find a resume flag at the TOP LEVEL of the command, never inside a quoted
+ * argument. A regex over the raw string rewrote `grok -p "explain the -r flag"`
+ * into `grok -p "explain the -r <id>` — a mangled command with an unterminated
+ * quote, typed straight into the restored pane.
+ */
+function findResumeFlag(command: string, flags: readonly string[]): ResumeFlagMatch | undefined {
+    const tokens = tokenizeCommand(command);
+
+    for (let i = 0; i < tokens.length; i++) {
+        const token = tokens[i];
+        const flag = flags.find((candidate) => token.value === candidate || token.value.startsWith(`${candidate}=`));
+
+        if (!flag) {
+            continue;
+        }
+
+        if (token.value.length > flag.length) {
+            return { flag, value: token.value.slice(flag.length + 1), start: token.start, end: token.end };
+        }
+
+        const next = tokens[i + 1];
+        if (next && !next.value.startsWith("-")) {
+            return { flag, value: next.value, start: token.start, end: next.end };
+        }
+
+        return { flag, start: token.start, end: token.end };
+    }
+
+    return undefined;
+}
+
+function spliceFlag(original: string, match: ResumeFlagMatch, replacement: string): string {
+    return original.slice(0, match.start) + replacement + original.slice(match.end);
+}
 
 /**
  * Pin the resume target inside the original command without touching anything
@@ -147,29 +280,108 @@ const CC_RUN_LAUNCHER = /^tools (?:cc|claude) run\b/;
  */
 function replaceResumeInPlace(original: string, sessionId: string): ReplayDerivation {
     const drift: string[] = [];
-    const match = original.match(/--resume(?:[= ]("[^"]*"|\S+))?/);
+    const match = findResumeFlag(original, ["--resume"]);
 
     if (!match) {
         drift.push(`--resume ${sessionId} added (session that was active in this pane)`);
         return { command: `${original} --resume ${sessionId}`, drift };
     }
 
-    if (match[1]) {
-        if (match[1].replace(/"/g, "") === sessionId) {
+    if (match.value !== undefined) {
+        if (match.value.replace(/"/g, "") === sessionId) {
             return { command: original, drift };
         }
 
-        drift.push(`resume target "${match[1]}" replaced with the session that was active here`);
+        drift.push(`resume target "${match.value}" replaced with the session that was active here`);
     } else {
         drift.push(`bare --resume (interactive picker) replaced with the concrete session id`);
     }
 
-    return { command: original.replace(match[0], `--resume ${sessionId}`), drift };
+    return { command: spliceFlag(original, match, `--resume ${sessionId}`), drift };
+}
+
+/**
+ * Pin a grok resume target. Grok accepts `-r` and `--resume`; keep whichever
+ * spelling the original used, and default to `-r` (what cmux-agent-resume types).
+ */
+function replaceGrokResume(original: string, sessionId: string): ReplayDerivation {
+    const drift: string[] = [];
+    const match = findResumeFlag(original, ["-r", "--resume"]);
+
+    if (!match) {
+        drift.push(`-r ${sessionId} added (session that was active in this pane)`);
+
+        return { command: `${original} -r ${sessionId}`, drift };
+    }
+
+    const current = match.value?.replace(/"/g, "");
+
+    if (current === sessionId) {
+        return { command: original, drift };
+    }
+
+    if (current !== undefined) {
+        drift.push(`resume target "${current}" replaced with the session that was active here`);
+    } else {
+        drift.push(`bare ${match.flag} (interactive picker) replaced with the concrete session id`);
+    }
+
+    return { command: spliceFlag(original, match, `${match.flag} ${sessionId}`), drift };
+}
+
+/**
+ * Pin a codex resume target. Codex resumes through a `resume <id>` SUBCOMMAND
+ * rather than a flag, so splice that subcommand in right after the launcher and
+ * leave every other flag as typed. Returning a bare `codex resume <id>` dropped
+ * `--model`, `--cd` and `--full-auto` from every restored pane.
+ */
+function replaceCodexResume(original: string, sessionId: string): ReplayDerivation {
+    const tokens = tokenizeCommand(original);
+    const launcher = tokens[0];
+    const next = tokens[1];
+
+    if (!launcher) {
+        return { command: original, drift: [] };
+    }
+
+    if (next?.value === "resume") {
+        const idToken = tokens[2];
+
+        if (!idToken || idToken.value.startsWith("-")) {
+            return {
+                command: `${original.slice(0, next.end)} ${sessionId}${original.slice(next.end)}`,
+                drift: ["bare resume (interactive picker) replaced with the concrete session id"],
+            };
+        }
+
+        if (idToken.value.replace(/"/g, "") === sessionId) {
+            return { command: original, drift: [] };
+        }
+
+        return {
+            command: original.slice(0, idToken.start) + sessionId + original.slice(idToken.end),
+            drift: [`resume target "${idToken.value}" replaced with the session that was active here`],
+        };
+    }
+
+    if (next && !next.value.startsWith("-")) {
+        // Another subcommand (`codex exec`, `codex mcp`): a resume target has no
+        // place inside it, so replay the resume on its own.
+        return {
+            command: `codex resume ${sessionId}`,
+            drift: [`codex resume ${sessionId} (session that was active in this pane)`],
+        };
+    }
+
+    return {
+        command: `${original.slice(0, launcher.end)} resume ${sessionId}${original.slice(launcher.end)}`,
+        drift: [`resume ${sessionId} added (session that was active in this pane)`],
+    };
 }
 
 /**
  * Derive the replay command from the captured original plus what we know about
- * the session that ran in the pane. Non-claude commands pass through untouched.
+ * the session that ran in the pane. Non-agent commands pass through untouched.
  */
 export function deriveReplayCommand(input: {
     original: string;
@@ -177,7 +389,19 @@ export function deriveReplayCommand(input: {
     account?: string;
 }): ReplayDerivation {
     const original = input.original.trim();
-    if (!input.sessionId || !CLAUDE_LAUNCHER.test(original)) {
+    if (!input.sessionId) {
+        return { command: original, drift: [] };
+    }
+
+    if (GROK_LAUNCHER.test(original)) {
+        return replaceGrokResume(original, input.sessionId);
+    }
+
+    if (CODEX_LAUNCHER.test(original)) {
+        return replaceCodexResume(original, input.sessionId);
+    }
+
+    if (!CLAUDE_LAUNCHER.test(original)) {
         return { command: original, drift: [] };
     }
 
@@ -187,39 +411,129 @@ export function deriveReplayCommand(input: {
         return replaceResumeInPlace(original, input.sessionId);
     }
 
+    return replaceCcRunResume(original, input.sessionId, input.account);
+}
+
+/**
+ * The concrete session id an agent command already resumes, or undefined when
+ * the launcher carries no pinned target.
+ *
+ * This is how a save-time journal lookup survives into the profile file. The
+ * journal is keyed by cmux surface uuid, which a saved profile does not store,
+ * so on restore the id inside the command IS the journal record for that pane.
+ */
+export function resumeTargetFromCommand(command: string): string | undefined {
+    const original = command.trim();
+    const kind = agentKindFromLauncher(original);
+
+    if (!kind) {
+        return undefined;
+    }
+
+    if (kind === "codex") {
+        const tokens = tokenizeCommand(original);
+
+        if (tokens[1]?.value !== "resume") {
+            return undefined;
+        }
+
+        const target = tokens[2]?.value.replace(/"/g, "");
+
+        return target && !target.startsWith("-") ? target : undefined;
+    }
+
+    const match = findResumeFlag(original, kind === "grok" ? ["-r", "--resume"] : ["--resume"]);
+
+    if (!match?.value) {
+        return undefined;
+    }
+
+    // cc run's OWN `--resume` takes a search query that can prompt, so only the
+    // pass-through flag after `--` names a session id.
+    if (CC_RUN_LAUNCHER.test(original)) {
+        const separator = passthroughStart(original);
+
+        if (separator === undefined || match.start < separator) {
+            return undefined;
+        }
+    }
+
+    return match.value.replace(/"/g, "");
+}
+
+/** Offset just past a top-level `--` separator, or undefined when there is none. */
+function passthroughStart(command: string): number | undefined {
+    const separator = tokenizeCommand(command).find((token) => token.value === "--");
+
+    return separator?.end;
+}
+
+/**
+ * Pin a `tools cc run` resume target IN PLACE, keeping every other flag the
+ * user typed. Rebuilding the command as `tools cc run <account> -- --resume
+ * <id>` dropped `--model opus`, `--verbose` and the launcher spelling from
+ * every restored pane — the same defect `replaceCodexResume` was fixed for.
+ *
+ * The resume target still lands AFTER `--`, where claude itself reads it: cc
+ * run's own `--resume <query>` runs a local search that can prompt, so it is
+ * not a deterministic replay target. A cc-run-level `--resume` in the original
+ * is therefore removed rather than spliced, and only that flag.
+ */
+function replaceCcRunResume(original: string, sessionId: string, pinnedAccount?: string): ReplayDerivation {
     const drift: string[] = [];
     // Both launcher spellings, or `tools claude run personal` would lose the
     // explicit account and replay under the journal's one (or none) while the
     // drift line claimed the original had no account.
-    const accountInOriginal = original.match(/^tools (?:cc|claude) run\s+(?!-)(\S+)/)?.[1];
-    const account = accountInOriginal ?? input.account;
+    const accountMatch = original.match(/^tools (?:cc|claude) run\s+(?!-)(\S+)/);
+    const account = accountMatch?.[1] ?? pinnedAccount;
+    let command = original;
 
-    if (!accountInOriginal && input.account) {
+    if (!accountMatch && pinnedAccount) {
+        const runToken = tokenizeCommand(command)[2];
         drift.push(
-            `account "${input.account}" added from the session pin journal — the original had none (it may have been picked interactively)`
+            `account "${pinnedAccount}" added from the session pin journal — the original had none (it may have been picked interactively)`
         );
+        command = runToken
+            ? `${command.slice(0, runToken.end)} ${pinnedAccount}${command.slice(runToken.end)}`
+            : `${command} ${pinnedAccount}`;
     }
-
-    const originalResume = original.match(/--resume(?:[= ]("[^"]*"|\S+))?/);
-    if (originalResume?.[1] && originalResume[1].replace(/"/g, "") !== input.sessionId) {
-        drift.push(`resume target "${originalResume[1]}" replaced with the session that was active here`);
-    } else if (!originalResume) {
-        drift.push(`-- --resume ${input.sessionId} added (session that was active in this pane)`);
-    } else if (originalResume && !originalResume[1]) {
-        drift.push(`bare --resume (interactive picker) replaced with the concrete session id`);
-    }
-
-    const command = account
-        ? `tools cc run ${account} -- --resume ${input.sessionId}`
-        : `tools cc run -- --resume ${input.sessionId}`;
 
     if (!account) {
         drift.push("no account recorded for this session — cc run will ask for one");
     }
 
-    if (command !== original && drift.length === 0) {
-        drift.push("command rewritten to the deterministic pass-through resume form");
+    const match = findResumeFlag(command, ["--resume"]);
+    const separator = passthroughStart(command);
+
+    if (match && separator !== undefined && match.start >= separator) {
+        const current = match.value?.replace(/"/g, "");
+
+        if (current === sessionId) {
+            return { command, drift };
+        }
+
+        drift.push(
+            current === undefined
+                ? "bare --resume (interactive picker) replaced with the concrete session id"
+                : `resume target "${current}" replaced with the session that was active here`
+        );
+
+        return { command: spliceFlag(command, match, `--resume ${sessionId}`), drift };
     }
 
-    return { command, drift };
+    if (match) {
+        // cc run's own --resume: drop just that flag, keep everything else.
+        drift.push(
+            match.value === undefined
+                ? "bare --resume (interactive picker) replaced with the concrete session id"
+                : `resume target "${match.value}" replaced with the session that was active here`
+        );
+        command = `${command.slice(0, match.start).trimEnd()}${command.slice(match.end)}`;
+    } else {
+        drift.push(`-- --resume ${sessionId} added (session that was active in this pane)`);
+    }
+
+    const tail = passthroughStart(command) === undefined ? "-- " : "";
+
+    return { command: `${command.trimEnd()} ${tail}--resume ${sessionId}`, drift };
 }

--- a/src/cmux/lib/offline-snapshot.test.ts
+++ b/src/cmux/lib/offline-snapshot.test.ts
@@ -95,4 +95,33 @@ describe("buildOfflinePanes", () => {
             expect(fourth.cwd).toBe("/tmp/four");
         }
     });
+
+    test("infers grok -r from the tab title when the process table is empty", () => {
+        const ws = workspaceFixture();
+        ws.panels[4] = {
+            id: "e",
+            type: "terminal",
+            title: "PRs merged into release/2026-09-03 - grok",
+            directory: "/tmp/four",
+        };
+        const panes = buildOfflinePanes(ws, FRAME, {
+            ttyCommands: new Map(),
+            surfaceSessions: new Map(),
+            grokSessions: [
+                {
+                    kind: "grok",
+                    sessionId: "01a05cc5-0ecf-7d40-945e-977e45b3f935",
+                    cwd: "/tmp/four",
+                    title: "PRs merged into release/2026-09-03",
+                },
+            ],
+        });
+
+        const surface = panes[2].surfaces[0];
+        expect(surface.type).toBe("terminal");
+        if (surface.type === "terminal") {
+            expect(surface.command).toBe("grok -r 01a05cc5-0ecf-7d40-945e-977e45b3f935");
+            expect(surface.command_source).toBe("offline");
+        }
+    });
 });

--- a/src/cmux/lib/offline-snapshot.ts
+++ b/src/cmux/lib/offline-snapshot.ts
@@ -1,15 +1,11 @@
+import { loadGrokCatalog, type ReplayCatalogSession, replayCommandForSurface } from "@app/cmux/lib/agent-replay";
 import {
     type AutosaveSession,
     type AutosaveWorkspace,
     flattenLayout,
     readAutosaveSession,
 } from "@app/cmux/lib/autosave";
-import {
-    collectTtyLaunchCommands,
-    deriveReplayCommand,
-    loadSurfaceSessions,
-    type SurfaceSessionInfo,
-} from "@app/cmux/lib/command-capture";
+import { collectTtyLaunchCommands, loadSurfaceSessions, type SurfaceSessionInfo } from "@app/cmux/lib/command-capture";
 import type { Pane, Profile, Surface, Window, Workspace } from "@app/cmux/lib/types";
 import { PROFILE_VERSION } from "@app/cmux/lib/types";
 import { logger } from "@genesiscz/utils/logger";
@@ -30,6 +26,7 @@ const DEFAULT_CELL_HEIGHT_PX = 17;
 export interface OfflineCaptureDeps {
     ttyCommands: Map<string, string>;
     surfaceSessions: Map<string, SurfaceSessionInfo>;
+    grokSessions?: ReplayCatalogSession[];
 }
 
 export interface OfflineCaptureOptions {
@@ -39,8 +36,18 @@ export interface OfflineCaptureOptions {
 
 export async function captureOfflineProfile(options: OfflineCaptureOptions): Promise<Profile> {
     const session = readAutosaveSession();
+    const cwds = [
+        ...session.windows.flatMap((window) =>
+            window.tabManager.workspaces.flatMap((workspace) => [
+                workspace.currentDirectory ?? "",
+                ...workspace.panels.map((panel) => panel.directory ?? ""),
+            ])
+        ),
+    ];
     const [ttyCommands, surfaceSessions] = await Promise.all([collectTtyLaunchCommands(), loadSurfaceSessions()]);
-    return buildOfflineProfile(session, { ttyCommands, surfaceSessions }, options);
+    const grokSessions = loadGrokCatalog(cwds);
+
+    return buildOfflineProfile(session, { ttyCommands, surfaceSessions, grokSessions }, options);
 }
 
 export function buildOfflineProfile(
@@ -109,18 +116,34 @@ export function buildOfflinePanes(
 
             const original = panel.ttyName ? deps.ttyCommands.get(panel.ttyName) : undefined;
             const session = deps.surfaceSessions.get(panel.id);
-            const derived = original
-                ? deriveReplayCommand({ original, sessionId: session?.sessionId, account: session?.account })
+            // Always "claude": the surface-session journal only records Claude
+            // sessions, so typing the kind from the tab title turned a claude
+            // uuid into a `grok -r` argument on any pane whose title ends in
+            // the word "grok".
+            const preferred: ReplayCatalogSession | undefined = session
+                ? {
+                      kind: "claude",
+                      sessionId: session.sessionId,
+                      cwd: panel.directory ?? "",
+                      title: panel.title ?? "",
+                      account: session.account,
+                  }
                 : undefined;
+
+            const derived = replayCommandForSurface(
+                { title: panel.title ?? "", cwd: panel.directory, command: original },
+                { sessions: deps.grokSessions ?? [] },
+                preferred
+            );
 
             surfaces.push({
                 type: "terminal",
                 title: panel.title ?? "",
                 cwd: panel.directory,
-                command: derived?.command,
-                command_source: derived ? "offline" : undefined,
-                command_original: derived && derived.command !== original ? original : undefined,
-                drift: derived && derived.drift.length > 0 ? derived.drift : undefined,
+                command: derived.command,
+                command_source: derived.command ? "offline" : undefined,
+                command_original: derived.command && derived.command !== original ? original : undefined,
+                drift: derived.drift.length > 0 ? derived.drift : undefined,
             });
         }
 

--- a/src/cmux/lib/restore-after-restart.test.ts
+++ b/src/cmux/lib/restore-after-restart.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import type { Profile } from "@app/cmux/lib/types";
+import { PROFILE_VERSION } from "@app/cmux/lib/types";
+import { filterReplayByAgents, isMissingEnumFlag, parseAgentList, parseRestoreSource } from "./restore-after-restart";
+
+describe("parseRestoreSource", () => {
+    test("accepts previous, live, profile", () => {
+        expect(parseRestoreSource("previous")).toBe("previous");
+        expect(parseRestoreSource("live")).toBe("live");
+        expect(parseRestoreSource("profile")).toBe("profile");
+        expect(parseRestoreSource("nope")).toBeUndefined();
+    });
+});
+
+describe("parseAgentList", () => {
+    test("defaults to all three agents", () => {
+        expect(parseAgentList(undefined)).toEqual(["claude", "grok", "codex"]);
+    });
+
+    test("parses a subset", () => {
+        expect(parseAgentList("grok,codex")).toEqual(["grok", "codex"]);
+    });
+
+    test("rejects an unknown name instead of dropping it", () => {
+        expect(() => parseAgentList("nope")).toThrow(/got "nope"/);
+        expect(() => parseAgentList("grok,foo")).toThrow(/got "grok,foo"/);
+    });
+});
+
+describe("isMissingEnumFlag", () => {
+    test("treats a bare commander true as missing", () => {
+        expect(isMissingEnumFlag(true)).toBe(true);
+        expect(isMissingEnumFlag("")).toBe(true);
+        expect(isMissingEnumFlag("grok")).toBe(false);
+        expect(isMissingEnumFlag(undefined)).toBe(false);
+    });
+});
+
+describe("filterReplayByAgents", () => {
+    const profile: Profile = {
+        version: PROFILE_VERSION,
+        name: "restart",
+        scope: "all",
+        captured_at: "2026-09-03T15:42:00.000Z",
+        cmux_version: "test",
+        windows: [
+            {
+                ref: "window:1",
+                title: "Window 1",
+                container_frame: { width: 100, height: 100 },
+                workspaces: [
+                    {
+                        ref: "workspace:1",
+                        title: "ws",
+                        selected: true,
+                        panes: [
+                            {
+                                ref: "pane:1",
+                                index: 0,
+                                columns: 80,
+                                rows: 24,
+                                pixel_frame: { x: 0, y: 0, width: 80, height: 24 },
+                                selected_surface_index: 0,
+                                surfaces: [
+                                    {
+                                        type: "terminal",
+                                        title: "PRs merged - grok",
+                                        command: "grok -r 01a05cc5-0ecf-7d40-945e-977e45b3f935",
+                                    },
+                                    {
+                                        type: "terminal",
+                                        title: "✳ Continue",
+                                        command: "claude --resume 6bdfb457-cee9-4202-8105-21be8a801757",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+
+    test("drops grok resume commands when grok is not selected", () => {
+        const filtered = filterReplayByAgents(profile, ["claude"]);
+        const surfaces = filtered.windows[0]?.workspaces[0]?.panes[0]?.surfaces ?? [];
+        expect(surfaces[0] && surfaces[0].type === "terminal" ? surfaces[0].command : "missing").toBeUndefined();
+        expect(surfaces[1] && surfaces[1].type === "terminal" ? surfaces[1].command : "missing").toContain("claude");
+    });
+});

--- a/src/cmux/lib/restore-after-restart.ts
+++ b/src/cmux/lib/restore-after-restart.ts
@@ -1,0 +1,89 @@
+import { inferLauncherFromTitle } from "@app/cmux/lib/agent-replay";
+import { agentKindFromLauncher, isAgentLauncher } from "@app/cmux/lib/command-capture";
+import type { Profile, TerminalSurface } from "@app/cmux/lib/types";
+import type { AgentKind } from "@genesiscz/utils/agent-sessions/types";
+
+export type RestoreRestartSource = "previous" | "live" | "profile";
+
+export const ALL_RESTORE_AGENTS: AgentKind[] = ["claude", "grok", "codex"];
+
+/** Commander sets a bare `--flag` to `true` when the option is `--flag [value]`. */
+export function isMissingEnumFlag(raw: unknown): boolean {
+    return raw === true || raw === "";
+}
+
+export function parseRestoreSource(raw: string | undefined): RestoreRestartSource | undefined {
+    if (raw === "previous" || raw === "live" || raw === "profile") {
+        return raw;
+    }
+
+    return undefined;
+}
+
+export function parseAgentList(raw: string | undefined): AgentKind[] {
+    if (!raw?.trim()) {
+        return [...ALL_RESTORE_AGENTS];
+    }
+
+    const kinds: AgentKind[] = [];
+    for (const part of raw.split(",")) {
+        const trimmed = part.trim().toLowerCase();
+        if (!trimmed) {
+            continue;
+        }
+
+        if (trimmed !== "claude" && trimmed !== "grok" && trimmed !== "codex") {
+            throw new Error(`--agents must be a comma list of claude, grok, codex (got "${raw}")`);
+        }
+
+        if (!kinds.includes(trimmed)) {
+            kinds.push(trimmed);
+        }
+    }
+
+    if (kinds.length === 0) {
+        throw new Error(`--agents must be a comma list of claude, grok, codex (got "${raw}")`);
+    }
+
+    return kinds;
+}
+
+function surfaceKind(surface: TerminalSurface): AgentKind | undefined {
+    return (
+        inferLauncherFromTitle(surface.title) ?? (surface.command ? agentKindFromLauncher(surface.command) : undefined)
+    );
+}
+
+/** Drop inferred resume commands for agents the user did not ask to restore. */
+export function filterReplayByAgents(profile: Profile, agents: AgentKind[]): Profile {
+    const allowed = new Set(agents);
+
+    return {
+        ...profile,
+        windows: profile.windows.map((window) => ({
+            ...window,
+            workspaces: window.workspaces.map((workspace) => ({
+                ...workspace,
+                panes: workspace.panes.map((pane) => ({
+                    ...pane,
+                    surfaces: pane.surfaces.map((surface) => {
+                        if (surface.type !== "terminal") {
+                            return surface;
+                        }
+
+                        const kind = surfaceKind(surface);
+                        if (!kind || allowed.has(kind)) {
+                            return surface;
+                        }
+
+                        if (surface.command && isAgentLauncher(surface.command)) {
+                            return { ...surface, command: undefined, command_source: undefined };
+                        }
+
+                        return surface;
+                    }),
+                })),
+            })),
+        })),
+    };
+}

--- a/src/cmux/lib/restore.ts
+++ b/src/cmux/lib/restore.ts
@@ -66,16 +66,25 @@ export function buildPlan(profile: Profile, opts: RestoreOptions): RestorePlan {
     return { workspaces };
 }
 
+/**
+ * Restore an ALREADY prepared profile (see `prepareProfileForRestore`).
+ *
+ * Preparing again here re-ran the whole inference over its own output: the
+ * synthetic `claude --resume '<id>'` from pass 1 became pass 2's "original", so
+ * the command typed differed from the plan the user had just confirmed and the
+ * drift note described a replacement that never happened. It also paid for a
+ * second Claude session-listing scan and a second grok directory walk.
+ */
 export async function restoreProfile(
-    profile: Profile,
+    playable: Profile,
     opts: RestoreOptions,
     events: RestoreEvents = {}
 ): Promise<RestoreOutcome> {
     const outcome: RestoreOutcome = { workspaces: [] };
-    const totalWorkspaces = profile.windows.reduce((acc, w) => acc + w.workspaces.length, 0);
+    const totalWorkspaces = playable.windows.reduce((acc, w) => acc + w.workspaces.length, 0);
     let visited = 0;
 
-    for (const window of profile.windows) {
+    for (const window of playable.windows) {
         for (const ws of window.workspaces) {
             visited += 1;
             const targetTitle = `${opts.prefix}${ws.title}`;

--- a/src/cmux/lib/snapshot.ts
+++ b/src/cmux/lib/snapshot.ts
@@ -1,10 +1,11 @@
-import { panelsById, readAutosaveSession } from "@app/cmux/lib/autosave";
 import {
-    collectTtyLaunchCommands,
-    deriveReplayCommand,
-    loadSurfaceSessions,
-    type SurfaceSessionInfo,
-} from "@app/cmux/lib/command-capture";
+    loadGrokCatalog,
+    type ReplayCatalog,
+    type ReplayCatalogSession,
+    replayCommandForSurface,
+} from "@app/cmux/lib/agent-replay";
+import { panelsById, readAutosaveSession } from "@app/cmux/lib/autosave";
+import { collectTtyLaunchCommands, loadSurfaceSessions, type SurfaceSessionInfo } from "@app/cmux/lib/command-capture";
 import { captureSurfaceState, cwdFromTitle } from "@app/cmux/lib/shell-probe";
 import type { Pane, Profile, ProfileScope, Surface, Window, Workspace } from "@app/cmux/lib/types";
 import { PROFILE_VERSION } from "@app/cmux/lib/types";
@@ -42,12 +43,14 @@ interface CommandCaptureContext {
     ttyCommands: Map<string, string>;
     panelTty: Map<string, string>;
     surfaceSessions: Map<string, SurfaceSessionInfo>;
+    replayCatalog: ReplayCatalog;
 }
 
 export async function buildCommandCaptureContext(): Promise<CommandCaptureContext> {
     const [ttyCommands, surfaceSessions] = await Promise.all([collectTtyLaunchCommands(), loadSurfaceSessions()]);
 
     const panelTty = new Map<string, string>();
+    const grokCwds: string[] = [];
     try {
         const session = readAutosaveSession();
         for (const [id, panel] of panelsById(session)) {
@@ -55,11 +58,25 @@ export async function buildCommandCaptureContext(): Promise<CommandCaptureContex
                 panelTty.set(id, panel.ttyName);
             }
         }
+
+        for (const window of session.windows) {
+            for (const workspace of window.tabManager.workspaces) {
+                if (workspace.currentDirectory) {
+                    grokCwds.push(workspace.currentDirectory);
+                }
+
+                for (const panel of workspace.panels) {
+                    if (panel.directory) {
+                        grokCwds.push(panel.directory);
+                    }
+                }
+            }
+        }
     } catch (error) {
         logger.debug({ error }, "[snapshot] autosave unavailable — foreground command capture degraded");
     }
 
-    return { ttyCommands, panelTty, surfaceSessions };
+    return { ttyCommands, panelTty, surfaceSessions, replayCatalog: { sessions: loadGrokCatalog(grokCwds) } };
 }
 
 interface ListPaneSurfacesResponse {
@@ -334,19 +351,35 @@ async function captureSurface(
     const foreground = tty ? capture?.ttyCommands.get(tty) : undefined;
     const original = foreground ?? captured.command.value;
     const session = capture && entry.id ? capture.surfaceSessions.get(entry.id) : undefined;
-
-    if (!original) {
+    // Always "claude": this id comes from the Claude cmux-refs journal and
+    // nowhere else. Typing it from the tab title made any pane whose title ends
+    // in the word "grok" (including a shell in a directory named grok) replay
+    // `grok -r <claude uuid>`, a session grok has never seen.
+    const preferred: ReplayCatalogSession | undefined = session
+        ? {
+              kind: "claude",
+              sessionId: session.sessionId,
+              cwd: cwd ?? "",
+              title,
+              account: session.account,
+          }
+        : undefined;
+    const derived = replayCommandForSurface(
+        { title, cwd, command: original },
+        capture?.replayCatalog ?? { sessions: [] },
+        preferred
+    );
+    if (!derived.command) {
         return { type: "terminal", title, cwd, screen: captured.screen };
     }
 
-    const derived = deriveReplayCommand({ original, sessionId: session?.sessionId, account: session?.account });
     return {
         type: "terminal",
         title,
         cwd,
         screen: captured.screen,
         command: derived.command,
-        command_source: foreground ? "foreground" : captured.command.source,
+        command_source: foreground ? "foreground" : derived.command !== original ? "inferred" : captured.command.source,
         command_original: derived.command !== original ? original : undefined,
         drift: derived.drift.length > 0 ? derived.drift : undefined,
     };

--- a/src/cmux/lib/types.ts
+++ b/src/cmux/lib/types.ts
@@ -2,7 +2,7 @@ export const PROFILE_VERSION = 1;
 
 export type ProfileScope = "all" | "window" | "workspace";
 
-export type CommandSource = "scrollback" | "foreground" | "offline" | "manual" | "none";
+export type CommandSource = "scrollback" | "foreground" | "offline" | "manual" | "inferred" | "none";
 
 export interface ScreenSnapshot {
     /** Raw rendered text returned by `cmux capture-pane` at save time. ANSI-stripped. */

--- a/src/grok/README.md
+++ b/src/grok/README.md
@@ -6,6 +6,9 @@ Drive xAI's `grok` CLI as an isolated headless worker. This is the grok counterp
 
 ```bash
 tools grok run --name fix-auth --cwd /abs/project --prompt-file /tmp/brief.md [--readonly] [--model grok-4.6]
+tools grok run --resume [query]          # TUI: grok -r <id>; query matches id, title, or transcript
+tools grok resume [query]                # alias of TUI resume
+tools grok history [query] [--all] [--format json] [-i]
 tools grok steer --name fix-auth --prompt "Now fix the second bug; still do not touch tests"
 tools grok read --name fix-auth [--turn 2]
 tools grok sessions
@@ -16,7 +19,9 @@ tools grok sessions
 ## What the harness bakes in
 
 - **Isolation.** Workers get `GROK_HOME=~/.genesis-tools/grok/worker-home` and the `GROK_CLAUDE_*_ENABLED=0` toggles, so they never load the user's `~/.claude` rules, permission settings, or personal skills. `--worker-home` overrides that home for parallel or test runs. It does **not** move the session records: those stay under `~/.genesis-tools/grok/sessions/` so `tools grok sessions` can list every worker, so two runs sharing a `--name` share one record whatever their home. Project-local config in the target repo (`CLAUDE.md`, a `.grok/` directory) still loads — `GROK_HOME` redirects user state only.
-- **Session bookkeeping.** The session uuid and cwd are stored in `~/.genesis-tools/grok/sessions/<name>.meta.json`; `steer` resumes with the identical `--cwd` automatically (grok keys sessions by cwd).
+- **Two session stores.** `tools grok history` / `run --resume` list TUI dirs under `~/.grok/sessions` (and the worker-home copy of that layout). `tools grok sessions` lists headless workers under `~/.genesis-tools/grok/sessions/<name>.meta.json`. Those are not the same inventory.
+- **TUI resume is not the worker.** `--resume` on `run` launches `grok -r <id>` with your normal env. It never sets `GROK_HOME` and never calls `runSession`. Worker mode still needs `--name` and `--cwd` with `--resume` absent.
+- **Session bookkeeping.** The worker uuid and cwd are stored in `~/.genesis-tools/grok/sessions/<name>.meta.json`; `steer` resumes with the identical `--cwd` automatically (grok keys sessions by cwd).
 - **Sticky read-only.** The grok CLI forgets `--tools` on every `--resume`; the harness re-arms the read-only allowlist on each steer of a `--readonly` session. `steer --writable` switches the session back to the project jail deliberately.
 - **Honest exit codes.** The grok CLI exits 0 even when a turn dies. `tools grok` parses the stream and exits 1 when no terminal `end` event is present.
 - **One claim per name, one transcript per turn.** `run` reserves the session name with `O_EXCL`, and each turn reserves its own log file the same way, so two concurrent invocations cannot both start turn 1 or truncate each other's transcript.

--- a/src/grok/commands/history.ts
+++ b/src/grok/commands/history.ts
@@ -1,0 +1,7 @@
+import { createGrokAdapter } from "@genesiscz/utils/agent-sessions/grok-sessions";
+import { registerAgentHistoryCommand } from "@genesiscz/utils/agent-sessions/history-cli";
+import type { Command } from "commander";
+
+export function registerGrokHistoryCommand(program: Command): void {
+    registerAgentHistoryCommand(program, createGrokAdapter(), "grok");
+}

--- a/src/grok/commands/resume.ts
+++ b/src/grok/commands/resume.ts
@@ -1,0 +1,20 @@
+import type { Command } from "commander";
+import { parseResumeLimit, runGrokTuiResume } from "../lib/tui-resume";
+
+export function registerGrokResumeCommand(program: Command): void {
+    program
+        .command("resume")
+        .description("Resume a grok TUI session by id, title, or content search")
+        .argument("[query]", "Session ID prefix, title, or search term")
+        .option("-l, --list", "List recent sessions")
+        .option("-a, --all", "Search all projects (default: current cwd)")
+        .option("-n, --limit <n>", "Number of sessions to show", "20")
+        .action(async (query: string | undefined, opts: { list?: boolean; all?: boolean; limit?: string }) => {
+            await runGrokTuiResume({
+                query,
+                list: Boolean(opts.list),
+                all: Boolean(opts.all),
+                limit: parseResumeLimit(opts.limit),
+            });
+        });
+}

--- a/src/grok/index.ts
+++ b/src/grok/index.ts
@@ -5,9 +5,12 @@ import { runTool } from "@genesiscz/utils/cli";
 import { out } from "@genesiscz/utils/logger";
 import { createBoxTable, formatDotStatus, truncateDisplay } from "@genesiscz/utils/table";
 import { Command } from "commander";
+import { registerGrokHistoryCommand } from "./commands/history";
+import { registerGrokResumeCommand } from "./commands/resume";
 import { turnErrPath, turnLogPath } from "./lib/paths";
 import { GrokSessionStore } from "./lib/store";
 import { parseTurnLog } from "./lib/stream";
+import { parseResumeLimit, runGrokTuiResume } from "./lib/tui-resume";
 import { runSession, steerSession, type TurnResult } from "./lib/worker";
 
 const program = new Command();
@@ -49,15 +52,33 @@ function printTurn(result: TurnResult): void {
 
 program
     .command("run")
-    .description("Start a new worker session and run turn 1 (blocking; can take minutes)")
-    .requiredOption("--name <name>", "session name (the steering handle)")
-    .requiredOption("--cwd <path>", "project directory the worker may touch")
+    .description("Start a new headless worker (--name/--cwd) or resume a grok TUI session (--resume)")
+    .option("--name <name>", "worker session name (the steering handle)")
+    .option("--cwd <path>", "project directory the worker may touch")
     .option("--prompt-file <path>", "brief file (preferred; inline prompts break on backticks)")
     .option("--prompt <text>", "inline brief")
     .option("--model <model>", "grok model id", "grok-4.6")
     .option("--readonly", "review mode: worker gets read_file,list_dir,grep only (sticky across steers)", false)
     .option("--worker-home <path>", "override the isolated GROK_HOME (default ~/.genesis-tools/grok/worker-home)")
+    .option("-r, --resume [query]", "Resume a grok TUI session by id, title, or transcript (not the headless worker)")
+    .option("-l, --list", "With --resume, list matching TUI sessions")
+    .option("-a, --all", "With --resume, search every project")
+    .option("-n, --limit <n>", "With --resume, number of sessions to show", "20")
     .action(async (options) => {
+        if (options.resume !== undefined || options.list) {
+            await runGrokTuiResume({
+                query: typeof options.resume === "string" ? options.resume : undefined,
+                list: Boolean(options.list),
+                all: Boolean(options.all),
+                limit: parseResumeLimit(options.limit),
+            });
+            return;
+        }
+
+        if (!options.name || !options.cwd) {
+            throw new Error("Worker mode needs --name and --cwd. To resume a TUI session, pass --resume [query].");
+        }
+
         const result = await runSession({
             name: options.name,
             cwd: options.cwd,
@@ -160,5 +181,8 @@ program
 
         out.println(table.toString());
     });
+
+registerGrokHistoryCommand(program);
+registerGrokResumeCommand(program);
 
 await runTool(program, { tool: "grok" });

--- a/src/grok/lib/tui-resume.test.ts
+++ b/src/grok/lib/tui-resume.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSession, AgentSessionAdapter } from "@genesiscz/utils/agent-sessions/types";
+import { env } from "@genesiscz/utils/env";
+import { buildGrokTuiSpawn, grokTuiResumeArgv, resolveGrokTuiSession } from "./tui-resume";
+
+const SESSION = {
+    sessionId: "sess_0001",
+    title: "resume me",
+    cwd: "/tmp/grok-tui-resume",
+} as AgentSession;
+
+describe("buildGrokTuiSpawn", () => {
+    test("resumes the picked session in its own cwd", () => {
+        const spawn = buildGrokTuiSpawn(SESSION);
+
+        expect(spawn.cmd.slice(1)).toEqual(["-r", "sess_0001"]);
+        expect(spawn.cwd).toBe("/tmp/grok-tui-resume");
+    });
+
+    test("the child env comes from the env facade, so a test override reaches it", async () => {
+        await env.testing.withOverrides({ GROK_TUI_RESUME_PROBE: "on" }, () => {
+            expect(buildGrokTuiSpawn(SESSION).env.GROK_TUI_RESUME_PROBE).toBe("on");
+        });
+
+        expect(buildGrokTuiSpawn(SESSION).env.GROK_TUI_RESUME_PROBE).toBeUndefined();
+    });
+});
+
+function session(id: string, title: string): AgentSession {
+    return {
+        kind: "grok",
+        sessionId: id,
+        cwd: "/Users/me/Projects/shop",
+        title,
+        mtime: new Date("2026-09-03T10:00:00.000Z"),
+        filePath: `/tmp/${id}.json`,
+    };
+}
+
+const A = session("01a05cc5-0ecf-7d40-945e-977e45b3f935", "PRs merged into release/2026-09-03");
+const B = session("01a05d17-c512-7dd2-abb6-e62d8c7d612a", "aws-costs");
+
+function adapterWithSearch(hits: AgentSession[]): AgentSessionAdapter {
+    return {
+        kind: "grok",
+        async list() {
+            return [A, B];
+        },
+        async search() {
+            return hits;
+        },
+    };
+}
+
+describe("parseResumeLimit", () => {
+    test("defaults and rejects non-integers", async () => {
+        const { parseResumeLimit } = await import("./tui-resume");
+        expect(parseResumeLimit(undefined)).toBe(20);
+        expect(parseResumeLimit("5")).toBe(5);
+        expect(() => parseResumeLimit("nope")).toThrow(/positive integer/);
+        expect(() => parseResumeLimit("20.5")).toThrow(/positive integer/);
+    });
+});
+
+describe("grokTuiResumeArgv", () => {
+    test("pins -r through resumeArgv", () => {
+        expect(grokTuiResumeArgv("/usr/bin/grok", A.sessionId)).toEqual(["/usr/bin/grok", "-r", A.sessionId]);
+    });
+});
+
+describe("resolveGrokTuiSession", () => {
+    test("a unique body-search hit resumes that session", async () => {
+        const session = await resolveGrokTuiSession({ query: "burn auth" }, adapterWithSearch([A]));
+        expect(session?.sessionId).toBe(A.sessionId);
+    });
+
+    test("an empty body search does not fall back to the unfiltered list", async () => {
+        process.exitCode = 0;
+        const session = await resolveGrokTuiSession({ query: "no-such-body" }, adapterWithSearch([]));
+        expect(session).toBeUndefined();
+        expect(process.exitCode).toBe(1);
+        process.exitCode = 0;
+    });
+});

--- a/src/grok/lib/tui-resume.ts
+++ b/src/grok/lib/tui-resume.ts
@@ -1,0 +1,133 @@
+import { formatHistoryMarkdown } from "@genesiscz/utils/agent-sessions/format-history";
+import { createGrokAdapter } from "@genesiscz/utils/agent-sessions/grok-sessions";
+import { pickSessionByQuery } from "@genesiscz/utils/agent-sessions/pick-session";
+import { resumeArgv } from "@genesiscz/utils/agent-sessions/resume-argv";
+import type { AgentSession, AgentSessionAdapter } from "@genesiscz/utils/agent-sessions/types";
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { env } from "@genesiscz/utils/env";
+import { out } from "@genesiscz/utils/logger";
+import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
+import { resolveGrokBinary } from "./worker";
+
+export interface TuiResumeOptions {
+    query?: string;
+    list?: boolean;
+    all?: boolean;
+    limit?: number;
+}
+
+export function grokTuiResumeArgv(binary: string, sessionId: string): string[] {
+    return [binary, ...resumeArgv("grok", sessionId).slice(1)];
+}
+
+export function parseResumeLimit(raw: string | undefined, fallback = 20): number {
+    if (raw === undefined || raw.trim() === "") {
+        return fallback;
+    }
+
+    const trimmed = raw.trim();
+    if (!/^\d+$/.test(trimmed)) {
+        throw new Error(`--limit must be a positive integer (got "${raw}")`);
+    }
+
+    const n = Number.parseInt(trimmed, 10);
+    if (n < 1) {
+        throw new Error(`--limit must be a positive integer (got "${raw}")`);
+    }
+
+    return n;
+}
+
+export async function resolveGrokTuiSession(
+    opts: TuiResumeOptions,
+    adapter: AgentSessionAdapter = createGrokAdapter()
+): Promise<AgentSession | undefined> {
+    const filters = {
+        cwd: opts.all ? undefined : process.cwd(),
+        all: Boolean(opts.all),
+        limit: opts.limit ?? 20,
+        query: opts.query,
+    };
+    const sessions = opts.query ? await adapter.search(filters) : await adapter.list({ ...filters, query: undefined });
+
+    if (opts.list) {
+        out.print(formatHistoryMarkdown(sessions, opts.query));
+        return undefined;
+    }
+
+    if (opts.query && sessions.length === 1) {
+        return sessions[0];
+    }
+
+    const picked = pickSessionByQuery(sessions, opts.query);
+    if (picked) {
+        return picked;
+    }
+
+    if (!isInteractive()) {
+        if (!opts.query) {
+            out.error(
+                `Pass a session id or title. ${suggestCommand("tools grok run --resume", { add: ["01a05cc5"] })}`
+            );
+            process.exitCode = 1;
+            return undefined;
+        }
+
+        out.error(`No unique grok session matched "${opts.query}". Use --list to see candidates.`);
+        process.exitCode = 1;
+        return undefined;
+    }
+
+    if (sessions.length === 0) {
+        out.error("No grok sessions found.");
+        process.exitCode = 1;
+        return undefined;
+    }
+
+    const p = await import("@clack/prompts");
+    const choice = await withCancel(
+        p.select({
+            message: "Resume which grok session?",
+            options: sessions.slice(0, opts.limit ?? 20).map((session) => ({
+                value: session.sessionId,
+                label: `${session.title} ${session.sessionId.slice(0, 8)}`,
+                hint: session.cwd,
+            })),
+        })
+    );
+
+    return sessions.find((session) => session.sessionId === choice);
+}
+
+/**
+ * The grok TUI is launched with the caller's environment, read through the env
+ * facade rather than `process.env` (repo rule), so `env.testing.set()` reaches
+ * this spawn like it reaches the worker's.
+ */
+export function buildGrokTuiSpawn(session: AgentSession): {
+    cmd: string[];
+    cwd: string;
+    env: Record<string, string | undefined>;
+} {
+    return {
+        cmd: grokTuiResumeArgv(resolveGrokBinary(), session.sessionId),
+        cwd: session.cwd,
+        env: env.getProcessEnv(),
+    };
+}
+
+export async function launchGrokTui(session: AgentSession): Promise<never> {
+    const proc = Bun.spawn({ ...buildGrokTuiSpawn(session), stdio: ["inherit", "inherit", "inherit"] });
+    const code = await proc.exited;
+    process.exit(code ?? 1);
+}
+
+export async function runGrokTuiResume(opts: TuiResumeOptions): Promise<void> {
+    const session = await resolveGrokTuiSession(opts);
+    if (!session) {
+        return;
+    }
+
+    out.println(`Resuming grok ${session.sessionId.slice(0, 8)} (${session.title}) in ${session.cwd}`);
+    await launchGrokTui(session);
+}

--- a/src/utils/agent-sessions/codex-sessions.test.ts
+++ b/src/utils/agent-sessions/codex-sessions.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { parseCodexRollout, searchCodexSessions } from "./codex-sessions";
+
+const ID = "01a067d4-d2b0-7532-8f59-9af2a29c2d0e";
+
+function rolloutLine(obj: unknown): string {
+    return `${SafeJSON.stringify(obj)}\n`;
+}
+
+describe("parseCodexRollout", () => {
+    test("reads session_meta and the first real user prompt, skipping AGENTS.md", () => {
+        const dir = mkdtempSync(join(tmpdir(), "codex-rollout-"));
+        const path = join(dir, `rollout-2026-09-03-${ID}.jsonl`);
+        writeFileSync(
+            path,
+            rolloutLine({
+                timestamp: "2026-09-03T15:13:15.994Z",
+                type: "session_meta",
+                payload: { session_id: ID, cwd: "/Users/me/Projects/shop" },
+            }) +
+                rolloutLine({
+                    type: "response_item",
+                    payload: {
+                        type: "message",
+                        role: "user",
+                        content: [
+                            {
+                                type: "input_text",
+                                text: "# AGENTS.md instructions for /Users/me/Projects/shop\nDo not",
+                            },
+                        ],
+                    },
+                }) +
+                rolloutLine({
+                    type: "response_item",
+                    payload: {
+                        type: "message",
+                        role: "user",
+                        content: [
+                            {
+                                type: "input_text",
+                                text: "codex mcp login apify doesnt work, handle auth in mcp-manager",
+                            },
+                        ],
+                    },
+                })
+        );
+
+        const session = parseCodexRollout(path);
+        expect(session?.sessionId).toBe(ID);
+        expect(session?.cwd).toBe("/Users/me/Projects/shop");
+        expect(session?.kind).toBe("codex");
+        expect(session?.prompt).toContain("mcp-manager");
+        expect(session?.title).toContain("codex mcp login");
+    });
+});
+
+describe("searchCodexSessions", () => {
+    test("finds a session by prompt text in a dated tree", () => {
+        const root = mkdtempSync(join(tmpdir(), "codex-root-"));
+        const day = join(root, "2026", "09", "03");
+        mkdirSync(day, { recursive: true });
+        const path = join(day, `rollout-2026-09-03T17-13-15-${ID}.jsonl`);
+        writeFileSync(
+            path,
+            rolloutLine({
+                timestamp: "2026-09-03T15:13:15.994Z",
+                type: "session_meta",
+                payload: { session_id: ID, cwd: "/Users/me/Projects/shop" },
+            }) +
+                rolloutLine({
+                    type: "response_item",
+                    payload: {
+                        type: "message",
+                        role: "user",
+                        content: [{ type: "input_text", text: "handle auth in mcp-manager" }],
+                    },
+                })
+        );
+
+        const hits = searchCodexSessions([root], { query: "mcp-manager" });
+        expect(hits).toHaveLength(1);
+        expect(hits[0]?.sessionId).toBe(ID);
+    });
+});

--- a/src/utils/agent-sessions/codex-sessions.ts
+++ b/src/utils/agent-sessions/codex-sessions.ts
@@ -1,0 +1,188 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { nativeSessionRoots } from "@genesiscz/utils/providers/session-paths";
+import { matchSessionText, sortAndLimit } from "./match";
+import type { AgentSearchFilters, AgentSearchHit, AgentSession, AgentSessionAdapter } from "./types";
+
+interface CodexLine {
+    type?: string;
+    timestamp?: string;
+    payload?: {
+        session_id?: string;
+        id?: string;
+        cwd?: string;
+        type?: string;
+        role?: string;
+        content?: Array<{ type?: string; text?: string }>;
+    };
+}
+
+function walkRollouts(root: string, files: string[]): void {
+    let entries: string[] = [];
+    try {
+        entries = readdirSync(root);
+    } catch {
+        return;
+    }
+
+    for (const name of entries) {
+        const path = join(root, name);
+        let st: ReturnType<typeof statSync>;
+        try {
+            st = statSync(path);
+        } catch {
+            continue;
+        }
+
+        if (st.isDirectory()) {
+            walkRollouts(path, files);
+            continue;
+        }
+
+        if (name.startsWith("rollout-") && (name.endsWith(".jsonl") || name.endsWith(".json"))) {
+            files.push(path);
+        }
+    }
+}
+
+function firstUserPrompt(payload: CodexLine["payload"]): string | undefined {
+    if (payload?.role !== "user") {
+        return undefined;
+    }
+
+    const texts = (payload.content ?? []).map((part) => part.text ?? "").filter(Boolean);
+    const text = texts.join("\n").trim();
+    if (!text || text.startsWith("# AGENTS.md")) {
+        return undefined;
+    }
+
+    return text;
+}
+
+export function parseCodexRollout(filePath: string, maxLines = 80): AgentSession | undefined {
+    let raw: string;
+    try {
+        raw = readFileSync(filePath, "utf8");
+    } catch {
+        return undefined;
+    }
+
+    let sessionId = "";
+    let cwd = "";
+    let prompt: string | undefined;
+    let stamp = "";
+
+    const lines = raw.split("\n");
+    const scan = Math.min(lines.length, maxLines);
+
+    for (let i = 0; i < scan; i++) {
+        const line = lines[i];
+        if (!line.trim()) {
+            continue;
+        }
+
+        let parsed: CodexLine;
+        try {
+            parsed = SafeJSON.parse(line, { strict: true }) as CodexLine;
+        } catch {
+            continue;
+        }
+
+        if (parsed.type === "session_meta") {
+            sessionId = parsed.payload?.session_id || parsed.payload?.id || sessionId;
+            cwd = parsed.payload?.cwd || cwd;
+            stamp = parsed.timestamp || stamp;
+        }
+
+        if (!prompt) {
+            prompt = firstUserPrompt(parsed.payload);
+        }
+
+        if (sessionId && cwd && prompt) {
+            break;
+        }
+    }
+
+    if (!sessionId) {
+        const fromName = basename(filePath).match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+        sessionId = fromName?.[1] ?? "";
+    }
+
+    if (!sessionId) {
+        return undefined;
+    }
+
+    let mtime = stamp ? new Date(stamp) : new Date(NaN);
+    if (Number.isNaN(mtime.getTime())) {
+        try {
+            mtime = new Date(statSync(filePath).mtimeMs);
+        } catch {
+            mtime = new Date(0);
+        }
+    }
+
+    const title = prompt ? prompt.split("\n")[0].slice(0, 80) : sessionId;
+
+    return {
+        kind: "codex",
+        sessionId,
+        cwd,
+        title,
+        prompt,
+        mtime,
+        filePath,
+        project: cwd.split("/").pop(),
+    };
+}
+
+export function listCodexSessionsFromRoots(roots: string[]): AgentSession[] {
+    const files: string[] = [];
+    for (const root of roots) {
+        walkRollouts(root, files);
+    }
+
+    const sessions: AgentSession[] = [];
+    const seen = new Set<string>();
+
+    for (const file of files) {
+        const session = parseCodexRollout(file);
+        if (!session || seen.has(session.sessionId)) {
+            continue;
+        }
+
+        seen.add(session.sessionId);
+        sessions.push(session);
+    }
+
+    return sessions;
+}
+
+export function searchCodexSessions(roots: string[], filters: AgentSearchFilters): AgentSearchHit[] {
+    const hits: AgentSearchHit[] = [];
+
+    for (const session of listCodexSessionsFromRoots(roots)) {
+        const extras = session.prompt ? [session.prompt] : [];
+        const hit = matchSessionText(session, extras, filters);
+        if (hit) {
+            hits.push(hit);
+        }
+    }
+
+    return sortAndLimit(hits, filters.limit);
+}
+
+export function createCodexAdapter(roots?: string[]): AgentSessionAdapter {
+    const resolved = roots ?? nativeSessionRoots("codex", homedir());
+
+    return {
+        kind: "codex",
+        async list(filters) {
+            return searchCodexSessions(resolved, { ...filters, query: undefined });
+        },
+        async search(filters) {
+            return searchCodexSessions(resolved, filters);
+        },
+    };
+}

--- a/src/utils/agent-sessions/format-history.test.ts
+++ b/src/utils/agent-sessions/format-history.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { formatHistoryJson, formatHistoryMarkdown } from "./format-history";
+import type { AgentSearchHit } from "./types";
+
+const hit: AgentSearchHit = {
+    kind: "grok",
+    sessionId: "01a05cc5-0ecf-7d40-945e-977e45b3f935",
+    cwd: "/Users/me/Projects/shop",
+    title: "PRs merged into release/2026-09-03",
+    mtime: new Date("2026-09-02T10:00:00.000Z"),
+    filePath: "/tmp/summary.json",
+    matchedText: "please restore the panes",
+};
+
+describe("formatHistoryMarkdown", () => {
+    test("includes the query, title, id and match snippet", () => {
+        const md = formatHistoryMarkdown([hit], "restore");
+        expect(md).toContain('matching "restore"');
+        expect(md).toContain("PRs merged into release/2026-09-03");
+        expect(md).toContain("01a05cc5-0ecf-7d40-945e-977e45b3f935");
+        expect(md).toContain("please restore the panes");
+        expect(md).toContain("**Kind:** grok");
+    });
+});
+
+describe("formatHistoryJson", () => {
+    test("emits sessionId and kind", () => {
+        const parsed = SafeJSON.parse(formatHistoryJson([hit])) as Array<{ sessionId: string; kind: string }>;
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0]?.sessionId).toBe(hit.sessionId);
+        expect(parsed[0]?.kind).toBe("grok");
+    });
+});

--- a/src/utils/agent-sessions/format-history.ts
+++ b/src/utils/agent-sessions/format-history.ts
@@ -1,0 +1,38 @@
+import { SafeJSON } from "@genesiscz/utils/json";
+import type { AgentSearchHit } from "./types";
+
+export function formatHistoryMarkdown(hits: AgentSearchHit[], query?: string): string {
+    const q = query ? `"${query}"` : "all";
+    const lines = [`## Found ${hits.length} conversation${hits.length === 1 ? "" : "s"} matching ${q}`, ""];
+
+    for (let i = 0; i < hits.length; i++) {
+        const hit = hits[i];
+        const date = hit.mtime.toISOString().slice(0, 10);
+        lines.push(`### ${i + 1}. ${hit.title}`);
+        lines.push(`**Date:** ${date} | **Kind:** ${hit.kind} | **Session ID:** \`${hit.sessionId}\``);
+        lines.push(`**Cwd:** \`${hit.cwd}\``);
+        if (hit.matchedText) {
+            lines.push("");
+            lines.push(hit.matchedText.replace(/\n/g, " ").trim());
+        }
+        lines.push("");
+    }
+
+    return lines.join("\n");
+}
+
+export function formatHistoryJson(hits: AgentSearchHit[]): string {
+    return `${SafeJSON.stringify(
+        hits.map((hit) => ({
+            kind: hit.kind,
+            sessionId: hit.sessionId,
+            title: hit.title,
+            cwd: hit.cwd,
+            mtime: hit.mtime.toISOString(),
+            matchedText: hit.matchedText,
+            filePath: hit.filePath,
+        })),
+        null,
+        2
+    )}\n`;
+}

--- a/src/utils/agent-sessions/grok-sessions.test.ts
+++ b/src/utils/agent-sessions/grok-sessions.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { extractGrokUserQueries, listGrokSessionsFromRoot, searchGrokSessions } from "./grok-sessions";
+
+const ID_A = "01a05cc5-0ecf-7d40-945e-977e45b3f935";
+const ID_B = "01a05d17-c512-7dd2-abb6-e62d8c7d612a";
+
+function writeSession(
+    root: string,
+    cwd: string,
+    id: string,
+    opts: { title: string; updated: string; query?: string }
+): void {
+    const dir = join(root, encodeURIComponent(cwd), id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+        join(dir, "summary.json"),
+        SafeJSON.stringify({
+            info: { id, cwd },
+            generated_title: opts.title,
+            session_summary: opts.title,
+            updated_at: opts.updated,
+        })
+    );
+    if (opts.query) {
+        writeFileSync(
+            join(dir, "chat_history.jsonl"),
+            `${SafeJSON.stringify({
+                type: "user",
+                content: [{ type: "text", text: `<user_query>\n${opts.query}\n</user_query>` }],
+            })}\n`
+        );
+    }
+}
+
+describe("extractGrokUserQueries", () => {
+    test("pulls the tagged user_query out of a chat_history line", () => {
+        const line = SafeJSON.stringify({
+            type: "user",
+            content: [{ type: "text", text: "<user_query>\nrestore cmux panes\n</user_query>" }],
+        });
+        expect(extractGrokUserQueries(`${line}\n`)).toEqual(["restore cmux panes"]);
+    });
+
+    test("skips harness user_info blobs", () => {
+        const info = SafeJSON.stringify({
+            type: "user",
+            content: [{ type: "text", text: "<user_info>\nOS Version: macos\n</user_info>" }],
+        });
+        const real = SafeJSON.stringify({
+            type: "user",
+            content: [{ type: "text", text: "<user_query>\nrestore cmux panes\n</user_query>" }],
+        });
+        expect(extractGrokUserQueries(`${info}\n${real}\n`)).toEqual(["restore cmux panes"]);
+    });
+});
+
+describe("listGrokSessionsFromRoot", () => {
+    test("reads summary.json from encoded-cwd uuid dirs", () => {
+        const root = mkdtempSync(join(tmpdir(), "grok-sessions-"));
+        writeSession(root, "/Users/me/Projects/shop", ID_A, {
+            title: "PRs merged into release/2026-09-03",
+            updated: "2026-09-02T10:00:00.000Z",
+        });
+        writeSession(root, "/Users/me/Projects/App", ID_B, {
+            title: "aws-costs",
+            updated: "2026-09-03T10:00:00.000Z",
+        });
+
+        const listed = listGrokSessionsFromRoot(root);
+        expect(listed.map((s) => s.sessionId).sort()).toEqual([ID_A, ID_B].sort());
+        const prs = listed.find((s) => s.sessionId === ID_A);
+        expect(prs?.cwd).toBe("/Users/me/Projects/shop");
+        expect(prs?.title).toBe("PRs merged into release/2026-09-03");
+        expect(prs?.kind).toBe("grok");
+    });
+});
+
+describe("searchGrokSessions", () => {
+    test("filters by cwd, query in title, and query in user_query", () => {
+        const root = mkdtempSync(join(tmpdir(), "grok-search-"));
+        const shop = "/Users/me/Projects/shop";
+        writeSession(root, shop, ID_A, {
+            title: "PRs merged into release/2026-09-03",
+            updated: "2026-09-02T10:00:00.000Z",
+            query: "please restore the panes",
+        });
+        writeSession(root, shop, ID_B, {
+            title: "aws-costs",
+            updated: "2026-09-03T10:00:00.000Z",
+            query: "how much did we spend",
+        });
+
+        const byTitle = searchGrokSessions(root, { query: "PRs merged", cwd: shop });
+        expect(byTitle.map((s) => s.sessionId)).toEqual([ID_A]);
+
+        const byBody = searchGrokSessions(root, { query: "restore the panes", cwd: shop });
+        expect(byBody.map((s) => s.sessionId)).toEqual([ID_A]);
+        expect(byBody[0]?.matchedText).toContain("restore the panes");
+
+        const limited = searchGrokSessions(root, { cwd: shop, limit: 1 });
+        expect(limited).toHaveLength(1);
+        expect(limited[0]?.sessionId).toBe(ID_B);
+    });
+});

--- a/src/utils/agent-sessions/grok-sessions.ts
+++ b/src/utils/agent-sessions/grok-sessions.ts
@@ -1,0 +1,222 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { nativeSessionRoots } from "@genesiscz/utils/providers/session-paths";
+import { matchSessionText, sortAndLimit } from "./match";
+import type { AgentSearchFilters, AgentSearchHit, AgentSession, AgentSessionAdapter } from "./types";
+
+const USER_QUERY_RE = /<user_query>\s*([\s\S]*?)\s*<\/user_query>/i;
+
+interface GrokSummary {
+    info?: { id?: string; cwd?: string };
+    generated_title?: string;
+    session_summary?: string;
+    updated_at?: string;
+    created_at?: string;
+}
+
+export function grokSessionsRoot(home = homedir()): string {
+    return nativeSessionRoots("grok", home)[0] ?? join(home, ".grok", "sessions");
+}
+
+export function grokSessionsRoots(home = homedir()): string[] {
+    return nativeSessionRoots("grok", home);
+}
+
+function isUuidDir(name: string): boolean {
+    return /^[0-9a-f-]{20,}$/i.test(name);
+}
+
+export function extractGrokUserQueries(chatHistoryText: string): string[] {
+    const queries: string[] = [];
+
+    for (const line of chatHistoryText.split("\n")) {
+        if (!line.includes("user_query") && !line.includes('"type":"user"')) {
+            continue;
+        }
+
+        let parsed: { type?: string; content?: unknown };
+        try {
+            parsed = SafeJSON.parse(line, { strict: true }) as { type?: string; content?: unknown };
+        } catch {
+            continue;
+        }
+
+        if (parsed.type !== "user") {
+            continue;
+        }
+
+        const blobs: string[] = [];
+        if (typeof parsed.content === "string") {
+            blobs.push(parsed.content);
+        } else if (Array.isArray(parsed.content)) {
+            for (const part of parsed.content) {
+                if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
+                    blobs.push(part.text);
+                }
+            }
+        }
+
+        for (const blob of blobs) {
+            const tagged = blob.match(USER_QUERY_RE);
+            if (tagged?.[1]?.trim()) {
+                queries.push(tagged[1].trim());
+                continue;
+            }
+
+            const text = blob.trim();
+            if (text.length === 0 || text.startsWith("<user_info>") || text.startsWith("<git_status>")) {
+                continue;
+            }
+
+            queries.push(text);
+        }
+    }
+
+    return queries;
+}
+
+function readSummary(dir: string, encodedCwd: string): AgentSession | undefined {
+    const summaryPath = join(dir, "summary.json");
+    let raw: string;
+    try {
+        raw = readFileSync(summaryPath, "utf8");
+    } catch {
+        return undefined;
+    }
+
+    let parsed: GrokSummary;
+    try {
+        parsed = SafeJSON.parse(raw, { strict: true }) as GrokSummary;
+    } catch {
+        return undefined;
+    }
+
+    const sessionId = parsed.info?.id ?? "";
+    if (!sessionId) {
+        return undefined;
+    }
+
+    const cwd = parsed.info?.cwd || decodeURIComponent(encodedCwd);
+    const title = parsed.generated_title || parsed.session_summary || sessionId;
+    const stamp = parsed.updated_at || parsed.created_at;
+    let mtime = new Date(stamp ?? 0);
+    if (Number.isNaN(mtime.getTime())) {
+        try {
+            mtime = new Date(statSync(summaryPath).mtimeMs);
+        } catch {
+            mtime = new Date(0);
+        }
+    }
+
+    return {
+        kind: "grok",
+        sessionId,
+        cwd,
+        title,
+        summary: parsed.session_summary,
+        mtime,
+        filePath: summaryPath,
+        project: cwd.split("/").pop(),
+    };
+}
+
+export function listGrokSessionsFromRoot(sessionsRoot: string): AgentSession[] {
+    let cwdDirs: string[] = [];
+    try {
+        cwdDirs = readdirSync(sessionsRoot);
+    } catch {
+        return [];
+    }
+
+    const sessions: AgentSession[] = [];
+
+    for (const encoded of cwdDirs) {
+        const cwdDir = join(sessionsRoot, encoded);
+        let names: string[] = [];
+        try {
+            if (!statSync(cwdDir).isDirectory()) {
+                continue;
+            }
+            names = readdirSync(cwdDir);
+        } catch {
+            continue;
+        }
+
+        for (const name of names) {
+            if (!isUuidDir(name)) {
+                continue;
+            }
+
+            const session = readSummary(join(cwdDir, name), encoded);
+            if (session) {
+                sessions.push(session);
+            }
+        }
+    }
+
+    return sessions;
+}
+
+function extraTextsFor(session: AgentSession): string[] {
+    const historyPath = join(dirname(session.filePath), "chat_history.jsonl");
+    try {
+        return extractGrokUserQueries(readFileSync(historyPath, "utf8"));
+    } catch {
+        return [];
+    }
+}
+
+export function listGrokSessionsFromRoots(roots: string[]): AgentSession[] {
+    const seen = new Set<string>();
+    const sessions: AgentSession[] = [];
+
+    for (const root of roots) {
+        for (const session of listGrokSessionsFromRoot(root)) {
+            if (seen.has(session.sessionId)) {
+                continue;
+            }
+            seen.add(session.sessionId);
+            sessions.push(session);
+        }
+    }
+
+    return sessions;
+}
+
+export function searchGrokSessions(sessionsRoot: string, filters: AgentSearchFilters): AgentSearchHit[] {
+    return searchGrokSessionsInRoots([sessionsRoot], filters);
+}
+
+export function searchGrokSessionsInRoots(roots: string[], filters: AgentSearchFilters): AgentSearchHit[] {
+    const hits: AgentSearchHit[] = [];
+
+    for (const session of listGrokSessionsFromRoots(roots)) {
+        const extras = filters.query ? extraTextsFor(session) : [];
+        if (filters.query && extras[0] && !session.prompt) {
+            session.prompt = extras[0];
+        }
+
+        const hit = matchSessionText(session, extras, filters);
+        if (hit) {
+            hits.push(hit);
+        }
+    }
+
+    return sortAndLimit(hits, filters.limit);
+}
+
+export function createGrokAdapter(sessionsRoot?: string): AgentSessionAdapter {
+    const roots = sessionsRoot ? [sessionsRoot] : grokSessionsRoots();
+
+    return {
+        kind: "grok",
+        async list(filters) {
+            return searchGrokSessionsInRoots(roots, { ...filters, query: undefined });
+        },
+        async search(filters) {
+            return searchGrokSessionsInRoots(roots, filters);
+        },
+    };
+}

--- a/src/utils/agent-sessions/history-cli.test.ts
+++ b/src/utils/agent-sessions/history-cli.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { filtersFromHistoryOptions } from "./history-cli";
+
+describe("filtersFromHistoryOptions", () => {
+    test("defaults cwd to the process cwd unless --all", () => {
+        const scoped = filtersFromHistoryOptions("restore", { limit: "5" }, "/Users/me/Projects/shop");
+        expect(scoped.cwd).toBe("/Users/me/Projects/shop");
+        expect(scoped.limit).toBe(5);
+        expect(scoped.query).toBe("restore");
+
+        const byLeaf = filtersFromHistoryOptions("restore", { project: "GenesisTools" }, "/Users/me/Projects/shop");
+        expect(byLeaf.cwd).toBeUndefined();
+        expect(byLeaf.project).toBe("GenesisTools");
+
+        const all = filtersFromHistoryOptions(undefined, { all: true }, "/Users/me/Projects/shop");
+        expect(all.cwd).toBeUndefined();
+        expect(all.all).toBe(true);
+    });
+});
+
+describe("filtersFromHistoryOptions --project", () => {
+    test("--project fills the project filter, not cwd", () => {
+        // It used to land in `cwd`, which is compared against the ABSOLUTE path,
+        // so `-p GenesisTools` matched nothing and printed "No conversations".
+        const filters = filtersFromHistoryOptions("rebase", { project: "shop" }, "/Users/me/Projects/other");
+
+        expect(filters.project).toBe("shop");
+        expect(filters.cwd).toBeUndefined();
+    });
+
+    test("--cwd still pins the absolute directory", () => {
+        const filters = filtersFromHistoryOptions(undefined, { cwd: "/Users/me/Projects/shop" }, "/Users/me/other");
+
+        expect(filters.cwd).toBe("/Users/me/Projects/shop");
+        expect(filters.project).toBeUndefined();
+    });
+
+    test("--all wins over --project", () => {
+        const filters = filtersFromHistoryOptions(undefined, { all: true, project: "shop" }, "/Users/me/other");
+
+        expect(filters.project).toBeUndefined();
+        expect(filters.cwd).toBeUndefined();
+    });
+});

--- a/src/utils/agent-sessions/history-cli.ts
+++ b/src/utils/agent-sessions/history-cli.ts
@@ -1,0 +1,126 @@
+import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
+import { out } from "@genesiscz/utils/logger";
+import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
+import type { Command } from "commander";
+import { formatHistoryJson, formatHistoryMarkdown } from "./format-history";
+import type { AgentSearchFilters, AgentSessionAdapter } from "./types";
+
+export interface HistoryCliOptions {
+    all?: boolean;
+    cwd?: string;
+    project?: string;
+    since?: string;
+    until?: string;
+    limit?: string;
+    exact?: boolean;
+    regex?: boolean;
+    format?: string;
+    interactive?: boolean;
+}
+
+function parseDate(value: string | undefined): Date | undefined {
+    if (!value) {
+        return undefined;
+    }
+
+    if (value === "yesterday") {
+        const d = new Date();
+        d.setDate(d.getDate() - 1);
+        d.setHours(0, 0, 0, 0);
+        return d;
+    }
+
+    const days = value.match(/^(\d+)\s+days?\s+ago$/i);
+    if (days) {
+        const d = new Date();
+        d.setDate(d.getDate() - Number(days[1]));
+        return d;
+    }
+
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+export function filtersFromHistoryOptions(
+    query: string | undefined,
+    options: HistoryCliOptions,
+    defaultCwd: string
+): AgentSearchFilters {
+    const project = options.all ? undefined : options.project;
+    // `--project` filters by leaf name, so it must not also pin the default cwd:
+    // the point of naming another project is to look outside this one.
+    const cwd = options.all || project ? options.cwd : options.cwd || defaultCwd;
+
+    return {
+        query,
+        cwd,
+        project,
+        all: Boolean(options.all),
+        since: parseDate(options.since),
+        until: parseDate(options.until),
+        limit: options.limit ? Number(options.limit) : 20,
+        exact: Boolean(options.exact),
+        regex: Boolean(options.regex),
+    };
+}
+
+export function registerAgentHistoryCommand(program: Command, adapter: AgentSessionAdapter, toolName: string): void {
+    program
+        .command("history")
+        .description(`Search ${adapter.kind} conversation history`)
+        .argument("[query]", "Search query (fuzzy match by default)")
+        .option("-i, --interactive", "Interactive mode with prompts")
+        .option("-p, --project <name>", "Filter by project/cwd leaf name")
+        .option("--cwd <path>", "Filter by working directory")
+        .option("--all", "Search all projects (ignore cwd)")
+        .option("--since <date>", "Filter by date (e.g. '7 days ago', 'yesterday')")
+        .option("--until <date>", "Filter until date")
+        .option("-l, --limit <n>", "Limit results", "20")
+        .option("--exact", "Exact match instead of fuzzy")
+        .option("--regex", "Use regex for query")
+        .option("--format <type>", "Output format: ai (default), json", "ai")
+        .action(async (query: string | undefined, options: HistoryCliOptions) => {
+            if (options.interactive && !isInteractive()) {
+                out.error(
+                    `--interactive needs a TTY. ${suggestCommand(`tools ${toolName} history`, { add: ["--all"] })}`
+                );
+                process.exitCode = 1;
+                return;
+            }
+
+            const filters = filtersFromHistoryOptions(query, options, process.cwd());
+            const hits = await adapter.search(filters);
+
+            if (hits.length === 0) {
+                out.println("No conversations found matching your criteria.");
+                return;
+            }
+
+            let selected = hits;
+            if (options.interactive) {
+                const p = await import("@clack/prompts");
+                const choice = await withCancel(
+                    p.select({
+                        message: `Which ${adapter.kind} session?`,
+                        options: hits.map((hit) => ({
+                            value: hit.sessionId,
+                            label: hit.title,
+                            hint: hit.sessionId.slice(0, 8),
+                        })),
+                    })
+                );
+                const picked = hits.find((hit) => hit.sessionId === choice);
+                selected = picked ? [picked] : [];
+                if (selected.length === 0) {
+                    return;
+                }
+            }
+
+            if (options.format === "json") {
+                out.print(formatHistoryJson(selected));
+                return;
+            }
+
+            out.print(formatHistoryMarkdown(selected, query));
+        });
+}

--- a/src/utils/agent-sessions/index.ts
+++ b/src/utils/agent-sessions/index.ts
@@ -1,0 +1,21 @@
+export { createCodexAdapter, listCodexSessionsFromRoots, parseCodexRollout } from "./codex-sessions";
+export { formatHistoryJson, formatHistoryMarkdown } from "./format-history";
+export {
+    createGrokAdapter,
+    extractGrokUserQueries,
+    grokSessionsRoot,
+    grokSessionsRoots,
+    listGrokSessionsFromRoot,
+    listGrokSessionsFromRoots,
+} from "./grok-sessions";
+export { filtersFromHistoryOptions, registerAgentHistoryCommand } from "./history-cli";
+export { haystackMatch, matchSessionText, sessionMatchesCwd, sortAndLimit } from "./match";
+export { pickSessionByQuery } from "./pick-session";
+export { resumeArgv, resumeCommandLine } from "./resume-argv";
+export type {
+    AgentKind,
+    AgentSearchFilters,
+    AgentSearchHit,
+    AgentSession,
+    AgentSessionAdapter,
+} from "./types";

--- a/src/utils/agent-sessions/match.test.ts
+++ b/src/utils/agent-sessions/match.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { haystackMatch, sessionMatchesCwd } from "./match";
+import type { AgentSession } from "./types";
+
+describe("sessionMatchesCwd", () => {
+    const session: AgentSession = {
+        kind: "grok",
+        sessionId: "s1",
+        cwd: "/Users/me/Projects/shop",
+        title: "t",
+        mtime: new Date(0),
+        filePath: "/tmp/s1.jsonl",
+        project: "shop",
+    };
+
+    test("matches a project by leaf name", () => {
+        expect(sessionMatchesCwd(session, { project: "shop" })).toBe(true);
+        expect(sessionMatchesCwd(session, { project: "side" })).toBe(false);
+    });
+
+    test("derives the leaf name when the adapter did not record one", () => {
+        expect(sessionMatchesCwd({ ...session, project: undefined }, { project: "shop" })).toBe(true);
+    });
+
+    test("cwd stays an exact absolute comparison", () => {
+        expect(sessionMatchesCwd(session, { cwd: "/Users/me/Projects/shop" })).toBe(true);
+        expect(sessionMatchesCwd(session, { cwd: "shop" })).toBe(false);
+    });
+
+    test("--all ignores both", () => {
+        expect(sessionMatchesCwd(session, { all: true, project: "side", cwd: "/nope" })).toBe(true);
+    });
+});
+
+describe("haystackMatch", () => {
+    test("fuzzy requires every word", () => {
+        expect(haystackMatch("PRs merged into release", "PRs merged", {})).toBe(true);
+        expect(haystackMatch("PRs merged into release", "PRs missing", {})).toBe(false);
+    });
+
+    test("exact is case-insensitive substring, matching Claude history", () => {
+        expect(haystackMatch("PRs merged into release", "merged into", { exact: true })).toBe(true);
+        expect(haystackMatch("PRs merged into release", "PRs merged into release", { exact: true })).toBe(true);
+    });
+});

--- a/src/utils/agent-sessions/match.ts
+++ b/src/utils/agent-sessions/match.ts
@@ -1,0 +1,89 @@
+import type { AgentSearchFilters, AgentSearchHit, AgentSession } from "./types";
+
+export function sessionMatchesTime(session: AgentSession, filters: AgentSearchFilters): boolean {
+    if (filters.since && session.mtime < filters.since) {
+        return false;
+    }
+
+    if (filters.until && session.mtime > filters.until) {
+        return false;
+    }
+
+    return true;
+}
+
+export function sessionMatchesCwd(session: AgentSession, filters: AgentSearchFilters): boolean {
+    if (filters.all) {
+        return true;
+    }
+
+    if (filters.cwd && session.cwd !== filters.cwd) {
+        return false;
+    }
+
+    if (filters.project) {
+        // `--project GenesisTools` used to land in `filters.cwd` and be compared
+        // against the absolute cwd, so it matched nothing, ever. The leaf name
+        // is its own field; not every adapter fills it, so derive it when absent.
+        const leaf = session.project ?? session.cwd.split("/").filter(Boolean).pop();
+
+        if (leaf !== filters.project) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export function haystackMatch(haystack: string, query: string, filters: AgentSearchFilters): boolean {
+    if (filters.regex) {
+        try {
+            return new RegExp(query, "i").test(haystack);
+        } catch {
+            return false;
+        }
+    }
+
+    const hay = haystack.toLowerCase();
+    const needle = query.toLowerCase();
+
+    if (filters.exact) {
+        return hay.includes(needle);
+    }
+
+    const words = needle.split(/\s+/).filter(Boolean);
+    return words.every((word) => hay.includes(word));
+}
+
+export function matchSessionText(
+    session: AgentSession,
+    extraTexts: string[],
+    filters: AgentSearchFilters
+): AgentSearchHit | undefined {
+    if (!sessionMatchesCwd(session, filters) || !sessionMatchesTime(session, filters)) {
+        return undefined;
+    }
+
+    const query = filters.query?.trim();
+    if (!query) {
+        return session;
+    }
+
+    const fields = [session.sessionId, session.title, session.summary ?? "", session.prompt ?? "", ...extraTexts];
+    for (const field of fields) {
+        if (field && haystackMatch(field, query, filters)) {
+            return { ...session, matchedText: field.slice(0, 240) };
+        }
+    }
+
+    return undefined;
+}
+
+export function sortAndLimit(hits: AgentSearchHit[], limit?: number): AgentSearchHit[] {
+    hits.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+    if (limit !== undefined && limit >= 0) {
+        return hits.slice(0, limit);
+    }
+
+    return hits;
+}

--- a/src/utils/agent-sessions/pick-session.test.ts
+++ b/src/utils/agent-sessions/pick-session.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { pickSessionByQuery } from "./pick-session";
+import type { AgentSession } from "./types";
+
+function session(id: string, title: string): AgentSession {
+    return {
+        kind: "grok",
+        sessionId: id,
+        cwd: "/Users/me/Projects/shop",
+        title,
+        mtime: new Date("2026-09-03T10:00:00.000Z"),
+        filePath: `/tmp/${id}.json`,
+    };
+}
+
+const A = session("01a05cc5-0ecf-7d40-945e-977e45b3f935", "PRs merged into release/2026-09-03");
+const B = session("01a05d17-c512-7dd2-abb6-e62d8c7d612a", "aws-costs");
+
+describe("pickSessionByQuery", () => {
+    test("matches a unique id prefix", () => {
+        expect(pickSessionByQuery([A, B], "01a05cc5")?.sessionId).toBe(A.sessionId);
+    });
+
+    test("matches a unique title substring", () => {
+        expect(pickSessionByQuery([A, B], "aws-costs")?.sessionId).toBe(B.sessionId);
+    });
+
+    test("returns undefined when two titles could match", () => {
+        expect(pickSessionByQuery([A, B], "01a05")).toBeUndefined();
+    });
+});

--- a/src/utils/agent-sessions/pick-session.ts
+++ b/src/utils/agent-sessions/pick-session.ts
@@ -1,0 +1,27 @@
+import type { AgentSession } from "./types";
+
+/**
+ * Resolve a resume query against a session list. Unique id prefix wins, then a
+ * unique title substring. Ambiguous or empty returns undefined so the CLI can
+ * prompt or list.
+ */
+export function pickSessionByQuery(sessions: AgentSession[], query: string | undefined): AgentSession | undefined {
+    if (!query?.trim()) {
+        return undefined;
+    }
+
+    const q = query.trim().toLowerCase();
+    const byId = sessions.filter(
+        (session) => session.sessionId.toLowerCase() === q || session.sessionId.toLowerCase().startsWith(q)
+    );
+    if (byId.length === 1) {
+        return byId[0];
+    }
+
+    const byTitle = sessions.filter((session) => session.title.toLowerCase().includes(q));
+    if (byTitle.length === 1) {
+        return byTitle[0];
+    }
+
+    return undefined;
+}

--- a/src/utils/agent-sessions/resume-argv.test.ts
+++ b/src/utils/agent-sessions/resume-argv.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { resumeArgv, resumeCommandLine } from "./resume-argv";
+
+const GROK_ID = "01a05cc5-0ecf-7d40-945e-977e45b3f935";
+const CLAUDE_ID = "6bdfb457-cee9-4202-8105-21be8a801757";
+const CODEX_ID = "01a067d4-d2b0-7532-8f59-9af2a29c2d0e";
+
+describe("resumeArgv", () => {
+    test("grok uses -r <id>", () => {
+        expect(resumeArgv("grok", GROK_ID)).toEqual(["grok", "-r", GROK_ID]);
+    });
+
+    test("codex uses resume <id>", () => {
+        expect(resumeArgv("codex", CODEX_ID)).toEqual(["codex", "resume", CODEX_ID]);
+    });
+
+    test("claude without an account uses the bare binary", () => {
+        expect(resumeArgv("claude", CLAUDE_ID)).toEqual(["claude", "--resume", CLAUDE_ID]);
+    });
+
+    test("claude with an account goes through tools claude start", () => {
+        expect(resumeArgv("claude", CLAUDE_ID, "work")).toEqual([
+            "tools",
+            "claude",
+            "start",
+            "work",
+            "--",
+            "--resume",
+            CLAUDE_ID,
+        ]);
+    });
+});
+
+describe("resumeCommandLine", () => {
+    test("joins grok -r without extra quotes on a uuid", () => {
+        expect(resumeCommandLine("grok", GROK_ID)).toBe(`grok -r ${GROK_ID}`);
+    });
+});

--- a/src/utils/agent-sessions/resume-argv.ts
+++ b/src/utils/agent-sessions/resume-argv.ts
@@ -1,0 +1,27 @@
+import type { AgentKind } from "./types";
+
+/**
+ * Argv that resumes an interactive TUI session. Shared by cmux replay,
+ * `tools grok run --resume`, and restore-after-restart.
+ */
+export function resumeArgv(kind: AgentKind, sessionId: string, account?: string | null): string[] {
+    if (kind === "grok") {
+        return ["grok", "-r", sessionId];
+    }
+
+    if (kind === "codex") {
+        return ["codex", "resume", sessionId];
+    }
+
+    if (account) {
+        return ["tools", "claude", "start", account, "--", "--resume", sessionId];
+    }
+
+    return ["claude", "--resume", sessionId];
+}
+
+export function resumeCommandLine(kind: AgentKind, sessionId: string, account?: string | null): string {
+    return resumeArgv(kind, sessionId, account)
+        .map((token) => (/\s/.test(token) ? `'${token.replace(/'/g, `'\\''`)}'` : token))
+        .join(" ");
+}

--- a/src/utils/agent-sessions/types.ts
+++ b/src/utils/agent-sessions/types.ts
@@ -1,0 +1,38 @@
+export type AgentKind = "claude" | "grok" | "codex";
+
+export interface AgentSession {
+    kind: AgentKind;
+    sessionId: string;
+    cwd: string;
+    title: string;
+    summary?: string;
+    prompt?: string;
+    mtime: Date;
+    filePath: string;
+    project?: string;
+    account?: string | null;
+}
+
+export interface AgentSearchFilters {
+    query?: string;
+    /** Absolute working directory; compared exactly. */
+    cwd?: string;
+    /** Project leaf name (the last path segment of the cwd); compared exactly. */
+    project?: string;
+    all?: boolean;
+    since?: Date;
+    until?: Date;
+    limit?: number;
+    exact?: boolean;
+    regex?: boolean;
+}
+
+export interface AgentSearchHit extends AgentSession {
+    matchedText?: string;
+}
+
+export interface AgentSessionAdapter {
+    kind: AgentKind;
+    list(filters: AgentSearchFilters): Promise<AgentSession[]>;
+    search(filters: AgentSearchFilters): Promise<AgentSearchHit[]>;
+}

--- a/src/utils/tmux/sessions.test.ts
+++ b/src/utils/tmux/sessions.test.ts
@@ -4,6 +4,7 @@ import { resetTmuxBinCache, setTmuxBinForTests } from "@genesiscz/utils/tmux/bin
 import {
     buildTmuxSpawnEnv,
     createTmuxSession,
+    createTmuxSessionRunning,
     getTmuxScrollState,
     listTmuxSessionActivePanes,
     listTmuxSessionCommands,
@@ -286,6 +287,27 @@ describe("tmux sessions", () => {
                     cmd.includes("truecolor")
             )
         ).toBe(true);
+    });
+
+    test("createTmuxSessionRunning puts argv after -- instead of a login shell", async () => {
+        setTmuxBinForTests("/mock/tmux");
+        const calls: string[][] = [];
+        setTmuxSpawnSyncForTests((cmd) => {
+            calls.push(cmd);
+            return { exitCode: 0, stdout: "" };
+        });
+
+        await createTmuxSessionRunning("claude-auth", "/tmp", ["claude", "--resume", "abc"], {
+            CLAUDE_CODE_OAUTH_TOKEN: "tok",
+        });
+
+        const created = calls.find((cmd) => cmd.includes("new-session"));
+        expect(created).toBeDefined();
+        const dash = created?.indexOf("--") ?? -1;
+        expect(created?.slice(dash)?.[0]).toBe("--");
+        expect(created?.slice(dash)).toContain("/usr/bin/env");
+        expect(created?.some((token) => token === "CLAUDE_CODE_OAUTH_TOKEN=tok")).toBe(true);
+        expect(created?.slice(-3)).toEqual(["claude", "--resume", "abc"]);
     });
 
     test("getTmuxScrollState parses display-message output", async () => {

--- a/src/utils/tmux/sessions.ts
+++ b/src/utils/tmux/sessions.ts
@@ -372,6 +372,53 @@ export async function createTmuxSession(sessionName: string, cwd: string, comman
 }
 
 /**
+ * Detached tmux session whose first pane runs `argv` (not a login shell).
+ * Used by `tools claude run --tmux` so Claude is the session process.
+ */
+export async function createTmuxSessionRunning(
+    sessionName: string,
+    cwd: string,
+    argv: string[],
+    extraEnv: Record<string, string | undefined> = {}
+): Promise<void> {
+    if (argv.length === 0) {
+        throw new Error("createTmuxSessionRunning needs a command");
+    }
+
+    const envArgv = ["/usr/bin/env"];
+    const merged: Record<string, string | undefined> = { ...buildTmuxSpawnEnv(), ...extraEnv };
+    for (const [key, value] of Object.entries(merged)) {
+        if (typeof value === "string" && value.length > 0 && !key.includes("=") && !key.includes("\n")) {
+            envArgv.push(`${key}=${value}`);
+        }
+    }
+
+    const tmuxBin = resolveTmuxBin();
+    const result = await runTmux(
+        [tmuxBin, "new-session", "-d", "-s", sessionName, "-c", cwd, "--", ...envArgv, ...argv],
+        { cwd }
+    );
+
+    if (result.exitCode !== 0) {
+        throw new Error(`Failed to create tmux session ${sessionName}${tmuxErrorDetail(result.stderr)}`);
+    }
+
+    await Promise.all([ensureTmuxSessionEnvironment(sessionName), ensureTmuxServerPersists(tmuxBin)]);
+}
+
+/** Live tmux session name for this process, or undefined when not attached. */
+export async function currentTmuxSessionName(): Promise<string | undefined> {
+    if (!env.get("TMUX")) {
+        return undefined;
+    }
+
+    const tmuxBin = resolveTmuxBin();
+    const result = await runTmux([tmuxBin, "display-message", "-p", "#{session_name}"]);
+    const name = result.stdout.trim();
+    return result.exitCode === 0 && name.length > 0 ? name : undefined;
+}
+
+/**
  * Pin the tmux server so sessions survive detach/teardown instead of dying,
  * AND scrub the server's global environment of color-killing inheritance from
  * whichever process happened to bootstrap it.


### PR DESCRIPTION
Restore cmux panes after a restart with Claude, Grok, and Codex resume commands. Search and resume Grok TUI sessions the same way as Claude. Wrap Anthropic `tools claude start`/`run` in tmux and rename a bound ttyd.

## Commands

```bash
tools cmux restore-after-restart --source previous --dry-run
tools cmux restore-after-restart --source previous --agents grok,claude --enter -y
tools grok history [query]
tools grok run --resume [query]
tools grok resume [query]
tools claude start work --tmux --resume "auth callback"
```

Restore is always non-destructive (new workspaces, default prefix `restart-`). `--source previous` reads cmux `*-previous.json` (the layout from before last launch).

## Adapter

Shared `src/utils/agent-sessions/` owns grok/codex disk list/search and `resumeArgv`. Claude history stays on the existing `search.ts` stack (not copied). Cmux replay, grok history, and grok TUI resume call that layer.

## What this does not do

- Port Claude history summarize/dashboard/extract to Grok
- Kill existing cmux workspaces
- Change the headless `tools grok run --name/--cwd` worker except that `--resume` is a TUI mode switch
- Auto-create ttyd sessions (rename only)
- `tools claude proxy` / slash targets (`--tmux` is Anthropic start/run only)
- `tools codex history` (adapter exists; no CLI door)

## Test plan

- [x] `bun run test src/cmux/lib/restore-after-restart.test.ts`
- [x] `bun run test src/cmux/lib/agent-replay.test.ts`
- [x] `bun run test src/grok/lib/tui-resume.test.ts`
- [x] `bun run test src/utils/agent-sessions/`
- [x] Live dry-run: `bun src/cmux/index.ts restore-after-restart --source previous --dry-run --yes`
- [ ] Human: `tools cmux restore-after-restart --source previous --list` after a real cmux restart
- [ ] Human: `tools grok run --resume` on a TTY
- [ ] Human: `tools claude start <account> --tmux --resume <query>` inside an existing ttyd

## Notes

Retargeted onto `master` at 2026-09-04 02:07. Cherry-picked the campaign-only foundation first (agent-replay, agent-sessions adapter, grok history/TUI resume, resume splice) so the feature commits compile on master. Campaign backup ref: `backup/pr349-on-campaign` (`fb19824f6`). Not merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tmux support to Claude launches, including session naming, resume titles, attachment, and headless execution.
  * Added `cmux restore-after-restart` with autosave/profile sources, agent filtering, previews, dry runs, confirmations, and progress reporting.
  * Added Grok history and resume commands with search, project filtering, limits, and interactive selection.
  * Added session history and search support for Grok and Codex.
  * Improved snapshot and restore replay for Claude, Grok, and Codex sessions.

* **Documentation**
  * Updated Claude, Grok, and cmux command documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->