### PR TITLE
fix(ai/config): withLock passes the caller's wait budget to the config lock

### DIFF
--- a/src/utils/ai/AIConfig.ts
+++ b/src/utils/ai/AIConfig.ts
@@ -428,7 +428,7 @@ export class AIConfig {
      * Mutate `data` in the callback; it's persisted automatically on return.
      * Use for operations that need async I/O while holding the lock (e.g. token refresh).
      */
-    async withLock<T>(fn: (data: AIConfigData) => Promise<T>, _timeout?: number): Promise<T> {
+    async withLock<T>(fn: (data: AIConfigData) => Promise<T>, timeout?: number): Promise<T> {
         const store = await AiConfigStore.load();
 
         return store.withLock(async (config) => {
@@ -462,6 +462,6 @@ export class AIConfig {
             this.data = applyDefaults(projectToV3(config));
 
             return result;
-        });
+        }, timeout);
     }
 }

--- a/src/utils/ai/config/AiConfigStore.test.ts
+++ b/src/utils/ai/config/AiConfigStore.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
+import { Storage } from "@genesiscz/utils/storage/storage";
 import { AiConfigStore, adaptOlderConfig } from "./AiConfigStore";
 import { _clearExternalRefScanners, registerExternalRefScanner } from "./refs";
 import { type AccountEntry, type AiConfigData, CONFIG_VERSION } from "./schema";
@@ -288,6 +289,22 @@ describe("AiConfigStore mutation", () => {
 
         const count = await store.withLock(async (data) => data.accounts.length);
         expect(count).toBe(3);
+    });
+
+    test("withLock passes the caller's wait budget to the config lock", async () => {
+        const store = await AiConfigStore.load();
+        const lock = spyOn(Storage.prototype, "withConfigLock");
+
+        try {
+            await store.withLock(async () => undefined, 60_000);
+            expect(lock).toHaveBeenCalledTimes(1);
+            expect(lock.mock.calls[0][1]).toBe(60_000);
+
+            await store.withLock(async () => undefined);
+            expect(lock.mock.calls[1][1]).toBeUndefined();
+        } finally {
+            lock.mockRestore();
+        }
     });
 });
 

--- a/src/utils/ai/config/AiConfigStore.ts
+++ b/src/utils/ai/config/AiConfigStore.ts
@@ -246,7 +246,14 @@ export class AiConfigStore {
         });
     }
 
-    async withLock<T>(fn: (data: AiConfigData) => Promise<T>): Promise<T> {
+    /**
+     * `timeout` is how long to WAIT for the lock, not how long to hold it. A token
+     * refresh runs its network call inside `fn`, so when several accounts refresh at
+     * once each later one waits for every earlier one; the 5 s default was sized for a
+     * plain config edit and timed them out (observed 2026-09-06: nine accounts, one DNS
+     * outage, `LockTimeoutError` on every account but the first).
+     */
+    async withLock<T>(fn: (data: AiConfigData) => Promise<T>, timeout?: number): Promise<T> {
         return this.storage.withConfigLock(async () => {
             // BEFORE the callback, not only before the write: callers nest vault
             // writes inside `fn` (the lock-order contract says config lock first,
@@ -268,6 +275,6 @@ export class AiConfigStore {
             this.config = validated;
             this.stamp = AiConfigStore.stampOf(this.storage);
             return result;
-        });
+        }, timeout);
     }
 }


### PR DESCRIPTION
## What

`AIConfig.withLock(fn, timeout)` has accepted a lock wait budget since the AI overhaul (219ff440b) and never passed it on: the parameter was `_timeout` and the store's `withLock` took none. Every caller waited the file lock's 5 s default, including the anthropic token refresh in `src/utils/claude/subscription-auth.ts`, which asks for 60 s because it runs its network call inside the lock.

## Why it matters

Nine accounts refresh at the same hour. Each refresh holds the config lock across the OAuth call, so each later one waits for every earlier one. On 2026-09-06 a DNS outage (18:23 to 19:49) made each holder sit for its retry budget, and every other account failed with `LockTimeoutError: Failed to acquire file lock at ~/.genesis-tools/ai/config.json.lock within 5000ms` (2083 such lines on 2026-09-05, 95 on 2026-09-06 in `~/.genesis-tools/logs/`). A slow refresh should make the others wait, not fail.

## Changes

- `AiConfigStore.withLock(fn, timeout?)` forwards `timeout` to `Storage.withConfigLock`.
- `AIConfig.withLock(fn, timeout?)` forwards it to the store.
- Test: `withLock passes the caller's wait budget to the config lock` (spy on `Storage.prototype.withConfigLock`; a copy-restore mutation check turned it red when the pass-through was dropped).

## Verify

```
bun run test src/utils/ai/config src/utils/claude   # 268 pass, 0 fail
bunx tsgo --noEmit
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI configuration updates by supporting an optional wait time when configuration access is temporarily locked.
  * Ensured configured wait limits are consistently passed through to the underlying storage layer.
  * Preserved existing locking, validation, synchronization, persistence, and cache-refresh behavior when no wait time is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->