### PR TITLE
fix(launchd): write the launcher into plists even when tools runs under the app

### DIFF
--- a/src/utils/DashboardApp/lifecycle.ts
+++ b/src/utils/DashboardApp/lifecycle.ts
@@ -228,6 +228,17 @@ async function preparePort(ctx: LifecycleContext, port: number, opts: UpOptions)
     }
 
     if (conflict.state === "stale") {
+        // A launchd-managed service comes straight back after its pid dies, so killing the port
+        // owner alone never frees the port — `up` on a running agent failed here every time, which
+        // also blocked migrating one to GenesisTools.app. Unload the agent first; the launchd
+        // branch below reinstalls and reloads it. `down()` has always done this; this path had not.
+        if (config.launchd?.available && isLaunchdInstalled(ctx.plistLabel)) {
+            out.log.step(`Unloading launchd agent ${ctx.plistLabel} before reclaiming port ${port}…`);
+            await bootoutLaunchd(ctx.plistLabel).catch((err) => {
+                logger.warn({ err }, `[${config.key}] launchd bootout before port reclaim failed`);
+            });
+        }
+
         out.log.step(`Reclaiming port ${port} from stale pid ${conflict.owner.pid} (${conflict.owner.command})`);
         await killPortOwner(conflict.owner);
         clearPid(config.key);

--- a/src/utils/macos/genesis-app.launchd.test.ts
+++ b/src/utils/macos/genesis-app.launchd.test.ts
@@ -3,7 +3,13 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
-import { launchdPlistNeedsGenesisApp, launchdProgramArgumentsXml } from "./genesis-app";
+import {
+    GENESIS_APP_BUNDLE_ID,
+    genesisAppLauncher,
+    launchdPlistNeedsGenesisApp,
+    launchdProgramArgumentsXml,
+    wrapWithGenesisApp,
+} from "./genesis-app";
 
 /** A fake home with a built launcher, so wrapWithGenesisApp() has something to prepend. */
 function homeWithLauncher(): { home: string; launcher: string } {
@@ -67,6 +73,39 @@ describe("launchdPlistNeedsGenesisApp", () => {
         });
         await env.testing.withOverrides({ ...clean, GENESIS_TOOLS_HOME: home, GENESIS_TOOLS_NO_APP: "1" }, () => {
             expect(launchdPlistNeedsGenesisApp(bare)).toBe(false);
+        });
+    });
+});
+
+describe("writing a plist while running under the app", () => {
+    // Regression: `tools` runs every command through the launcher, so the writer always saw
+    // isRunningUnderGenesisApp() === true. Asking the spawn-time question there produced plists
+    // with the bare command and made the migration detector answer "nothing to migrate", which
+    // disabled the whole feature in real use while the tests (which never set the marker) passed.
+    const underApp = { GENESIS_TOOLS_APP_BUNDLE_ID: GENESIS_APP_BUNDLE_ID, GENESIS_TOOLS_NO_APP: undefined };
+
+    it("still puts the launcher into ProgramArguments", async () => {
+        const { home, launcher } = homeWithLauncher();
+        await env.testing.withOverrides({ ...underApp, GENESIS_TOOLS_HOME: home }, () => {
+            expect(wrapWithGenesisApp(["/usr/bin/bun", "run", "x.ts"])[0]).toBe(launcher);
+            expect(launchdProgramArgumentsXml(["/usr/bin/bun"])).toContain(launcher);
+        });
+    });
+
+    it("still reports a bare plist as needing migration", async () => {
+        const { home } = homeWithLauncher();
+        const bare = join(home, "bare.plist");
+        writeFileSync(bare, "<string>/usr/bin/bun</string>");
+        await env.testing.withOverrides({ ...underApp, GENESIS_TOOLS_HOME: home }, () => {
+            expect(launchdPlistNeedsGenesisApp(bare)).toBe(true);
+        });
+    });
+
+    it("does not double-wrap a process this command spawns itself", async () => {
+        const { home } = homeWithLauncher();
+        await env.testing.withOverrides({ ...underApp, GENESIS_TOOLS_HOME: home }, () => {
+            // The dispatcher question stays "no": the tree is already covered.
+            expect(genesisAppLauncher()).toBeNull();
         });
     });
 });

--- a/src/utils/macos/genesis-app.ts
+++ b/src/utils/macos/genesis-app.ts
@@ -41,13 +41,17 @@ export function isRunningUnderGenesisApp(): boolean {
     return env.tools.getAppBundleId() === GENESIS_APP_BUNDLE_ID;
 }
 
