### PR TITLE
fix(security): SecretStore.set skips a rewrite when the vault already holds the value

### DIFF
--- a/src/utils/ai/config/v3-adapter.test.ts
+++ b/src/utils/ai/config/v3-adapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { randomBytes } from "node:crypto";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "@genesiscz/utils/env";
@@ -46,8 +46,11 @@ function config(accounts: AccountEntry[], defaults: AiConfigData["defaults"] = {
     return { version: CONFIG_VERSION, accounts, defaults };
 }
 
+let home: string;
+
 beforeEach(() => {
-    env.testing.set("GENESIS_TOOLS_HOME", mkdtempSync(join(tmpdir(), "gt-adapter-")));
+    home = mkdtempSync(join(tmpdir(), "gt-adapter-"));
+    env.testing.set("GENESIS_TOOLS_HOME", home);
     _setMasterKeyProvidersForTest(fakeKeyring());
     _resetSecretsForTest();
 });
@@ -128,6 +131,21 @@ describe("applyV3Tokens", () => {
         expect(isSecureRef(entry.credentials.apiKey)).toBe(true);
         expect(entry.credentials.expiresAt).toBe(99);
         expect(await (await secrets()).get("ai/acc_max/apiKey")).toBe("sk-literal");
+    });
+
+    test("re-applying the values a v3 read resolved leaves the vault file untouched", async () => {
+        const entry = account();
+        await applyV3Tokens(entry, { accessToken: "sk-ant-live", refreshToken: "rt-live", longLivedToken: "llt" });
+        const vaultFile = join(home, ".genesis-tools", "security", "vault.json");
+        const before = readFileSync(vaultFile, "utf8");
+
+        // What a facade save does for every account, changed or not: read the
+        // resolved v3 shape back and apply it again.
+        await applyV3Tokens(entry, toV3Account(entry, config([entry])).tokens);
+
+        expect(readFileSync(vaultFile, "utf8")).toBe(before);
+        expect(isSecureRef(entry.credentials.accessToken)).toBe(true);
+        expect(await (await secrets()).get("ai/acc_max/refreshToken")).toBe("rt-live");
     });
 
     test("apiKeyEnv from a legacy caller becomes useEnvApiKey", async () => {

--- a/src/utils/security/SecretStore.test.ts
+++ b/src/utils/security/SecretStore.test.ts
@@ -53,6 +53,38 @@ describe("SecretStore", () => {
         expect(await resolveSecret(ref)).toBe("xai-secret-value");
     });
 
+    test("set() with the value already stored does not rewrite the vault", async () => {
+        const store = await secrets();
+        await store.set("ai/acc_x/apiKey", "xai-secret-value");
+        const before = readFileSync(vaultPath(), "utf8");
+
+        const ref = await store.set("ai/acc_x/apiKey", "xai-secret-value");
+
+        // A rewrite mints a fresh IV and updatedAt, so identical bytes prove no write happened.
+        expect(readFileSync(vaultPath(), "utf8")).toBe(before);
+        expect(ref).toEqual({ type: "secure", path: "ai/acc_x/apiKey" });
+        expect(await store.get("ai/acc_x/apiKey")).toBe("xai-secret-value");
+    });
+
+    test("set() with a different value still rewrites, and a value that will not decrypt is replaced", async () => {
+        const store = await secrets();
+        await store.set("ai/acc_x/apiKey", "xai-secret-value");
+        const before = readFileSync(vaultPath(), "utf8");
+
+        await store.set("ai/acc_x/apiKey", "xai-rotated-value");
+
+        expect(readFileSync(vaultPath(), "utf8")).not.toBe(before);
+        expect(await store.get("ai/acc_x/apiKey")).toBe("xai-rotated-value");
+
+        // Corrupt the stored ciphertext: the unchanged-check must fall through to a write, not throw.
+        const vault: VaultFile = SafeJSON.parse(readFileSync(vaultPath(), "utf8"), { strict: true });
+        vault.entries["ai/acc_x/apiKey"].ct = Buffer.from("garbage").toString("base64");
+        writeFileSync(vaultPath(), SafeJSON.stringify(vault));
+
+        await store.set("ai/acc_x/apiKey", "xai-rotated-value");
+        expect(await store.get("ai/acc_x/apiKey")).toBe("xai-rotated-value");
+    });
+
     test("never writes the plaintext to disk", async () => {
         const store = await secrets();
         await store.set("ai/acc_x/apiKey", "xai-secret-value");

--- a/src/utils/security/SecretStore.ts
+++ b/src/utils/security/SecretStore.ts
@@ -183,21 +183,48 @@ class FileSecretStore implements SecretStore {
         }
     }
 
+    /**
+     * A write whose value is already stored is skipped. The v3 facade resolves
+     * every SecureRef to its value on read and re-applies every account on save,
+     * so one token refresh used to re-encrypt all 33 secrets of 11 accounts
+     * (2,045 vault rewrites in three hours on 2026-09-06). The check runs under
+     * the vault lock so it compares against what a concurrent writer left, and a
+     * stored entry that will not decrypt is replaced, never reported.
+     */
     async set(path: string, value: string): Promise<SecureRef> {
         const ref = secureRef(path);
-        const entry = encryptEntry(await masterKey(), path, value);
+        const master = await masterKey();
+        const entry = encryptEntry(master, path, value);
 
-        await this.storage.withFileLock({
+        const written = await this.storage.withFileLock({
             file: this.vaultPath(),
             fn: async () => {
                 const vault = this.read();
+                if (this.holdsValue(master, path, vault.entries[path], value)) {
+                    return false;
+                }
+
                 vault.entries[path] = entry;
                 this.write(vault);
+                return true;
             },
         });
 
-        logger.debug({ path }, "stored secret in vault");
+        logger.debug({ path }, written ? "stored secret in vault" : "vault secret unchanged, rewrite skipped");
         return ref;
+    }
+
+    private holdsValue(master: Buffer, path: string, stored: VaultEntry | undefined, value: string): boolean {
+        if (!stored) {
+            return false;
+        }
+
+        try {
+            return decryptEntry(master, path, stored) === value;
+        } catch (err) {
+            logger.debug({ err, path }, "stored vault entry does not decrypt; overwriting it");
+            return false;
+        }
     }
 
     async delete(path: string): Promise<boolean> {


### PR DESCRIPTION
## Why

On 2026-09-06 the vault at `~/.genesis-tools/security/vault.json` was rewritten **2,045 times in three hours** (`stored secret in vault` in the tool log). Every usage poll that refreshed one account's token ended in a v3 facade save. That save loops over every account and calls `applyV3Tokens`, which calls `SecretStore.set` for every string token. Because the facade resolves every SecureRef to its value on read, one refresh re-encrypted all 33 secrets of 11 accounts, including an unchanged HuggingFace API key. Each rewrite takes the vault file lock, mints a new IV, and rewrites the file.

## What

`SecretStore.set` now compares the incoming value against what the vault already holds, inside the existing vault lock, and returns the ref without writing when they match. The guard sits in the shared primitive, so every caller is covered. A stored entry that does not decrypt is overwritten as before.

Untouched on purpose: the poll cadence, the refresh logic, `applyV3Tokens`, and `vaultAdmin` (rotation and import write through `vaultAdmin.write`, not `set`).

## Proof

- `SecretStore.test.ts`: a second `set()` with the same value leaves the vault file byte-identical (fails without the guard: new iv/ct/tag/updatedAt). Negative control: a different value still rewrites, and a corrupted entry is replaced rather than reported.
- `v3-adapter.test.ts`: applying the tokens a v3 read resolved back through `applyV3Tokens` leaves the vault file untouched, which is the exact facade-save path.
- `bun run test src/utils/security src/utils/ai/config src/utils/claude`: 263 pass, 0 fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided unnecessary vault rewrites when reapplying unchanged tokens or secrets.
  * Preserved secure references and stored refresh-token values during token reapplication.
  * Replaced corrupted secret entries instead of failing when they cannot be decrypted.
  * Ensured changed secrets are written correctly while unchanged secrets remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->