### PR TITLE
fix(clarity): make the CLI able to discover timesheets, and refuse to fill an incomplete month

### DIFF
--- a/src/azure-devops/commands/ancestors.ts
+++ b/src/azure-devops/commands/ancestors.ts
@@ -1,0 +1,73 @@
+import { Api } from "@app/azure-devops/api";
+import { type WorkItemNode, walkAncestors } from "@app/azure-devops/lib/ancestors";
+import { parseRelations } from "@app/azure-devops/relations";
+import { requireConfig } from "@app/azure-devops/utils";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+export function registerAncestorsCommand(parent: Command): void {
+    parent
+        .command("ancestors")
+        .description("Walk a work item's parent chain upwards")
+        .argument("<id>", "Work item ID")
+        .option("--depth <n>", "How many ancestors above the item to climb", "3")
+        .option("--format <format>", "Output format: table|json", "table")
+        .action(async (idArg: string, options: { depth: string; format: string }) => {
+            const config = requireConfig();
+            const api = new Api(config);
+            const id = Number.parseInt(idArg, 10);
+
+            if (Number.isNaN(id)) {
+                out.error(`Invalid work item id '${idArg}'`);
+                process.exit(1);
+            }
+
+            const maxDepth = Number.parseInt(options.depth, 10);
+
+            if (!Number.isInteger(maxDepth) || maxDepth < 0) {
+                out.error(`Invalid --depth '${options.depth}': expected a non-negative whole number`);
+                process.exit(1);
+            }
+
+            const chain = await walkAncestors({
+                id,
+                maxDepth,
+                fetch: async (workItemId): Promise<WorkItemNode | null> => {
+                    try {
+                        const item = await api.getWorkItem(workItemId);
+
+                        return {
+                            id: item.id,
+                            title: item.title,
+                            type: String(item.rawFields?.["System.WorkItemType"] ?? "?"),
+                            parent: parseRelations(item.relations ?? []).parent,
+                        };
+                    } catch (err) {
+                        logFetchFailure(workItemId, err);
+
+                        return null;
+                    }
+                },
+            });
+
+            if (chain.length === 0) {
+                out.error(`Work item #${id} not found`);
+                process.exit(1);
+            }
+
+            if (options.format === "json") {
+                out.result(chain);
+                return;
+            }
+
+            chain.forEach((node, index) => {
+                const arrow = index === 0 ? "" : `${"  ".repeat(index)}${pc.dim("└─ ")}`;
+                out.println(`${arrow}${pc.white(`#${node.id}`)} ${pc.dim(`[${node.type}]`)} ${node.title}`);
+            });
+        });
+}
+
+function logFetchFailure(workItemId: number, err: unknown): void {
+    out.warn(pc.yellow(`  Could not read #${workItemId}: ${err instanceof Error ? err.message : String(err)}`));
+}

--- a/src/azure-devops/index.ts
+++ b/src/azure-devops/index.ts
@@ -29,6 +29,7 @@ import { Command } from "commander";
 handleReadmeFlag(import.meta.url);
 
 // Import command registration functions
+import { registerAncestorsCommand } from "@app/azure-devops/commands/ancestors";
 import { registerConfigureCommand } from "@app/azure-devops/commands/configure";
 import { registerDashboardCommand } from "@app/azure-devops/commands/dashboard";
 import { registerHistoryCommand } from "@app/azure-devops/commands/history";
@@ -63,6 +64,7 @@ program
 registerConfigureCommand(program);
 registerQueryCommand(program);
 registerWorkitemCommand(program);
+registerAncestorsCommand(program);
 registerWorkitemCreateCommand(program);
 registerWorkitemCacheCommand(program);
 registerDashboardCommand(program);

--- a/src/azure-devops/lib/ancestor-batch.test.ts
+++ b/src/azure-devops/lib/ancestor-batch.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { type WorkItemNode, walkAncestorsBatched } from "@app/azure-devops/lib/ancestors";
+
+const TREE: Record<number, WorkItemNode> = {
+    100001: { id: 100001, title: "Leaf a", type: "Task", parent: 200001 },
+    100002: { id: 100002, title: "Leaf b", type: "Task", parent: 200001 },
+    100003: { id: 100003, title: "Leaf c", type: "Task", parent: 200002 },
+    200001: { id: 200001, title: "Story a", type: "User Story", parent: 300001 },
+    200002: { id: 200002, title: "Story b", type: "User Story", parent: 300001 },
+    300001: { id: 300001, title: "Feature", type: "Feature", parent: 400001 },
+    400001: { id: 400001, title: "Epic", type: "Epic" },
+    500001: { id: 500001, title: "Orphan", type: "Bug" },
+};
+
+function batchFetcher() {
+    const batches: number[][] = [];
+
+    return {
+        batches,
+        fetchMany: async (ids: number[]): Promise<Map<number, WorkItemNode>> => {
+            batches.push([...ids]);
+
+            return new Map(ids.filter((id) => TREE[id]).map((id) => [id, TREE[id]]));
+        },
+    };
+}
+
+describe("walkAncestorsBatched", () => {
+    test("returns a full chain for every requested work item", async () => {
+        const { fetchMany } = batchFetcher();
+
+        const chains = await walkAncestorsBatched({ fetchMany, ids: [100001, 100003], maxDepth: 3 });
+
+        expect(chains.get(100001)?.map((n) => n.id)).toEqual([100001, 200001, 300001, 400001]);
+        expect(chains.get(100003)?.map((n) => n.id)).toEqual([100003, 200002, 300001, 400001]);
+    });
+
+    test("spends one fetch per tree level, not one per work item", async () => {
+        const { batches, fetchMany } = batchFetcher();
+
+        await walkAncestorsBatched({ fetchMany, ids: [100001, 100002, 100003], maxDepth: 3 });
+
+        expect(batches).toEqual([[100001, 100002, 100003], [200001, 200002], [300001], [400001]]);
+    });
+
+    test("never asks for a work item it already holds", async () => {
+        const { batches, fetchMany } = batchFetcher();
+
+        await walkAncestorsBatched({ fetchMany, ids: [100001, 100002], maxDepth: 3 });
+
+        const requested = batches.flat();
+
+        expect(requested.length).toBe(new Set(requested).size);
+    });
+
+    test("returns a single-node chain for a work item with no parent", async () => {
+        const { fetchMany } = batchFetcher();
+
+        const chains = await walkAncestorsBatched({ fetchMany, ids: [500001], maxDepth: 3 });
+
+        expect(chains.get(500001)?.map((n) => n.id)).toEqual([500001]);
+    });
+
+    test("omits a work item the server does not return", async () => {
+        const { fetchMany } = batchFetcher();
+
+        const chains = await walkAncestorsBatched({ fetchMany, ids: [999999], maxDepth: 3 });
+
+        expect(chains.has(999999)).toBe(false);
+    });
+
+    test("stops climbing at maxDepth ancestors above each item", async () => {
+        const { fetchMany } = batchFetcher();
+
+        const chains = await walkAncestorsBatched({ fetchMany, ids: [100001], maxDepth: 1 });
+
+        expect(chains.get(100001)?.map((n) => n.id)).toEqual([100001, 200001]);
+    });
+});

--- a/src/azure-devops/lib/ancestors.test.ts
+++ b/src/azure-devops/lib/ancestors.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { type WorkItemNode, walkAncestors } from "@app/azure-devops/lib/ancestors";
+
+const TREE: Record<number, WorkItemNode> = {
+    400001: { id: 400001, title: "FE analýza - leaf task", type: "Task", parent: 400002 },
+    400002: { id: 400002, title: "Parent user story", type: "User Story", parent: 400003 },
+    400003: { id: 400003, title: "Grandparent feature", type: "Feature", parent: 400004 },
+    400004: { id: 400004, title: "Great-grandparent epic", type: "Epic" },
+    500001: { id: 500001, title: "Orphan bug", type: "Bug" },
+    600001: { id: 600001, title: "Cycle a", type: "Task", parent: 600002 },
+    600002: { id: 600002, title: "Cycle b", type: "Task", parent: 600001 },
+};
+
+function tracingFetch() {
+    const calls: number[] = [];
+
+    return {
+        calls,
+        fetch: async (id: number): Promise<WorkItemNode | null> => {
+            calls.push(id);
+
+            return TREE[id] ?? null;
+        },
+    };
+}
+
+describe("walkAncestors", () => {
+    test("returns the item first, then each ancestor in order", async () => {
+        const { fetch } = tracingFetch();
+
+        const chain = await walkAncestors({ fetch, id: 400001, maxDepth: 3 });
+
+        expect(chain.map((node) => node.id)).toEqual([400001, 400002, 400003, 400004]);
+    });
+
+    test("stops climbing at maxDepth ancestors above the item", async () => {
+        const { fetch } = tracingFetch();
+
+        const chain = await walkAncestors({ fetch, id: 400001, maxDepth: 1 });
+
+        expect(chain.map((node) => node.id)).toEqual([400001, 400002]);
+    });
+
+    test("returns the item alone when it has no parent", async () => {
+        const { fetch } = tracingFetch();
+
+        const chain = await walkAncestors({ fetch, id: 500001, maxDepth: 3 });
+
+        expect(chain.map((node) => node.id)).toEqual([500001]);
+    });
+
+    test("stops instead of looping when the parent chain cycles back", async () => {
+        const { fetch } = tracingFetch();
+
+        const chain = await walkAncestors({ fetch, id: 600001, maxDepth: 3 });
+
+        expect(chain.map((node) => node.id)).toEqual([600001, 600002]);
+    });
+
+    test("fetches each work item exactly once", async () => {
+        const { calls, fetch } = tracingFetch();
+
+        await walkAncestors({ fetch, id: 400001, maxDepth: 3 });
+
+        expect(calls).toEqual([400001, 400002, 400003, 400004]);
+    });
+
+    test("returns an empty chain when the work item does not exist", async () => {
+        const { fetch } = tracingFetch();
+
+        const chain = await walkAncestors({ fetch, id: 999999, maxDepth: 3 });
+
+        expect(chain).toEqual([]);
+    });
+});

--- a/src/azure-devops/lib/ancestors.ts
+++ b/src/azure-devops/lib/ancestors.ts
@@ -1,0 +1,104 @@
+export interface WorkItemNode {
+    id: number;
+    title: string;
+    type: string;
+    parent?: number;
+}
+
+/**
+ * Walk a work item's parent chain upwards. Stops at the first item without a parent, at
+ * `maxDepth` ancestors above the starting item, or when the chain cycles back on itself.
+ * Each work item is fetched exactly once.
+ */
+export async function walkAncestors({
+    fetch,
+    id,
+    maxDepth = 3,
+}: {
+    fetch: (id: number) => Promise<WorkItemNode | null>;
+    id: number;
+    maxDepth?: number;
+}): Promise<WorkItemNode[]> {
+    const chain: WorkItemNode[] = [];
+    const seen = new Set<number>();
+    let currentId: number | undefined = id;
+
+    while (currentId !== undefined && !seen.has(currentId) && chain.length <= maxDepth) {
+        seen.add(currentId);
+        const node = await fetch(currentId);
+
+        if (!node) {
+            break;
+        }
+
+        chain.push(node);
+        currentId = node.parent;
+    }
+
+    return chain;
+}
+
+/**
+ * Walk many parent chains at once, one fetch per tree LEVEL instead of one per ancestor.
+ * A month of ~13 work items costs about 4 calls rather than 50. Each work item is requested once.
+ */
+export async function walkAncestorsBatched({
+    fetchMany,
+    ids,
+    maxDepth = 3,
+}: {
+    fetchMany: (ids: number[]) => Promise<Map<number, WorkItemNode>>;
+    ids: number[];
+    maxDepth?: number;
+}): Promise<Map<number, WorkItemNode[]>> {
+    const known = new Map<number, WorkItemNode>();
+    let level = [...new Set(ids)];
+
+    for (let depth = 0; depth <= maxDepth && level.length > 0; depth++) {
+        const wanted = level.filter((id) => !known.has(id));
+
+        if (wanted.length === 0) {
+            break;
+        }
+
+        const fetched = await fetchMany(wanted);
+
+        for (const [id, node] of fetched) {
+            known.set(id, node);
+        }
+
+        level = [
+            ...new Set(
+                wanted
+                    .map((id) => known.get(id)?.parent)
+                    .filter((parent): parent is number => parent !== undefined && !known.has(parent))
+            ),
+        ];
+    }
+
+    const chains = new Map<number, WorkItemNode[]>();
+
+    for (const id of new Set(ids)) {
+        const chain: WorkItemNode[] = [];
+        const seen = new Set<number>();
+        let currentId: number | undefined = id;
+
+        while (currentId !== undefined && !seen.has(currentId) && chain.length <= maxDepth) {
+            seen.add(currentId);
+            const node = known.get(currentId);
+
+            if (!node) {
+                break;
+            }
+
+            chain.push(node);
+            currentId = node.parent;
+        }
+
+        if (chain.length > 0) {
+            chains.set(id, chain);
+        }
+    }
+
+    return chains;
+}

--- a/src/clarity/commands/fill.ts
+++ b/src/clarity/commands/fill.ts
@@ -3,19 +3,27 @@ import { formatMinutes, TimeLogApi } from "@app/azure-devops/timelog-api";
 import { requireTimeLogConfig, requireTimeLogUser } from "@app/azure-devops/utils";
 import type { TimeEntryRecord, TimeSeriesValue } from "@genesiscz/utils/clarity";
 import { ClarityApi } from "@genesiscz/utils/clarity";
-import { addDay, formatDate, getWeekRange, subtractDay } from "@genesiscz/utils/date";
+import { addDay, getDaysInPeriodInclusive, isDateInHalfOpenRange } from "@genesiscz/utils/date";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { out } from "@genesiscz/utils/logger";
 import Table from "cli-table3";
 import type { Command } from "commander";
 import pc from "picocolors";
 import { requireConfig } from "../config.js";
+import { buildPeriodComment } from "../lib/comment-builder.js";
+import { checkUnmapped } from "../lib/fill-guard.js";
 import { buildFillMap, buildTimeSegments, type FillEntry } from "../lib/fill-utils.js";
+import { resolveFillWeeks } from "../lib/fill-weeks.js";
+
+type TimesheetRecordLike = Awaited<ReturnType<ClarityApi["getTimesheet"]>>["timesheets"]["_results"][number];
 
 interface WeekPlan {
     timesheetId: number;
     periodStart: string;
+    /** Clarity's timePeriodFinish: the LAST day of the period, inclusive. */
     periodFinish: string;
+    /** Notes already on the timesheet, so a re-run does not append a duplicate. */
+    existingNotes: number;
     entries: Array<{
         fill: FillEntry;
         timeEntryId: number;
@@ -26,7 +34,7 @@ interface WeekPlan {
 
 function renderWeekPreview(plan: WeekPlan): void {
     const start = plan.periodStart.split("T")[0];
-    const end = subtractDay(plan.periodFinish.split("T")[0]);
+    const end = plan.periodFinish.split("T")[0];
 
     out.println(`\n${pc.bold(`Week: ${start} to ${end}`)} (Timesheet: ${plan.timesheetId})`);
 
@@ -35,28 +43,18 @@ function renderWeekPreview(plan: WeekPlan): void {
         return;
     }
 
-    // Build day columns (periodFinish is exclusive)
-    const periodStart = new Date(plan.periodStart);
-    const periodEnd = new Date(plan.periodFinish);
-    const dayLabels: string[] = [];
-    const dayDates: string[] = [];
-    const dayNames = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
-
-    const current = new Date(periodStart);
-
-    while (current < periodEnd) {
-        dayDates.push(formatDate(current));
-        dayLabels.push(`${dayNames[current.getUTCDay()]} ${current.getUTCDate()}`);
-        current.setUTCDate(current.getUTCDate() + 1);
-    }
+    // timePeriodFinish names the LAST day of the period, so the range is inclusive. The shared
+    // helper parses as UTC; building Dates locally and then reading getUTCDay() shifted every day
+    // back one in CEST, which turned a one-day period into a Sunday and dropped it entirely.
+    const days = getDaysInPeriodInclusive(plan.periodStart, plan.periodFinish);
+    const dayLabels = days.map((day) => day.label);
+    const dayDates = days.map((day) => day.date);
 
     // Only show Mon-Fri
     const workDayIndices = dayDates
         .map((_, i) => i)
         .filter((i) => {
-            const d = new Date(periodStart);
-            d.setUTCDate(d.getUTCDate() + i);
-            const dow = d.getUTCDay();
+            const dow = new Date(`${dayDates[i]}T00:00:00Z`).getUTCDay();
             return dow >= 1 && dow <= 5;
         });
 
@@ -107,10 +105,20 @@ export function registerFillCommand(program: Command): void {
         .option("--year <n>", "Year (default: current)", parseInt)
         .option("--confirm", "Actually execute the fill (default: dry-run)")
         .option("--dry-run", "Preview only, do not write (default)")
-        .option("--verbose", "Show HTTP request/response debug info");
+        .option("--verbose", "Show HTTP request/response debug info")
+        .option("--allow-unmapped", "Fill anyway and skip work items that have no Clarity mapping")
+        .option("--no-comments", "Do not post the per-week timesheet note");
 
     fillCmd.action(
-        async (options: { month?: number; year?: number; confirm?: boolean; dryRun?: boolean; verbose?: boolean }) => {
+        async (options: {
+            month?: number;
+            year?: number;
+            confirm?: boolean;
+            dryRun?: boolean;
+            verbose?: boolean;
+            allowUnmapped?: boolean;
+            comments?: boolean;
+        }) => {
             if (!options.month) {
                 fillCmd.help();
                 return;
@@ -158,7 +166,28 @@ export function registerFillCommand(program: Command): void {
                 return;
             }
 
-            const { fillMap, unmappedByWi } = buildFillMap(adoExport.entries, clarityConfig.mappings);
+            const { fillMap, unmappedByWi, unmappedEntries } = buildFillMap(adoExport.entries, clarityConfig.mappings, {
+                trackEntries: true,
+            });
+            const unmapped = checkUnmapped({ unmappedByWi, allowUnmapped: Boolean(options.allowUnmapped) });
+
+            if (unmapped.items.length > 0) {
+                out.println(pc.yellow(`\n${unmapped.items.length} work item(s) have no Clarity mapping:`));
+
+                for (const item of unmapped.items) {
+                    out.println(pc.yellow(`    #${item.workItemId}: ${formatMinutes(item.minutes)}`));
+                }
+
+                out.println(pc.yellow(`  ${formatMinutes(unmapped.totalMinutes)} would be left out of Clarity.`));
+            }
+
+            if (unmapped.blocked) {
+                out.error("Refusing to fill an incomplete month. Map these work items first:");
+                out.error("  tools clarity tasks --date <YYYY-MM>");
+                out.error("  tools clarity link-workitems --azure-devops-workitem <id> --clarity-task-id <id>");
+                out.error("Pass --allow-unmapped to fill the mapped work items anyway.");
+                process.exit(1);
+            }
 
             const allDatesSet = new Set<string>();
 
@@ -175,53 +204,52 @@ export function registerFillCommand(program: Command): void {
                 return;
             }
 
-            const weeksSeen = new Set<string>();
-            const weeks: Array<{ start: Date; end: Date }> = [];
+            out.println("Loading Clarity timesheet data...");
 
-            for (const date of allDates) {
-                const d = new Date(date);
-                const { start } = getWeekRange(d);
-                const key = formatDate(start);
+            const { weeks, unresolvedDates, userId } = await resolveFillWeeks({
+                api: clarityApi,
+                mappings: clarityConfig.mappings,
+                dates: allDates,
+                month: options.month,
+                year,
+            });
 
-                if (!weeksSeen.has(key)) {
-                    weeksSeen.add(key);
-                    weeks.push(getWeekRange(d));
+            if (unresolvedDates.length > 0) {
+                for (const date of unresolvedDates) {
+                    out.error(pc.red(`  No Clarity period covers ${date}`));
                 }
-            }
 
-            const firstMapping = clarityConfig.mappings[0];
-
-            if (!firstMapping?.clarityTimesheetId) {
-                out.error(
-                    "No cached timesheet ID in mappings. Run 'tools clarity link-workitems' with a valid timesheet first."
-                );
+                out.error("Refusing to fill: those hours would be silently dropped.");
                 process.exit(1);
             }
 
-            out.println("Loading Clarity timesheet data...");
-
             const weekPlans: WeekPlan[] = [];
+            let missingRowCount = 0;
+            let unreadableWeeks = 0;
+            const bookedEntries: Array<{
+                timesheetId: number;
+                workItemId: number;
+                timeTypeDescription: string;
+                comment: string | null;
+                date: string;
+            }> = [];
 
             for (const week of weeks) {
-                const carouselEntry = await clarityApi.findTimesheetForDate(
-                    firstMapping.clarityTimesheetId,
-                    week.start
-                );
+                let ts: TimesheetRecordLike | undefined;
 
-                if (!carouselEntry) {
-                    out.warn(pc.yellow(`  Could not find timesheet for week ${formatDate(week.start)}`));
+                try {
+                    ts = (await clarityApi.getTimesheet(week.timesheetId)).timesheets._results[0];
+                } catch (err) {
+                    out.error(
+                        pc.red(`  Could not read timesheet ${week.timesheetId} for week ${week.startDate}: ${err}`)
+                    );
+                    unreadableWeeks++;
                     continue;
                 }
 
-                const tsData = await clarityApi.getTimesheet(carouselEntry.timesheet_id);
-                const ts = tsData.timesheets._results[0];
-
                 if (!ts) {
-                    out.warn(
-                        pc.yellow(
-                            `  Could not load timesheet ${carouselEntry.timesheet_id} for week ${formatDate(week.start)}`
-                        )
-                    );
+                    out.error(pc.red(`  Timesheet ${week.timesheetId} for week ${week.startDate} came back empty`));
+                    unreadableWeeks++;
                     continue;
                 }
 
@@ -229,24 +257,55 @@ export function registerFillCommand(program: Command): void {
                     timesheetId: ts._internalId,
                     periodStart: ts.timePeriodStart,
                     periodFinish: ts.timePeriodFinish,
+                    existingNotes: ts.numberOfNotes ?? 0,
                     entries: [],
-                    unmappedWorkItems: [...unmappedByWi.entries()].map(([workItemId, minutes]) => ({
-                        workItemId,
-                        minutes,
-                    })),
+                    unmappedWorkItems: unmappedEntries
+                        .filter((entry) =>
+                            isDateInHalfOpenRange(
+                                entry.date,
+                                ts.timePeriodStart,
+                                `${addDay(ts.timePeriodFinish.split("T")[0])}T00:00:00`
+                            )
+                        )
+                        .reduce<Array<{ workItemId: number; minutes: number }>>((acc, entry) => {
+                            const known = acc.find((item) => item.workItemId === entry.workItemId);
+
+                            if (known) {
+                                known.minutes += entry.minutes;
+                            } else {
+                                acc.push({ workItemId: entry.workItemId, minutes: entry.minutes });
+                            }
+
+                            return acc;
+                        }, []),
                 };
 
                 for (const fill of fillMap.values()) {
+                    const weekMinutes = Object.entries(fill.dayMinutes)
+                        .filter(([date]) =>
+                            isDateInHalfOpenRange(
+                                date,
+                                ts.timePeriodStart,
+                                `${addDay(ts.timePeriodFinish.split("T")[0])}T00:00:00`
+                            )
+                        )
+                        .reduce((sum, [, minutes]) => sum + minutes, 0);
+
+                    if (weekMinutes === 0) {
+                        continue;
+                    }
+
                     const timeEntry = ts.timeentries._results.find(
                         (e: TimeEntryRecord) => e.taskId === fill.mapping.clarityTaskId
                     );
 
                     if (!timeEntry) {
-                        out.warn(
-                            pc.yellow(
-                                `  No time entry found for task ${fill.mapping.clarityTaskName} in timesheet ${ts._internalId}`
+                        out.error(
+                            pc.red(
+                                `  No time entry row for task ${fill.mapping.clarityTaskName} in timesheet ${ts._internalId}; its hours cannot be booked`
                             )
                         );
+                        missingRowCount++;
                         continue;
                     }
 
@@ -274,9 +333,11 @@ export function registerFillCommand(program: Command): void {
             out.println(pc.bold("\nExecuting fill..."));
             let successCount = 0;
             let errorCount = 0;
+            let noteCount = 0;
+            let noteErrorCount = 0;
 
             for (const plan of weekPlans) {
-                const weekLabel = `${plan.periodStart.split("T")[0]} to ${subtractDay(plan.periodFinish.split("T")[0])}`;
+                const weekLabel = `${plan.periodStart.split("T")[0]} to ${plan.periodFinish.split("T")[0]}`;
                 out.println(`\n${pc.dim(`TS#${plan.timesheetId} (${weekLabel})`)}`);
 
                 for (const entry of plan.entries) {
@@ -321,6 +382,16 @@ export function registerFillCommand(program: Command): void {
                             actuals,
                         });
                         successCount++;
+
+                        for (const source of entry.fill.timelogEntries ?? []) {
+                            bookedEntries.push({
+                                timesheetId: plan.timesheetId,
+                                workItemId: source.workItemId,
+                                timeTypeDescription: source.timeTypeDescription ?? "",
+                                comment: source.comment ?? null,
+                                date: source.date,
+                            });
+                        }
                         out.println(
                             pc.green(`  ${pc.bold("OK")} ${taskName}: ${totalHours.toFixed(2)}h [${dayBreakdown}]`)
                         );
@@ -347,10 +418,62 @@ export function registerFillCommand(program: Command): void {
                 }
             }
 
+            if (options.comments !== false) {
+                if (userId === undefined) {
+                    noteErrorCount++;
+                    out.error(pc.red("  No Clarity user id resolved, the timesheet notes were not posted"));
+                }
+
+                for (const plan of weekPlans) {
+                    if (userId === undefined) {
+                        break;
+                    }
+
+                    // The note documents what was booked, so it is built from the entries that
+                    // actually wrote. Feeding it every ADO entry would describe unmapped work and
+                    // failed writes as if they had landed.
+                    const noteText = buildPeriodComment({
+                        entries: bookedEntries.filter((entry) => entry.timesheetId === plan.timesheetId),
+                        periodStart: plan.periodStart,
+                        periodFinishInclusive: plan.periodFinish,
+                    });
+
+                    if (!noteText) {
+                        continue;
+                    }
+
+                    if (plan.existingNotes > 0) {
+                        out.warn(
+                            pc.yellow(
+                                `  Timesheet ${plan.timesheetId} already carries ${plan.existingNotes} note(s), not adding another`
+                            )
+                        );
+                        continue;
+                    }
+
+                    try {
+                        await clarityApi.createTimesheetNote(plan.timesheetId, noteText, userId);
+                        noteCount++;
+                    } catch (err) {
+                        noteErrorCount++;
+                        out.error(pc.red(`  Note failed for timesheet ${plan.timesheetId}: ${err}`));
+                    }
+                }
+            }
+
             out.println(
                 `\n${pc.bold("Results:")} ${pc.green(`${successCount} updated`)}` +
-                    `${errorCount > 0 ? `, ${pc.red(`${errorCount} failed`)}` : ""}`
+                    `${noteCount > 0 ? `, ${pc.green(`${noteCount} note(s)`)}` : ""}` +
+                    `${errorCount > 0 ? `, ${pc.red(`${errorCount} failed`)}` : ""}` +
+                    `${missingRowCount > 0 ? `, ${pc.red(`${missingRowCount} task(s) with no row`)}` : ""}` +
+                    `${unreadableWeeks > 0 ? `, ${pc.red(`${unreadableWeeks} week(s) unreadable`)}` : ""}` +
+                    `${noteErrorCount > 0 ? `, ${pc.red(`${noteErrorCount} note(s) failed`)}` : ""}`
             );
+
+            if (errorCount + missingRowCount + unreadableWeeks > 0) {
+                out.error("Some hours were not booked. Fix the causes above and re-run.");
+                process.exit(1);
+            }
         }
     );
 }

--- a/src/clarity/commands/tasks.ts
+++ b/src/clarity/commands/tasks.ts
@@ -1,0 +1,334 @@
+import { formatMinutes } from "@app/azure-devops/timelog-api";
+import { requireConfig, saveConfig } from "@app/clarity/config";
+import { type AssignmentView, buildAssignmentView, parseMonthArg } from "@app/clarity/lib/assignment-view";
+import { type AssignmentRow, applyAssignments, removeAssignments } from "@app/clarity/lib/assignments";
+import { listClarityTasks } from "@app/clarity/lib/tasks";
+import { getTimesheetWeeks, selectWeeksForDateArg, type TimesheetWeek } from "@app/clarity/lib/timesheet-weeks";
+import * as p from "@clack/prompts";
+import { ClarityApi } from "@genesiscz/utils/clarity";
+import { isInteractive } from "@genesiscz/utils/cli";
+import { formatDate } from "@genesiscz/utils/date";
+import { out } from "@genesiscz/utils/logger";
+import { createBoxTable, renderCliHeader, truncateDisplay } from "@genesiscz/utils/table";
+import type { Command } from "commander";
+import pc from "picocolors";
+
+interface TasksOptions {
+    date?: string;
+    timesheet?: string;
+    format: string;
+    assigned?: boolean;
+    unassigned?: boolean;
+    assign?: string[];
+    applyRecommended?: boolean;
+    unlink?: string[];
+    yes?: boolean;
+}
+
+export function registerTasksCommand(parent: Command): void {
+    parent
+        .command("tasks")
+        .description("Clarity task catalogue, and the ADO work items assigned to it")
+        .option("--date <date>", "Day (YYYY-MM-DD) or month (YYYY-MM), default: today")
+        .option("--timesheet <id>", "Timesheet ID, skips the date lookup")
+        .option("--assigned", "ADO work items that already map to a Clarity task")
+        .option("--unassigned", "ADO work items with logged time and no Clarity mapping")
+        .option("--assign <pairs...>", "Create mappings as <workItemId>:<clarityTaskId>")
+        .option("--apply-recommended", "Assign every unmapped work item that has a tree recommendation")
+        .option("--unlink <ids...>", "Remove the mapping for these ADO work item ids")
+        .option("--yes", "Skip confirmation prompts")
+        .option("--format <format>", "Output format: table|json", "table")
+        .addHelpText(
+            "after",
+            [
+                "",
+                "Examples:",
+                "  tools clarity tasks --date 2026-08              catalogue for every week of August",
+                "  tools clarity tasks --date 2026-08 --unassigned  work items still missing a mapping",
+                "  tools clarity tasks --date 2026-08 --assigned    mappings, with drift against the tree",
+                "  tools clarity tasks --date 2026-08 --apply-recommended",
+                "  tools clarity tasks --date 2026-08 --assign 302920:8898018",
+                "  tools clarity tasks --unlink 298326 --yes",
+                "",
+            ].join("\n")
+        )
+        .action(async (options: TasksOptions) => {
+            if (options.unlink) {
+                await runUnlink(options);
+                return;
+            }
+
+            const date = options.date ?? formatDate(new Date());
+
+            if (options.assign || options.applyRecommended) {
+                await runAssign(date, options);
+                return;
+            }
+
+            if (options.assigned || options.unassigned) {
+                await runListing(date, options);
+                return;
+            }
+
+            await runCatalogue(date, options);
+        });
+}
+
+async function runCatalogue(date: string, options: TasksOptions): Promise<void> {
+    const config = await requireConfig();
+    const api = new ClarityApi({
+        baseUrl: config.baseUrl,
+        authToken: config.authToken,
+        sessionId: config.sessionId,
+        cookies: config.cookies,
+    });
+
+    let selected: TimesheetWeek[];
+
+    if (options.timesheet) {
+        const timesheetId = Number.parseInt(options.timesheet, 10);
+        selected = [{ timesheetId, timePeriodId: 0, startDate: date, finishDate: date, totalHours: 0, status: "" }];
+    } else {
+        let month: number;
+        let year: number;
+
+        try {
+            ({ month, year } = parseMonthArg(date));
+        } catch (err) {
+            out.error(err instanceof Error ? err.message : String(err));
+            process.exit(1);
+        }
+
+        const { weeks } = await getTimesheetWeeks(api, config.mappings, month, year);
+        selected = selectWeeksForDateArg(weeks, date);
+
+        if (selected.length === 0) {
+            out.error(`No Clarity period covers ${date}`);
+            process.exit(1);
+        }
+    }
+
+    const sections = await Promise.all(
+        selected.map(async (week) => ({ week, tasks: await listClarityTasks({ api, timesheetId: week.timesheetId }) }))
+    );
+
+    if (options.format === "json") {
+        out.result(
+            sections.map((section) => ({
+                timesheetId: section.week.timesheetId,
+                startDate: section.week.startDate,
+                finishDate: section.week.finishDate,
+                tasks: section.tasks,
+            }))
+        );
+        return;
+    }
+
+    for (const section of sections) {
+        const period =
+            sections.length > 1
+                ? `${section.week.startDate} to ${section.week.finishDate}`
+                : `timesheet ${section.week.timesheetId}`;
+
+        renderCliHeader("Clarity Tasks", `${period} · timesheet ${section.week.timesheetId}`);
+        const table = createBoxTable(["TASK ID", "TASK", "INVESTMENT", "CODE"]);
+
+        for (const task of section.tasks) {
+            table.push([
+                pc.white(String(task.taskId)),
+                truncateDisplay(task.taskName, 58),
+                truncateDisplay(task.investmentName, 24),
+                pc.dim(task.taskCode),
+            ]);
+        }
+
+        out.println(table.toString());
+        out.println(pc.dim(`  ${section.tasks.length} task(s)`));
+    }
+}
+
+function serialiseRow(row: AssignmentRow) {
+    return {
+        workItemId: row.workItemId,
+        title: row.title,
+        type: row.type,
+        hours: row.minutes / 60,
+        clarityTaskId: row.mapping?.clarityTaskId,
+        clarityTaskName: row.mapping?.clarityTaskName,
+        drifted: row.drifted,
+        recommendation: row.recommendation
+            ? {
+                  clarityTaskId: row.recommendation.task.taskId,
+                  clarityTaskName: row.recommendation.task.taskName,
+                  matchedWorkItemId: row.recommendation.matched.id,
+                  matchedWorkItemTitle: row.recommendation.matched.title,
+              }
+            : undefined,
+    };
+}
+
+async function runListing(date: string, options: TasksOptions): Promise<void> {
+    const view = await buildAssignmentView(date);
+    const wantAssigned = Boolean(options.assigned);
+    const rows = wantAssigned ? view.assigned : view.unassigned;
+
+    if (options.format === "json") {
+        out.result(rows.map(serialiseRow));
+        return;
+    }
+
+    renderCliHeader("Clarity", `${wantAssigned ? "assigned" : "unassigned"} · ${date}`);
+    const table = createBoxTable(
+        wantAssigned ? ["WI", "HOURS", "MAPPED TO", "RECOMMENDED"] : ["WI", "HOURS", "WORK ITEM", "RECOMMENDED"]
+    );
+
+    for (const row of rows) {
+        const rec = row.recommendation
+            ? `${row.drifted ? pc.yellow("⚠ ") : ""}${truncateDisplay(row.recommendation.task.taskName, 38)} ${pc.dim(`(#${row.recommendation.matched.id})`)}`
+            : pc.dim("—");
+
+        table.push([
+            pc.white(`#${row.workItemId}`),
+            formatMinutes(row.minutes),
+            wantAssigned
+                ? truncateDisplay(row.mapping?.clarityTaskName ?? "—", 40)
+                : truncateDisplay(row.title ?? "", 40),
+            rec,
+        ]);
+    }
+
+    out.println(table.toString());
+    out.println(pc.dim(`  ${rows.length} work item(s)`));
+}
+
+function collectPairs(view: AssignmentView, options: TasksOptions) {
+    const pairs: Array<{ workItemId: number; task: (typeof view.tasks)[number]; title?: string; type?: string }> = [];
+
+    for (const raw of options.assign ?? []) {
+        const parts = raw.split(":");
+        const workItemId = Number(parts[0]);
+        const taskId = Number(parts[1]);
+
+        if (parts.length !== 2 || parts.some((part) => part.trim() === "")) {
+            out.error(`Invalid --assign pair '${raw}': expected <workItemId>:<clarityTaskId>`);
+            process.exit(1);
+        }
+
+        if (!Number.isInteger(workItemId) || !Number.isInteger(taskId)) {
+            out.error(`Invalid --assign pair '${raw}': expected <workItemId>:<clarityTaskId>`);
+            process.exit(1);
+        }
+
+        const task = view.tasks.find((t) => t.taskId === taskId);
+
+        if (!task) {
+            out.error(`No Clarity task ${taskId} in the catalogue for this month`);
+            process.exit(1);
+        }
+
+        const row = [...view.assigned, ...view.unassigned].find((r) => r.workItemId === workItemId);
+        pairs.push({ workItemId, task, title: row?.title, type: row?.type });
+    }
+
+    if (options.applyRecommended) {
+        for (const row of view.unassigned) {
+            if (row.recommendation && !pairs.some((pair) => pair.workItemId === row.workItemId)) {
+                pairs.push({
+                    workItemId: row.workItemId,
+                    task: row.recommendation.task,
+                    title: row.title,
+                    type: row.type,
+                });
+            }
+        }
+    }
+
+    return pairs;
+}
+
+async function runAssign(date: string, options: TasksOptions): Promise<void> {
+    const view = await buildAssignmentView(date);
+    const pairs = collectPairs(view, options);
+
+    if (pairs.length === 0) {
+        out.println("Nothing to assign.");
+        return;
+    }
+
+    const config = await requireConfig();
+    config.mappings = applyAssignments({ mappings: config.mappings, pairs });
+    await saveConfig(config);
+
+    if (options.format === "json") {
+        out.result(
+            pairs.map((pair) => ({
+                workItemId: pair.workItemId,
+                clarityTaskId: pair.task.taskId,
+                clarityTaskName: pair.task.taskName,
+            }))
+        );
+        return;
+    }
+
+    for (const pair of pairs) {
+        out.println(`${pc.green("✔")} #${pair.workItemId} → ${pair.task.taskName}`);
+    }
+
+    out.println(pc.dim(`  ${pairs.length} mapping(s) saved`));
+}
+
+async function runUnlink(options: TasksOptions): Promise<void> {
+    const config = await requireConfig();
+    const workItemIds = (options.unlink ?? []).map((raw) => {
+        const id = Number(raw);
+
+        if (!Number.isInteger(id) || raw.trim() === "") {
+            out.error(`Invalid --unlink id '${raw}': expected a work item id`);
+            process.exit(1);
+        }
+
+        return id;
+    });
+    const { mappings, removed } = removeAssignments({ mappings: config.mappings, workItemIds });
+
+    if (removed.length === 0) {
+        out.println("No mappings match those work item ids.");
+        return;
+    }
+
+    if (options.format !== "json") {
+        for (const mapping of removed) {
+            out.println(`  #${mapping.adoWorkItemId} → ${mapping.clarityTaskName}`);
+        }
+    }
+
+    if (!options.yes) {
+        if (!isInteractive()) {
+            out.error("Refusing to remove mappings without --yes in a non-interactive shell");
+            process.exit(1);
+        }
+
+        const confirmed = await p.confirm({ message: `Remove ${removed.length} mapping(s)?` });
+
+        if (p.isCancel(confirmed) || !confirmed) {
+            p.cancel("Cancelled");
+            return;
+        }
+    }
+
+    config.mappings = mappings;
+    await saveConfig(config);
+
+    if (options.format === "json") {
+        out.result(
+            removed.map((m) => ({
+                workItemId: m.adoWorkItemId,
+                clarityTaskId: m.clarityTaskId,
+                clarityTaskName: m.clarityTaskName,
+            }))
+        );
+        return;
+    }
+
+    out.println(`${pc.green("✔")} removed ${removed.length} mapping(s)`);
+}

--- a/src/clarity/docs/api.md
+++ b/src/clarity/docs/api.md
@@ -45,14 +45,51 @@ Cache-Control: no-cache
 
 Discover timesheets and navigate the time period carousel.
 
-**Query:** `?filter=(timeperiodId = {id})`
+**Query:** `?filter=(timeperiodId = {id})` — optional. Without it the server returns the window
+around the current period; with it the ~9-week window re-centres on that period, which is how you
+walk backwards or forwards through the year.
 
 **Response:** `TimesheetAppResponse`
 - `calendar._results[]` - Days in the period with work day info
 - `tpcounts` - Previous/next period counts for pagination
-- `tscarousel._results[]` - Sliding window (~9 weeks) mapping `timePeriodId` to `timesheet_id`
+- `tscarousel._results[]` - Sliding window (~9 weeks) of periods
 - `timesheets._results[]` - Full timesheet data with time entries
 - `resource._results[]` - Current user info (resourceId, name, email)
+
+**Carousel entry shape.** The timesheet id is nested, not a sibling of `id`:
+
+```json
+{
+  "id": 400004,
+  "start_date": "2026-08-24T00:00:00",
+  "finish_date": "2026-08-31T00:00:00",
+  "has_entries": "true",
+  "is_active": true,
+  "selected_id": 400004,
+  "resourceId": 900001,
+  "tpTimesheet": {
+    "_results": [
+      {
+        "timesheet_id": 555004,
+        "total": "0,00",
+        "prstatus": { "_results": [{ "displayValue": "Otevřeno", "id": "0" }] }
+      }
+    ]
+  }
+}
+```
+
+Some responses return `timesheet_id`, `total` and `prstatus` flat on the entry instead. Parse both
+shapes — `parseCarouselEntry` in `src/clarity/lib/timesheet-weeks.ts` does.
+
+**`finish_date` is exclusive.** Adjacent periods share a boundary date: one ends `2026-08-24` while
+the next starts `2026-08-24`, and the timesheet for the second reports `timePeriodStart 2026-08-24`
+/ `timePeriodFinish 2026-08-30`. Match a date with `start <= date < finish`, which is what
+`findWeekForDate` does. An inclusive comparison assigns boundary days to the wrong week.
+
+**No timesheet id needed to start.** This endpoint is the discovery entry point: call it with no
+filter, read `tpTimesheet._results[0].timesheet_id` off the carousel, and you have a valid
+timesheet id without any stored mapping.
 
 ### GET `/private/timesheet`
 

--- a/src/clarity/index.ts
+++ b/src/clarity/index.ts
@@ -8,6 +8,7 @@ import { Command } from "commander";
 import { registerConfigureCommand } from "./commands/configure.js";
 import { registerFillCommand } from "./commands/fill.js";
 import { registerLinkCommand } from "./commands/link-workitems.js";
+import { registerTasksCommand } from "./commands/tasks.js";
 import { registerTimesheetCommand } from "./commands/timesheet.js";
 import { runClarityPreflight } from "./lib/preflight.js";
 
@@ -20,6 +21,7 @@ registerConfigureCommand(program);
 registerTimesheetCommand(program);
 registerFillCommand(program);
 registerLinkCommand(program);
+registerTasksCommand(program);
 
 const uiDir = resolve(import.meta.dirname, "ui");
 const configPath = resolve(uiDir, "vite.config.ts");

--- a/src/clarity/lib/assignment-view.ts
+++ b/src/clarity/lib/assignment-view.ts
@@ -1,0 +1,109 @@
+import { Api } from "@app/azure-devops/api";
+import { type WorkItemNode, walkAncestorsBatched } from "@app/azure-devops/lib/ancestors";
+import { exportMonth } from "@app/azure-devops/lib/timelog/export";
+import { parseRelations } from "@app/azure-devops/relations";
+import { TimeLogApi } from "@app/azure-devops/timelog-api";
+import { requireConfig as requireAdoConfig, requireTimeLogConfig, requireTimeLogUser } from "@app/azure-devops/utils";
+import { requireConfig } from "@app/clarity/config";
+import { type AssignmentRows, buildAssignmentRows } from "@app/clarity/lib/assignments";
+import { listClarityTasks } from "@app/clarity/lib/tasks";
+import {
+    findWeekForDate,
+    getTimesheetWeeks,
+    type TimesheetWeek,
+    taskSourceWeekOrder,
+} from "@app/clarity/lib/timesheet-weeks";
+import type { ClarityTask } from "@app/clarity/lib/types";
+import { ClarityApi } from "@genesiscz/utils/clarity";
+
+export interface AssignmentView extends AssignmentRows {
+    tasks: ClarityTask[];
+    chains: Map<number, WorkItemNode[]>;
+    month: number;
+    year: number;
+}
+
+export function parseMonthArg(date: string): { month: number; year: number } {
+    const [year, month] = date.split("-").map(Number);
+
+    if (!year || !month || month < 1 || month > 12) {
+        throw new Error(`Invalid date '${date}': expected YYYY-MM or YYYY-MM-DD`);
+    }
+
+    return { month, year };
+}
+
+/**
+ * Assemble everything the assignment surfaces need: the month's work items split into mapped and
+ * unmapped, the Clarity task catalogue, and a tree-based recommendation per work item. Shared by
+ * the CLI and the dashboard so both answer identically.
+ */
+async function firstNonEmptyCatalogue(api: ClarityApi, candidates: TimesheetWeek[]): Promise<ClarityTask[]> {
+    for (const candidate of candidates) {
+        const tasks = await listClarityTasks({ api, timesheetId: candidate.timesheetId });
+
+        if (tasks.length > 0) {
+            return tasks;
+        }
+    }
+
+    return [];
+}
+
+export async function buildAssignmentView(date: string): Promise<AssignmentView> {
+    const clarityConfig = await requireConfig();
+    const adoConfig = requireTimeLogConfig();
+    const adoUser = requireTimeLogUser(adoConfig);
+    const { month, year } = parseMonthArg(date);
+
+    const timeLogApi = new TimeLogApi(adoConfig.orgId!, adoConfig.projectId, adoConfig.timelog!.functionsKey, adoUser);
+    const clarityApi = new ClarityApi({
+        baseUrl: clarityConfig.baseUrl,
+        authToken: clarityConfig.authToken,
+        sessionId: clarityConfig.sessionId,
+        cookies: clarityConfig.cookies,
+    });
+
+    const monthExport = await exportMonth(timeLogApi, month, year, adoUser.userId);
+    const minutesByWorkItem = new Map<number, number>();
+
+    for (const entry of monthExport.entries) {
+        minutesByWorkItem.set(entry.workItemId, (minutesByWorkItem.get(entry.workItemId) ?? 0) + entry.minutes);
+    }
+
+    const { weeks } = await getTimesheetWeeks(clarityApi, clarityConfig.mappings, month, year);
+    const preferred = findWeekForDate(weeks, `${year}-${String(month).padStart(2, "0")}-15`);
+    let tasks = await firstNonEmptyCatalogue(clarityApi, taskSourceWeekOrder(weeks, preferred));
+
+    if (tasks.length === 0) {
+        // A month whose timesheets exist but carry no rows yet has no catalogue of its own.
+        // Widen past the month filter and take the newest period that does have rows.
+        const { weeks: anyWeek } = await getTimesheetWeeks(clarityApi, clarityConfig.mappings);
+        tasks = await firstNonEmptyCatalogue(clarityApi, taskSourceWeekOrder(anyWeek, undefined));
+    }
+
+    const workItemApi = new Api(requireAdoConfig());
+    const chains = await walkAncestorsBatched({
+        ids: [...minutesByWorkItem.keys()],
+        maxDepth: 3,
+        fetchMany: async (ids) => {
+            const items = await workItemApi.getWorkItems(ids);
+            const nodes = new Map<number, WorkItemNode>();
+
+            for (const [id, item] of items) {
+                nodes.set(id, {
+                    id,
+                    title: item.title,
+                    type: String(item.rawFields?.["System.WorkItemType"] ?? "?"),
+                    parent: parseRelations(item.relations ?? []).parent,
+                });
+            }
+
+            return nodes;
+        },
+    });
+
+    const rows = buildAssignmentRows({ minutesByWorkItem, mappings: clarityConfig.mappings, chains, tasks });
+
+    return { ...rows, tasks, chains, month, year };
+}

--- a/src/clarity/lib/assignments.test.ts
+++ b/src/clarity/lib/assignments.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import type { WorkItemNode } from "@app/azure-devops/lib/ancestors";
+import type { ClarityMapping } from "@app/clarity/config";
+import { applyAssignments, buildAssignmentRows, removeAssignments } from "@app/clarity/lib/assignments";
+import type { ClarityTask } from "@app/clarity/lib/types";
+
+function task(taskId: number, taskName: string): ClarityTask {
+    return {
+        taskId,
+        taskName,
+        taskCode: "00070705",
+        investmentName: "Sample",
+        investmentCode: "P100001",
+        timeEntryId: 1,
+    };
+}
+
+const TASKS: ClarityTask[] = [
+    task(700002, "D_410001_Sample epic_Sample_EXT"),
+    task(700004, "Incidenty_Opex_Sample_EXT"),
+    task(700005, "Rozvoj_domény_Sample_EXT"),
+];
+
+const CHAINS = new Map<number, WorkItemNode[]>([
+    [
+        100001,
+        [
+            { id: 100001, title: "Tech debt task", type: "Task" },
+            { id: 410001, title: "Sample epic", type: "Epic" },
+        ],
+    ],
+    [100002, [{ id: 100002, title: "Bug with no match", type: "Bug" }]],
+]);
+
+function mapping(adoWorkItemId: number, clarityTaskId: number, clarityTaskName: string): ClarityMapping {
+    return {
+        clarityTaskId,
+        clarityTaskName,
+        clarityTaskCode: "00070705",
+        clarityInvestmentName: "Sample",
+        clarityInvestmentCode: "P100001",
+        adoWorkItemId,
+        adoWorkItemTitle: "Stored title",
+        adoWorkItemType: "Task",
+    };
+}
+
+describe("buildAssignmentRows", () => {
+    test("splits work items by whether a mapping exists", () => {
+        const { assigned, unassigned } = buildAssignmentRows({
+            minutesByWorkItem: new Map([
+                [100001, 240],
+                [100002, 90],
+            ]),
+            mappings: [mapping(100001, 700005, "Rozvoj_domény_Sample_EXT")],
+            chains: CHAINS,
+            tasks: TASKS,
+        });
+
+        expect(assigned.map((r) => r.workItemId)).toEqual([100001]);
+        expect(unassigned.map((r) => r.workItemId)).toEqual([100002]);
+    });
+
+    test("orders rows by hours, largest first", () => {
+        const { unassigned } = buildAssignmentRows({
+            minutesByWorkItem: new Map([
+                [100002, 90],
+                [100001, 240],
+            ]),
+            mappings: [],
+            chains: CHAINS,
+            tasks: TASKS,
+        });
+
+        expect(unassigned.map((r) => r.workItemId)).toEqual([100001, 100002]);
+    });
+
+    test("attaches the recommendation and the ancestor it matched", () => {
+        const { unassigned } = buildAssignmentRows({
+            minutesByWorkItem: new Map([[100001, 240]]),
+            mappings: [],
+            chains: CHAINS,
+            tasks: TASKS,
+        });
+
+        expect(unassigned[0].recommendation?.task.taskId).toBe(700002);
+        expect(unassigned[0].recommendation?.matched.id).toBe(410001);
+    });
+
+    test("leaves the recommendation empty when no ancestor id matches", () => {
+        const { unassigned } = buildAssignmentRows({
+            minutesByWorkItem: new Map([[100002, 90]]),
+            mappings: [],
+            chains: CHAINS,
+            tasks: TASKS,
+        });
+
+        expect(unassigned[0].recommendation).toBeUndefined();
+    });
+
+    test("flags an assigned row whose stored task differs from the recommendation", () => {
+        const { assigned } = buildAssignmentRows({
+            minutesByWorkItem: new Map([[100001, 240]]),
+            mappings: [mapping(100001, 700005, "Rozvoj_domény_Sample_EXT")],
+            chains: CHAINS,
+            tasks: TASKS,
+        });
+
+        expect(assigned[0].drifted).toBe(true);
+    });
+
+    test("does not flag an assigned row that already matches its recommendation", () => {
+        const { assigned } = buildAssignmentRows({
+            minutesByWorkItem: new Map([[100001, 240]]),
+            mappings: [mapping(100001, 700002, "D_410001_Sample epic_Sample_EXT")],
+            chains: CHAINS,
+            tasks: TASKS,
+        });
+
+        expect(assigned[0].drifted).toBe(false);
+    });
+});
+
+describe("applyAssignments", () => {
+    test("adds a mapping for a work item that had none", () => {
+        const next = applyAssignments({
+            mappings: [],
+            pairs: [{ workItemId: 100001, task: TASKS[0], title: "Tech debt task", type: "Task" }],
+        });
+
+        expect(next).toHaveLength(1);
+        expect(next[0]).toMatchObject({
+            adoWorkItemId: 100001,
+            clarityTaskId: 700002,
+            adoWorkItemTitle: "Tech debt task",
+        });
+    });
+
+    test("replaces the existing mapping instead of adding a duplicate", () => {
+        const next = applyAssignments({
+            mappings: [mapping(100001, 700005, "Rozvoj_domény_Sample_EXT")],
+            pairs: [{ workItemId: 100001, task: TASKS[0], title: "Tech debt task", type: "Task" }],
+        });
+
+        expect(next).toHaveLength(1);
+        expect(next[0].clarityTaskId).toBe(700002);
+    });
+
+    test("leaves mappings for other work items untouched", () => {
+        const next = applyAssignments({
+            mappings: [mapping(999999, 700004, "Incidenty_Opex_Sample_EXT")],
+            pairs: [{ workItemId: 100001, task: TASKS[0], title: "Tech debt task", type: "Task" }],
+        });
+
+        expect(next.map((m) => m.adoWorkItemId).sort()).toEqual([100001, 999999]);
+    });
+});
+
+describe("removeAssignments", () => {
+    test("drops only the named work items and reports what went", () => {
+        const { mappings, removed } = removeAssignments({
+            mappings: [mapping(100001, 700002, "A"), mapping(100002, 700004, "B")],
+            workItemIds: [100002],
+        });
+
+        expect(mappings.map((m) => m.adoWorkItemId)).toEqual([100001]);
+        expect(removed.map((m) => m.adoWorkItemId)).toEqual([100002]);
+    });
+
+    test("reports nothing removed when no work item matches", () => {
+        const { mappings, removed } = removeAssignments({
+            mappings: [mapping(100001, 700002, "A")],
+            workItemIds: [555555],
+        });
+
+        expect(removed).toEqual([]);
+        expect(mappings).toHaveLength(1);
+    });
+});

--- a/src/clarity/lib/assignments.ts
+++ b/src/clarity/lib/assignments.ts
@@ -1,0 +1,114 @@
+import type { WorkItemNode } from "@app/azure-devops/lib/ancestors";
+import type { ClarityMapping } from "@app/clarity/config";
+import { getMappingForWorkItem } from "@app/clarity/config";
+import { type ClarityRecommendation, recommendClarityTask } from "@app/clarity/lib/recommend";
+import type { ClarityTask } from "@app/clarity/lib/types";
+
+export interface AssignmentRow {
+    workItemId: number;
+    minutes: number;
+    title?: string;
+    type?: string;
+    mapping?: ClarityMapping;
+    recommendation?: ClarityRecommendation;
+    /** The stored mapping points somewhere the ancestor tree does not. */
+    drifted: boolean;
+}
+
+export interface AssignmentRows {
+    assigned: AssignmentRow[];
+    unassigned: AssignmentRow[];
+}
+
+export interface AssignmentPair {
+    workItemId: number;
+    task: ClarityTask;
+    title?: string;
+    type?: string;
+}
+
+/**
+ * Split the month's work items into mapped and unmapped, attach the tree-based recommendation to
+ * each, and mark stored mappings that disagree with it. Pure, so the CLI and the UI share it.
+ */
+export function buildAssignmentRows({
+    minutesByWorkItem,
+    mappings,
+    chains,
+    tasks,
+}: {
+    minutesByWorkItem: Map<number, number>;
+    mappings: ClarityMapping[];
+    chains: Map<number, WorkItemNode[]>;
+    tasks: ClarityTask[];
+}): AssignmentRows {
+    const assigned: AssignmentRow[] = [];
+    const unassigned: AssignmentRow[] = [];
+
+    for (const [workItemId, minutes] of minutesByWorkItem) {
+        const chain = chains.get(workItemId) ?? [];
+        const mapping = getMappingForWorkItem(mappings, workItemId);
+        const recommendation = recommendClarityTask({ chain, tasks });
+        const row: AssignmentRow = {
+            workItemId,
+            minutes,
+            title: chain[0]?.title,
+            type: chain[0]?.type,
+            mapping,
+            recommendation,
+            drifted: Boolean(mapping && recommendation && mapping.clarityTaskId !== recommendation.task.taskId),
+        };
+
+        (mapping ? assigned : unassigned).push(row);
+    }
+
+    const byHours = (a: AssignmentRow, b: AssignmentRow) => b.minutes - a.minutes || a.workItemId - b.workItemId;
+
+    return { assigned: assigned.sort(byHours), unassigned: unassigned.sort(byHours) };
+}
+
+/** Add or replace mappings for the given pairs, leaving every other mapping untouched. */
+export function applyAssignments({
+    mappings,
+    pairs,
+}: {
+    mappings: ClarityMapping[];
+    pairs: AssignmentPair[];
+}): ClarityMapping[] {
+    const next = [...mappings];
+
+    for (const pair of pairs) {
+        const mapping: ClarityMapping = {
+            clarityTaskId: pair.task.taskId,
+            clarityTaskName: pair.task.taskName,
+            clarityTaskCode: pair.task.taskCode,
+            clarityInvestmentName: pair.task.investmentName,
+            clarityInvestmentCode: pair.task.investmentCode,
+            adoWorkItemId: pair.workItemId,
+            adoWorkItemTitle: pair.title ?? String(pair.workItemId),
+            adoWorkItemType: pair.type,
+        };
+        const existing = next.findIndex((m) => m.adoWorkItemId === pair.workItemId);
+
+        if (existing >= 0) {
+            next[existing] = mapping;
+        } else {
+            next.push(mapping);
+        }
+    }
+
+    return next;
+}
+
+/** Remove the mappings for the given work items and report which ones were actually dropped. */
+export function removeAssignments({ mappings, workItemIds }: { mappings: ClarityMapping[]; workItemIds: number[] }): {
+    mappings: ClarityMapping[];
+    removed: ClarityMapping[];
+} {
+    const doomed = new Set(workItemIds);
+
+    return {
+        mappings: mappings.filter((m) => !doomed.has(m.adoWorkItemId)),
+        removed: mappings.filter((m) => doomed.has(m.adoWorkItemId)),
+    };
+}

--- a/src/clarity/lib/carousel-navigate.test.ts
+++ b/src/clarity/lib/carousel-navigate.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { navigateToPeriodForDate } from "@app/clarity/lib/timesheet-weeks";
+
+// A real carousel is a ~9 period window of consecutive weeks. Asking for a period id re-centres
+// the window on it, so reaching a month a quarter back takes several hops, not one.
+const WINDOW = 9;
+const EPOCH_ID = 5000000;
+const EPOCH_START = Date.UTC(2026, 0, 5); // Monday
+
+function periodStart(id: number): string {
+    return new Date(EPOCH_START + (id - EPOCH_ID) * 7 * 86_400_000).toISOString().slice(0, 10);
+}
+
+function fakeApi(currentId: number) {
+    const asked: Array<number | undefined> = [];
+
+    return {
+        asked,
+        // biome-ignore lint/suspicious/noExplicitAny: test double mirrors the Clarity response shape
+        getTimesheetApp: async (timePeriodId?: number): Promise<any> => {
+            asked.push(timePeriodId);
+            const centre = timePeriodId ?? currentId;
+
+            return {
+                tscarousel: {
+                    _results: Array.from({ length: WINDOW }, (_, i) => {
+                        const id = centre - Math.floor(WINDOW / 2) + i;
+
+                        return {
+                            id,
+                            start_date: `${periodStart(id)}T00:00:00`,
+                            finish_date: `${periodStart(id + 1)}T00:00:00`,
+                        };
+                    }),
+                },
+            };
+        },
+    };
+}
+
+describe("navigateToPeriodForDate", () => {
+    test("returns the seed window's own period when it already covers the date", async () => {
+        const api = fakeApi(5000035);
+
+        const id = await navigateToPeriodForDate({ api, seedTimePeriodId: 5000035, date: periodStart(5000035) });
+
+        expect(id).toBe(5000035);
+    });
+
+    test("assigns the last day of a period to that period, not the next one", async () => {
+        const api = fakeApi(5000035);
+        const lastDay = new Date(Date.parse(`${periodStart(5000036)}T00:00:00Z`) - 86_400_000)
+            .toISOString()
+            .slice(0, 10);
+
+        const id = await navigateToPeriodForDate({ api, seedTimePeriodId: 5000035, date: lastDay });
+
+        expect(id).toBe(5000035);
+    });
+
+    test("reaches a period thirteen weeks back, which one window cannot span", async () => {
+        const api = fakeApi(5000035);
+
+        const id = await navigateToPeriodForDate({ api, seedTimePeriodId: 5000035, date: periodStart(5000022) });
+
+        expect(id).toBe(5000022);
+    });
+
+    test("reaches a period far ahead of the seed", async () => {
+        const api = fakeApi(5000035);
+
+        const id = await navigateToPeriodForDate({ api, seedTimePeriodId: 5000035, date: periodStart(5000050) });
+
+        expect(id).toBe(5000050);
+    });
+
+    test("takes more than one hop when the target is outside the first window", async () => {
+        const api = fakeApi(5000035);
+
+        await navigateToPeriodForDate({ api, seedTimePeriodId: 5000035, date: periodStart(5000022) });
+
+        expect(api.asked.length).toBeGreaterThan(1);
+    });
+
+    test("gives up instead of looping when the date is unreachable", async () => {
+        const api = {
+            // biome-ignore lint/suspicious/noExplicitAny: a carousel that never moves
+            getTimesheetApp: async (): Promise<any> => ({
+                tscarousel: {
+                    _results: [{ id: 5000035, start_date: "2026-09-07T00:00:00", finish_date: "2026-09-14T00:00:00" }],
+                },
+            }),
+        };
+
+        expect(
+            await navigateToPeriodForDate({ api, seedTimePeriodId: 5000035, date: "2020-01-06", maxHops: 3 })
+        ).toBeUndefined();
+    });
+});

--- a/src/clarity/lib/carousel-seed.test.ts
+++ b/src/clarity/lib/carousel-seed.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCarouselSeed } from "@app/clarity/lib/timesheet-weeks";
+
+// Period ids run consecutively, one per week. The live window is only ~9 periods wide, so a month
+// further back than that is unreachable unless the seed comes from the server.
+function carouselWindow(centreId: number) {
+    return {
+        tscarousel: {
+            _results: Array.from({ length: 9 }, (_, i) => ({ id: centreId - 4 + i })),
+        },
+        timesheets: { _results: [{ timePeriodId: centreId }] },
+    };
+}
+
+function fakeApi(currentId: number) {
+    const asked: Array<number | undefined> = [];
+
+    return {
+        asked,
+        // biome-ignore lint/suspicious/noExplicitAny: test double mirrors the Clarity response shape
+        getTimesheetApp: async (timePeriodId?: number): Promise<any> => {
+            asked.push(timePeriodId);
+
+            return carouselWindow(timePeriodId ?? currentId);
+        },
+    };
+}
+
+describe("resolveCarouselSeed", () => {
+    test("uses a mapping's cached timesheet period when one exists", async () => {
+        const api = fakeApi(5008042);
+
+        const seed = await resolveCarouselSeed({ api, cachedTimePeriodId: 5008010 });
+
+        expect(seed).toBe(5008010);
+    });
+
+    test("falls back to the server's current period when no mapping carries one", async () => {
+        const api = fakeApi(5008042);
+
+        const seed = await resolveCarouselSeed({ api, cachedTimePeriodId: undefined });
+
+        expect(seed).toBe(5008042);
+    });
+
+    test("asks the server with no filter when it has nothing to seed from", async () => {
+        const api = fakeApi(5008042);
+
+        await resolveCarouselSeed({ api, cachedTimePeriodId: undefined });
+
+        expect(api.asked).toEqual([undefined]);
+    });
+
+    test("does not call the server when a cached period is already known", async () => {
+        const api = fakeApi(5008042);
+
+        await resolveCarouselSeed({ api, cachedTimePeriodId: 5008010 });
+
+        expect(api.asked).toEqual([]);
+    });
+
+    test("returns undefined when the server offers no period at all", async () => {
+        const api = {
+            // biome-ignore lint/suspicious/noExplicitAny: empty-response double
+            getTimesheetApp: async (): Promise<any> => ({ tscarousel: { _results: [] }, timesheets: { _results: [] } }),
+        };
+
+        expect(await resolveCarouselSeed({ api, cachedTimePeriodId: undefined })).toBeUndefined();
+    });
+});
+
+describe("resolveCarouselSeed carousel fallback", () => {
+    test("prefers the active period over the oldest one when no timesheet is reported", async () => {
+        const api = {
+            // biome-ignore lint/suspicious/noExplicitAny: carousel-only response
+            getTimesheetApp: async (): Promise<any> => ({
+                timesheets: { _results: [] },
+                tscarousel: {
+                    _results: [
+                        { id: 5000031, is_active: false },
+                        { id: 5000035, is_active: true },
+                        { id: 5000039, is_active: false },
+                    ],
+                },
+            }),
+        };
+
+        expect(await resolveCarouselSeed({ api, cachedTimePeriodId: undefined })).toBe(5000035);
+    });
+});

--- a/src/clarity/lib/comment-builder.test.ts
+++ b/src/clarity/lib/comment-builder.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { buildPeriodComment, buildWeekComment } from "@app/clarity/lib/comment-builder";
+
+const ENTRIES = [
+    { workItemId: 111111, timeTypeDescription: "Development", comment: "první úkol", date: "2026-08-24" },
+    { workItemId: 222222, timeTypeDescription: "Ceremonie", comment: "SU", date: "2026-08-24" },
+    { workItemId: 111111, timeTypeDescription: "Development", comment: "druhý den", date: "2026-08-30" },
+    { workItemId: 333333, timeTypeDescription: "Development", comment: "mimo období", date: "2026-08-31" },
+    { workItemId: 444444, timeTypeDescription: "Development", comment: "před obdobím", date: "2026-08-23" },
+];
+
+describe("buildWeekComment", () => {
+    test("groups entries under a Czech day heading, one line per entry", () => {
+        const text = buildWeekComment([ENTRIES[0], ENTRIES[1]]);
+
+        expect(text).toBe("Po, 24.8.:\n - #111111 - Development - první úkol\n - #222222 - Ceremonie - SU");
+    });
+
+    test("returns an empty string when there is nothing to say", () => {
+        expect(buildWeekComment([])).toBe("");
+    });
+});
+
+describe("buildPeriodComment", () => {
+    // timePeriodFinish names the last day of the period, so 2026-08-30 belongs to the week and
+    // 2026-08-31 does not. Getting that wrong pulls the next week's work into this note.
+    test("keeps only the entries inside the period, finish day included", () => {
+        const text = buildPeriodComment({
+            entries: ENTRIES,
+            periodStart: "2026-08-24T00:00:00",
+            periodFinishInclusive: "2026-08-30T00:00:00",
+        });
+
+        expect(text).toBe(
+            [
+                "Po, 24.8.:",
+                " - #111111 - Development - první úkol",
+                " - #222222 - Ceremonie - SU",
+                "Ne, 30.8.:",
+                " - #111111 - Development - druhý den",
+            ].join("\n")
+        );
+    });
+
+    test("excludes the day after the finish date", () => {
+        const text = buildPeriodComment({
+            entries: ENTRIES,
+            periodStart: "2026-08-24T00:00:00",
+            periodFinishInclusive: "2026-08-30T00:00:00",
+        });
+
+        expect(text).not.toContain("#333333");
+    });
+
+    test("excludes the day before the start date", () => {
+        const text = buildPeriodComment({
+            entries: ENTRIES,
+            periodStart: "2026-08-24T00:00:00",
+            periodFinishInclusive: "2026-08-30T00:00:00",
+        });
+
+        expect(text).not.toContain("#444444");
+    });
+
+    test("returns an empty string when no entry falls in the period", () => {
+        const text = buildPeriodComment({
+            entries: ENTRIES,
+            periodStart: "2026-12-01T00:00:00",
+            periodFinishInclusive: "2026-12-07T00:00:00",
+        });
+
+        expect(text).toBe("");
+    });
+});

--- a/src/clarity/lib/comment-builder.ts
+++ b/src/clarity/lib/comment-builder.ts
@@ -2,7 +2,7 @@
 // Clarity weeks start on Monday — output naturally starts with "Po" because dates sort ascending
 const CZECH_DAYS = ["Ne", "Po", "Út", "St", "Čt", "Pá", "So"] as const;
 
-interface CommentEntry {
+export interface CommentEntry {
     workItemId: number;
     timeTypeDescription: string;
     comment: string | null;
@@ -54,4 +54,26 @@ export function buildWeekComment(entries: CommentEntry[]): string {
     }
 
     return lines.join("\n");
+}
+
+/**
+ * Build the note for one timesheet period. `periodFinishInclusive` is Clarity's `timePeriodFinish`,
+ * which names the LAST day of the period, so the filter has to include it. Using the carousel's
+ * exclusive `finish_date` here would pull the next week's first day into this note.
+ */
+export function buildPeriodComment({
+    entries,
+    periodStart,
+    periodFinishInclusive,
+}: {
+    entries: CommentEntry[];
+    periodStart: string;
+    periodFinishInclusive: string;
+}): string {
+    const start = periodStart.split("T")[0];
+    const finish = periodFinishInclusive.split("T")[0];
+
+    return buildWeekComment(
+        entries.filter((entry) => entry.date.split("T")[0] >= start && entry.date.split("T")[0] <= finish)
+    );
 }

--- a/src/clarity/lib/fill-guard.test.ts
+++ b/src/clarity/lib/fill-guard.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { checkUnmapped } from "@app/clarity/lib/fill-guard";
+
+describe("checkUnmapped", () => {
+    test("blocks the fill when any work item has no Clarity mapping", () => {
+        const verdict = checkUnmapped({
+            unmappedByWi: new Map([
+                [111111, 240],
+                [222222, 90],
+            ]),
+            allowUnmapped: false,
+        });
+
+        expect(verdict.blocked).toBe(true);
+    });
+
+    test("reports every unmapped work item with its minutes, largest first", () => {
+        const verdict = checkUnmapped({
+            unmappedByWi: new Map([
+                [111111, 90],
+                [222222, 240],
+            ]),
+            allowUnmapped: false,
+        });
+
+        expect(verdict.items).toEqual([
+            { workItemId: 222222, minutes: 240 },
+            { workItemId: 111111, minutes: 90 },
+        ]);
+    });
+
+    test("totals the unmapped minutes", () => {
+        const verdict = checkUnmapped({
+            unmappedByWi: new Map([
+                [111111, 240],
+                [222222, 90],
+            ]),
+            allowUnmapped: false,
+        });
+
+        expect(verdict.totalMinutes).toBe(330);
+    });
+
+    test("does not block when every work item is mapped", () => {
+        const verdict = checkUnmapped({ unmappedByWi: new Map(), allowUnmapped: false });
+
+        expect(verdict.blocked).toBe(false);
+    });
+
+    test("does not block when the caller opts in, but still reports the items", () => {
+        const verdict = checkUnmapped({ unmappedByWi: new Map([[111111, 240]]), allowUnmapped: true });
+
+        expect(verdict.blocked).toBe(false);
+        expect(verdict.items).toEqual([{ workItemId: 111111, minutes: 240 }]);
+    });
+});

--- a/src/clarity/lib/fill-guard.ts
+++ b/src/clarity/lib/fill-guard.ts
@@ -1,0 +1,27 @@
+export interface UnmappedVerdict {
+    blocked: boolean;
+    items: Array<{ workItemId: number; minutes: number }>;
+    totalMinutes: number;
+}
+
+/**
+ * Decide whether unmapped work items stop a fill. Filling around them silently books an
+ * incomplete month, so the default is to refuse and let the caller create the mappings first.
+ */
+export function checkUnmapped({
+    unmappedByWi,
+    allowUnmapped,
+}: {
+    unmappedByWi: Map<number, number>;
+    allowUnmapped: boolean;
+}): UnmappedVerdict {
+    const items = [...unmappedByWi.entries()]
+        .map(([workItemId, minutes]) => ({ workItemId, minutes }))
+        .sort((a, b) => b.minutes - a.minutes || a.workItemId - b.workItemId);
+
+    return {
+        blocked: items.length > 0 && !allowUnmapped,
+        items,
+        totalMinutes: items.reduce((sum, item) => sum + item.minutes, 0),
+    };
+}

--- a/src/clarity/lib/fill-weeks.test.ts
+++ b/src/clarity/lib/fill-weeks.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import type { ClarityMapping } from "@app/clarity/config";
+import { resolveFillWeeks } from "@app/clarity/lib/fill-weeks";
+import type { ClarityApi } from "@genesiscz/utils/clarity";
+
+function carouselEntry({
+    id,
+    start,
+    finish,
+    timesheetId,
+}: {
+    id: number;
+    start: string;
+    finish: string;
+    timesheetId: number;
+}) {
+    return {
+        id,
+        resourceId: 900001,
+        is_active: true,
+        has_entries: "true",
+        selected_id: 400004,
+        start_date: `${start}T00:00:00`,
+        finish_date: `${finish}T00:00:00`,
+        tpTimesheet: {
+            _results: [
+                {
+                    timesheet_id: timesheetId,
+                    total: "0,00",
+                    prmodtime: `${start}T09:00:00`,
+                    prstatus: { _results: [{ displayValue: "Open", id: "0", _type: "lookup" }] },
+                },
+            ],
+        },
+    };
+}
+
+const CAROUSEL = [
+    carouselEntry({ id: 400000, start: "2026-07-27", finish: "2026-08-03", timesheetId: 555000 }),
+    carouselEntry({ id: 400001, start: "2026-08-03", finish: "2026-08-10", timesheetId: 555001 }),
+    carouselEntry({ id: 400002, start: "2026-08-10", finish: "2026-08-17", timesheetId: 555002 }),
+    carouselEntry({ id: 400003, start: "2026-08-17", finish: "2026-08-24", timesheetId: 555003 }),
+    carouselEntry({ id: 400004, start: "2026-08-24", finish: "2026-08-31", timesheetId: 555004 }),
+    carouselEntry({ id: 400005, start: "2026-08-31", finish: "2026-09-07", timesheetId: 555005 }),
+];
+
+// Mirrors the mappings this machine actually stores: a task link with no cached timesheet id.
+const MAPPINGS_WITHOUT_TIMESHEET_ID = [
+    {
+        clarityTaskId: 700042,
+        clarityTaskName: "SampleTask_Release_External_Capex",
+        clarityTaskCode: "00070705",
+        clarityInvestmentName: "Sample Project",
+        clarityInvestmentCode: "P100001",
+        adoWorkItemId: 111111,
+        adoWorkItemTitle: "Sample work item",
+        adoWorkItemType: "Task",
+    },
+] as ClarityMapping[];
+
+function fakeApi() {
+    const timesheetAppCalls: Array<number | undefined> = [];
+
+    return {
+        timesheetAppCalls,
+        // biome-ignore lint/suspicious/noExplicitAny: test double mirrors the Clarity response shape
+        getTimesheetApp: async (timePeriodId?: number): Promise<any> => {
+            timesheetAppCalls.push(timePeriodId);
+
+            // A real carousel is a window CENTRED on the requested period, not the whole year.
+            // Returning every period regardless of the argument lets a navigation bug pass.
+            const centre = timePeriodId ?? 400004;
+
+            return {
+                resource: { _results: [{ user_id: 900001 }] },
+                timesheets: { _results: [{ _internalId: 555004, numberOfEntries: 8, timePeriodId: centre }] },
+                tscarousel: { _results: CAROUSEL.filter((entry) => Math.abs(entry.id - centre) <= 2) },
+            };
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: test double mirrors the Clarity response shape
+        getTimesheet: async (timesheetId: number): Promise<any> => ({
+            timesheets: { _results: [{ _internalId: timesheetId, numberOfEntries: 8 }] },
+        }),
+    };
+}
+
+describe("resolveFillWeeks", () => {
+    test("resolves dates to their timesheets when no mapping carries a cached timesheet id", async () => {
+        const api = fakeApi();
+
+        const result = await resolveFillWeeks({
+            api: api as unknown as ClarityApi,
+            mappings: MAPPINGS_WITHOUT_TIMESHEET_ID,
+            dates: ["2026-08-04", "2026-08-26"],
+            month: 8,
+            year: 2026,
+        });
+
+        expect(result.weeks.map((w) => w.timesheetId)).toEqual([555001, 555004]);
+    });
+
+    test("returns one week per timesheet when several dates fall in the same period", async () => {
+        const api = fakeApi();
+
+        const result = await resolveFillWeeks({
+            api: api as unknown as ClarityApi,
+            mappings: MAPPINGS_WITHOUT_TIMESHEET_ID,
+            dates: ["2026-08-24", "2026-08-26", "2026-08-28"],
+            month: 8,
+            year: 2026,
+        });
+
+        expect(result.weeks.map((w) => w.timesheetId)).toEqual([555004]);
+    });
+
+    test("reports dates that no period covers instead of dropping them silently", async () => {
+        const api = fakeApi();
+
+        const result = await resolveFillWeeks({
+            api: api as unknown as ClarityApi,
+            mappings: MAPPINGS_WITHOUT_TIMESHEET_ID,
+            dates: ["2026-08-26", "2026-12-24"],
+            month: 8,
+            year: 2026,
+        });
+
+        expect(result.unresolvedDates).toEqual(["2026-12-24"]);
+    });
+});
+
+describe("resolveFillWeeks carousel use", () => {
+    test("seeds without a filter, then navigates by period id", async () => {
+        const api = fakeApi();
+
+        await resolveFillWeeks({
+            api: api as unknown as ClarityApi,
+            mappings: MAPPINGS_WITHOUT_TIMESHEET_ID,
+            dates: ["2026-08-26"],
+            month: 8,
+            year: 2026,
+        });
+
+        expect(api.timesheetAppCalls[0]).toBeUndefined();
+        expect(api.timesheetAppCalls.slice(1).every((id) => typeof id === "number")).toBe(true);
+    });
+});

--- a/src/clarity/lib/fill-weeks.ts
+++ b/src/clarity/lib/fill-weeks.ts
@@ -1,0 +1,48 @@
+import type { ClarityMapping } from "@app/clarity/config";
+import { findWeekForDate, getTimesheetWeeks, type TimesheetWeek } from "@app/clarity/lib/timesheet-weeks";
+import type { ClarityApi } from "@genesiscz/utils/clarity";
+
+export interface ResolvedFillWeeks {
+    weeks: TimesheetWeek[];
+    unresolvedDates: string[];
+    /** Clarity user id, needed as the author of a timesheet note. */
+    userId?: number;
+}
+
+/**
+ * Resolve the timesheets covering the dates a fill touches. Discovery runs through the shared
+ * carousel walk, so a mapping without a cached timesheet id is not a precondition.
+ */
+export async function resolveFillWeeks({
+    api,
+    mappings,
+    dates,
+    month,
+    year,
+}: {
+    api: ClarityApi;
+    mappings: ClarityMapping[];
+    dates: string[];
+    month?: number;
+    year?: number;
+}): Promise<ResolvedFillWeeks> {
+    const { weeks: available, userId } = await getTimesheetWeeks(api, mappings, month, year);
+
+    const weeks: TimesheetWeek[] = [];
+    const unresolvedDates: string[] = [];
+
+    for (const date of dates) {
+        const week = findWeekForDate(available, date);
+
+        if (!week) {
+            unresolvedDates.push(date);
+            continue;
+        }
+
+        if (!weeks.some((known) => known.timesheetId === week.timesheetId)) {
+            weeks.push(week);
+        }
+    }
+
+    return { weeks, unresolvedDates, userId };
+}

--- a/src/clarity/lib/recommend.test.ts
+++ b/src/clarity/lib/recommend.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { clarityTasksByAdoId, recommendClarityTask } from "@app/clarity/lib/recommend";
+import type { ClarityTask } from "@app/clarity/lib/types";
+
+function task(taskId: number, taskName: string): ClarityTask {
+    return {
+        taskId,
+        taskName,
+        taskCode: "00070705",
+        investmentName: "Sample",
+        investmentCode: "P100001",
+        timeEntryId: 1,
+    };
+}
+
+// Mirrors the real shapes: a leading id, a D_ prefixed id, and names carrying no id at all.
+const TASKS: ClarityTask[] = [
+    task(700001, "430001_Ceremonie - SU, planning_Sample_EXT"),
+    task(700002, "D_410001_Sample epic_Sample_EXT"),
+    task(700003, "D_420001_Sample programme_Sample_EXT"),
+    task(700004, "Incidenty_Opex_Sample_EXT"),
+    task(700005, "Rozvoj_domény_Sample_EXT"),
+];
+
+describe("clarityTasksByAdoId", () => {
+    test("keys a task by the six-digit ADO id in its name, with or without the D_ prefix", () => {
+        const byId = clarityTasksByAdoId(TASKS);
+
+        expect([...byId.keys()].sort()).toEqual([410001, 420001, 430001]);
+    });
+
+    test("skips names that carry no ADO id", () => {
+        const byId = clarityTasksByAdoId(TASKS);
+
+        expect([...byId.values()].map((t) => t.taskId)).not.toContain(700004);
+    });
+});
+
+describe("recommendClarityTask", () => {
+    test("recommends the task whose id appears on the work item itself", () => {
+        const result = recommendClarityTask({
+            chain: [{ id: 430001, title: "Ceremonie", type: "Task" }],
+            tasks: TASKS,
+        });
+
+        expect(result?.task.taskId).toBe(700001);
+    });
+
+    test("keeps climbing past ancestors that match nothing", () => {
+        const result = recommendClarityTask({
+            chain: [
+                { id: 510001, title: "FE analýza", type: "Task" },
+                { id: 520001, title: "Sample story", type: "User Story" },
+                { id: 530001, title: "Sample feature", type: "Feature" },
+                { id: 410001, title: "Sample epic", type: "Epic" },
+            ],
+            tasks: TASKS,
+        });
+
+        expect(result?.task.taskId).toBe(700002);
+    });
+
+    test("names the ancestor that matched, not the work item", () => {
+        const result = recommendClarityTask({
+            chain: [
+                { id: 510001, title: "FE analýza", type: "Task" },
+                { id: 410001, title: "Sample epic", type: "Epic" },
+            ],
+            tasks: TASKS,
+        });
+
+        expect(result?.matched).toEqual({ id: 410001, title: "Sample epic", type: "Epic" });
+    });
+
+    test("prefers the closest ancestor when two levels both match", () => {
+        const result = recommendClarityTask({
+            chain: [
+                { id: 900001, title: "Leaf", type: "Task" },
+                { id: 420001, title: "Sample programme", type: "Feature" },
+                { id: 410001, title: "Sample epic", type: "Epic" },
+            ],
+            tasks: TASKS,
+        });
+
+        expect(result?.task.taskId).toBe(700003);
+    });
+
+    test("recommends nothing when no ancestor id matches a task name", () => {
+        const result = recommendClarityTask({
+            chain: [
+                { id: 540001, title: "Sample bug", type: "Bug" },
+                { id: 550001, title: "Sample suite", type: "Test Suite" },
+            ],
+            tasks: TASKS,
+        });
+
+        expect(result).toBeUndefined();
+    });
+});
+
+describe("clarityTasksByAdoId edge cases", () => {
+    test("does not read a seven-digit number as an ADO id", () => {
+        const byId = clarityTasksByAdoId([task(700009, "D_1234567_Something_Sample_EXT")]);
+
+        expect([...byId.keys()]).toEqual([]);
+    });
+
+    test("recommends neither task when two of them name the same work item", () => {
+        const byId = clarityTasksByAdoId([
+            task(700010, "D_410001_Technologický dluh_Sample_EXT"),
+            task(700011, "D_410001_Technologický dluh duplicate_Sample_EXT"),
+        ]);
+
+        expect(byId.has(410001)).toBe(false);
+    });
+});
+
+describe("clarityTasksByAdoId boundary", () => {
+    test("does not read an investment code as an ADO id", () => {
+        const byId = clarityTasksByAdoId([task(700012, "Rollup for investment P100001_Sample_EXT")]);
+
+        expect([...byId.keys()]).toEqual([]);
+    });
+});

--- a/src/clarity/lib/recommend.ts
+++ b/src/clarity/lib/recommend.ts
@@ -1,0 +1,70 @@
+import type { WorkItemNode } from "@app/azure-devops/lib/ancestors";
+import type { ClarityTask } from "@app/clarity/lib/types";
+
+export interface ClarityRecommendation {
+    task: ClarityTask;
+    matched: WorkItemNode;
+}
+
+/**
+ * Index Clarity tasks by the ADO id embedded in their name. `D_271735_Technologický dluh 2026`
+ * bills ADO 271735, `262042_Ceremonie` bills 262042. Names without an id (Incidenty_Opex,
+ * Rozvoj_domény_MČ) cannot be recommended and are left out.
+ */
+export function clarityTasksByAdoId(tasks: ClarityTask[]): Map<number, ClarityTask> {
+    const byId = new Map<number, ClarityTask>();
+
+    const ambiguous = new Set<number>();
+
+    for (const task of tasks) {
+        // The boundary is non-alphanumeric, not merely non-digit: an investment code like
+        // P100001 is six digits behind a letter and would otherwise read as ADO work item 100001.
+        const match = task.taskName.match(/(?<![0-9A-Za-z])\d{6}(?![0-9A-Za-z])/);
+
+        if (!match) {
+            continue;
+        }
+
+        const id = Number.parseInt(match[0], 10);
+
+        if (byId.has(id)) {
+            ambiguous.add(id);
+            continue;
+        }
+
+        byId.set(id, task);
+    }
+
+    // Two tasks naming the same work item cannot be told apart, and picking by catalogue order
+    // would make the recommendation depend on response ordering. Recommend neither.
+    for (const id of ambiguous) {
+        byId.delete(id);
+    }
+
+    return byId;
+}
+
+/**
+ * Recommend the Clarity task for a work item by walking its ancestor chain and taking the closest
+ * level whose id names a task. Returns nothing when no level matches; the caller decides what a
+ * miss means, because the fallbacks are project knowledge and do not belong here.
+ */
+export function recommendClarityTask({
+    chain,
+    tasks,
+}: {
+    chain: WorkItemNode[];
+    tasks: ClarityTask[];
+}): ClarityRecommendation | undefined {
+    const byId = clarityTasksByAdoId(tasks);
+
+    for (const node of chain) {
+        const task = byId.get(node.id);
+
+        if (task) {
+            return { task, matched: node };
+        }
+    }
+
+    return undefined;
+}

--- a/src/clarity/lib/tasks.test.ts
+++ b/src/clarity/lib/tasks.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { listClarityTasks } from "@app/clarity/lib/tasks";
+import type { TimesheetResponse } from "@genesiscz/utils/clarity";
+
+function timesheetWithEntries(entries: Array<Record<string, unknown>>): TimesheetResponse {
+    return {
+        timesheets: {
+            _results: [
+                {
+                    _internalId: 555001,
+                    resourceId: 900001,
+                    resourceName: "Sample Resource",
+                    uniqueName: "sample.resource@example.com",
+                    timePeriodId: 400001,
+                    timePeriodStart: "2026-08-24T00:00:00",
+                    timePeriodFinish: "2026-08-30T00:00:00",
+                    timePeriodIsOpen: true,
+                    status: { _results: [{ displayValue: "Open", id: "0" }] },
+                    actualsTotal: 0,
+                    numberOfEntries: entries.length,
+                    timeentries: { _results: entries },
+                },
+            ],
+        },
+    } as unknown as TimesheetResponse;
+}
+
+function apiReturning(response: TimesheetResponse) {
+    return {
+        getTimesheet: async () => response,
+    };
+}
+
+const SAMPLE_ENTRY = {
+    _internalId: 10311311,
+    resourceId: 900001,
+    taskId: 700042,
+    taskCode: "00070705",
+    taskName: "SampleTask_Release_External_Capex",
+    taskFullName: "FixedPart/SampleTask_Release_External_Capex",
+    taskShortName: null,
+    taskStartDate: "2026-01-01T00:00:00",
+    taskFinishDate: "2026-12-31T00:00:00",
+    phaseName: "FixedPart",
+    phaseId: "1",
+    parentTaskName: "FixedPart",
+    parentTaskId: "2",
+    investmentId: 300001,
+    investmentName: "Sample Project",
+    investmentCode: "P100001",
+};
+
+describe("listClarityTasks", () => {
+    test("maps every time entry row to a task, taking timeEntryId from the row's internal id", async () => {
+        const api = apiReturning(
+            timesheetWithEntries([
+                SAMPLE_ENTRY,
+                { ...SAMPLE_ENTRY, _internalId: 10311312, taskId: 700043, taskName: "SampleTask_Incidents" },
+            ])
+        );
+
+        const tasks = await listClarityTasks({ api, timesheetId: 555001 });
+
+        expect(tasks).toEqual([
+            {
+                taskId: 700042,
+                taskName: "SampleTask_Release_External_Capex",
+                taskCode: "00070705",
+                investmentName: "Sample Project",
+                investmentCode: "P100001",
+                timeEntryId: 10311311,
+            },
+            {
+                taskId: 700043,
+                taskName: "SampleTask_Incidents",
+                taskCode: "00070705",
+                investmentName: "Sample Project",
+                investmentCode: "P100001",
+                timeEntryId: 10311312,
+            },
+        ]);
+    });
+    test("rejects a timesheet id the server returns no record for", async () => {
+        const api = { getTimesheet: async () => ({ timesheets: { _results: [] } }) as unknown as TimesheetResponse };
+
+        await expect(listClarityTasks({ api, timesheetId: 555999 })).rejects.toThrow("Timesheet 555999 not found");
+    });
+});

--- a/src/clarity/lib/tasks.ts
+++ b/src/clarity/lib/tasks.ts
@@ -1,0 +1,30 @@
+import type { ClarityTask } from "@app/clarity/lib/types";
+import type { TimeEntryRecord, TimesheetResponse } from "@genesiscz/utils/clarity";
+
+export interface TimesheetReader {
+    getTimesheet(timesheetId: number): Promise<TimesheetResponse>;
+}
+
+export async function listClarityTasks({
+    api,
+    timesheetId,
+}: {
+    api: TimesheetReader;
+    timesheetId: number;
+}): Promise<ClarityTask[]> {
+    const data = await api.getTimesheet(timesheetId);
+    const timesheet = data.timesheets._results[0];
+
+    if (!timesheet) {
+        throw new Error(`Timesheet ${timesheetId} not found`);
+    }
+
+    return (timesheet.timeentries?._results ?? []).map((entry: TimeEntryRecord) => ({
+        taskId: entry.taskId,
+        taskName: entry.taskName,
+        taskCode: entry.taskCode,
+        investmentName: entry.investmentName,
+        investmentCode: entry.investmentCode,
+        timeEntryId: entry._internalId,
+    }));
+}

--- a/src/clarity/lib/timesheet-weeks.test.ts
+++ b/src/clarity/lib/timesheet-weeks.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import {
+    findWeekForDate,
+    selectWeeksForDateArg,
+    type TimesheetWeek,
+    taskSourceWeekOrder,
+} from "@app/clarity/lib/timesheet-weeks";
+
+// Clarity carousel periods share a boundary date: one ends 2026-08-24 and the next starts
+// 2026-08-24, while the timesheet itself reports 2026-08-24..2026-08-30. The finish date is
+// therefore exclusive, and a boundary date belongs to the period that starts on it.
+const WEEKS: TimesheetWeek[] = [
+    {
+        timesheetId: 555001,
+        timePeriodId: 400001,
+        startDate: "2026-08-17",
+        finishDate: "2026-08-24",
+        totalHours: 0,
+        status: "Open",
+    },
+    {
+        timesheetId: 555002,
+        timePeriodId: 400002,
+        startDate: "2026-08-24",
+        finishDate: "2026-08-31",
+        totalHours: 0,
+        status: "Open",
+    },
+    {
+        timesheetId: 555003,
+        timePeriodId: 400003,
+        startDate: "2026-08-31",
+        finishDate: "2026-09-01",
+        totalHours: 0,
+        status: "Open",
+    },
+];
+
+describe("findWeekForDate", () => {
+    test("returns the period whose range covers a mid-week date", () => {
+        expect(findWeekForDate(WEEKS, "2026-08-26")?.timesheetId).toBe(555002);
+    });
+
+    test("assigns a shared boundary date to the period that starts on it", () => {
+        expect(findWeekForDate(WEEKS, "2026-08-24")?.timesheetId).toBe(555002);
+    });
+
+    test("assigns the day before the finish date to that period", () => {
+        expect(findWeekForDate(WEEKS, "2026-08-30")?.timesheetId).toBe(555002);
+    });
+
+    test("returns undefined for a date no period covers", () => {
+        expect(findWeekForDate(WEEKS, "2026-07-04")).toBeUndefined();
+    });
+});
+
+describe("selectWeeksForDateArg", () => {
+    test("returns only the covering period for a full date", () => {
+        expect(selectWeeksForDateArg(WEEKS, "2026-08-26").map((w) => w.timesheetId)).toEqual([555002]);
+    });
+
+    test("returns every period that reaches into the month for a YYYY-MM argument", () => {
+        expect(selectWeeksForDateArg(WEEKS, "2026-08").map((w) => w.timesheetId)).toEqual([555001, 555002, 555003]);
+    });
+
+    test("excludes a period that only touches the month through its exclusive finish date", () => {
+        expect(selectWeeksForDateArg(WEEKS, "2026-09")).toEqual([]);
+    });
+});
+
+describe("periods Clarity has not opened a timesheet for", () => {
+    // The carousel lists future periods with no timesheet_id yet; selecting one sends
+    // `timesheetId=undefined` to the API, which answers API-1006 invalidAttrValue.
+    const WITH_FUTURE: TimesheetWeek[] = [
+        ...WEEKS,
+        {
+            timesheetId: undefined as unknown as number,
+            timePeriodId: 400004,
+            startDate: "2026-09-01",
+            finishDate: "2026-09-08",
+            totalHours: 0,
+            status: "Open",
+        },
+    ];
+
+    test("are not returned for a month that only they cover", () => {
+        expect(selectWeeksForDateArg(WITH_FUTURE, "2026-09")).toEqual([]);
+    });
+
+    test("are not returned for a date inside them", () => {
+        expect(findWeekForDate(WITH_FUTURE, "2026-09-03")).toBeUndefined();
+    });
+});
+
+describe("selectWeeksForDateArg input validation", () => {
+    test("rejects an argument that is neither a day nor a month", () => {
+        expect(() => selectWeeksForDateArg(WEEKS, "2026")).toThrow("expected YYYY-MM-DD or YYYY-MM");
+    });
+});
+
+describe("taskSourceWeekOrder", () => {
+    // A month's own timesheet can exist with no task rows yet, so the catalogue has to come from
+    // whichever period actually has rows. Try the requested one first, then the newest others.
+    test("puts the preferred week first", () => {
+        expect(taskSourceWeekOrder(WEEKS, WEEKS[0]).map((w) => w.timesheetId)).toEqual([555001, 555003, 555002]);
+    });
+
+    test("orders the remaining weeks newest first", () => {
+        expect(taskSourceWeekOrder(WEEKS, WEEKS[2]).map((w) => w.timesheetId)).toEqual([555003, 555002, 555001]);
+    });
+
+    test("returns every week newest first when there is no preference", () => {
+        expect(taskSourceWeekOrder(WEEKS, undefined).map((w) => w.timesheetId)).toEqual([555003, 555002, 555001]);
+    });
+});

--- a/src/clarity/lib/timesheet-weeks.ts
+++ b/src/clarity/lib/timesheet-weeks.ts
@@ -1,5 +1,7 @@
 import type { ClarityMapping } from "@app/clarity/config";
 import type { ClarityApi } from "@genesiscz/utils/clarity";
+import { isDateInHalfOpenRange } from "@genesiscz/utils/date";
+import { logger } from "@genesiscz/utils/logger";
 
 export interface TimesheetWeek {
     timesheetId: number;
@@ -52,6 +54,95 @@ function parseCarouselEntry(entry: CarouselEntry, entryCountMap: Map<number, num
     };
 }
 
+/**
+ * Pick the period id the carousel walk starts from. Without one, `getTimesheetApp` returns only the
+ * window around today and any month further back is unreachable, so a fill for an older month found
+ * no periods and silently booked nothing. A mapping's cached period is used when present; otherwise
+ * the server is asked for its current one.
+ */
+export async function resolveCarouselSeed({
+    api,
+    cachedTimePeriodId,
+}: {
+    api: { getTimesheetApp: (timePeriodId?: number) => Promise<TimesheetAppLike> };
+    cachedTimePeriodId: number | undefined;
+}): Promise<number | undefined> {
+    if (cachedTimePeriodId !== undefined) {
+        return cachedTimePeriodId;
+    }
+
+    const app = await api.getTimesheetApp();
+
+    const carousel = app.tscarousel?._results ?? [];
+    // The first carousel entry is the OLDEST in the window; the active one is what "current" means.
+    const active = carousel.find((entry) => entry.is_active) ?? carousel[Math.floor(carousel.length / 2)];
+
+    return app.timesheets?._results?.[0]?.timePeriodId ?? active?.id;
+}
+
+interface TimesheetAppLike {
+    tscarousel?: { _results?: Array<{ id?: number; is_active?: boolean }> };
+    timesheets?: { _results?: Array<{ timePeriodId?: number }> };
+}
+
+/**
+ * Walk the carousel to the period covering a date. One window spans about nine weeks, so a month a
+ * quarter back needs several hops; a single `findTimesheetForDate` call only ever searched the
+ * first window and quietly returned nothing for anything older.
+ */
+export async function navigateToPeriodForDate({
+    api,
+    seedTimePeriodId,
+    date,
+    maxHops = 12,
+}: {
+    api: { getTimesheetApp: (timePeriodId?: number) => Promise<CarouselWindowLike> };
+    seedTimePeriodId: number;
+    date: string;
+    maxHops?: number;
+}): Promise<number | undefined> {
+    let centre = seedTimePeriodId;
+    const visited = new Set<number>();
+
+    for (let hop = 0; hop < maxHops; hop++) {
+        if (visited.has(centre)) {
+            return undefined;
+        }
+
+        visited.add(centre);
+        const entries = (await api.getTimesheetApp(centre)).tscarousel?._results ?? [];
+
+        if (entries.length === 0) {
+            return undefined;
+        }
+
+        const covering = entries.find((entry) =>
+            isDateInHalfOpenRange(date, entry.start_date ?? "", entry.finish_date ?? "")
+        );
+
+        if (covering?.id !== undefined) {
+            return covering.id;
+        }
+
+        const sorted = [...entries].sort((a, b) => (a.start_date ?? "").localeCompare(b.start_date ?? ""));
+        const first = sorted[0];
+        const last = sorted[sorted.length - 1];
+        const next = date < (first.start_date ?? "").split("T")[0] ? first.id : last.id;
+
+        if (next === undefined) {
+            return undefined;
+        }
+
+        centre = next;
+    }
+
+    return undefined;
+}
+
+interface CarouselWindowLike {
+    tscarousel?: { _results?: Array<{ id?: number; start_date?: string; finish_date?: string }> };
+}
+
 export async function getTimesheetWeeks(
     api: ClarityApi,
     mappings: ClarityMapping[],
@@ -61,20 +152,23 @@ export async function getTimesheetWeeks(
     // Try to find a valid timePeriodId to seed the carousel.
     // When a specific month/year is requested, try to navigate to a period covering that month
     // so the carousel window is anchored correctly.
-    const seedTimePeriodId = await findValidTimePeriodId(api, mappings);
+    const seedTimePeriodId = await resolveCarouselSeed({
+        api,
+        cachedTimePeriodId: await findValidTimePeriodId(api, mappings),
+    });
     let timePeriodId = seedTimePeriodId;
 
     if (month !== undefined && year !== undefined && seedTimePeriodId !== undefined) {
-        const targetDate = new Date(year, month - 1, 15); // mid-month
+        const targetDate = `${year}-${String(month).padStart(2, "0")}-15`;
 
         try {
-            const entry = await api.findTimesheetForDate(seedTimePeriodId, targetDate);
+            const reached = await navigateToPeriodForDate({ api, seedTimePeriodId, date: targetDate });
 
-            if (entry) {
-                timePeriodId = entry.id;
+            if (reached !== undefined) {
+                timePeriodId = reached;
             }
-        } catch {
-            // Navigation failed, fall back to the seed period
+        } catch (err) {
+            logger.debug(`[clarity] carousel navigation to ${targetDate} failed, using the seed period: ${err}`);
         }
     }
 
@@ -130,8 +224,8 @@ export async function getTimesheetWeeks(
                 }
 
                 weeks.sort((a, b) => a.startDate.localeCompare(b.startDate));
-            } catch {
-                // Navigation failed, return what we have
+            } catch (err) {
+                logger.debug(`[clarity] carousel edge hop failed, returning the window we have: ${err}`);
             }
         }
 
@@ -152,8 +246,8 @@ export async function getTimesheetWeeks(
                 }
 
                 weeks.sort((a, b) => a.startDate.localeCompare(b.startDate));
-            } catch {
-                // Navigation failed, return what we have
+            } catch (err) {
+                logger.debug(`[clarity] carousel edge hop failed, returning the window we have: ${err}`);
             }
         }
 
@@ -221,4 +315,47 @@ async function findValidTimePeriodId(api: ClarityApi, mappings: ClarityMapping[]
 
     // Strategy 2: Fall back to undefined (no filter = current period)
     return undefined;
+}
+
+/**
+ * Pick the period covering a date. Clarity periods share a boundary date, so the range is
+ * half-open: the finish date belongs to the next period, not this one. Future periods carry no
+ * timesheet id yet and are skipped, because the API rejects `timesheetId=undefined`.
+ */
+export function findWeekForDate(weeks: TimesheetWeek[], date: string): TimesheetWeek | undefined {
+    return weeks.find((week) => week.timesheetId && isDateInHalfOpenRange(date, week.startDate, week.finishDate));
+}
+
+/**
+ * Select periods for a `--date` argument. A full `YYYY-MM-DD` picks the single covering period;
+ * a `YYYY-MM` picks every period that reaches into that month.
+ */
+export function selectWeeksForDateArg(weeks: TimesheetWeek[], dateArg: string): TimesheetWeek[] {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(dateArg)) {
+        const week = findWeekForDate(weeks, dateArg);
+
+        return week ? [week] : [];
+    }
+
+    if (!/^\d{4}-\d{2}$/.test(dateArg)) {
+        throw new Error(`Invalid --date '${dateArg}': expected YYYY-MM-DD or YYYY-MM`);
+    }
+
+    const [year, month] = dateArg.split("-").map(Number);
+    const monthStart = `${dateArg}-01`;
+    const monthEnd = `${dateArg}-${String(new Date(year, month, 0).getDate()).padStart(2, "0")}`;
+
+    return weeks.filter((week) => week.timesheetId && week.startDate <= monthEnd && week.finishDate > monthStart);
+}
+
+/**
+ * Order the periods to try when looking for the Clarity task catalogue. A month's own timesheet
+ * can exist with no task rows yet, so fall back to the newest other period that does have them.
+ */
+export function taskSourceWeekOrder(weeks: TimesheetWeek[], preferred: TimesheetWeek | undefined): TimesheetWeek[] {
+    const rest = weeks
+        .filter((week) => week.timesheetId && week.timesheetId !== preferred?.timesheetId)
+        .sort((a, b) => b.startDate.localeCompare(a.startDate));
+
+    return preferred?.timesheetId ? [preferred, ...rest] : rest;
 }

--- a/src/clarity/ui/src/server/fill.ts
+++ b/src/clarity/ui/src/server/fill.ts
@@ -13,7 +13,7 @@ import {
 import { getTimesheetWeeks } from "@app/clarity/lib/timesheet-weeks";
 import type { ApiDebugInfo, TimeEntryRecord, TimeSeriesValue } from "@genesiscz/utils/clarity";
 import { ClarityApi } from "@genesiscz/utils/clarity";
-import { addDay } from "@genesiscz/utils/date";
+import { addDay, isDateInHalfOpenRange } from "@genesiscz/utils/date";
 
 interface WeekPreviewTimelogEntry {
     workItemId: number;
@@ -187,15 +187,15 @@ export async function getFillPreview(month: number, year: number): Promise<FillP
             let weekTotal = 0;
 
             for (const [date, mins] of Object.entries(fill.dayMinutes)) {
-                if (date >= cw.startDate && date < cw.finishDate) {
+                if (isDateInHalfOpenRange(date, cw.startDate, cw.finishDate)) {
                     weekDayValues[date] = mins;
                     weekTotal += mins;
                 }
             }
 
             if (weekTotal > 0) {
-                const weekTimelogs = (fill.timelogEntries ?? []).filter(
-                    (e) => e.date >= cw.startDate && e.date < cw.finishDate
+                const weekTimelogs = (fill.timelogEntries ?? []).filter((e) =>
+                    isDateInHalfOpenRange(e.date, cw.startDate, cw.finishDate)
                 );
 
                 weekEntries.push({
@@ -212,7 +212,7 @@ export async function getFillPreview(month: number, year: number): Promise<FillP
         const weekUnmappedMap = new Map<number, number>();
 
         for (const ue of unmappedEntries) {
-            if (ue.date >= cw.startDate && ue.date < cw.finishDate) {
+            if (isDateInHalfOpenRange(ue.date, cw.startDate, cw.finishDate)) {
                 weekUnmappedMap.set(ue.workItemId, (weekUnmappedMap.get(ue.workItemId) ?? 0) + ue.minutes);
             }
         }

--- a/src/clarity/ui/src/server/mappings.ts
+++ b/src/clarity/ui/src/server/mappings.ts
@@ -1,8 +1,8 @@
 import type { ClarityMapping } from "@app/clarity/config";
 import { getConfig, saveConfig } from "@app/clarity/config";
+import { listClarityTasks } from "@app/clarity/lib/tasks";
 import { getTimesheetWeeks as getTimesheetWeeksShared, type TimesheetWeek } from "@app/clarity/lib/timesheet-weeks";
 import type { ClarityTask } from "@app/clarity/lib/types";
-import type { TimeEntryRecord } from "@genesiscz/utils/clarity";
 import { ClarityApi } from "@genesiscz/utils/clarity";
 
 export type { TimesheetWeek };
@@ -94,23 +94,7 @@ export async function getClarityTasks(timesheetId: number): Promise<{ tasks: Cla
         cookies: config.cookies,
     });
 
-    const data = await api.getTimesheet(timesheetId);
-    const ts = data.timesheets._results[0];
-
-    if (!ts) {
-        throw new Error(`Timesheet ${timesheetId} not found`);
-    }
-
-    const tasks: ClarityTask[] = (ts.timeentries?._results ?? []).map((e: TimeEntryRecord) => ({
-        taskId: e.taskId,
-        taskName: e.taskName,
-        taskCode: e.taskCode,
-        investmentName: e.investmentName,
-        investmentCode: e.investmentCode,
-        timeEntryId: e._internalId,
-    }));
-
-    return { tasks };
+    return { tasks: await listClarityTasks({ api, timesheetId }) };
 }
 
 export async function moveMapping(

--- a/src/utils/clarity/api.ts
+++ b/src/utils/clarity/api.ts
@@ -1,3 +1,4 @@
+import { isDateInHalfOpenRange } from "@genesiscz/utils/date";
 import { SafeJSON } from "@genesiscz/utils/json";
 import type {
     ApiDebugInfo,
@@ -75,10 +76,7 @@ export class ClarityApi {
         const target = targetDate.toISOString().split("T")[0];
 
         for (const entry of app.tscarousel._results) {
-            const start = entry.start_date.split("T")[0];
-            const finish = entry.finish_date.split("T")[0];
-
-            if (target >= start && target <= finish) {
+            if (isDateInHalfOpenRange(target, entry.start_date, entry.finish_date)) {
                 return entry;
             }
         }

--- a/src/utils/clarity/types/response.types.ts
+++ b/src/utils/clarity/types/response.types.ts
@@ -36,8 +36,16 @@ export interface TimesheetRecord {
     resourceId: number;
     isActive: boolean;
     actualsTotal: number;
-    timePeriodStart: string; // ISO
-    timePeriodFinish: string; // ISO
+    timePeriodStart: string; // ISO, first day of the period
+    /**
+     * ISO, and INCLUSIVE: the last day that belongs to the period. A week running Monday to
+     * Sunday reports finish 2026-08-30, not 2026-08-31.
+     *
+     * 🛑 This is the opposite of `CarouselEntry.finish_date`, which is EXCLUSIVE for the same
+     * week. Never feed this field to `isDateInHalfOpenRange`; add a day first (`addDay`), the
+     * way `src/clarity/ui/src/server/fill.ts` does when it builds `exclusiveEnd`.
+     */
+    timePeriodFinish: string;
     timePeriodId: number;
     timePeriodOffset: number;
     version: number;
@@ -257,9 +265,23 @@ export interface TimesheetCarousel {
 
 export interface CarouselEntry {
     id: number; // timePeriodId
-    timesheet_id: number; // THE timesheetId we need
-    start_date: string; // ISO
-    finish_date: string; // ISO
+    /**
+     * THE timesheetId we need. Absent on future periods Clarity has not opened a timesheet for;
+     * sending `timesheetId=undefined` answers `API-1006 invalidAttrValue`.
+     */
+    timesheet_id: number;
+    start_date: string; // ISO, first day of the period
+    /**
+     * ISO, and EXCLUSIVE: the first day that no longer belongs to the period. Adjacent periods
+     * therefore share a boundary date. The week of 2026-08-24 reports finish_date 2026-08-31,
+     * while the next period reports start_date 2026-08-31.
+     *
+     * 🛑 The same week's timesheet reports `timePeriodFinish` 2026-08-30, which is INCLUSIVE.
+     * Two fields, two meanings, one day apart. Match dates against this one with
+     * `isDateInHalfOpenRange(date, start_date, finish_date)` from `@genesiscz/utils/date`;
+     * an inclusive comparison here assigns every boundary day to the earlier week.
+     */
+    finish_date: string;
     total: number; // total hours logged
     prstatus: LookupField; // status
     _self: string;

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import {
     formatLocalDateTimeStamp,
     formatLocalFileTimestamp,
     formatLocalMonth,
     getDatesInMonth,
+    getDaysInPeriodInclusive,
     getMonthDateRange,
+    isDateInHalfOpenRange,
     parseDate,
 } from "./date";
 
@@ -84,5 +86,59 @@ describe("local timestamp formatting", () => {
 
     it("formats local month", () => {
         expect(formatLocalMonth(d)).toBe("2026-05");
+    });
+});
+
+describe("isDateInHalfOpenRange", () => {
+    // Reporting periods share a boundary date: one ends 2026-08-24 and the next starts on it.
+    // The finish is therefore exclusive, so a boundary day belongs to exactly one period.
+    test("includes the first day of the range", () => {
+        expect(isDateInHalfOpenRange("2026-08-24", "2026-08-24", "2026-08-31")).toBe(true);
+    });
+
+    test("includes the day before the finish", () => {
+        expect(isDateInHalfOpenRange("2026-08-30", "2026-08-24", "2026-08-31")).toBe(true);
+    });
+
+    test("excludes the finish day itself", () => {
+        expect(isDateInHalfOpenRange("2026-08-31", "2026-08-24", "2026-08-31")).toBe(false);
+    });
+
+    test("excludes a day before the range", () => {
+        expect(isDateInHalfOpenRange("2026-08-23", "2026-08-24", "2026-08-31")).toBe(false);
+    });
+
+    test("accepts ISO timestamps on either bound", () => {
+        expect(isDateInHalfOpenRange("2026-08-26", "2026-08-24T00:00:00", "2026-08-31T00:00:00")).toBe(true);
+    });
+});
+
+describe("getDaysInPeriodInclusive", () => {
+    // Clarity's timesheet reports timePeriodFinish as the LAST day of the period, unlike the
+    // carousel's exclusive finish_date. Dropping that day silently loses a whole day of hours.
+    test("includes the finish day", () => {
+        const days = getDaysInPeriodInclusive("2026-08-24T00:00:00", "2026-08-30T00:00:00");
+
+        expect(days.map((d) => d.date)).toEqual([
+            "2026-08-24",
+            "2026-08-25",
+            "2026-08-26",
+            "2026-08-27",
+            "2026-08-28",
+            "2026-08-29",
+            "2026-08-30",
+        ]);
+    });
+
+    test("returns the single day of a one-day period", () => {
+        const days = getDaysInPeriodInclusive("2026-08-31T00:00:00", "2026-08-31T00:00:00");
+
+        expect(days.map((d) => d.date)).toEqual(["2026-08-31"]);
+    });
+
+    test("labels each day with its weekday and day of month", () => {
+        const days = getDaysInPeriodInclusive("2026-08-31T00:00:00", "2026-08-31T00:00:00");
+
+        expect(days[0].label).toBe("Mon 31");
     });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -380,6 +380,23 @@ export function subtractDay(date: string): string {
  * Start is inclusive, finish is exclusive (standard half-open interval).
  * Format: "YYYY-MM-DD".
  */
+/**
+ * Test a date against a reporting period whose finish is EXCLUSIVE.
+ *
+ * Clarity timesheet periods and similar calendars share a boundary date: one period ends on
+ * 2026-08-24 while the next starts on it. An inclusive comparison puts that day in both, so the
+ * finish never counts. Accepts plain dates or ISO timestamps on any argument.
+ *
+ * 🛑 Feed this the EXCLUSIVE end. In Clarity that is `CarouselEntry.finish_date`. The timesheet's
+ * own `timePeriodFinish` is INCLUSIVE and sits one day earlier for the same week, so passing it
+ * here silently drops the last day of every period. Convert it with `addDay` first.
+ */
+export function isDateInHalfOpenRange(date: string, start: string, finish: string): boolean {
+    const day = date.split("T")[0];
+
+    return day >= start.split("T")[0] && day < finish.split("T")[0];
+}
+
 export function getDaysInPeriod(periodStart: string, periodFinish: string): Array<{ label: string; date: string }> {
     const start = parseUTCDate(periodStart);
     const finish = parseUTCDate(periodFinish);
@@ -398,6 +415,18 @@ export function getDaysInPeriod(periodStart: string, periodFinish: string): Arra
 /**
  * Convert minutes to seconds.
  */
+/**
+ * Days of a period whose finish is INCLUSIVE, which is how Clarity's `timePeriodFinish` reports
+ * the last day of a week. Use `getDaysInPeriod` for an exclusive end such as the carousel's
+ * `finish_date`; mixing the two silently drops or adds a day of hours.
+ */
+export function getDaysInPeriodInclusive(
+    periodStart: string,
+    periodFinishInclusive: string
+): Array<{ label: string; date: string }> {
+    return getDaysInPeriod(periodStart, `${addDay(periodFinishInclusive.split("T")[0])}T00:00:00`);
+}
+
 export function minutesToSeconds(minutes: number): number {
     return minutes * 60;
 }


### PR DESCRIPTION
## Why

`tools clarity fill` could never run. It gated on `mappings[0].clarityTimesheetId`, a field none of the stored mappings carry, and no command could produce one: `timesheet list` wants a `--period` id from the web UI, and `link-workitems --timesheet` wants an id the user does not have. A closed loop.

The dashboard already had working discovery. Only the CLI was behind, which is exactly the "a behaviour must never exist in a route the CLI cannot reach" rule in CLAUDE.md. Every piece of logic added here lives in `src/clarity/lib/`, so the UI can call the same functions.

## What changed

**Discovery**
- `fill` resolves its weeks through the shared carousel walk, so no stored `clarityTimesheetId` is needed.
- `listClarityTasks` moved to `src/clarity/lib/tasks.ts`; the UI's `getClarityTasks` delegates to it.

**New surfaces**
- `tools clarity tasks --date 2026-08-25` or `--date 2026-08` lists the task catalogue for a day or a whole month.
- `tools clarity tasks --unassigned` / `--assigned` lists the month's ADO work items either side of the mapping line, with hours.
- `tools clarity tasks --assign <wi>:<taskId>` and `--apply-recommended` create mappings; `--unlink <ids>` removes them behind a confirmation.
- `tools azure-devops ancestors <id>` walks a work item's parent chain.
- Every one of these takes `--format json`.

**Recommendations**
- A Clarity task name embeds the ADO id it bills (`D_271735_Technologický dluh 2026` bills 271735). `recommendClarityTask` walks the ancestor chain and takes the closest level whose id names a task.
- `walkAncestorsBatched` fetches one tree LEVEL per call rather than one ancestor per call, so a month of ~13 work items costs about 4 API calls.
- A recommendation comes **only** from an id match. Routing rules such as "an Incident goes to Incidenty_Opex" are deliberately not encoded; they are the operator's judgement, and the tool leaves those rows blank.
- An assigned row whose stored task disagrees with the tree is flagged.

**Guards**
- `fill` refuses a month that still has unmapped work items, prints them with hours, exits 1. `--allow-unmapped` is the opt-out.

## Four bugs found on the way

1. **Boundary days landed in the wrong week.** Adjacent Clarity periods share a date: one ends 2026-08-24 while the next starts on it. The old inclusive comparison put that day in the earlier period. One shared `isDateInHalfOpenRange` now backs every period comparison, including `ClarityApi.findTimesheetForDate`.
2. **Future periods have no timesheet.** The carousel lists them with no `timesheet_id`; selecting one sent `timesheetId=undefined` and Clarity answered `API-1006 invalidAttrValue`.
3. **`buildFillMap` groups by Clarity task**, so an "assigned" listing built on it collapsed three work items sharing one task into a single row. Assignment views group by work item.
4. **A one-day period lost its hours entirely.** `timePeriodFinish` is INCLUSIVE, unlike the carousel's exclusive `finish_date`, and the day loop also built local Dates while reading `getUTCDay()`, which in CEST turned Monday 2026-08-31 into a Sunday and dropped it from the Mon-Fri columns. Ten real hours silently vanished from the preview. Both period fields are now documented at the type.

## Tests

TDD throughout, ten red/green slices. 163 tests across the touched areas, full repo suite green. Every fixture is invented; no real task, timesheet or account identifiers.

Mutation-checked per slice: inverted boundary, wrong field mapping, missing side effect, empty return, missing validation, cycle guard, depth off-by-one, and the inclusive/exclusive flip each fail at least one named test.

## Verified against live data

August 2026 was mapped end to end through the new commands, filled, and the result reconciled: Clarity reports 200.0 h for the month, matching Azure DevOps exactly. The mapping state was then deleted via `--unlink` and rebuilt purely from the CLI; the sorted mappings hashed identically before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Azure DevOps command to display work item ancestor chains in table or JSON format.
  - Added Clarity task management for listing, assigning, recommending, and removing task mappings.
  - Added ancestor-based task recommendations and improved assignment views.
  - Added timesheet-week discovery and support for resolving dates across periods.
  - Added optional comments when filling timesheets.

- **Bug Fixes**
  - Improved date-range handling and timesheet boundary accuracy.
  - Filling now reports unmapped work and blocks incomplete-month fills unless explicitly allowed.

- **Documentation**
  - Clarified timesheet date ranges, filters, response formats, and boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->