### PR TITLE
fix(clarity,azure-devops): PR #351 review follow-up — an unopened period is never a fillable week

### DIFF
--- a/src/azure-devops/lib/ancestor-batch.test.ts
+++ b/src/azure-devops/lib/ancestor-batch.test.ts
@@ -53,6 +53,21 @@ describe("walkAncestorsBatched", () => {
         expect(requested.length).toBe(new Set(requested).size);
     });
 
+    test("never re-asks for a starting id the server omitted, even as another item's parent", async () => {
+        const batches: number[][] = [];
+        // 200001 is a starting id, is omitted by the server, and is also 100001's parent. Caching
+        // only what came back would ask for it a second time one level up.
+        const fetchMany = async (ids: number[]): Promise<Map<number, WorkItemNode>> => {
+            batches.push([...ids]);
+
+            return new Map(ids.filter((id) => TREE[id] && id !== 200001).map((id) => [id, TREE[id]]));
+        };
+
+        await walkAncestorsBatched({ fetchMany, ids: [100001, 200001], maxDepth: 3 });
+
+        expect(batches.flat().filter((id) => id === 200001).length).toBe(1);
+    });
+
     test("returns a single-node chain for a work item with no parent", async () => {
         const { fetchMany } = batchFetcher();
 

--- a/src/azure-devops/lib/ancestors.ts
+++ b/src/azure-devops/lib/ancestors.ts
@@ -52,10 +52,17 @@ export async function walkAncestorsBatched({
     maxDepth?: number;
 }): Promise<Map<number, WorkItemNode[]>> {
     const known = new Map<number, WorkItemNode>();
+    // A work item the API omits never lands in `known`, so without a separate record of what was
+    // asked for, an omitted id named as someone else's parent is requested again a level later.
+    const attempted = new Set<number>();
     let level = [...new Set(ids)];
 
     for (let depth = 0; depth <= maxDepth && level.length > 0; depth++) {
-        const wanted = level.filter((id) => !known.has(id));
+        const wanted = level.filter((id) => !attempted.has(id));
+
+        for (const id of wanted) {
+            attempted.add(id);
+        }
 
         if (wanted.length === 0) {
             break;
@@ -71,7 +78,7 @@ export async function walkAncestorsBatched({
             ...new Set(
                 wanted
                     .map((id) => known.get(id)?.parent)
-                    .filter((parent): parent is number => parent !== undefined && !known.has(parent))
+                    .filter((parent): parent is number => parent !== undefined && !attempted.has(parent))
             ),
         ];
     }

--- a/src/clarity/commands/link-workitems.ts
+++ b/src/clarity/commands/link-workitems.ts
@@ -9,7 +9,12 @@ import pc from "picocolors";
 import type { ClarityMapping } from "../config.js";
 import { getConfig, getMappingForWorkItem, requireConfig, saveConfig } from "../config.js";
 import { getTimelogWorkItems, type TimelogWorkItemGroup } from "../lib/timelog-workitems.js";
-import { getTimesheetWeeks, type TimesheetWeek } from "../lib/timesheet-weeks.js";
+import {
+    getTimesheetWeeks,
+    hasTimesheetId,
+    type IdentifiedTimesheetWeek,
+    type TimesheetWeek,
+} from "../lib/timesheet-weeks.js";
 
 interface ClarityProject {
     taskId: number;
@@ -132,7 +137,11 @@ export async function runInteractiveLinking(): Promise<void> {
         return;
     }
 
-    if (weeks.length === 0) {
+    // A period Clarity has not opened a timesheet for has no id to read entries with, so it cannot
+    // be picked here at all.
+    const selectableWeeks = weeks.filter(hasTimesheetId);
+
+    if (selectableWeeks.length === 0) {
         clack.log.warn("No timesheet weeks found.");
         clack.outro("Done");
         return;
@@ -140,7 +149,7 @@ export async function runInteractiveLinking(): Promise<void> {
 
     // State machine
     let step = 1;
-    let selectedWeek: TimesheetWeek | null = null;
+    let selectedWeek: IdentifiedTimesheetWeek | null = null;
     let selectedTask: ClarityProject | null = null;
     let projects: ClarityProject[] = [];
     let workItems: TimelogWorkItemGroup[] = [];
@@ -150,7 +159,7 @@ export async function runInteractiveLinking(): Promise<void> {
             // Step 1: Select week
             const result = await clack.select({
                 message: "Select timesheet week:",
-                options: weeks.map((w) => ({
+                options: selectableWeeks.map((w) => ({
                     value: w,
                     label: formatWeekLabel(w),
                     hint: `${w.totalHours}h – ${w.status}`,

--- a/src/clarity/commands/tasks.ts
+++ b/src/clarity/commands/tasks.ts
@@ -3,7 +3,12 @@ import { requireConfig, saveConfig } from "@app/clarity/config";
 import { type AssignmentView, buildAssignmentView, parseMonthArg } from "@app/clarity/lib/assignment-view";
 import { type AssignmentRow, applyAssignments, removeAssignments } from "@app/clarity/lib/assignments";
 import { listClarityTasks } from "@app/clarity/lib/tasks";
-import { getTimesheetWeeks, selectWeeksForDateArg, type TimesheetWeek } from "@app/clarity/lib/timesheet-weeks";
+import {
+    getTimesheetWeeks,
+    hasTimesheetId,
+    type IdentifiedTimesheetWeek,
+    selectWeeksForDateArg,
+} from "@app/clarity/lib/timesheet-weeks";
 import * as p from "@clack/prompts";
 import { ClarityApi } from "@genesiscz/utils/clarity";
 import { isInteractive } from "@genesiscz/utils/cli";
@@ -59,6 +64,19 @@ export function registerTasksCommand(parent: Command): void {
             }
 
             const date = options.date ?? formatDate(new Date());
+            const wantsAssignmentView =
+                Boolean(options.assign) ||
+                Boolean(options.applyRecommended) ||
+                Boolean(options.assigned) ||
+                Boolean(options.unassigned);
+
+            if (options.timesheet && wantsAssignmentView) {
+                // The assignment view is built from a MONTH of ADO time entries, so a single
+                // timesheet id cannot scope it. Accepting the flag here would silently report the
+                // default date's month instead of the timesheet the user named.
+                out.error("--timesheet only applies to the task catalogue. Use --date <YYYY-MM> for this action.");
+                process.exit(1);
+            }
 
             if (options.assign || options.applyRecommended) {
                 await runAssign(date, options);
@@ -83,7 +101,7 @@ async function runCatalogue(date: string, options: TasksOptions): Promise<void> 
         cookies: config.cookies,
     });
 
-    let selected: TimesheetWeek[];
+    let selected: IdentifiedTimesheetWeek[];
 
     if (options.timesheet) {
         const timesheetId = Number.parseInt(options.timesheet, 10);
@@ -100,7 +118,8 @@ async function runCatalogue(date: string, options: TasksOptions): Promise<void> 
         }
 
         const { weeks } = await getTimesheetWeeks(api, config.mappings, month, year);
-        selected = selectWeeksForDateArg(weeks, date);
+        // A period with no opened timesheet has no catalogue to read, so it is not a match.
+        selected = selectWeeksForDateArg(weeks, date).filter(hasTimesheetId);
 
         if (selected.length === 0) {
             out.error(`No Clarity period covers ${date}`);

--- a/src/clarity/commands/tasks.ts
+++ b/src/clarity/commands/tasks.ts
@@ -7,6 +7,7 @@ import {
     getTimesheetWeeks,
     hasTimesheetId,
     type IdentifiedTimesheetWeek,
+    parseTimesheetArg,
     selectWeeksForDateArg,
 } from "@app/clarity/lib/timesheet-weeks";
 import * as p from "@clack/prompts";
@@ -70,11 +71,18 @@ export function registerTasksCommand(parent: Command): void {
                 Boolean(options.assigned) ||
                 Boolean(options.unassigned);
 
-            if (options.timesheet && wantsAssignmentView) {
+            const timesheet = parseTimesheetArg(options.timesheet);
+
+            if (timesheet.supplied && wantsAssignmentView) {
                 // The assignment view is built from a MONTH of ADO time entries, so a single
                 // timesheet id cannot scope it. Accepting the flag here would silently report the
                 // default date's month instead of the timesheet the user named.
                 out.error("--timesheet only applies to the task catalogue. Use --date <YYYY-MM> for this action.");
+                process.exit(1);
+            }
+
+            if (timesheet.supplied && timesheet.id === undefined) {
+                out.error(`Invalid --timesheet '${options.timesheet}': expected a positive timesheet id`);
                 process.exit(1);
             }
 
@@ -103,8 +111,9 @@ async function runCatalogue(date: string, options: TasksOptions): Promise<void> 
 
     let selected: IdentifiedTimesheetWeek[];
 
-    if (options.timesheet) {
-        const timesheetId = Number.parseInt(options.timesheet, 10);
+    const timesheetId = parseTimesheetArg(options.timesheet).id;
+
+    if (timesheetId !== undefined) {
         selected = [{ timesheetId, timePeriodId: 0, startDate: date, finishDate: date, totalHours: 0, status: "" }];
     } else {
         let month: number;

--- a/src/clarity/lib/assignment-view.ts
+++ b/src/clarity/lib/assignment-view.ts
@@ -10,6 +10,7 @@ import { listClarityTasks } from "@app/clarity/lib/tasks";
 import {
     findWeekForDate,
     getTimesheetWeeks,
+    hasTimesheetId,
     type TimesheetWeek,
     taskSourceWeekOrder,
 } from "@app/clarity/lib/timesheet-weeks";
@@ -40,6 +41,10 @@ export function parseMonthArg(date: string): { month: number; year: number } {
  */
 async function firstNonEmptyCatalogue(api: ClarityApi, candidates: TimesheetWeek[]): Promise<ClarityTask[]> {
     for (const candidate of candidates) {
+        if (!hasTimesheetId(candidate)) {
+            continue;
+        }
+
         const tasks = await listClarityTasks({ api, timesheetId: candidate.timesheetId });
 
         if (tasks.length > 0) {

--- a/src/clarity/lib/fill-weeks.test.ts
+++ b/src/clarity/lib/fill-weeks.test.ts
@@ -60,9 +60,11 @@ const MAPPINGS_WITHOUT_TIMESHEET_ID = [
 
 function fakeApi() {
     const timesheetAppCalls: Array<number | undefined> = [];
+    const openPeriods = new Set(CAROUSEL.map((entry) => entry.id));
 
     return {
         timesheetAppCalls,
+        openPeriods,
         // biome-ignore lint/suspicious/noExplicitAny: test double mirrors the Clarity response shape
         getTimesheetApp: async (timePeriodId?: number): Promise<any> => {
             timesheetAppCalls.push(timePeriodId);
@@ -74,7 +76,11 @@ function fakeApi() {
             return {
                 resource: { _results: [{ user_id: 900001 }] },
                 timesheets: { _results: [{ _internalId: 555004, numberOfEntries: 8, timePeriodId: centre }] },
-                tscarousel: { _results: CAROUSEL.filter((entry) => Math.abs(entry.id - centre) <= 2) },
+                tscarousel: {
+                    _results: CAROUSEL.filter((entry) => Math.abs(entry.id - centre) <= 2).map((entry) =>
+                        openPeriods.has(entry.id) ? entry : { ...entry, tpTimesheet: { _results: [] } }
+                    ),
+                },
             };
         },
         // biome-ignore lint/suspicious/noExplicitAny: test double mirrors the Clarity response shape
@@ -110,6 +116,24 @@ describe("resolveFillWeeks", () => {
             year: 2026,
         });
 
+        expect(result.weeks.map((w) => w.timesheetId)).toEqual([555004]);
+    });
+
+    test("treats a period Clarity has not opened a timesheet for as an uncovered date", async () => {
+        const api = fakeApi();
+        // 2026-08-10..17 exists in the carousel but Clarity has not opened its timesheet, so it
+        // has no id to write to; sending an absent id answers API-1006.
+        api.openPeriods.delete(400002);
+
+        const result = await resolveFillWeeks({
+            api: api as unknown as ClarityApi,
+            mappings: MAPPINGS_WITHOUT_TIMESHEET_ID,
+            dates: ["2026-08-12", "2026-08-26"],
+            month: 8,
+            year: 2026,
+        });
+
+        expect(result.unresolvedDates).toEqual(["2026-08-12"]);
         expect(result.weeks.map((w) => w.timesheetId)).toEqual([555004]);
     });
 

--- a/src/clarity/lib/fill-weeks.ts
+++ b/src/clarity/lib/fill-weeks.ts
@@ -1,9 +1,9 @@
 import type { ClarityMapping } from "@app/clarity/config";
-import { findWeekForDate, getTimesheetWeeks, type TimesheetWeek } from "@app/clarity/lib/timesheet-weeks";
+import { findWeekForDate, getTimesheetWeeks, type IdentifiedTimesheetWeek } from "@app/clarity/lib/timesheet-weeks";
 import type { ClarityApi } from "@genesiscz/utils/clarity";
 
 export interface ResolvedFillWeeks {
-    weeks: TimesheetWeek[];
+    weeks: IdentifiedTimesheetWeek[];
     unresolvedDates: string[];
     /** Clarity user id, needed as the author of a timesheet note. */
     userId?: number;
@@ -28,7 +28,7 @@ export async function resolveFillWeeks({
 }): Promise<ResolvedFillWeeks> {
     const { weeks: available, userId } = await getTimesheetWeeks(api, mappings, month, year);
 
-    const weeks: TimesheetWeek[] = [];
+    const weeks: IdentifiedTimesheetWeek[] = [];
     const unresolvedDates: string[] = [];
 
     for (const date of dates) {

--- a/src/clarity/lib/timesheet-weeks.test.ts
+++ b/src/clarity/lib/timesheet-weeks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     findWeekForDate,
+    parseTimesheetArg,
     selectWeeksForDateArg,
     type TimesheetWeek,
     taskSourceWeekOrder,
@@ -111,5 +112,29 @@ describe("taskSourceWeekOrder", () => {
 
     test("returns every week newest first when there is no preference", () => {
         expect(taskSourceWeekOrder(WEEKS, undefined).map((w) => w.timesheetId)).toEqual([555003, 555002, 555001]);
+    });
+});
+
+describe("parseTimesheetArg", () => {
+    test("an absent flag is not supplied", () => {
+        expect(parseTimesheetArg(undefined)).toEqual({ supplied: false });
+    });
+
+    test("a blank value counts as supplied so the caller cannot fall through to today's date", () => {
+        expect(parseTimesheetArg("")).toEqual({ supplied: true });
+        expect(parseTimesheetArg("   ")).toEqual({ supplied: true });
+    });
+
+    test("a non-numeric or non-positive value is supplied but has no id", () => {
+        expect(parseTimesheetArg("abc")).toEqual({ supplied: true });
+        expect(parseTimesheetArg("12abc")).toEqual({ supplied: true });
+        expect(parseTimesheetArg("1.5")).toEqual({ supplied: true });
+        expect(parseTimesheetArg("0")).toEqual({ supplied: true });
+        expect(parseTimesheetArg("-3")).toEqual({ supplied: true });
+    });
+
+    test("a positive whole id parses", () => {
+        expect(parseTimesheetArg("555004")).toEqual({ supplied: true, id: 555004 });
+        expect(parseTimesheetArg(" 555004 ")).toEqual({ supplied: true, id: 555004 });
     });
 });

--- a/src/clarity/lib/timesheet-weeks.ts
+++ b/src/clarity/lib/timesheet-weeks.ts
@@ -17,6 +17,25 @@ export interface TimesheetWeek {
     entryCount?: number;
 }
 
+/**
+ * Resolve an explicit `--timesheet` argument. A flag that was passed at all must name a real
+ * timesheet: `--timesheet ""` is truthy-false, so a bare truthiness test lets a blank value fall
+ * through to the default date and quietly act on the wrong month.
+ */
+export function parseTimesheetArg(raw: string | undefined): { supplied: boolean; id?: number } {
+    if (raw === undefined) {
+        return { supplied: false };
+    }
+
+    const id = Number(raw.trim());
+
+    if (!Number.isSafeInteger(id) || id <= 0) {
+        return { supplied: true };
+    }
+
+    return { supplied: true, id };
+}
+
 /** A week Clarity has actually opened a timesheet for, so its id is safe to send to the API. */
 export type IdentifiedTimesheetWeek = TimesheetWeek & { timesheetId: number };
 

--- a/src/clarity/lib/timesheet-weeks.ts
+++ b/src/clarity/lib/timesheet-weeks.ts
@@ -4,13 +4,24 @@ import { isDateInHalfOpenRange } from "@genesiscz/utils/date";
 import { logger } from "@genesiscz/utils/logger";
 
 export interface TimesheetWeek {
-    timesheetId: number;
+    /**
+     * Absent on future periods Clarity has not opened a timesheet for. Every call that sends this
+     * to the API must narrow it first; `timesheetId=undefined` answers `API-1006 invalidAttrValue`.
+     */
+    timesheetId: number | undefined;
     timePeriodId: number;
     startDate: string;
     finishDate: string;
     totalHours: number;
     status: string;
     entryCount?: number;
+}
+
+/** A week Clarity has actually opened a timesheet for, so its id is safe to send to the API. */
+export type IdentifiedTimesheetWeek = TimesheetWeek & { timesheetId: number };
+
+export function hasTimesheetId(week: TimesheetWeek): week is IdentifiedTimesheetWeek {
+    return week.timesheetId !== undefined;
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: Clarity carousel entries have inconsistent shapes
@@ -255,7 +266,9 @@ export async function getTimesheetWeeks(
     }
 
     // Fetch entry counts for weeks that don't have them yet (not in current period's timesheets section)
-    const needsCount = weeks.filter((w) => w.entryCount === undefined && w.timesheetId);
+    const needsCount = weeks.filter(
+        (w): w is IdentifiedTimesheetWeek => w.entryCount === undefined && hasTimesheetId(w)
+    );
 
     if (needsCount.length > 0) {
         const results = await Promise.allSettled(
@@ -322,8 +335,11 @@ async function findValidTimePeriodId(api: ClarityApi, mappings: ClarityMapping[]
  * half-open: the finish date belongs to the next period, not this one. Future periods carry no
  * timesheet id yet and are skipped, because the API rejects `timesheetId=undefined`.
  */
-export function findWeekForDate(weeks: TimesheetWeek[], date: string): TimesheetWeek | undefined {
-    return weeks.find((week) => week.timesheetId && isDateInHalfOpenRange(date, week.startDate, week.finishDate));
+export function findWeekForDate(weeks: TimesheetWeek[], date: string): IdentifiedTimesheetWeek | undefined {
+    return weeks.find(
+        (week): week is IdentifiedTimesheetWeek =>
+            hasTimesheetId(week) && isDateInHalfOpenRange(date, week.startDate, week.finishDate)
+    );
 }
 
 /**

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -413,9 +413,6 @@ export function getDaysInPeriod(periodStart: string, periodFinish: string): Arra
 }
 
 /**
- * Convert minutes to seconds.
- */
-/**
  * Days of a period whose finish is INCLUSIVE, which is how Clarity's `timePeriodFinish` reports
  * the last day of a week. Use `getDaysInPeriod` for an exclusive end such as the carousel's
  * `finish_date`; mixing the two silently drops or adds a day of hours.
@@ -427,6 +424,9 @@ export function getDaysInPeriodInclusive(
     return getDaysInPeriod(periodStart, `${addDay(periodFinishInclusive.split("T")[0])}T00:00:00`);
 }
 
+/**
+ * Convert minutes to seconds.
+ */
 export function minutesToSeconds(minutes: number): number {
     return minutes * 60;
 }


### PR DESCRIPTION
Follow-up to #351, which merged while its review round was still in flight. These are the Major/Medium CodeRabbit and eve findings from that round, verified against the merged code.

## `TimesheetWeek.timesheetId` was typed `number` but can be absent

Clarity does not open a timesheet for a future period, so `parseCarouselEntry` could hand `undefined` to APIs typed as requiring `number` — which answers `API-1006 invalidAttrValue`. The type is now `number | undefined`, with `IdentifiedTimesheetWeek` and a `hasTimesheetId` guard as the narrowed form.

`findWeekForDate` returns the narrowed type, so `resolveFillWeeks` yields only opened periods and `fill.ts` needs no guard of its own. `tsgo` found exactly five unguarded call sites (`fill`, `tasks`, `link-workitems`, `assignment-view`, the entry-count fetch) and all five are closed.

## `--timesheet` was ignored for the assignment and listing actions

`tools clarity tasks --timesheet 123 --assign …` built its view from today's month instead. `buildAssignmentView` needs a *month* of ADO time entries, so a single timesheet id cannot scope it; the flag is now rejected for those actions with a message naming `--date <YYYY-MM>`.

## The batched ancestor walk re-requested ids the API omitted

`walkAncestorsBatched` filtered on `known`, which only holds returned nodes, so an omitted id named as another item's parent was fetched again one level up. It now records an `attempted` set.

## Orphaned doc comment in `src/utils/date.ts`

`/** Convert minutes to seconds. */` sat above `getDaysInPeriodInclusive`. Moved back onto `minutesToSeconds`.

## Verification

- Two regression tests, both mutation-checked: dropping `hasTimesheetId` from `findWeekForDate` turns the fill-weeks test red; the ancestor test pins one batch per omitted id.
- `bun run test`: 8147 pass, 0 fail. `tsgo --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated requests for unavailable work items during ancestor lookup.
  * Improved handling of future periods without an opened timesheet.
  * Prevented requests using missing or invalid timesheet IDs.
  * Assignment, recommendation, and listing actions now require a month-scoped date and reject unsupported timesheet selection.
  * Interactive linking only offers weeks with opened timesheets and warns when none are available.
  * Dates in periods without an opened timesheet are reported as unresolved.

* **Documentation**
  * Clarified the documentation for minute-to-second conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->