-/** The launcher to prepend to a command, or null when the tree is already covered or the app is absent. */
-export function genesisAppLauncher(): string | null {
-    if (process.platform !== "darwin" || env.tools.isAppLauncherDisabled() || isRunningUnderGenesisApp()) {
-        return null;
-    }
-
-    if (isGenesisAppDisabledByMarker()) {
+/**
+ * The installed launcher, or null when there is none to use: not macOS, the app was never built,
+ * or routing is switched off by env var or marker.
+ *
+ * Deliberately blind to whether THIS process already runs under the app. Anything that records the
+ * launcher for a *later* execution — a launchd plist, or the check for whether one still needs
+ * migrating — must ask this question, because the answer has to be the same whether the writing
+ * command happened to be launched through the app or not.
+ */
+export function installedGenesisAppLauncher(): string | null {
+    if (process.platform !== "darwin" || env.tools.isAppLauncherDisabled() || isGenesisAppDisabledByMarker()) {
         return null;
     }
 
@@ -55,8 +59,24 @@ export function genesisAppLauncher(): string | null {
     return existsSync(launcher) ? launcher : null;
 }
 
+/**
+ * The launcher to prepend to a command this process is about to spawn, or null when there is
+ * nothing to add — including the case where this process ALREADY runs under the app, since
+ * re-wrapping would add a second pair of launcher stages for no gain.
+ */
+export function genesisAppLauncher(): string | null {
+    return isRunningUnderGenesisApp() ? null : installedGenesisAppLauncher();
+}
+
+/**
+ * Put the launcher in front of a command that will be executed later, by launchd.
+ *
+ * Uses the installed launcher rather than `genesisAppLauncher()`: `tools` itself runs under the
+ * app, so asking the spawn-time question here wrote plists with the bare command and silently
+ * disabled the whole feature.
+ */
 export function wrapWithGenesisApp(command: readonly string[]): string[] {
-    const launcher = genesisAppLauncher();
+    const launcher = installedGenesisAppLauncher();
     return launcher ? [launcher, ...command] : [...command];
 }
 
@@ -78,7 +98,7 @@ export function launchdProgramArgumentsXml(command: readonly string[], indent = 
  * user-triggered start; nothing rewrites a live job behind the user's back.
  */
 export function launchdPlistNeedsGenesisApp(plistPath: string): boolean {
-    const launcher = genesisAppLauncher();
+    const launcher = installedGenesisAppLauncher();
 
     if (!launcher || !existsSync(plistPath)) {
         return false;


### PR DESCRIPTION
## The bug

PR #350 shipped a launchd migration that cannot fire. Found while trying to demonstrate it on the CLI right after that merge.

Every `tools` command runs through GenesisTools.app, so the process that writes a launchd plist always has `isRunningUnderGenesisApp() === true`. `wrapWithGenesisApp()` asked `genesisAppLauncher()`, which deliberately returns `null` in that state. That is the right answer to *"should I prepend the launcher to the child I am about to spawn"* — the tree is already covered — but the wrong answer to *"what belongs in a plist launchd will run later"*.

Observed on master, `tools` running normally:

```
UNDER app -> wrap: /Users/Martin/.bun/bin/bun          ← the launcher is missing
UNDER app -> needsMigration: false                     ← a bare plist reports "nothing to do"
```

So on master:

- Installing or refreshing any service from the CLI writes a plist **without** the launcher. New installs are affected too, not just migrations.
- `launchdPlistNeedsGenesisApp()` is always false, so the hints in `tools daemon status` and `tools automate daemon status`, and the migration branch in `tools daemon restart`, never run.
- Only `tools macos permissions` reported the truth, because it takes the launcher path from the installed bundle rather than from the spawn-time helper. That disagreement is what exposed it: the permissions report listed six jobs as outside the app while `tools daemon status` said nothing needed migrating.

## The fix

Split the two questions, which were conflated in one helper:

- **`installedGenesisAppLauncher()`** — is a launcher installed and enabled (macOS, bundle present, not disabled by env var or marker)? Blind to whether *this* process runs under it. Used by everything that records the launcher for a later execution: `wrapWithGenesisApp()` and `launchdPlistNeedsGenesisApp()`.
- **`genesisAppLauncher()`** — should I prepend it to a process I am spawning now? Still `null` when already under the app, so `tools` never adds a second pair of launcher stages.

After the fix, same probe:

```
UNDER app -> plist wrap: …/GenesisTools.app/Contents/MacOS/GenesisTools
UNDER app -> needsMigration: true
UNDER app -> spawn wrap (should be null): null
```

## Why the tests missed it

Every existing case ran without `GENESIS_TOOLS_APP_BUNDLE_ID` set, i.e. never under the app — precisely the state the bug lived in. Three regression tests now pin the under-app behaviour: plist writing still embeds the launcher, a bare plist still reports as needing migration, and spawning still refuses to double-wrap.

`bun run test src/utils/macos src/macos src/utils/DashboardApp src/daemon src/automate src/update`: 477 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS background task launching when running from the Genesis app.
  - Prevented child processes from being wrapped with the app launcher more than once.
  - Ensured deferred commands continue using the installed launcher correctly.
  - Improved migration handling for existing launch configurations, including when the app is currently running.
  - Added safeguards to keep launch configuration generation enabled in app-based environments.
  - Improved stale port recovery by unloading background launch tasks before reclaiming the port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->