### PR TITLE
Make cmux capture portable and improve workspace restoration

### DIFF
--- a/src/claude/lib/cmux/session-refs.test.ts
+++ b/src/claude/lib/cmux/session-refs.test.ts
@@ -3,9 +3,18 @@ import { mkdtempSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SafeJSON } from "@genesiscz/utils/json";
-import { lookupSessionCmuxRefs } from "./session-refs";
+import { loadAllSessionCmuxRefs, lookupSessionCmuxRefs } from "./session-refs";
 
 const SESSION = "7a4630a0-6834-47a1-a5b5-d3b3bbae58f9";
+
+test("historical lookup retains the pane before restart instead of a later resumed copy", () => {
+    const beforeMs = Date.now() - 1000;
+    const path = journal([
+        entry({ surfaceId: "original", at: beforeMs - 1 }),
+        entry({ surfaceId: "copy", at: beforeMs + 1 }),
+    ]);
+    expect(loadAllSessionCmuxRefs(path, { beforeMs }).get(SESSION)?.surfaceId).toBe("original");
+});
 
 function journal(lines: object[]): string {
     const dir = mkdtempSync(join(tmpdir(), "cmux-refs-"));

--- a/src/claude/lib/cmux/session-refs.ts
+++ b/src/claude/lib/cmux/session-refs.ts
@@ -45,7 +45,7 @@ const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
  */
 const MAX_JOURNAL_READ_BYTES = 512 * 1024;
 
-function readJournalTail(refsPath: string): string | null {
+function readJournalTail(refsPath: string, historical: boolean = false): string | null {
     if (!existsSync(refsPath)) {
         return null;
     }
@@ -53,7 +53,7 @@ function readJournalTail(refsPath: string): string | null {
     try {
         const size = statSync(refsPath).size;
 
-        if (size <= MAX_JOURNAL_READ_BYTES) {
+        if (historical || size <= MAX_JOURNAL_READ_BYTES) {
             return readFileSync(refsPath, "utf8");
         }
 
@@ -85,15 +85,18 @@ function readJournalTail(refsPath: string): string | null {
  * Entries older than MAX_AGE_MS are dropped; surface-less entries (plain
  * Terminal/tmux launches) are kept — callers that need a cmux target filter.
  */
-export function loadAllSessionCmuxRefs(refsPath: string = CMUX_REFS_PATH): Map<string, SessionCmuxRefs> {
+export function loadAllSessionCmuxRefs(
+    refsPath: string = CMUX_REFS_PATH,
+    options: { beforeMs?: number } = {}
+): Map<string, SessionCmuxRefs> {
     const refs = new Map<string, SessionCmuxRefs>();
-    const raw = readJournalTail(refsPath);
+    const raw = readJournalTail(refsPath, options.beforeMs !== undefined);
 
     if (raw === null) {
         return refs;
     }
 
-    const cutoff = Date.now() - MAX_AGE_MS;
+    const cutoff = (options.beforeMs ?? Date.now()) - MAX_AGE_MS;
 
     for (const line of raw.split("\n")) {
         if (!line.trim()) {
@@ -114,6 +117,10 @@ export function loadAllSessionCmuxRefs(refsPath: string = CMUX_REFS_PATH): Map<s
         }
 
         if (typeof entry.sessionId !== "string" || (entry.at ?? 0) < cutoff) {
+            continue;
+        }
+
+        if (options.beforeMs !== undefined && entry.at > options.beforeMs) {
             continue;
         }
 

--- a/src/cmux/README.md
+++ b/src/cmux/README.md
@@ -178,11 +178,15 @@ tools zsh cmux install
 
 Installation previews its managed rc block and asks before editing your zsh rc file. In non-interactive use, pass `--yes` to approve that edit; `--dry-run` previews without writing files or starting a collector. Uninstall follows the same confirmation rule. Repeating installation reports that it is already installed and does not duplicate or rewrite an unchanged rc block.
 
-The installer generates the hook and standalone runtimes under `~/.genesis-tools/cmux/`; their source lives in this repository. The installed runtime does not depend on the checkout or worktree remaining at its original path. Bun must remain installed; the hook uses PATH and then a global Bun fallback. Existing rc content is backed up before an approved change, and concurrent edits after preview are refused.
+The installer generates the hook and standalone runtimes under `~/.genesis-tools/cmux/`; their source lives in this repository. Installation and the viewport collector require Bun. The lightweight zsh command hook uses built-in append/stat operations and does not launch Bun per command. Installed files do not depend on the checkout or worktree remaining at its original path. Existing rc content is backed up before an approved change, and concurrent edits after preview are refused.
 
-Rerun `install` after updating GenesisTools to rebuild the installed artifacts. The generated hook invokes a stable managed symlink, `runtime/capture-record.js`, which points to the current versioned bundle. Switching that symlink updates the recorder for already-loaded modern hooks without pointing them into a removable worktree. Source-code changes are not silently hot-loaded. Changes to the shell functions themselves require re-sourcing the hook or a new shell, just as they would with a direct symlink to a source script.
+Rerun `install` after updating GenesisTools to rebuild the installed artifacts. The stable managed symlink `runtime/capture-record.js` remains available for older loaded recorder-based hooks; updating it refreshes their recorder without depending on a removable worktree. Current hooks append lightweight NUL-delimited spool records directly, which the capture reader validates alongside legacy JSONL journals. Source-code changes are not silently hot-loaded. Changes to shell functions require re-sourcing the hook or a new shell, just as with a direct symlink to a source script.
 
 New interactive cmux zsh terminals capture automatically. Existing idle shells can reload `~/.genesis-tools/cmux/capture.zsh`; running agents are not interrupted. Reinstalling the same version is idempotent. A changed collector version takes over through a new ownership token; the old process exits without PID signals.
+
+The viewport collector currently runs for the current login only; it is not a launchd login service and is not automatically restarted after a reboot or process crash. Command capture resumes in new zsh shells, but to resume viewport sampling rerun `tools cmux capture install` (or `tools zsh cmux install`, with the same custom home/rc options if used). Status distinguishes `enabled, not running` from `running` and prints this recovery guidance. Existing cached viewports remain available while the collector is stopped.
+
+Stable-ID association is independent of viewport sampling: a missing association starts one background resolver, which retries native autosave discovery for up to 30 seconds. Shell events can retry later at most once per 30 seconds until an association exists. It does not block command execution, and it also runs with `--no-screens`. The association task requires the installed Bun recorder; the lightweight command write itself does not.
 
 ```bash
 tools cmux capture status
@@ -202,7 +206,7 @@ All three lifecycle commands support `--home <directory>`, `--rc <path>`, and `-
 
 ## What is recorded
 
-- Exact local zsh command text and launch directory, synchronously before execution. Completion retains the command and its exit status. Pipelines and quotes are preserved; tab titles are never executed as commands.
+- Exact local zsh command text and launch directory, written before execution. Completion retains the command and its exit status. The write finishes before the command starts, but the lightweight spool does not force a disk fsync per event; abrupt power loss can lose recently buffered writes. Pipelines and quotes are preserved; tab titles are never executed as commands.
 - Runtime surface UUID plus cmux's persisted `stableSurfaceId` when available. `surface:N` is an in-memory routing reference, not a durable identifier. Workspace IDs are informational: moving a panel does not redirect its history to another panel. A saved association bridges stale shell environment IDs; the collector fills associations after native autosave supplies a new panel's stable identity.
 - Current visible terminal text, sampled roughly every 15 seconds plus collection time, with a maximum of 200 lines / 200,000 characters per surface. This is a viewport snapshot, not a full scrollback recorder. Unchanged viewports are not rewritten.
 - Native autosave layout, pane proportions, tab order/selection, titles and directories. Native saved text and browser URLs are retained when provided. The current viewport cache also feeds offline/previous-autosave recovery.
@@ -213,7 +217,7 @@ The collector reads local socket data only. It never focuses or initializes dorm
 
 Viewport cache has a 64 MiB total budget, including previous versions and the pre-restart archive. Oldest snapshots are removed when the budget is exceeded. The collector preserves the last cached screens when the native previous-autosave generation changes, and historical restore never substitutes a newer screen for an older cutoff.
 
-Command journals retain two generations of up to 1 MiB per surface. Old surface journals remain until explicitly removed; commands over 65,536 characters are rejected visibly. Runtime diagnostics retain two 1 MiB generations. Files are private local data: directories mode 0700, new data files mode 0600. Commands and visible output can contain sensitive text, so do not publish the data directory or copy its contents into test fixtures.
+Command spools retain two bounded generations of approximately 1 MiB per surface; existing JSONL journals remain readable and retain their separate two-generation limit. Old surface records remain until explicitly removed; the lightweight hook visibly rejects commands over 65,536 bytes. Runtime diagnostics retain two 1 MiB generations. Files are private local data: directories mode 0700, new data files mode 0600. Commands and visible output can contain sensitive text, so do not publish the data directory or copy its contents into test fixtures.
 
 Capture can miss output between samples, terminals that never initialized, and data older than the retention budget. Recording must be installed before a command runs; it cannot recover missing earlier commands retrospectively.
 

--- a/src/cmux/README.md
+++ b/src/cmux/README.md
@@ -54,10 +54,7 @@ tools cmux profiles save work --force            # overwrite
 | `-f, --force` | Overwrite an existing profile of the same name |
 | `--offline` | Build the profile from the autosave file plus the process table instead of the socket |
 
-`--offline` exists for the case the socket cannot answer, which is exactly when you most
-need a capture. ⚠️ It is a **weaker** capture: no visible screen and no scrollback, so the
-per-pane command comes from the process table rather than from history. `save` falls back to
-it automatically when the UI is starved, and says so.
+`--offline` captures from native autosave and the local command/viewport caches without activating any UI. It preserves available saved output, but cannot fetch a fresh viewport while the socket is unavailable. `save` falls back to it when the UI is starved and reports that fallback.
 
 ---
 
@@ -168,3 +165,73 @@ is the one place that decides this.
 
 - Profiles are JSON under `~/.genesis-tools/cmux/profiles/`. `edit` opens one, and `path` tells you where it is, so hand-tuning a layout is expected rather than discouraged.
 - Related: `tools claude cmux` reopens recent Claude Code sessions as cmux workspaces, which is the session-oriented counterpart to this layout-oriented tool. [`tools tmux`](../tmux/README.md) does the equivalent job for tmux.
+
+## Install automatic capture
+
+The same installer is available through either tool:
+
+```bash
+tools cmux capture install
+# Equivalent:
+tools zsh cmux install
+```
+
+Installation previews its managed rc block and asks before editing your zsh rc file. In non-interactive use, pass `--yes` to approve that edit; `--dry-run` previews without writing files or starting a collector. Uninstall follows the same confirmation rule. Repeating installation reports that it is already installed and does not duplicate or rewrite an unchanged rc block.
+
+The installer generates the hook and standalone runtimes under `~/.genesis-tools/cmux/`; their source lives in this repository. The installed runtime does not depend on the checkout or worktree remaining at its original path. Bun must remain installed; the hook uses PATH and then a global Bun fallback. Existing rc content is backed up before an approved change, and concurrent edits after preview are refused.
+
+Rerun `install` after updating GenesisTools to rebuild the installed artifacts. The generated hook invokes a stable managed symlink, `runtime/capture-record.js`, which points to the current versioned bundle. Switching that symlink updates the recorder for already-loaded modern hooks without pointing them into a removable worktree. Source-code changes are not silently hot-loaded. Changes to the shell functions themselves require re-sourcing the hook or a new shell, just as they would with a direct symlink to a source script.
+
+New interactive cmux zsh terminals capture automatically. Existing idle shells can reload `~/.genesis-tools/cmux/capture.zsh`; running agents are not interrupted. Reinstalling the same version is idempotent. A changed collector version takes over through a new ownership token; the old process exits without PID signals.
+
+```bash
+tools cmux capture status
+# Equivalent:
+tools zsh cmux status
+
+# Commands only, without viewport sampling:
+tools cmux capture install --no-screens
+
+# Stop sampling and remove the managed rc block; keep captured data:
+tools cmux capture uninstall
+# Equivalent:
+tools zsh cmux uninstall
+```
+
+All three lifecycle commands support `--home <directory>`, `--rc <path>`, and `--json`. Install/uninstall support `--dry-run` and `--yes` for preview and rc-edit approval. Status is read-only. Uninstall leaves existing shell functions loaded until that shell reloads or exits. `capture shell zsh` remains an advanced script-generation command; use `install` for portable managed installation.
+
+## What is recorded
+
+- Exact local zsh command text and launch directory, synchronously before execution. Completion retains the command and its exit status. Pipelines and quotes are preserved; tab titles are never executed as commands.
+- Runtime surface UUID plus cmux's persisted `stableSurfaceId` when available. `surface:N` is an in-memory routing reference, not a durable identifier. Workspace IDs are informational: moving a panel does not redirect its history to another panel. A saved association bridges stale shell environment IDs; the collector fills associations after native autosave supplies a new panel's stable identity.
+- Current visible terminal text, sampled roughly every 15 seconds plus collection time, with a maximum of 200 lines / 200,000 characters per surface. This is a viewport snapshot, not a full scrollback recorder. Unchanged viewports are not rewritten.
+- Native autosave layout, pane proportions, tab order/selection, titles and directories. Native saved text and browser URLs are retained when provided. The current viewport cache also feeds offline/previous-autosave recovery.
+
+The collector reads local socket data only. It never focuses or initializes dormant terminals, types commands, launches agents, or answers dialogs. A socket outage stops that collection pass and leaves the previous cache intact. A process lock and ownership token prevent duplicate collectors from the same installation.
+
+## Resource use and retention
+
+Viewport cache has a 64 MiB total budget, including previous versions and the pre-restart archive. Oldest snapshots are removed when the budget is exceeded. The collector preserves the last cached screens when the native previous-autosave generation changes, and historical restore never substitutes a newer screen for an older cutoff.
+
+Command journals retain two generations of up to 1 MiB per surface. Old surface journals remain until explicitly removed; commands over 65,536 characters are rejected visibly. Runtime diagnostics retain two 1 MiB generations. Files are private local data: directories mode 0700, new data files mode 0600. Commands and visible output can contain sensitive text, so do not publish the data directory or copy its contents into test fixtures.
+
+Capture can miss output between samples, terminals that never initialized, and data older than the retention budget. Recording must be installed before a command runs; it cannot recover missing earlier commands retrospectively.
+
+## Covered examples
+
+- `tail -f service.log`, `bun run dev`, and CLI monitors: preserve command, launch directory, viewport text, and surrounding cmux layout. Restore can relaunch the command when explicitly requested.
+- `git status`, `tools ai usage`, and other completed commands: retain the last command and visible output even after the process exits.
+- Commands with quoted arguments, pipes, and multiple shell statements: retain the typed shell syntax rather than a flattened process argument list.
+- Moving an existing terminal between panes/workspaces: retain the surface association independently of workspace location and current numbered references.
+- `vim notes.md`, `ssh example-host`, or `tmux attach -t example`: preserve the outer launch command and visible snapshot. Application-specific state is not implied.
+- Browser tabs: restore their saved URL, including a browser as the first tab in a pane, when the URL was available to capture.
+
+## Uncovered or approximate examples
+
+- Unsaved editor buffers, cursor/selection state, running process memory, shell-local variables, background job state, and exact process IDs.
+- Commands typed inside an SSH shell, nested shell, or TUI: only the owning local zsh launch command is captured.
+- Browser cookies, form inputs, authentication flows, navigation history, and exact page state.
+- Exact window placement, pixel/cell equality from offline estimates, and cmux-specific non-terminal panels such as project or custom-sidebar tools.
+- Agent authentication, resume confirmations, and a second process trying to own a session already running elsewhere. Restore never auto-confirms these.
+
+Saved terminal text is historical output, not evidence that its original program is running. By default restore types the command for inspection; `--enter` explicitly requests execution. Success of the launcher does not guarantee the restarted application returns to identical internal state.

--- a/src/cmux/capture-record.ts
+++ b/src/cmux/capture-record.ts
@@ -1,0 +1,25 @@
+import { recordCapturedCommand } from "@app/cmux/lib/capture-journal";
+import { resolveCapturedSurfaceIdentity } from "@app/cmux/lib/capture-surface-identity";
+import { logger } from "@genesiscz/utils/logger";
+
+const [phase, surfaceId, cwd, workspaceId, exitStatus, directory] = process.argv.slice(2);
+
+try {
+    if (phase !== "running" && phase !== "completed") {
+        throw new Error("Expected running or completed capture event");
+    }
+
+    recordCapturedCommand({
+        phase,
+        surfaceId,
+        stableSurfaceId: resolveCapturedSurfaceIdentity({ surfaceId, journalDirectory: directory || undefined }),
+        cwd,
+        workspaceId: workspaceId || undefined,
+        exitStatus: exitStatus ? Number(exitStatus) : undefined,
+        directory: directory || undefined,
+        command: await Bun.stdin.text(),
+    });
+} catch (error) {
+    logger.error({ error }, "[cmux-capture] could not persist shell command");
+    process.exitCode = 1;
+}

--- a/src/cmux/capture-record.ts
+++ b/src/cmux/capture-record.ts
@@ -1,10 +1,22 @@
-import { recordCapturedCommand } from "@app/cmux/lib/capture-journal";
+import { associateCapturedSurface, recordCapturedCommand } from "@app/cmux/lib/capture-journal";
 import { resolveCapturedSurfaceIdentity } from "@app/cmux/lib/capture-surface-identity";
 import { logger } from "@genesiscz/utils/logger";
 
 const [phase, surfaceId, cwd, workspaceId, exitStatus, directory] = process.argv.slice(2);
 
 try {
+    if (phase === "--associate") {
+        for (let attempt = 0; attempt < 15; attempt++) {
+            const stableSurfaceId = resolveCapturedSurfaceIdentity({ surfaceId, journalDirectory: cwd || undefined });
+            if (stableSurfaceId) {
+                associateCapturedSurface({ surfaceId, stableSurfaceId, directory: cwd || undefined });
+                process.exit(0);
+            }
+            await Bun.sleep(2000);
+        }
+        logger.debug({ surfaceId }, "[cmux-capture] identity association deferred until a later shell event");
+        process.exit(0);
+    }
     if (phase !== "running" && phase !== "completed") {
         throw new Error("Expected running or completed capture event");
     }

--- a/src/cmux/capture-watch.ts
+++ b/src/cmux/capture-watch.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import { autosaveDir, listAutosaveFiles, readAutosaveSession } from "@app/cmux/lib/autosave";
 import { advanceScreenEpoch, pruneSavedScreens } from "@app/cmux/lib/screen-cache";
@@ -49,7 +49,9 @@ try {
     process.exit(1);
 }
 
-writeFileSync(pidPath, ownership, { mode: 0o600 });
+const temporaryPidPath = `${pidPath}.${ownerToken}.tmp`;
+writeFileSync(temporaryPidPath, ownership, { mode: 0o600 });
+renameSync(temporaryPidPath, pidPath);
 process.on("SIGTERM", () => {
     stopping = true;
 });

--- a/src/cmux/capture-watch.ts
+++ b/src/cmux/capture-watch.ts
@@ -1,0 +1,110 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { autosaveDir, listAutosaveFiles, readAutosaveSession } from "@app/cmux/lib/autosave";
+import { advanceScreenEpoch, pruneSavedScreens } from "@app/cmux/lib/screen-cache";
+import { collectTerminalScreens } from "@app/cmux/lib/screen-collector";
+import { rpc } from "@genesiscz/utils/cmux/lib/socket";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+
+const args = process.argv.slice(2);
+const controlDir = args[args.indexOf("--control-dir") + 1];
+const ownerToken = args[args.indexOf("--owner-token") + 1];
+if (
+    !args.includes("--control-dir") ||
+    !args.includes("--owner-token") ||
+    !isAbsolute(controlDir ?? "") ||
+    !/^[a-f\d-]{36}$/i.test(ownerToken ?? "")
+) {
+    throw new Error("Expected --control-dir <absolute path> --owner-token <UUID>");
+}
+
+mkdirSync(controlDir, { recursive: true, mode: 0o700 });
+const marker = join(controlDir, "screens.enabled");
+const pidPath = join(controlDir, "screens.pid.json");
+const lock = join(controlDir, `screens.${ownerToken}.lock`);
+const ownership = SafeJSON.stringify({ pid: process.pid, ownerToken });
+let stopping = false;
+function enabled(): boolean {
+    if (stopping || !existsSync(marker)) {
+        return false;
+    }
+
+    try {
+        return readFileSync(marker, "utf8").trim() === ownerToken;
+    } catch (error) {
+        logger.debug({ error }, "[cmux-screens] enable marker unavailable");
+        return false;
+    }
+}
+
+if (!enabled()) {
+    process.exit(0);
+}
+
+try {
+    writeFileSync(lock, ownership, { flag: "wx", mode: 0o600 });
+} catch (error) {
+    logger.warn({ error }, "[cmux-screens] collector already owns this installation token");
+    process.exit(1);
+}
+
+writeFileSync(pidPath, ownership, { mode: 0o600 });
+process.on("SIGTERM", () => {
+    stopping = true;
+});
+process.on("SIGINT", () => {
+    stopping = true;
+});
+try {
+    while (enabled()) {
+        try {
+            const session = readAutosaveSession();
+            const previous = listAutosaveFiles(autosaveDir(), "previous")[0];
+            const directory = join(controlDir, "screens");
+            advanceScreenEpoch({ directory, epoch: previous ? `${previous.path}:${previous.mtimeMs}` : "initial" });
+            const started = Date.now();
+            const result = await collectTerminalScreens({
+                session,
+                directory,
+                shouldContinue: enabled,
+                journalDirectory: join(controlDir, "command-journal"),
+                readText: async (surfaceId) => {
+                    const result = await rpc<{ text: string }>(
+                        "surface.read_text",
+                        { surface_id: surfaceId, scrollback: false, lines: 200 },
+                        { timeoutMs: 1000 }
+                    );
+                    return result.text;
+                },
+            });
+            if (!enabled()) {
+                break;
+            }
+
+            const cacheBytes = pruneSavedScreens({ directory });
+            writeFileSync(
+                join(controlDir, "screens.last-run.json"),
+                SafeJSON.stringify({ ...result, durationMs: Date.now() - started, cacheBytes, atMs: Date.now() }),
+                { mode: 0o600 }
+            );
+            logger.debug(result, "[cmux-screens] read-only collection finished");
+        } catch (error) {
+            logger.debug({ error }, "[cmux-screens] autosave or socket unavailable; retaining cached output");
+        }
+
+        for (let i = 0; i < 60 && enabled(); i++) {
+            await Bun.sleep(250);
+        }
+    }
+} finally {
+    for (const path of [pidPath, lock]) {
+        try {
+            if (existsSync(path) && readFileSync(path, "utf8") === ownership) {
+                unlinkSync(path);
+            }
+        } catch (error) {
+            logger.debug({ error, path }, "[cmux-screens] collector ownership cleanup failed");
+        }
+    }
+}

--- a/src/cmux/commands/capture-install.test.ts
+++ b/src/cmux/commands/capture-install.test.ts
@@ -65,6 +65,7 @@ test.each([
     const result = await rawInvoke({ tool, action: "install", home });
     expect(result.exitCode).not.toBe(0);
     expect(result.error).toContain("--yes");
+    expect(SafeJSON.parse(result.output, { strict: true })).toMatchObject({ confirmationRequired: true });
     expect(readFileSync(rc, "utf8")).toBe(before);
     expect(existsSync(join(home, ".genesis-tools/cmux/runtime"))).toBe(false);
     const preview = await rawInvoke({ tool, action: "install", home, flags: ["--dry-run"] });
@@ -92,5 +93,6 @@ test.each(["cmux", "zsh"] as const)("%s requires confirmation before uninstall e
     const result = await rawInvoke({ tool, action: "uninstall", home });
     expect(result.exitCode).not.toBe(0);
     expect(result.error).toContain("--yes");
+    expect(SafeJSON.parse(result.output, { strict: true })).toMatchObject({ confirmationRequired: true });
     expect(readFileSync(rc, "utf8")).toBe(before);
 });

--- a/src/cmux/commands/capture-install.test.ts
+++ b/src/cmux/commands/capture-install.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+async function rawInvoke(input: { tool: "cmux" | "zsh"; action: string; home: string; flags?: string[] }) {
+    const proc = Bun.spawn(
+        [
+            process.execPath,
+            resolve(`src/${input.tool}/index.ts`),
+            input.tool === "cmux" ? "capture" : "cmux",
+            input.action,
+            "--home",
+            input.home,
+            "--no-screens",
+            "--json",
+            ...(input.flags ?? []),
+        ],
+        {
+            env: { HOME: input.home, GENESIS_TOOLS_HOME: input.home, PATH: "/usr/bin:/bin" },
+            stdin: "ignore",
+            stdout: "pipe",
+            stderr: "pipe",
+        }
+    );
+    const [output, error, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    return { output, error, exitCode };
+}
+
+async function invoke(input: { tool: "cmux" | "zsh"; action: string; home: string }) {
+    const { output, error, exitCode } = await rawInvoke({ ...input, flags: ["--yes"] });
+    expect({ exitCode, error: exitCode === 0 ? "" : error }).toEqual({ exitCode: 0, error: "" });
+    return SafeJSON.parse(output) as { installed: boolean; hookPath: string; runtimePath: string };
+}
+
+test.each([
+    "cmux",
+    "zsh",
+] as const)("%s installs the same capture feature that the other alias inspects and uninstalls", async (tool) => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-install-alias-"));
+    const rc = join(home, ".zshrc");
+    writeFileSync(rc, "export FICTIONAL_SETTING=keep\n");
+    const other = tool === "cmux" ? "zsh" : "cmux";
+    const installed = await invoke({ tool, action: "install", home });
+    expect(installed.installed).toBe(true);
+    const status = await invoke({ tool: other, action: "status", home });
+    expect(status).toMatchObject({ installed: true, hookPath: installed.hookPath, runtimePath: installed.runtimePath });
+    expect((await invoke({ tool: other, action: "uninstall", home })).installed).toBe(false);
+    expect(readFileSync(rc, "utf8")).toBe("export FICTIONAL_SETTING=keep\n");
+});
+
+test.each([
+    "cmux",
+    "zsh",
+] as const)("%s refuses an unconfirmed rc edit and offers a read-only preview", async (tool) => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-confirm-install-"));
+    const rc = join(home, ".zshrc");
+    const before = "export EXAMPLE_SETTING=preserve\n";
+    writeFileSync(rc, before);
+    const result = await rawInvoke({ tool, action: "install", home });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.error).toContain("--yes");
+    expect(readFileSync(rc, "utf8")).toBe(before);
+    expect(existsSync(join(home, ".genesis-tools/cmux/runtime"))).toBe(false);
+    const preview = await rawInvoke({ tool, action: "install", home, flags: ["--dry-run"] });
+    expect(preview.exitCode).toBe(0);
+    expect(readFileSync(rc, "utf8")).toBe(before);
+    expect(existsSync(join(home, ".genesis-tools/cmux/runtime"))).toBe(false);
+});
+
+test("reinstall warns already installed and does not rewrite the rc", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-already-installed-"));
+    await invoke({ tool: "cmux", action: "install", home });
+    const rc = join(home, ".zshrc");
+    const before = readFileSync(rc, "utf8");
+    const result = await rawInvoke({ tool: "zsh", action: "install", home });
+    expect(result.exitCode).toBe(0);
+    expect(result.error).toContain("already installed");
+    expect(readFileSync(rc, "utf8")).toBe(before);
+});
+
+test.each(["cmux", "zsh"] as const)("%s requires confirmation before uninstall edits the rc", async (tool) => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-uninstall-confirm-"));
+    await invoke({ tool, action: "install", home });
+    const rc = join(home, ".zshrc");
+    const before = readFileSync(rc, "utf8");
+    const result = await rawInvoke({ tool, action: "uninstall", home });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.error).toContain("--yes");
+    expect(readFileSync(rc, "utf8")).toBe(before);
+});

--- a/src/cmux/commands/capture-install.test.ts
+++ b/src/cmux/commands/capture-install.test.ts
@@ -35,7 +35,7 @@ async function rawInvoke(input: { tool: "cmux" | "zsh"; action: string; home: st
 async function invoke(input: { tool: "cmux" | "zsh"; action: string; home: string }) {
     const { output, error, exitCode } = await rawInvoke({ ...input, flags: ["--yes"] });
     expect({ exitCode, error: exitCode === 0 ? "" : error }).toEqual({ exitCode: 0, error: "" });
-    return SafeJSON.parse(output) as { installed: boolean; hookPath: string; runtimePath: string };
+    return SafeJSON.parse(output, { strict: true }) as { installed: boolean; hookPath: string; runtimePath: string };
 }
 
 test.each([

--- a/src/cmux/commands/capture-install.ts
+++ b/src/cmux/commands/capture-install.ts
@@ -64,11 +64,20 @@ export function registerCaptureLifecycleCommands(parent: Command): void {
                     }
 
                     if (plan.changesRc && !flags.yes) {
-                        p.note(
-                            plan.block || "Remove only the managed cmux capture block.",
-                            `Proposed change to ${plan.rcPath}`
-                        );
-                        if (!isInteractive()) {
+                        if (flags.json) {
+                            out.result({
+                                action,
+                                rcPath: plan.rcPath,
+                                willChangeRc: true,
+                                proposedBlock: plan.block,
+                                confirmationRequired: true,
+                            });
+                        } else {
+                            out.log.info(
+                                `Proposed change to ${plan.rcPath}:\n${plan.block || "Remove only the managed cmux capture block."}`
+                            );
+                        }
+                        if (!isInteractive() || flags.json) {
                             out.log.error(
                                 "Changing the shell rc file requires confirmation. Re-run with --yes, or use --dry-run to preview. No installation changes were made."
                             );
@@ -95,6 +104,11 @@ export function registerCaptureLifecycleCommands(parent: Command): void {
                         "changed" in result && result.changed
                             ? "cmux capture is already installed; updated its generated runtime or configuration."
                             : "cmux capture is already installed and current; no changes were needed."
+                    );
+                }
+                if (result.screens.enabled && !result.screens.running) {
+                    out.log.warn(
+                        "Viewport collector is enabled but stopped. It is not a login service; rerun capture install with the same home/rc options after reboot or process exit to restart sampling."
                     );
                 }
                 if (flags.json) {

--- a/src/cmux/commands/capture-install.ts
+++ b/src/cmux/commands/capture-install.ts
@@ -1,0 +1,123 @@
+import {
+    type CaptureInstallOptions,
+    captureInstallationStatus,
+    installCapture,
+    planCaptureRcChange,
+    uninstallCapture,
+} from "@app/cmux/lib/capture-installer";
+import * as p from "@clack/prompts";
+import { isInteractive } from "@genesiscz/utils/cli";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+interface Flags {
+    home?: string;
+    rc?: string;
+    json?: boolean;
+    screens?: boolean;
+    yes?: boolean;
+    dryRun?: boolean;
+}
+
+export function registerCaptureLifecycleCommands(parent: Command): void {
+    for (const action of ["install", "uninstall", "status"] as const) {
+        parent
+            .command(action)
+            .description(
+                action === "install"
+                    ? "Bundle and install durable cmux capture for future zsh shells"
+                    : action === "uninstall"
+                      ? "Remove the managed rc block; retain journal data and installed artifacts"
+                      : "Inspect capture installation without modifying files"
+            )
+            .option("--home <directory>", "Home directory containing .genesis-tools (default: configured tools home)")
+            .option("--rc <path>", "Zsh rc file to manage (default: <home>/.zshrc)")
+            .option("--no-screens", "Disable the background screen collector; retain command capture")
+            .option("--json", "Emit installation details as JSON")
+            .option("--yes", "Approve changes to the shell rc file without prompting")
+            .option("--dry-run", "Preview installation/removal without writing files or starting processes")
+            .action(async (flags: Flags) => {
+                const options: CaptureInstallOptions & { screens?: boolean } = {
+                    home: flags.home,
+                    rcPath: flags.rc,
+                    screens: flags.screens,
+                };
+                const beforeStatus = captureInstallationStatus(options);
+                if (action !== "status") {
+                    const plan = planCaptureRcChange({ ...options, action });
+                    if (flags.dryRun) {
+                        const preview = {
+                            action,
+                            rcPath: plan.rcPath,
+                            willChangeRc: plan.changesRc,
+                            installed: beforeStatus.installed,
+                            proposedBlock: plan.block,
+                        };
+                        if (flags.json) {
+                            out.result(preview);
+                        } else {
+                            out.println(
+                                `${action}: ${plan.rcPath}${plan.changesRc ? " will change" : " needs no edit"}\n${plan.block || "Remove the managed cmux capture block."}\nNo files were written. Re-run with --yes to approve rc changes.`
+                            );
+                        }
+                        return;
+                    }
+
+                    if (plan.changesRc && !flags.yes) {
+                        p.note(
+                            plan.block || "Remove only the managed cmux capture block.",
+                            `Proposed change to ${plan.rcPath}`
+                        );
+                        if (!isInteractive()) {
+                            out.log.error(
+                                "Changing the shell rc file requires confirmation. Re-run with --yes, or use --dry-run to preview. No installation changes were made."
+                            );
+                            process.exitCode = 1;
+                            return;
+                        }
+                        const approved = await p.confirm({ message: `Apply this change to ${plan.rcPath}?` });
+                        if (p.isCancel(approved) || !approved) {
+                            p.cancel("No installation changes were made.");
+                            return;
+                        }
+                    }
+                    options.rcPath = plan.rcPath;
+                    options.expectedRc = plan.before;
+                }
+                const result =
+                    action === "install"
+                        ? await installCapture(options)
+                        : action === "uninstall"
+                          ? uninstallCapture(options)
+                          : captureInstallationStatus(options);
+                if (action === "install" && beforeStatus.installed) {
+                    out.log.warn(
+                        "changed" in result && result.changed
+                            ? "cmux capture is already installed; updated its generated runtime or configuration."
+                            : "cmux capture is already installed and current; no changes were needed."
+                    );
+                }
+                if (flags.json) {
+                    out.result(result);
+                    return;
+                }
+
+                out.println(
+                    `cmux capture: ${result.installed ? "installed" : "not installed"}\nrc: ${result.rcPath}\nhook: ${result.hookPath}\nruntime: ${result.runtimePath ?? "not generated"}`
+                );
+                const screens = result.screens;
+                out.println(
+                    `screens: ${screens.enabled ? (screens.running ? "running" : "enabled, not running") : screens.running ? "stopping" : "disabled"}${screens.pid ? ` (pid ${screens.pid})` : ""}`
+                );
+                if ("backupPath" in result && result.backupPath) {
+                    out.println(`backup: ${result.backupPath}`);
+                }
+
+                if (action === "install") {
+                    out.println(
+                        "New interactive cmux shells will capture commands. Existing running shells are unchanged."
+                    );
+                }
+            });
+    }
+}

--- a/src/cmux/commands/capture.ts
+++ b/src/cmux/commands/capture.ts
@@ -1,0 +1,21 @@
+import { registerCaptureLifecycleCommands } from "@app/cmux/commands/capture-install";
+import { renderCaptureShell } from "@app/cmux/lib/capture-shell";
+import { out } from "@genesiscz/utils/logger";
+import type { Command } from "commander";
+
+export function registerCaptureCommand(parent: Command): void {
+    const capture = parent
+        .command("capture")
+        .description("Configure durable shell-command capture for offline restoration");
+    registerCaptureLifecycleCommands(capture);
+    capture
+        .command("shell <shell>")
+        .description("Print sourceable shell integration (currently zsh); does not edit shell configuration")
+        .action((shell: string) => {
+            if (shell !== "zsh") {
+                throw new Error("Command capture currently supports zsh. Use: tools cmux capture shell zsh");
+            }
+
+            out.print(renderCaptureShell());
+        });
+}

--- a/src/cmux/commands/profiles/restore.ts
+++ b/src/cmux/commands/profiles/restore.ts
@@ -112,9 +112,12 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
         const summary = outcome.workspaces
             .map((w) => {
                 const status = w.converged ? pc.green("✓") : pc.yellow("≈");
-                const dimensionNote = w.converged
-                    ? "exact size match"
-                    : `off by ${w.maxCellDelta} cell${w.maxCellDelta === 1 ? "" : "s"}`;
+                const dimensionNote =
+                    w.maxCellDelta === null
+                        ? "cell sizes unverified: autosave dimensions were estimated"
+                        : w.converged
+                          ? "exact size match"
+                          : `off by ${w.maxCellDelta} cell${w.maxCellDelta === 1 ? "" : "s"}`;
                 return `  ${status} ${pc.cyan(w.title)} ${pc.dim(`(${dimensionNote})`)}`;
             })
             .join("\n");

--- a/src/cmux/commands/profiles/restore.ts
+++ b/src/cmux/commands/profiles/restore.ts
@@ -1,6 +1,12 @@
 import { prepareProfileForRestore } from "@app/cmux/lib/agent-replay";
 import { renderProfileCommandDetail } from "@app/cmux/lib/format";
-import { buildPlan, type RestoreOptions, reportWaitingPrompts, restoreProfile } from "@app/cmux/lib/restore";
+import {
+    buildPlan,
+    type RestoreOptions,
+    reportWaitingPrompts,
+    restoreFailureMessages,
+    restoreProfile,
+} from "@app/cmux/lib/restore";
 import { ProfileNotFoundError, ProfileStore } from "@app/cmux/lib/store";
 import type { Profile } from "@app/cmux/lib/types";
 import * as p from "@clack/prompts";
@@ -107,17 +113,24 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
                 spinner.message(`Restoring ${index}/${total}: ${title}`);
             },
         });
-        spinner.stop(`Restored ${outcome.workspaces.length} workspace(s) in ${Date.now() - startedAt} ms`);
+        const failures = restoreFailureMessages(outcome);
+        spinner.stop(`Processed ${outcome.workspaces.length} workspace(s) in ${Date.now() - startedAt} ms`);
+        if (failures.length > 0) {
+            process.exitCode = 1;
+            p.note(failures.join("\n"), "Pane restore failures");
+        }
 
         const summary = outcome.workspaces
             .map((w) => {
                 const status = w.converged ? pc.green("✓") : pc.yellow("≈");
                 const dimensionNote =
-                    w.maxCellDelta === null
-                        ? "cell sizes unverified: autosave dimensions were estimated"
-                        : w.converged
-                          ? "exact size match"
-                          : `off by ${w.maxCellDelta} cell${w.maxCellDelta === 1 ? "" : "s"}`;
+                    w.failures.length > 0
+                        ? `partial restoration: ${w.failures.length} pane(s) failed`
+                        : w.maxCellDelta === null
+                          ? "cell sizes unverified: autosave dimensions were estimated"
+                          : w.converged
+                            ? "exact size match"
+                            : `off by ${w.maxCellDelta} cell${w.maxCellDelta === 1 ? "" : "s"}`;
                 return `  ${status} ${pc.cyan(w.title)} ${pc.dim(`(${dimensionNote})`)}`;
             })
             .join("\n");
@@ -130,7 +143,11 @@ async function runRestore(name: string, flags: RestoreFlags): Promise<void> {
             );
         }
 
-        p.outro(pc.green("Done."));
+        p.outro(
+            failures.length > 0
+                ? pc.yellow("Partial restore — some panes or commands were not restored.")
+                : pc.green("Done.")
+        );
     } catch (error) {
         spinner.stop("Restore failed.");
         logger.error({ error }, "[cmux restore] failed");

--- a/src/cmux/commands/profiles/save.test.ts
+++ b/src/cmux/commands/profiles/save.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import { registerSaveCommand } from "@app/cmux/commands/profiles/save";
+import * as offline from "@app/cmux/lib/offline-snapshot";
+import * as snapshot from "@app/cmux/lib/snapshot";
+import { ProfileStore } from "@app/cmux/lib/store";
+import { PROFILE_VERSION } from "@app/cmux/lib/types";
+import * as health from "@genesiscz/utils/cmux/lib/health";
+import { Command } from "commander";
+
+afterEach(() => mock.restore());
+
+test.each([
+    { explicitOffline: false, noScreen: true },
+    { explicitOffline: true, noScreen: false },
+    { explicitOffline: true, noScreen: true },
+])("offline capture preserves the requested screen setting: %j", async ({ explicitOffline, noScreen }) => {
+    spyOn(health, "probeCmuxHealth").mockResolvedValue({
+        state: "ui-starved",
+        probes: { ping: { ok: true, ms: 1 }, identify: { ok: false, ms: 1 } },
+    });
+    spyOn(snapshot, "getCmuxVersion").mockResolvedValue("fixture");
+    spyOn(ProfileStore.prototype, "exists").mockReturnValue(false);
+    spyOn(ProfileStore.prototype, "write").mockReturnValue("/tmp/fixture-profile.yaml");
+    const capture = spyOn(offline, "captureOfflineProfile").mockResolvedValue({
+        version: PROFILE_VERSION,
+        name: "fixture",
+        scope: "all",
+        captured_at: "2026-01-01T00:00:00Z",
+        cmux_version: "fixture",
+        windows: [],
+    });
+    const program = new Command();
+    registerSaveCommand(program);
+    await program.parseAsync([
+        "node",
+        "fixture",
+        "save",
+        "fixture",
+        ...(explicitOffline ? ["--offline"] : ["--scope", "all"]),
+        ...(noScreen ? ["--no-screen"] : []),
+        "--force",
+    ]);
+    expect(capture).toHaveBeenCalledWith({ name: "fixture", note: undefined, captureScreen: !noScreen });
+});

--- a/src/cmux/commands/profiles/save.ts
+++ b/src/cmux/commands/profiles/save.ts
@@ -42,7 +42,7 @@ export function registerSaveCommand(parent: Command): void {
         .option("-f, --force", "Overwrite an existing profile of the same name")
         .option(
             "--offline",
-            "Capture WITHOUT the cmux socket: layout from the app's autosave file, commands from the process table. The automatic fallback when cmux's UI thread is starved. No screen contents; scope is always everything in the autosave."
+            "Capture WITHOUT the cmux socket: autosave layout, recovered commands and available native/cached screens. Use --no-screen to omit output; scope is always everything in the autosave."
         )
         .action(async (name: string | undefined, flags: SaveFlags) => {
             await runSave(name, flags);
@@ -63,7 +63,7 @@ async function runSave(rawName: string | undefined, flags: SaveFlags): Promise<v
     const scope = offline ? "all" : await resolveScope(flags, interactive);
     rejectIncompatibleScopeFlags(scope, flags);
     const { captureCwd, captureScreen, captureHistory } = offline
-        ? { captureCwd: true, captureScreen: false, captureHistory: true }
+        ? { captureCwd: true, captureScreen: flags.screen !== false, captureHistory: true }
         : await resolveCaptureFlags(flags, interactive);
     const name = await resolveName(rawName, scope, interactive);
 
@@ -84,7 +84,10 @@ async function runSave(rawName: string | undefined, flags: SaveFlags): Promise<v
             offline = true;
             out.log.warn(
                 `cmux is ${health.state} — falling back to OFFLINE capture (autosave + process table). ` +
-                    "Screen contents are not captured this way. Run `tools cmux doctor` for triage."
+                    (captureScreen
+                        ? "Available cached/native screen contents are included. "
+                        : "Screen contents are excluded. ") +
+                    "Run `tools cmux doctor` for triage."
             );
         }
     }
@@ -129,7 +132,7 @@ async function runSave(rawName: string | undefined, flags: SaveFlags): Promise<v
 
     try {
         const profile = offline
-            ? await captureOfflineProfile({ name, note: flags.note })
+            ? await captureOfflineProfile({ name, note: flags.note, captureScreen })
             : await captureProfile(options, {
                   onWorkspaceStart: ({ title, index, total }) => {
                       spinner.message(`Capturing workspace ${index}/${total}: ${title}`);

--- a/src/cmux/commands/rescue.ts
+++ b/src/cmux/commands/rescue.ts
@@ -12,10 +12,9 @@ import { ProfileExistsError, ProfileStore } from "@app/cmux/lib/store";
 import type { Profile } from "@app/cmux/lib/types";
 import * as p from "@clack/prompts";
 import { isInteractive, suggestCommand } from "@genesiscz/utils/cli";
-import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { runCmuxJSON, sendSurfaceText } from "@genesiscz/utils/cmux/lib/cli";
 import { probeCmuxHealth } from "@genesiscz/utils/cmux/lib/health";
 import { paneList, workspaceList } from "@genesiscz/utils/cmux/lib/socket";
-import { surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
 import { logger, out } from "@genesiscz/utils/logger";
 import { withCancel } from "@genesiscz/utils/prompts/clack/helpers";
 import type { Command } from "commander";
@@ -282,7 +281,7 @@ async function replayIntoReopenedSurfaces(profile: Profile, entries: ReplayEntry
                 continue;
             }
 
-            await runCmuxOk(["send", ...surfaceTargetArgs(target.ref, liveWs.ref), `${entry.command}\n`]);
+            await sendSurfaceText({ surfaceRef: target.ref, text: `${entry.command}\n` });
             sent += 1;
             await new Promise((resolve) => setTimeout(resolve, 300));
         }

--- a/src/cmux/commands/restore-after-restart.ts
+++ b/src/cmux/commands/restore-after-restart.ts
@@ -1,5 +1,7 @@
 import { prepareProfileForRestore } from "@app/cmux/lib/agent-replay";
 import { readAutosaveSession, readPreviousAutosaveSession } from "@app/cmux/lib/autosave";
+import { loadCapturedCommands } from "@app/cmux/lib/capture-journal";
+import { loadSurfaceSessions } from "@app/cmux/lib/command-capture";
 import { renderProfileCommandDetail, renderProfileTree } from "@app/cmux/lib/format";
 import { buildOfflineProfile } from "@app/cmux/lib/offline-snapshot";
 import { buildPlan, type RestoreOptions, reportWaitingPrompts, restoreProfile } from "@app/cmux/lib/restore";
@@ -11,6 +13,7 @@ import {
     parseRestoreSource,
     type RestoreRestartSource,
 } from "@app/cmux/lib/restore-after-restart";
+import { loadSavedScreens } from "@app/cmux/lib/screen-cache";
 import { captureProfile, getCmuxVersion } from "@app/cmux/lib/snapshot";
 import { ProfileNotFoundError, ProfileStore } from "@app/cmux/lib/store";
 import type { Profile } from "@app/cmux/lib/types";
@@ -32,6 +35,7 @@ interface RestartFlags {
     list?: boolean;
     dryRun?: boolean;
     yes?: boolean;
+    window?: string;
 }
 
 const SOURCES: RestoreRestartSource[] = ["previous", "live", "profile"];
@@ -52,17 +56,27 @@ async function captureLiveProfile(): Promise<Profile> {
         const session = readAutosaveSession();
         return buildOfflineProfile(
             session,
-            { ttyCommands: new Map(), surfaceSessions: new Map() },
+            {
+                ttyCommands: new Map(),
+                surfaceSessions: new Map(),
+                surfaceCommands: loadCapturedCommands(),
+                surfaceScreens: loadSavedScreens(),
+            },
             { name: "restart-live", note: "autosave fallback for restore-after-restart" }
         );
     }
 }
 
-function capturePreviousProfile(): Profile {
+async function capturePreviousProfile(): Promise<Profile> {
     const session = readPreviousAutosaveSession();
     return buildOfflineProfile(
         session,
-        { ttyCommands: new Map(), surfaceSessions: new Map() },
+        {
+            ttyCommands: new Map(),
+            surfaceSessions: await loadSurfaceSessions({ beforeMs: session.savedAtMs }),
+            surfaceCommands: loadCapturedCommands({ beforeMs: session.savedAtMs }),
+            surfaceScreens: loadSavedScreens({ beforeMs: session.savedAtMs }),
+        },
         { name: "restart-previous", note: "previous autosave (pre-restart)" }
     );
 }
@@ -159,6 +173,7 @@ export function registerRestoreAfterRestartCommand(program: Command): void {
         .option("--enter", "Press Enter after typing each resume command")
         .option("--no-replay", "Only cd into cwd, do not type resume commands")
         .option("--prefix <str>", "Workspace name prefix (default restart-)")
+        .option("--window <ref>", "Restore into this cmux window")
         .option("--list", "Print the layout and inferred commands, then exit")
         .option("--dry-run", "Print the restore plan without modifying cmux")
         .option("-y, --yes", "Do not ask for confirmation")
@@ -238,6 +253,7 @@ async function runRestoreAfterRestart(flags: RestartFlags): Promise<void> {
         enter: enter && flags.replay !== false,
         yes: Boolean(flags.yes),
         dryRun: Boolean(flags.dryRun),
+        window: flags.window,
     };
 
     const plan = buildPlan(inferred, opts);
@@ -288,13 +304,13 @@ async function runRestoreAfterRestart(flags: RestartFlags): Promise<void> {
             },
         });
         spinner.stop(`Restored ${outcome.workspaces.length} workspace(s) in ${Date.now() - startedAt} ms`);
-        p.outro(pc.green("Done."));
         if (opts.enter) {
             await reportWaitingPrompts(
                 outcome.workspaces.map((w) => w.ref),
                 "Restore"
             );
         }
+        p.outro(pc.green("Done."));
     } catch (error) {
         spinner.stop("Restore failed.");
         logger.error({ error }, "[restore-after-restart] failed");

--- a/src/cmux/commands/restore-after-restart.ts
+++ b/src/cmux/commands/restore-after-restart.ts
@@ -4,7 +4,13 @@ import { loadCapturedCommands } from "@app/cmux/lib/capture-journal";
 import { loadSurfaceSessions } from "@app/cmux/lib/command-capture";
 import { renderProfileCommandDetail, renderProfileTree } from "@app/cmux/lib/format";
 import { buildOfflineProfile } from "@app/cmux/lib/offline-snapshot";
-import { buildPlan, type RestoreOptions, reportWaitingPrompts, restoreProfile } from "@app/cmux/lib/restore";
+import {
+    buildPlan,
+    type RestoreOptions,
+    reportWaitingPrompts,
+    restoreFailureMessages,
+    restoreProfile,
+} from "@app/cmux/lib/restore";
 import {
     ALL_RESTORE_AGENTS,
     filterReplayByAgents,
@@ -303,14 +309,23 @@ async function runRestoreAfterRestart(flags: RestartFlags): Promise<void> {
                 spinner.message(`Restoring ${index}/${total}: ${title}`);
             },
         });
-        spinner.stop(`Restored ${outcome.workspaces.length} workspace(s) in ${Date.now() - startedAt} ms`);
+        const failures = restoreFailureMessages(outcome);
+        spinner.stop(`Processed ${outcome.workspaces.length} workspace(s) in ${Date.now() - startedAt} ms`);
+        if (failures.length > 0) {
+            process.exitCode = 1;
+            p.note(failures.join("\n"), "Pane restore failures");
+        }
         if (opts.enter) {
             await reportWaitingPrompts(
                 outcome.workspaces.map((w) => w.ref),
                 "Restore"
             );
         }
-        p.outro(pc.green("Done."));
+        p.outro(
+            failures.length > 0
+                ? pc.yellow("Partial restore — some panes or commands were not restored.")
+                : pc.green("Done.")
+        );
     } catch (error) {
         spinner.stop("Restore failed.");
         logger.error({ error }, "[restore-after-restart] failed");

--- a/src/cmux/commands/restore-after-restart.ts
+++ b/src/cmux/commands/restore-after-restart.ts
@@ -58,7 +58,7 @@ async function captureLiveProfile(): Promise<Profile> {
             session,
             {
                 ttyCommands: new Map(),
-                surfaceSessions: new Map(),
+                surfaceSessions: await loadSurfaceSessions(),
                 surfaceCommands: loadCapturedCommands(),
                 surfaceScreens: loadSavedScreens(),
             },

--- a/src/cmux/commands/restore-outcome.test.ts
+++ b/src/cmux/commands/restore-outcome.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import { registerRestoreCommand } from "@app/cmux/commands/profiles/restore";
+import { registerRestoreAfterRestartCommand } from "@app/cmux/commands/restore-after-restart";
+import * as replay from "@app/cmux/lib/agent-replay";
+import * as restore from "@app/cmux/lib/restore";
+import { ProfileStore } from "@app/cmux/lib/store";
+import { PROFILE_VERSION, type Profile } from "@app/cmux/lib/types";
+import * as prompts from "@clack/prompts";
+import * as health from "@genesiscz/utils/cmux/lib/health";
+import { Command } from "commander";
+
+const originalExitCode = process.exitCode;
+afterEach(() => {
+    mock.restore();
+    process.exitCode = originalExitCode;
+});
+
+test.each([
+    { restart: false, failed: true },
+    { restart: true, failed: true },
+    { restart: false, failed: false },
+    { restart: true, failed: false },
+])("restore adapters report partial failure accurately: %j", async ({ restart, failed }) => {
+    process.exitCode = 0;
+    const profile: Profile = {
+        version: PROFILE_VERSION,
+        name: "fixture",
+        scope: "all",
+        captured_at: "2026-01-01T00:00:00Z",
+        cmux_version: "fixture",
+        windows: [],
+    };
+    spyOn(ProfileStore.prototype, "read").mockReturnValue(profile);
+    spyOn(replay, "prepareProfileForRestore").mockResolvedValue(profile);
+    spyOn(health, "ensureCmuxResponsive").mockResolvedValue({
+        state: "healthy",
+        probes: { ping: { ok: true, ms: 1 }, identify: { ok: true, ms: 1 } },
+    });
+    spyOn(restore, "restoreProfile").mockResolvedValue({
+        workspaces: [
+            {
+                ref: "workspace:1",
+                title: "fixture",
+                converged: !failed,
+                maxCellDelta: failed ? null : 0,
+                failures: failed ? [{ paneRef: "pane:1", message: "fixture failure" }] : [],
+            },
+        ],
+    });
+    const outro = spyOn(prompts, "outro").mockImplementation(() => {});
+    const program = new Command();
+    if (restart) {
+        registerRestoreAfterRestartCommand(program);
+        await program.parseAsync([
+            "node",
+            "fixture",
+            "restore-after-restart",
+            "--source",
+            "profile",
+            "--profile",
+            "fixture",
+            "--yes",
+        ]);
+    } else {
+        registerRestoreCommand(program);
+        await program.parseAsync(["node", "fixture", "restore", "fixture", "--yes"]);
+    }
+    expect(process.exitCode).toBe(failed ? 1 : 0);
+    expect(outro.mock.calls.at(-1)?.[0]).toContain(failed ? "Partial restore" : "Done.");
+});

--- a/src/cmux/index.ts
+++ b/src/cmux/index.ts
@@ -14,6 +14,7 @@
  *   tools cmux send-self <text> [--no-enter]
  */
 
+import { registerCaptureCommand } from "@app/cmux/commands/capture";
 import { registerDoctorCommand } from "@app/cmux/commands/doctor";
 import { registerProfilesCommand } from "@app/cmux/commands/profiles";
 import { registerRescueCommand } from "@app/cmux/commands/rescue";
@@ -35,6 +36,7 @@ program
     .showHelpAfterError(true)
     .option("-v, --verbose", "Enable debug logging");
 
+registerCaptureCommand(program);
 registerProfilesCommand(program);
 registerRestoreAfterRestartCommand(program);
 registerSendSelfCommand(program);

--- a/src/cmux/lib/agent-replay.test.ts
+++ b/src/cmux/lib/agent-replay.test.ts
@@ -48,6 +48,10 @@ function terminal(title: string, extra: Partial<TerminalSurface> = {}): Terminal
 }
 
 describe("inferLauncherFromTitle", () => {
+    test("recognizes Claude's quarter-circle status titles", () => {
+        expect(inferLauncherFromTitle("◐ account migration")).toBe("claude");
+        expect(inferLauncherFromTitle("◑ transcript work")).toBe("claude");
+    });
     test("detects a grok tab even when the live title has a spinner prefix", () => {
         expect(inferLauncherFromTitle("PRs merged into release/2026-09-03 - grok")).toBe("grok");
         expect(inferLauncherFromTitle("project-notes - grok · 33a9c763")).toBe("grok");
@@ -362,5 +366,36 @@ describe("withInferredReplayCommands", () => {
             expect(surface.command).not.toContain(decoy);
             expect(surface.command_original).toBeUndefined();
         }
+    });
+});
+
+test("shell journal commands survive restoration even when the title names another agent", () => {
+    const profile = profileWith([
+        {
+            type: "terminal",
+            title: "grok",
+            command: "codex --model custom",
+            command_source: "shell-journal",
+            cwd: "/launch cwd",
+        },
+    ]);
+    const restored = withInferredReplayCommands(profile, catalog([grokSession()]));
+    expect(restored.windows[0].workspaces[0].panes[0].surfaces[0]).toMatchObject({
+        command: "codex --model custom",
+        command_source: "shell-journal",
+        cwd: "/launch cwd",
+    });
+});
+
+test("raw journal launchers can infer matching sessions without trusting conflicting titles", () => {
+    const profile = profileWith([
+        terminal("PRs merged into release/2026-09-03 - grok", {
+            command: "grok --model custom",
+            command_source: "shell-journal",
+        }),
+    ]);
+    const restored = withInferredReplayCommands(profile, catalog([grokSession()]));
+    expect(restored.windows[0].workspaces[0].panes[0].surfaces[0]).toMatchObject({
+        command: `grok --model custom -r ${GROK_ID}`,
     });
 });

--- a/src/cmux/lib/agent-replay.ts
+++ b/src/cmux/lib/agent-replay.ts
@@ -30,7 +30,7 @@ export interface ReplayCatalog {
     sessions: ReplayCatalogSession[];
 }
 
-const SPINNER_PREFIX = /^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✳⠐●○]\s*/u;
+const SPINNER_PREFIX = /^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✳⠐●○◐◑◒◓]\s*/u;
 
 export function inferLauncherFromTitle(title: string): AgentKind | undefined {
     if (/\s-\s+grok\b/i.test(title) || /\bgrok\s*$/i.test(title.trim())) {
@@ -41,7 +41,7 @@ export function inferLauncherFromTitle(title: string): AgentKind | undefined {
         return "codex";
     }
 
-    if (/^[✳⠐]/.test(title.trim())) {
+    if (/^[✳⠐◐◑◒◓]/.test(title.trim())) {
         return "claude";
     }
 
@@ -220,13 +220,18 @@ function pinnedSessionForSurface(
 }
 
 export function replayCommandForSurface(
-    surface: Pick<TerminalSurface, "title" | "cwd" | "command">,
+    surface: Pick<TerminalSurface, "title" | "cwd" | "command" | "command_source">,
     catalog: ReplayCatalog,
     preferred?: ReplayCatalogSession
 ): { command?: string; drift: string[] } {
     const captured = surface.command?.trim();
-    const launcher = inferLauncherFromTitle(surface.title);
+    const titleLauncher = inferLauncherFromTitle(surface.title);
     const capturedKind = captured ? agentKindFromLauncher(captured) : undefined;
+    const trusted = surface.command_source === "shell-journal";
+    const launcher = trusted ? capturedKind : titleLauncher;
+    if (trusted && captured && !isAgentLauncher(captured)) {
+        return { command: surface.command, drift: [] };
+    }
     // A crash capture often attributes the surviving grok tty to a Claude tab.
     // The tab title is the identity; a mismatched launcher is discarded.
     const original = captured && capturedKind && launcher && capturedKind !== launcher ? undefined : captured;
@@ -287,6 +292,16 @@ export function withInferredReplayCommands(profile: Profile, catalog: ReplayCata
                     ...pane,
                     surfaces: pane.surfaces.map((surface) => {
                         if (surface.type !== "terminal") {
+                            return surface;
+                        }
+
+                        if (
+                            (surface.resume ||
+                                (surface.command_source === "shell-journal" &&
+                                    (!isAgentLauncher(surface.command ?? "") ||
+                                        resumeTargetFromCommand(surface.command ?? "")))) &&
+                            surface.command
+                        ) {
                             return surface;
                         }
 

--- a/src/cmux/lib/autosave.ts
+++ b/src/cmux/lib/autosave.ts
@@ -19,6 +19,23 @@ export interface AutosavePanel {
     directory?: string;
     ttyName?: string;
     listeningPorts?: number[];
+    browser?: { urlString?: string };
+    terminal?: {
+        workingDirectory?: string;
+        scrollback?: string;
+        tmuxStartCommand?: string;
+        agent?: {
+            kind: "claude" | "grok" | "codex";
+            sessionId?: string;
+            workingDirectory?: string;
+            launchCommand?: { arguments?: string[]; executablePath?: string; workingDirectory?: string };
+        };
+        resumeBinding?: { kind: "claude" | "grok" | "codex"; checkpointId?: string; cwd?: string; command?: string };
+    };
+}
+
+export function panelWorkingDirectory(panel: AutosavePanel): string | undefined {
+    return panel.directory ?? panel.terminal?.workingDirectory;
 }
 
 export interface AutosaveLayoutPaneNode {

--- a/src/cmux/lib/capture-collector-lifecycle.test.ts
+++ b/src/cmux/lib/capture-collector-lifecycle.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { copyFileSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { enableScreenCollector, screenCollectorStatus } from "@app/cmux/lib/capture-collector-lifecycle";
+import { installCapture, uninstallCapture } from "@app/cmux/lib/capture-installer";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+test("default install owns one detached collector and uninstall stops it without deleting cache", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-collector-home-"));
+    const root = join(home, ".genesis-tools/cmux");
+    try {
+        const installed = await installCapture({ home });
+        expect(installed.screens).toMatchObject({ enabled: true, running: true, ownerMatches: true });
+        const again = await installCapture({ home });
+        expect(again.screens.pid).toBe(installed.screens.pid);
+        expect(again.changed).toBe(false);
+        writeFileSync(join(root, "cached-fixture.txt"), "retain");
+    } finally {
+        uninstallCapture({ home });
+    }
+
+    for (let attempt = 0; attempt < 60 && screenCollectorStatus(root).running; attempt++) {
+        await Bun.sleep(25);
+    }
+
+    expect(screenCollectorStatus(root)).toMatchObject({ enabled: false, running: false });
+    expect(readFileSync(join(root, "cached-fixture.txt"), "utf8")).toBe("retain");
+});
+
+test("a stale owner PID cannot block a fresh collector token or cause a process signal", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-collector-stale-"));
+    const root = join(home, ".genesis-tools/cmux");
+    await installCapture({ home, screens: false });
+    const staleToken = "11111111-1111-4111-8111-111111111111";
+    writeFileSync(join(root, "screens.enabled"), staleToken);
+    writeFileSync(join(root, "screens.pid.json"), SafeJSON.stringify({ pid: process.pid, ownerToken: staleToken }));
+    writeFileSync(join(root, `screens.${staleToken}.lock`), "old owner");
+    expect(screenCollectorStatus(root).running).toBe(false);
+    try {
+        const installed = await installCapture({ home });
+        expect(installed.screens.running).toBe(true);
+        expect(readFileSync(join(root, "screens.enabled"), "utf8")).not.toBe(staleToken);
+    } finally {
+        uninstallCapture({ home });
+    }
+
+    for (let attempt = 0; attempt < 60 && screenCollectorStatus(root).running; attempt++) {
+        await Bun.sleep(25);
+    }
+
+    expect(screenCollectorStatus(root).running).toBe(false);
+});
+
+test("a new bundled collector version replaces the old owner without signaling it", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-collector-upgrade-"));
+    const root = join(home, ".genesis-tools/cmux");
+    try {
+        const installed = await installCapture({ home });
+        const runtimeDir = join(root, "runtime");
+        const source = readdirSync(runtimeDir).find((n) => n.startsWith("capture-watch-"))!;
+        const runtimePath = join(runtimeDir, "capture-watch-0000000000000000.js");
+        copyFileSync(join(runtimeDir, source), runtimePath);
+        expect(await enableScreenCollector({ root, runtimePath, bunPath: process.execPath })).toBe(true);
+        expect(screenCollectorStatus(root).pid).not.toBe(installed.screens.pid);
+    } finally {
+        uninstallCapture({ home });
+    }
+});

--- a/src/cmux/lib/capture-collector-lifecycle.test.ts
+++ b/src/cmux/lib/capture-collector-lifecycle.test.ts
@@ -1,10 +1,25 @@
-import { expect, test } from "bun:test";
-import { copyFileSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { copyFileSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { enableScreenCollector, screenCollectorStatus } from "@app/cmux/lib/capture-collector-lifecycle";
 import { installCapture, uninstallCapture } from "@app/cmux/lib/capture-installer";
+import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
+
+const originalEnvironment = env.testing.snapshot();
+const fixtureHome = mkdtempSync(join(tmpdir(), "cmux-collector-os-home-"));
+const fixtureBin = join(fixtureHome, "bin");
+const fixtureAutosave = join(fixtureHome, "Library/Application Support/cmux");
+mkdirSync(fixtureBin, { recursive: true });
+mkdirSync(fixtureAutosave, { recursive: true });
+writeFileSync(join(fixtureBin, "cmux"), "#!/bin/sh\nexit 99\n", { mode: 0o700 });
+writeFileSync(join(fixtureAutosave, "session-fixture.json"), SafeJSON.stringify({ windows: [] }));
+beforeEach(() => {
+    env.testing.set("HOME", fixtureHome);
+    env.testing.set("PATH", `${fixtureBin}:${originalEnvironment.PATH ?? ""}`);
+});
+afterEach(() => env.testing.restore(originalEnvironment));
 
 test("default install owns one detached collector and uninstall stops it without deleting cache", async () => {
     const home = mkdtempSync(join(tmpdir(), "cmux-collector-home-"));

--- a/src/cmux/lib/capture-collector-lifecycle.test.ts
+++ b/src/cmux/lib/capture-collector-lifecycle.test.ts
@@ -66,4 +66,16 @@ test("a new bundled collector version replaces the old owner without signaling i
     } finally {
         uninstallCapture({ home });
     }
+    for (let attempt = 0; attempt < 60 && screenCollectorStatus(root).running; attempt++) {
+        await Bun.sleep(25);
+    }
+    expect(screenCollectorStatus(root).running).toBe(false);
+});
+
+test("a malformed owner record reports not running instead of throwing", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-owner-repair-"));
+    await installCapture({ home, screens: false });
+    const root = join(home, ".genesis-tools/cmux");
+    writeFileSync(join(root, "screens.pid.json"), "{broken");
+    expect(screenCollectorStatus(root)).toMatchObject({ running: false, ownerMatches: false });
 });

--- a/src/cmux/lib/capture-collector-lifecycle.ts
+++ b/src/cmux/lib/capture-collector-lifecycle.ts
@@ -1,0 +1,143 @@
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+    closeSync,
+    existsSync,
+    mkdirSync,
+    openSync,
+    readFileSync,
+    renameSync,
+    unlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { parseJSON } from "@genesiscz/utils/json";
+import { z } from "zod";
+
+const ownerSchema = z.object({ pid: z.number().int().positive(), ownerToken: z.string().uuid() });
+
+export interface ScreenCollectorStatus {
+    enabled: boolean;
+    running: boolean;
+    ownerMatches: boolean;
+    pid?: number;
+    runtimeFile?: string;
+}
+
+function readOptional(path: string): string | undefined {
+    try {
+        return readFileSync(path, "utf8");
+    } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+export function screenCollectorStatus(root: string): ScreenCollectorStatus {
+    const marker = join(root, "screens.enabled");
+    const token = readOptional(marker)?.trim();
+    const enabled = token !== undefined;
+    const pidText = readOptional(join(root, "screens.pid.json"));
+    if (!pidText) {
+        return { enabled, running: false, ownerMatches: false };
+    }
+
+    const owner = ownerSchema.safeParse(parseJSON<object>(pidText));
+    if (!owner.success) {
+        return { enabled, running: false, ownerMatches: false };
+    }
+
+    const processInfo = spawnSync("/bin/ps", ["-p", String(owner.data.pid), "-o", "command="], { encoding: "utf8" });
+    const running =
+        processInfo.status === 0 &&
+        processInfo.stdout.includes("capture-watch-") &&
+        processInfo.stdout.includes(root) &&
+        processInfo.stdout.includes(owner.data.ownerToken);
+    const ownerMatches = token === owner.data.ownerToken;
+    return {
+        enabled,
+        running,
+        ownerMatches,
+        pid: running ? owner.data.pid : undefined,
+        runtimeFile: running ? processInfo.stdout.match(/capture-watch-[a-f0-9]{16}\.js/)?.[0] : undefined,
+    };
+}
+
+export function disableScreenCollector(root: string): boolean {
+    const marker = join(root, "screens.enabled");
+    if (!existsSync(marker)) {
+        return false;
+    }
+
+    unlinkSync(marker);
+    return true;
+}
+
+export async function enableScreenCollector(input: {
+    root: string;
+    runtimePath: string;
+    bunPath: string;
+}): Promise<boolean> {
+    let current = screenCollectorStatus(input.root);
+    for (let attempt = 0; attempt < 3 && current.enabled && current.ownerMatches && !current.running; attempt++) {
+        await Bun.sleep(25);
+        current = screenCollectorStatus(input.root);
+    }
+    if (
+        current.enabled &&
+        current.running &&
+        current.ownerMatches &&
+        current.runtimeFile === basename(input.runtimePath)
+    ) {
+        return false;
+    }
+
+    mkdirSync(input.root, { recursive: true, mode: 0o700 });
+    const marker = join(input.root, "screens.enabled");
+    const ownerToken = randomUUID();
+    const nextMarker = `${marker}.${ownerToken}.tmp`;
+    writeFileSync(nextMarker, ownerToken, { flag: "wx", mode: 0o600 });
+    renameSync(nextMarker, marker);
+    const logFd = openSync(join(input.root, "screens-process.log"), "a", 0o600);
+    let startError: Error | undefined;
+    try {
+        const child = spawn(
+            input.bunPath,
+            [input.runtimePath, "--control-dir", input.root, "--owner-token", ownerToken],
+            {
+                detached: true,
+                stdio: ["ignore", logFd, logFd],
+                env: {
+                    ...env.getProcessEnv(),
+
+                    GENESIS_TOOLS_HOME: dirname(dirname(input.root)),
+                },
+            }
+        );
+        child.once("error", (error) => {
+            startError = error;
+        });
+        child.unref();
+    } finally {
+        closeSync(logFd);
+    }
+
+    for (let attempt = 0; attempt < 80; attempt++) {
+        if (startError) {
+            throw startError;
+        }
+
+        const status = screenCollectorStatus(input.root);
+        if (status.running && status.ownerMatches) {
+            return true;
+        }
+
+        await Bun.sleep(25);
+    }
+
+    throw new Error(`cmux screen collector did not start; inspect ${join(input.root, "screens-process.log")}`);
+}

--- a/src/cmux/lib/capture-collector-lifecycle.ts
+++ b/src/cmux/lib/capture-collector-lifecycle.ts
@@ -13,6 +13,7 @@ import {
 import { basename, dirname, join } from "node:path";
 import { env } from "@genesiscz/utils/env";
 import { parseJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
 import { z } from "zod";
 
 const ownerSchema = z.object({ pid: z.number().int().positive(), ownerToken: z.string().uuid() });
@@ -46,7 +47,14 @@ export function screenCollectorStatus(root: string): ScreenCollectorStatus {
         return { enabled, running: false, ownerMatches: false };
     }
 
-    const owner = ownerSchema.safeParse(parseJSON<object>(pidText));
+    let parsed: object | null;
+    try {
+        parsed = parseJSON<object>(pidText);
+    } catch (error) {
+        logger.debug({ error, root }, "[cmux-screens] unreadable ownership record");
+        return { enabled, running: false, ownerMatches: false };
+    }
+    const owner = ownerSchema.safeParse(parsed);
     if (!owner.success) {
         return { enabled, running: false, ownerMatches: false };
     }

--- a/src/cmux/lib/capture-installer.test.ts
+++ b/src/cmux/lib/capture-installer.test.ts
@@ -20,6 +20,8 @@ import {
     uninstallCapture,
 } from "@app/cmux/lib/capture-installer";
 import { loadCapturedCommands } from "@app/cmux/lib/capture-journal";
+import { buildOfflinePanes } from "@app/cmux/lib/offline-snapshot";
+import { SafeJSON } from "@genesiscz/utils/json";
 
 test("installation is idempotent and uninstall preserves unrelated rc bytes and journal data", async () => {
     const home = mkdtempSync(join(tmpdir(), "cmux-install-home-"));
@@ -61,8 +63,40 @@ test("installed recorder survives removal of its source checkout entrypoint and 
     const result = await installCapture({ home, recorderEntrypoint: entrypoint, screens: false });
     renameSync(source, `${source}-removed`);
     expect(existsSync(entrypoint)).toBe(false);
+    const direct = Bun.spawn(
+        [
+            resolveCaptureBun(),
+            result.runtimePath!,
+            "completed",
+            "44444444-4444-4444-8444-444444444444",
+            home,
+            "",
+            "0",
+            join(home, ".genesis-tools/cmux/command-journal"),
+        ],
+        {
+            cwd: tmpdir(),
+            stdin: "pipe",
+            stdout: "pipe",
+            stderr: "pipe",
+            env: { HOME: home, GENESIS_TOOLS_HOME: home, PATH: "/usr/bin:/bin" },
+        }
+    );
+    direct.stdin.write("printf direct-runtime");
+    direct.stdin.end();
+    const [directCode, directError] = await Promise.all([
+        direct.exited,
+        new Response(direct.stderr).text(),
+        new Response(direct.stdout).text(),
+    ]);
+    expect({ directCode, directError }).toEqual({ directCode: 0, directError: "" });
+    expect(
+        loadCapturedCommands({ directory: join(home, ".genesis-tools/cmux/command-journal") }).get(
+            "44444444-4444-4444-8444-444444444444"
+        )?.command
+    ).toBe("printf direct-runtime");
     const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
-        cwd: "/private/tmp",
+        cwd: tmpdir(),
         stdin: "pipe",
         stdout: "pipe",
         stderr: "pipe",
@@ -144,7 +178,7 @@ test("reinstall updates a stable runtime entrypoint without rewriting shell conf
     expect(second.runtimePath).not.toBe(first.runtimePath);
     expect(readFileSync(second.rcPath, "utf8")).toBe(rc);
     expect(readFileSync(second.hookPath, "utf8")).toBe(hook);
-    const proc = Bun.spawn([process.execPath, entry], { cwd: "/private/tmp", stdout: "pipe", stderr: "pipe" });
+    const proc = Bun.spawn([process.execPath, entry], { cwd: tmpdir(), stdout: "pipe", stderr: "pipe" });
     expect(await new Response(proc.stdout).text()).toBe("version-two");
     expect(await proc.exited).toBe(0);
 });
@@ -211,4 +245,69 @@ test("an rc edit during bundling cannot publish a new runtime link", async () =>
     } finally {
         spy.mockRestore();
     }
+});
+
+test("commands-only shell startup associates identity for recovery after runtime IDs change", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-no-screens-identity-"));
+    const runtimeId = "11111111-1111-4111-8111-111111111111";
+    const stableId = "22222222-2222-4222-8222-222222222222";
+    const installed = await installCapture({ home, screens: false });
+    const native = join(home, "Library/Application Support/cmux");
+    mkdirSync(native, { recursive: true });
+    writeFileSync(
+        join(native, "session-fixture.json"),
+        SafeJSON.stringify({
+            windows: [
+                {
+                    tabManager: {
+                        workspaces: [
+                            {
+                                layout: { type: "pane", pane: { panelIds: [runtimeId] } },
+                                panels: [{ id: runtimeId, stableSurfaceId: stableId, type: "terminal" }],
+                            },
+                        ],
+                    },
+                },
+            ],
+        })
+    );
+    const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { PATH: "/bin:/usr/bin", HOME: home, GENESIS_TOOLS_HOME: home, CMUX_SURFACE_ID: runtimeId },
+    });
+    proc.stdin.write(`source '${installed.hookPath}'\nprintf '%s' saved-command\n`);
+    proc.stdin.end();
+    const [code] = await Promise.all([proc.exited, new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+    expect(code).toBe(0);
+    const directory = join(home, ".genesis-tools/cmux/command-journal");
+    for (let attempt = 0; attempt < 100 && !existsSync(join(directory, `${runtimeId}.identity`)); attempt++) {
+        await Bun.sleep(20);
+    }
+    const commands = loadCapturedCommands({ directory });
+    expect(commands.get(stableId)?.stableSurfaceId).toBe(stableId);
+    const nextId = "33333333-3333-4333-8333-333333333333";
+    const panes = buildOfflinePanes(
+        {
+            layout: { type: "pane", pane: { panelIds: [nextId] } },
+            panels: [{ id: nextId, stableSurfaceId: stableId, type: "terminal" }],
+        },
+        { x: 0, y: 0, width: 800, height: 600 },
+        { ttyCommands: new Map(), surfaceSessions: new Map(), surfaceCommands: commands }
+    );
+    expect(panes[0].surfaces[0]).toMatchObject({
+        command: "printf '%s' saved-command",
+        command_source: "shell-journal",
+    });
+    expect(captureInstallationStatus({ home }).screens.enabled).toBe(false);
+});
+
+test("status detects and reinstall repairs a missing managed recorder symlink", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-link-repair-"));
+    await installCapture({ home, screens: false });
+    const entry = join(home, ".genesis-tools/cmux/runtime/capture-record.js");
+    renameSync(entry, `${entry}.old`);
+    expect(captureInstallationStatus({ home }).runtimeValid).toBe(false);
+    expect((await installCapture({ home, screens: false })).runtimeValid).toBe(true);
 });

--- a/src/cmux/lib/capture-installer.test.ts
+++ b/src/cmux/lib/capture-installer.test.ts
@@ -1,0 +1,181 @@
+import { expect, test } from "bun:test";
+import {
+    cpSync,
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    renameSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+    captureInstallationStatus,
+    installCapture,
+    resolveCaptureBun,
+    uninstallCapture,
+} from "@app/cmux/lib/capture-installer";
+import { loadCapturedCommands } from "@app/cmux/lib/capture-journal";
+
+test("installation is idempotent and uninstall preserves unrelated rc bytes and journal data", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-install-home-"));
+    const rcPath = join(home, ".zshrc");
+    const original = "# keep this exactly\r\nexport EXAMPLE='two words'";
+    writeFileSync(rcPath, original);
+    const installed = await installCapture({ home, screens: false });
+    expect(installed.installed).toBe(true);
+    expect(readFileSync(installed.backupPath!, "utf8")).toBe(original);
+    const firstRc = readFileSync(rcPath, "utf8");
+    const again = await installCapture({ home, screens: false });
+    expect(again.changed).toBe(false);
+    expect(again.backupPath).toBeUndefined();
+    expect(readFileSync(rcPath, "utf8")).toBe(firstRc);
+    const journal = join(home, ".genesis-tools/cmux/command-journal");
+    mkdirSync(journal, { recursive: true });
+    writeFileSync(join(journal, "keep.txt"), "fixture data");
+    uninstallCapture({ home });
+    expect(readFileSync(rcPath, "utf8")).toBe(original);
+    expect(readFileSync(join(journal, "keep.txt"), "utf8")).toBe("fixture data");
+    expect(captureInstallationStatus({ home }).installed).toBe(false);
+});
+
+test("status on an unconfigured home does not create files", () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-install-status-"));
+    expect(captureInstallationStatus({ home }).installed).toBe(false);
+    expect(readdirSync(home)).toEqual([]);
+});
+
+test("installed recorder survives removal of its source checkout entrypoint and runs from tmp", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-install-relocate-"));
+    const source = join(directory, "checkout");
+    const home = join(directory, "home");
+    const entrypoint = join(source, "src/cmux/capture-record.ts");
+    cpSync(resolve("src/cmux"), join(source, "src/cmux"), { recursive: true });
+    cpSync(resolve("tsconfig.json"), join(source, "tsconfig.json"));
+    symlinkSync(resolve("src/utils"), join(source, "src/utils"));
+    symlinkSync(resolve("node_modules"), join(source, "node_modules"));
+    const result = await installCapture({ home, recorderEntrypoint: entrypoint, screens: false });
+    renameSync(source, `${source}-removed`);
+    expect(existsSync(entrypoint)).toBe(false);
+    const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
+        cwd: "/private/tmp",
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+            HOME: home,
+            GENESIS_TOOLS_HOME: home,
+            PATH: "/usr/bin:/bin",
+            CMUX_SURFACE_ID: "11111111-1111-4111-8111-111111111111",
+        },
+    });
+    proc.stdin.write(`source '${result.hookPath}'\nprintf '%s' 'portable capture'\n`);
+    proc.stdin.end();
+    const [output, errors, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    expect(code).toBe(0);
+    expect(errors).not.toContain("capture failed");
+    expect(output).toContain("portable capture");
+    expect(
+        loadCapturedCommands({ directory: join(home, ".genesis-tools/cmux/command-journal") }).get(
+            "11111111-1111-4111-8111-111111111111"
+        )?.command
+    ).toBe("printf '%s' 'portable capture'");
+});
+
+test("legacy migration removes only our exact source line and backs up the original", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-install-legacy-"));
+    const rcPath = join(home, ".zshrc");
+    const original =
+        "# source ~/.genesis-tools/cmux/capture.zsh\nsource ~/.genesis-tools/cmux/capture.zsh\nsource ~/other/capture.zsh\n";
+    writeFileSync(rcPath, original);
+    const installed = await installCapture({ home, screens: false });
+    expect(readFileSync(installed.backupPath!, "utf8")).toBe(original);
+    expect(installed.legacySource).toBe(false);
+    expect((await installCapture({ home, screens: false })).changed).toBe(false);
+    uninstallCapture({ home });
+    expect(readFileSync(rcPath, "utf8")).toBe(
+        "# source ~/.genesis-tools/cmux/capture.zsh\nsource ~/other/capture.zsh\n"
+    );
+});
+
+test("malformed managed markers fail before changing shell configuration", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-install-malformed-"));
+    const rcPath = join(home, ".zshrc");
+    writeFileSync(rcPath, "# >>> GenesisTools cmux capture >>>\nuser content\n");
+    await expect(installCapture({ home, screens: false })).rejects.toThrow("malformed");
+    expect(readFileSync(rcPath, "utf8")).toBe("# >>> GenesisTools cmux capture >>>\nuser content\n");
+    expect(existsSync(join(home, ".genesis-tools"))).toBe(false);
+});
+
+test("Bun selection prefers PATH over a transient macOS launcher execPath", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-bun-selection-"));
+    const bun = join(directory, "bun");
+    symlinkSync(process.argv[0], bun);
+    expect(
+        resolveCaptureBun({ searchPath: directory, execPath: "/fixture/gt-macos", argv0: "/fixture/gt-macos" })
+    ).toBe(bun);
+    expect(
+        resolveCaptureBun({ searchPath: "/nonexistent", execPath: "/fixture/gt-macos", argv0: process.argv[0] })
+    ).toBe(process.argv[0]);
+    expect(() =>
+        resolveCaptureBun({ searchPath: "/nonexistent", execPath: "/fixture/gt-macos", argv0: "/fixture/gt-macos" })
+    ).toThrow("Bun executable");
+});
+
+test("reinstall updates a stable runtime entrypoint without rewriting shell configuration", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-runtime-update-"));
+    const source = join(home, "example-recorder.ts");
+    writeFileSync(source, 'process.stdout.write("version-one");');
+    const first = await installCapture({ home, screens: false, recorderEntrypoint: source });
+    const hook = readFileSync(first.hookPath, "utf8");
+    const rc = readFileSync(first.rcPath, "utf8");
+    const entry = join(home, ".genesis-tools/cmux/runtime/capture-record.js");
+    expect(existsSync(entry)).toBe(true);
+    writeFileSync(source, 'process.stdout.write("version-two");');
+    const second = await installCapture({ home, screens: false, recorderEntrypoint: source });
+    expect(second.runtimePath).not.toBe(first.runtimePath);
+    expect(readFileSync(second.rcPath, "utf8")).toBe(rc);
+    expect(readFileSync(second.hookPath, "utf8")).toBe(hook);
+    const proc = Bun.spawn([process.execPath, entry], { cwd: "/private/tmp", stdout: "pipe", stderr: "pipe" });
+    expect(await new Response(proc.stdout).text()).toBe("version-two");
+    expect(await proc.exited).toBe(0);
+});
+
+test("an rc edit after preview refuses installation before writing artifacts", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-preview-race-"));
+    const rc = join(home, ".zshrc");
+    writeFileSync(rc, "export EXAMPLE_SETTING=newer\n");
+    await expect(
+        installCapture({ home, screens: false, expectedRc: "export EXAMPLE_SETTING=older\n" })
+    ).rejects.toThrow("changed after preview");
+    expect(readFileSync(rc, "utf8")).toBe("export EXAMPLE_SETTING=newer\n");
+    expect(existsSync(join(home, ".genesis-tools/cmux/runtime"))).toBe(false);
+});
+
+test("reinstallation preserves a managed block with unrelated content appended after it", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-install-position-"));
+    const rcPath = join(home, ".zshrc");
+    await installCapture({ home, screens: false });
+    const before = `${readFileSync(rcPath, "utf8")}\n# later configuration\nexport EXAMPLE=ok\n`;
+    writeFileSync(rcPath, before);
+    const result = await installCapture({ home, screens: false });
+    expect(result.changed).toBe(false);
+    expect(readFileSync(rcPath, "utf8")).toBe(before);
+});
+
+test("uninstall retains the separator between surrounding rc statements", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-install-separator-"));
+    const rcPath = join(home, ".zshrc");
+    writeFileSync(rcPath, "export FIRST=one");
+    await installCapture({ home, screens: false });
+    writeFileSync(rcPath, `${readFileSync(rcPath, "utf8")}export SECOND=two\n`);
+    uninstallCapture({ home });
+    expect(readFileSync(rcPath, "utf8")).toBe("export FIRST=one\nexport SECOND=two\n");
+});

--- a/src/cmux/lib/capture-installer.test.ts
+++ b/src/cmux/lib/capture-installer.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import {
     cpSync,
     existsSync,
@@ -6,6 +6,7 @@ import {
     mkdtempSync,
     readdirSync,
     readFileSync,
+    readlinkSync,
     renameSync,
     symlinkSync,
     writeFileSync,
@@ -178,4 +179,36 @@ test("uninstall retains the separator between surrounding rc statements", async 
     writeFileSync(rcPath, `${readFileSync(rcPath, "utf8")}export SECOND=two\n`);
     uninstallCapture({ home });
     expect(readFileSync(rcPath, "utf8")).toBe("export FIRST=one\nexport SECOND=two\n");
+});
+
+test("a malformed manifest is reported invalid and repaired by reinstall", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-manifest-repair-"));
+    await installCapture({ home, screens: false });
+    writeFileSync(join(home, ".genesis-tools/cmux/runtime/installation.json"), "{broken");
+    expect(captureInstallationStatus({ home }).runtimeValid).toBe(false);
+    expect((await installCapture({ home, screens: false })).runtimeValid).toBe(true);
+});
+
+test("an rc edit during bundling cannot publish a new runtime link", async () => {
+    const home = mkdtempSync(join(tmpdir(), "cmux-install-race-"));
+    await installCapture({ home, screens: false });
+    const link = join(home, ".genesis-tools/cmux/runtime/capture-record.js");
+    const originalLink = readlinkSync(link);
+    const entry = join(home, "recorder.ts");
+    writeFileSync(entry, 'process.stdout.write("new runtime");');
+    const build = Bun.build.bind(Bun);
+    const spy = spyOn(Bun, "build").mockImplementation(async (options) => {
+        const result = await build(options);
+        writeFileSync(join(home, ".zshrc"), "# changed during build\n");
+        return result;
+    });
+    try {
+        await expect(installCapture({ home, screens: false, recorderEntrypoint: entry })).rejects.toThrow(
+            "changed during installation"
+        );
+        expect(readlinkSync(link)).toBe(originalLink);
+        expect(readFileSync(join(home, ".zshrc"), "utf8")).toBe("# changed during build\n");
+    } finally {
+        spy.mockRestore();
+    }
 });

--- a/src/cmux/lib/capture-installer.ts
+++ b/src/cmux/lib/capture-installer.ts
@@ -199,12 +199,16 @@ export function captureInstallationStatus(options: CaptureInstallOptions = {}): 
     let runtimeFile: string | undefined;
 
     if (existsSync(location.manifestPath)) {
-        const manifest = manifestSchema.safeParse(SafeJSON.parse(readFileSync(location.manifestPath, "utf8")));
-        if (manifest.success) {
-            runtimeFile = manifest.data.runtimeFile;
-            runtimePath = join(location.runtimeDir, manifest.data.runtimeFile);
-            runtimeValid =
-                existsSync(runtimePath) && digest(readFileSync(runtimePath, "utf8")) === manifest.data.sha256;
+        try {
+            const manifest = manifestSchema.safeParse(SafeJSON.parse(readFileSync(location.manifestPath, "utf8")));
+            if (manifest.success) {
+                runtimeFile = manifest.data.runtimeFile;
+                runtimePath = join(location.runtimeDir, manifest.data.runtimeFile);
+                runtimeValid =
+                    existsSync(runtimePath) && digest(readFileSync(runtimePath, "utf8")) === manifest.data.sha256;
+            }
+        } catch (error) {
+            logger.warn({ error, path: location.manifestPath }, "[cmux-install] invalid installation manifest");
         }
     }
 
@@ -322,15 +326,19 @@ export async function installCapture(
         directory: join(location.root, "command-journal"),
     });
     const runtimeChanged = atomicWrite(runtimePath, runtime);
-    const linkChanged = updateRuntimeLink(location.runtimeDir, runtimeFile);
+
     const watcherChanged =
         watcher && watcherFile ? atomicWrite(join(location.runtimeDir, watcherFile), watcher) : false;
+    if (readRc(location.rcPath) !== before) {
+        throw new Error("Shell configuration changed during installation; review it again before installing.");
+    }
+    const backupPath = replaceRc({ path: location.rcPath, before, after });
+    const linkChanged = updateRuntimeLink(location.runtimeDir, runtimeFile);
     const hookChanged = atomicWrite(location.hookPath, hook);
     const manifestChanged = atomicWrite(
         location.manifestPath,
         `${SafeJSON.stringify({ version: 1, runtimeFile, sha256, watcherFile })}\n`
     );
-    const backupPath = replaceRc({ path: location.rcPath, before, after });
     const collectorChanged = watcherFile
         ? await enableScreenCollector({
               root: location.root,

--- a/src/cmux/lib/capture-installer.ts
+++ b/src/cmux/lib/capture-installer.ts
@@ -1,0 +1,367 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+    chmodSync,
+    copyFileSync,
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    readFileSync,
+    readlinkSync,
+    realpathSync,
+    renameSync,
+    statSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+    disableScreenCollector,
+    enableScreenCollector,
+    type ScreenCollectorStatus,
+    screenCollectorStatus,
+} from "@app/cmux/lib/capture-collector-lifecycle";
+import { renderCaptureShell } from "@app/cmux/lib/capture-shell";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { z } from "zod";
+
+const START = "# >>> GenesisTools cmux capture >>>";
+const END = "# <<< GenesisTools cmux capture <<<";
+const manifestSchema = z.object({
+    version: z.literal(1),
+    runtimeFile: z.string().regex(/^capture-record-[a-f0-9]{16}\.js$/),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    watcherFile: z
+        .string()
+        .regex(/^capture-watch-[a-f0-9]{16}\.js$/)
+        .optional(),
+});
+
+export interface CaptureInstallOptions {
+    home?: string;
+    rcPath?: string;
+    expectedRc?: string;
+}
+
+export interface CaptureInstallationStatus {
+    installed: boolean;
+    rcPath: string;
+    hookPath: string;
+    runtimePath?: string;
+    managedBlock: boolean;
+    legacySource: boolean;
+    hookPresent: boolean;
+    runtimeValid: boolean;
+    screens: ScreenCollectorStatus;
+}
+
+function paths(options: CaptureInstallOptions) {
+    const home = resolve(options.home ?? env.tools.getHome());
+    const root = join(home, ".genesis-tools/cmux");
+    const configuredRc = resolve(options.rcPath ?? join(home, ".zshrc"));
+    let symlink = false;
+    try {
+        symlink = lstatSync(configuredRc).isSymbolicLink();
+    } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+            throw error;
+        }
+    }
+
+    const rcPath = symlink ? realpathSync(configuredRc) : configuredRc;
+    return {
+        home,
+        root,
+        rcPath,
+        hookPath: join(root, "capture.zsh"),
+        runtimeDir: join(root, "runtime"),
+        manifestPath: join(root, "runtime/installation.json"),
+    };
+}
+
+function readRc(path: string): string {
+    if (!existsSync(path)) {
+        return "";
+    }
+
+    const bytes = readFileSync(path);
+    const text = bytes.toString("utf8");
+    if (!Buffer.from(text).equals(bytes)) {
+        throw new Error(`Refusing to rewrite non-UTF-8 shell configuration: ${path}`);
+    }
+
+    return text;
+}
+
+function stripManagedBlock(text: string): string {
+    const blocks = [
+        ...text.matchAll(
+            /(?:^|\n)# >>> GenesisTools cmux capture >>>\r?\n[\s\S]*?\r?\n# <<< GenesisTools cmux capture <<<(?=\r?\n|$)(?:\r?\n)?/g
+        ),
+    ];
+    if (blocks.length > 1 || ((text.includes(START) || text.includes(END)) && blocks.length !== 1)) {
+        throw new Error(
+            "The cmux capture block is malformed or duplicated; preserve the rc file and repair the markers first."
+        );
+    }
+
+    const block = blocks[0];
+    if (!block) {
+        return text;
+    }
+
+    const before = text.slice(0, block.index);
+    const after = text.slice(block.index + block[0].length);
+    const separator = before && after && !before.endsWith("\n") && !after.startsWith("\n") ? "\n" : "";
+    return before + separator + after;
+}
+
+function stripLegacySource(text: string, hookPath: string): string {
+    const known = new Set([
+        "source ~/.genesis-tools/cmux/capture.zsh",
+        ". ~/.genesis-tools/cmux/capture.zsh",
+        'source "$HOME/.genesis-tools/cmux/capture.zsh"',
+        '. "$HOME/.genesis-tools/cmux/capture.zsh"',
+        `source '${hookPath}'`,
+        `source "${hookPath}"`,
+        `source ${hookPath}`,
+    ]);
+    return text
+        .split(/(?<=\n)/)
+        .filter((line) => !known.has(line.trim()))
+        .join("");
+}
+
+function digest(text: string): string {
+    return createHash("sha256").update(text).digest("hex");
+}
+
+function atomicWrite(path: string, text: string): boolean {
+    if (existsSync(path) && readFileSync(path, "utf8") === text) {
+        return false;
+    }
+
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const temporary = `${path}.${randomUUID()}.tmp`;
+    writeFileSync(temporary, text, { mode: existsSync(path) ? statSync(path).mode & 0o777 : 0o600, flag: "wx" });
+    renameSync(temporary, path);
+    return true;
+}
+
+function replaceRc(input: { path: string; before: string; after: string }): string | undefined {
+    if (input.before === input.after) {
+        return undefined;
+    }
+
+    if (readRc(input.path) !== input.before) {
+        throw new Error("Shell configuration changed during installation; retry to preserve the concurrent edit.");
+    }
+
+    let backupPath: string | undefined;
+    if (existsSync(input.path)) {
+        backupPath = `${input.path}.cmux-backup-${Date.now()}-${randomUUID()}`;
+        copyFileSync(input.path, backupPath);
+        chmodSync(backupPath, 0o600);
+    }
+
+    atomicWrite(input.path, input.after);
+    return backupPath;
+}
+
+function updateRuntimeLink(runtimeDir: string, runtimeFile: string): boolean {
+    const path = join(runtimeDir, "capture-record.js");
+    try {
+        if (!lstatSync(path).isSymbolicLink()) {
+            throw new Error(`Refusing to replace a non-symlink runtime entrypoint: ${path}`);
+        }
+        if (readlinkSync(path) === runtimeFile) {
+            return false;
+        }
+    } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+            throw error;
+        }
+    }
+    const temporary = `${path}.${randomUUID()}.tmp`;
+    symlinkSync(runtimeFile, temporary, "file");
+    renameSync(temporary, path);
+    return true;
+}
+
+export function captureInstallationStatus(options: CaptureInstallOptions = {}): CaptureInstallationStatus {
+    const location = paths(options);
+    const rc = readRc(location.rcPath);
+    const unmanaged = stripManagedBlock(rc);
+    const managedBlock = unmanaged !== rc;
+    let runtimePath: string | undefined;
+    let runtimeValid = false;
+    let runtimeFile: string | undefined;
+
+    if (existsSync(location.manifestPath)) {
+        const manifest = manifestSchema.safeParse(SafeJSON.parse(readFileSync(location.manifestPath, "utf8")));
+        if (manifest.success) {
+            runtimeFile = manifest.data.runtimeFile;
+            runtimePath = join(location.runtimeDir, manifest.data.runtimeFile);
+            runtimeValid =
+                existsSync(runtimePath) && digest(readFileSync(runtimePath, "utf8")) === manifest.data.sha256;
+        }
+    }
+
+    const hookPresent = existsSync(location.hookPath);
+    const entrypoint = join(location.runtimeDir, "capture-record.js");
+    if (hookPresent && readFileSync(location.hookPath, "utf8").includes(entrypoint)) {
+        try {
+            runtimeValid =
+                runtimeValid && lstatSync(entrypoint).isSymbolicLink() && readlinkSync(entrypoint) === runtimeFile;
+        } catch (error) {
+            logger.debug({ error, entrypoint }, "[cmux-install] managed runtime link unavailable");
+            runtimeValid = false;
+        }
+    }
+    return {
+        installed: managedBlock && hookPresent && runtimeValid,
+        rcPath: location.rcPath,
+        hookPath: location.hookPath,
+        runtimePath,
+        managedBlock,
+        legacySource: stripLegacySource(unmanaged, location.hookPath) !== unmanaged,
+        hookPresent,
+        runtimeValid,
+        screens: screenCollectorStatus(location.root),
+    };
+}
+
+export function planCaptureRcChange(options: CaptureInstallOptions & { action: "install" | "uninstall" }) {
+    const location = paths(options);
+    const before = readRc(location.rcPath);
+    const base = stripManagedBlock(before);
+    const sourceLine = `source '${location.hookPath.replace(/'/g, "'\\''")}'`;
+    const block = `${START}\n${sourceLine}\n${END}`;
+    const installedBlock =
+        /(^|\n)# >>> GenesisTools cmux capture >>>\r?\n[\s\S]*?\r?\n# <<< GenesisTools cmux capture <<<(?=\r?\n|$)/;
+    const after =
+        options.action === "uninstall"
+            ? base
+            : base !== before
+              ? before.replace(installedBlock, (matched, prefix: string) => {
+                    const newline = matched.includes("\r\n") ? "\r\n" : "\n";
+                    return `${prefix}${block.split("\n").join(newline)}`;
+                })
+              : `${stripLegacySource(base, location.hookPath)}\n${block}\n`;
+    return {
+        rcPath: location.rcPath,
+        before,
+        after,
+        block: options.action === "install" ? block : "",
+        changesRc: before !== after,
+    };
+}
+
+async function bundleRuntime(entrypoint: string): Promise<string> {
+    const build = await Bun.build({
+        entrypoints: [entrypoint],
+        target: "bun",
+        format: "esm",
+        minify: true,
+        sourcemap: "none",
+        tsconfig: resolve(import.meta.dir, "../../../tsconfig.json"),
+        plugins: [
+            {
+                name: "standalone-capture-diagnostics",
+                setup(builder) {
+                    builder.onResolve({ filter: /^@genesiscz\/utils\/logger$/ }, () => ({
+                        path: resolve(import.meta.dir, "capture-runtime-logger.ts"),
+                    }));
+                },
+            },
+        ],
+    });
+    if (!build.success || build.outputs.length !== 1) {
+        throw new Error(`Unable to bundle cmux runtime: ${build.logs.map(String).join("\n")}`);
+    }
+
+    return build.outputs[0].text();
+}
+
+/** process.execPath can temporarily identify the macOS launcher during concurrent subprocess work. */
+export function resolveCaptureBun(options: { searchPath?: string; argv0?: string; execPath?: string } = {}): string {
+    const fromPath = Bun.which("bun", { PATH: options.searchPath ?? env.getProcessEnv().PATH ?? "" });
+    const candidate =
+        fromPath ??
+        [options.argv0 ?? process.argv[0], options.execPath ?? process.execPath].find(
+            (path) => path && ["bun", "bun.exe"].includes(basename(path))
+        );
+    if (!candidate || !existsSync(candidate)) {
+        throw new Error("Bun executable not found; put Bun on PATH before installing cmux capture.");
+    }
+
+    return resolve(candidate);
+}
+
+export async function installCapture(
+    options: CaptureInstallOptions & { recorderEntrypoint?: string; screens?: boolean } = {}
+): Promise<CaptureInstallationStatus & { changed: boolean; backupPath?: string }> {
+    const bunPath = resolveCaptureBun();
+    const location = paths(options);
+    const { before, after } = planCaptureRcChange({ ...options, action: "install" });
+    if (options.expectedRc !== undefined && before !== options.expectedRc) {
+        throw new Error("Shell configuration changed after preview; review it again before installing.");
+    }
+    const runtime = await bundleRuntime(options.recorderEntrypoint ?? resolve(import.meta.dir, "../capture-record.ts"));
+    const watcher =
+        options.screens === false ? undefined : await bundleRuntime(resolve(import.meta.dir, "../capture-watch.ts"));
+    const watcherFile = watcher ? `capture-watch-${digest(watcher).slice(0, 16)}.js` : undefined;
+    const sha256 = digest(runtime);
+    const runtimeFile = `capture-record-${sha256.slice(0, 16)}.js`;
+    const runtimePath = join(location.runtimeDir, runtimeFile);
+    const hook = renderCaptureShell({
+        recorderPath: join(location.runtimeDir, "capture-record.js"),
+        bunPath: /\/(?:\.worktrees|node_modules)\//.test(bunPath) ? "" : bunPath,
+        preferPathBun: true,
+        directory: join(location.root, "command-journal"),
+    });
+    const runtimeChanged = atomicWrite(runtimePath, runtime);
+    const linkChanged = updateRuntimeLink(location.runtimeDir, runtimeFile);
+    const watcherChanged =
+        watcher && watcherFile ? atomicWrite(join(location.runtimeDir, watcherFile), watcher) : false;
+    const hookChanged = atomicWrite(location.hookPath, hook);
+    const manifestChanged = atomicWrite(
+        location.manifestPath,
+        `${SafeJSON.stringify({ version: 1, runtimeFile, sha256, watcherFile })}\n`
+    );
+    const backupPath = replaceRc({ path: location.rcPath, before, after });
+    const collectorChanged = watcherFile
+        ? await enableScreenCollector({
+              root: location.root,
+              runtimePath: join(location.runtimeDir, watcherFile),
+              bunPath,
+          })
+        : disableScreenCollector(location.root);
+    return {
+        ...captureInstallationStatus(options),
+        changed:
+            runtimeChanged ||
+            linkChanged ||
+            watcherChanged ||
+            hookChanged ||
+            manifestChanged ||
+            collectorChanged ||
+            before !== after,
+        backupPath,
+    };
+}
+
+export function uninstallCapture(
+    options: CaptureInstallOptions = {}
+): CaptureInstallationStatus & { changed: boolean; backupPath?: string } {
+    const location = paths(options);
+    const { before, after } = planCaptureRcChange({ ...options, action: "uninstall" });
+    if (options.expectedRc !== undefined && before !== options.expectedRc) {
+        throw new Error("Shell configuration changed after preview; review it again before uninstalling.");
+    }
+
+    const backupPath = replaceRc({ path: location.rcPath, before, after });
+    const collectorChanged = disableScreenCollector(location.root);
+    return { ...captureInstallationStatus(options), changed: before !== after || collectorChanged, backupPath };
+}

--- a/src/cmux/lib/capture-journal.test.ts
+++ b/src/cmux/lib/capture-journal.test.ts
@@ -176,3 +176,55 @@ test("short appends are retried until a complete UTF-8 record is persisted", () 
         spy.mockRestore();
     }
 });
+
+test("shell spool cutoff, aliasing and recovery after a truncated record", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-spool-history-"));
+    const stableId = "22222222-2222-4222-8222-222222222222";
+    associateCapturedSurface({ directory, surfaceId, stableSurfaceId: stableId });
+    const encode = (command: string, seconds: number) =>
+        [
+            "",
+            "1",
+            surfaceId,
+            "completed",
+            "/tmp",
+            "",
+            "0",
+            String(seconds),
+            String(Buffer.byteLength(command)),
+            command,
+            "",
+        ].join("\0");
+    fs.writeFileSync(join(directory, `${surfaceId}.shell.previous`), encode("echo earlier", 1));
+    fs.writeFileSync(
+        join(directory, `${surfaceId}.shell`),
+        encode("echo incomplete", 2).slice(0, -5) + encode("echo café\nprintf later", 3)
+    );
+    expect(loadCapturedCommands({ directory, beforeMs: 1500 }).get(stableId)?.command).toBe("echo earlier");
+    expect(loadCapturedCommands({ directory }).get(stableId)?.command).toBe("echo café\nprintf later");
+});
+
+test("each alias is loaded once and normalized into returned command records", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-alias-cache-"));
+    const stableId = "22222222-2222-4222-8222-222222222222";
+    associateCapturedSurface({ directory, surfaceId, stableSurfaceId: stableId });
+    for (let index = 0; index < 10; index++) {
+        recordCapturedCommand({
+            directory,
+            surfaceId,
+            command: `echo ${index}`,
+            cwd: "/tmp",
+            phase: "completed",
+            atMs: index,
+        });
+    }
+    const original = fs.readFileSync;
+    const spy = spyOn(fs, "readFileSync").mockImplementation(original);
+    try {
+        const result = loadCapturedCommands({ directory });
+        expect(result.get(stableId)?.stableSurfaceId).toBe(stableId);
+        expect(spy.mock.calls.filter(([path]) => String(path).endsWith(".identity"))).toHaveLength(1);
+    } finally {
+        spy.mockRestore();
+    }
+});

--- a/src/cmux/lib/capture-journal.test.ts
+++ b/src/cmux/lib/capture-journal.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -151,4 +152,27 @@ test("the first command is linked after native autosave eventually supplies a st
     const stableSurfaceId = "55555555-5555-4555-8555-555555555555";
     associateCapturedSurface({ directory, surfaceId, stableSurfaceId });
     expect(loadCapturedCommands({ directory }).get(stableSurfaceId)?.command).toBe("tail -f service.log");
+});
+
+test("short appends are retried until a complete UTF-8 record is persisted", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-short-write-"));
+    const original = fs.writeSync;
+    const spy = spyOn(fs, "writeSync").mockImplementation((fd, data, offset, length) => {
+        if (typeof data === "string") {
+            return original(fd, data);
+        }
+        return original(
+            fd,
+            data,
+            typeof offset === "number" ? offset : 0,
+            Math.min(typeof length === "number" ? length : data.byteLength, 7)
+        );
+    });
+    try {
+        recordCapturedCommand({ directory, surfaceId, command: "echo café", cwd: "/tmp", phase: "completed" });
+        expect(loadCapturedCommands({ directory }).get(surfaceId)?.command).toBe("echo café");
+        expect(spy.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+        spy.mockRestore();
+    }
 });

--- a/src/cmux/lib/capture-journal.test.ts
+++ b/src/cmux/lib/capture-journal.test.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    associateCapturedSurface,
+    captureJournalDirectory,
+    loadCapturedCommands,
+    recordCapturedCommand,
+} from "@app/cmux/lib/capture-journal";
+import { env } from "@genesiscz/utils/env";
+
+const surfaceId = "11111111-1111-4111-8111-111111111111";
+
+test("recovers exact shell syntax and launch cwd after the process has completed", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-capture-test-"));
+    const command = "tools usage --name 'two words' | tail -n 4\nprintf '%s' \"$PWD\"";
+    recordCapturedCommand({ directory, surfaceId, command, cwd: "/launch cwd", phase: "running", atMs: 100 });
+    recordCapturedCommand({
+        directory,
+        surfaceId,
+        command,
+        cwd: "/launch cwd",
+        phase: "completed",
+        exitStatus: 7,
+        atMs: 200,
+    });
+    expect(loadCapturedCommands({ directory }).get(surfaceId)).toMatchObject({
+        command: "tools usage --name 'two words' | tail -n 4\nprintf '%s' \"$PWD\"",
+        cwd: "/launch cwd",
+        phase: "completed",
+        exitStatus: 7,
+    });
+    expect(loadCapturedCommands({ directory, beforeMs: 150 }).get(surfaceId)?.phase).toBe("running");
+    expect(loadCapturedCommands({ directory, beforeMs: 99 }).size).toBe(0);
+});
+
+test("rejects path traversal in a surface identity before writing", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-capture-invalid-"));
+    expect(() =>
+        recordCapturedCommand({ directory, surfaceId: "../outside", command: "pwd", cwd: "/tmp", phase: "running" })
+    ).toThrow();
+    expect(loadCapturedCommands({ directory }).size).toBe(0);
+});
+
+test("retains a previous generation for a cutoff when the per-surface journal rotates", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-capture-rotation-"));
+    recordCapturedCommand({ directory, surfaceId, command: "tools usage", cwd: "/old", phase: "running", atMs: 1 });
+
+    for (let index = 2; index <= 20; index++) {
+        recordCapturedCommand({
+            directory,
+            surfaceId,
+            command: "x".repeat(65536),
+            cwd: "/new",
+            phase: "running",
+            atMs: index,
+        });
+    }
+
+    expect(loadCapturedCommands({ directory, beforeMs: 1 }).get(surfaceId)?.command).toBe("tools usage");
+    expect(loadCapturedCommands({ directory }).get(surfaceId)?.atMs).toBe(20);
+});
+
+test("equal timestamps preserve append order across rotation while older records cannot replace newer ones", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-capture-ties-"));
+
+    for (let index = 0; index < 20; index++) {
+        recordCapturedCommand({
+            directory,
+            surfaceId,
+            command: "x".repeat(65536),
+            cwd: "/cwd",
+            phase: "running",
+            atMs: 500,
+        });
+    }
+
+    recordCapturedCommand({
+        directory,
+        surfaceId,
+        command: "newest-at-same-ms",
+        cwd: "/cwd",
+        phase: "completed",
+        exitStatus: 0,
+        atMs: 500,
+    });
+    recordCapturedCommand({
+        directory,
+        surfaceId,
+        command: "older-wall-clock",
+        cwd: "/cwd",
+        phase: "running",
+        atMs: 100,
+    });
+    expect(loadCapturedCommands({ directory }).get(surfaceId)?.command).toBe("newest-at-same-ms");
+    expect(loadCapturedCommands({ directory, beforeMs: 100 }).get(surfaceId)?.command).toBe("older-wall-clock");
+});
+
+// Regression test: pre-push no-homedir-genesis-tools — journal paths must respect the test sandbox.
+test("default journal directory uses the configured GenesisTools home", async () => {
+    await env.testing.withOverrides({ GENESIS_TOOLS_HOME: "/tmp/cmux-test-home" }, () => {
+        expect(captureJournalDirectory()).toBe("/tmp/cmux-test-home/.genesis-tools/cmux/command-journal");
+    });
+});
+
+// Regression: runtime UUIDs can change on restore while the persisted surface identity remains.
+test("stable identity retains command history across runtime IDs and workspace moves", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-stable-test-"));
+    const stableSurfaceId = "33333333-3333-4333-8333-333333333333";
+    recordCapturedCommand({
+        directory,
+        surfaceId,
+        stableSurfaceId,
+        command: "tail -f service.log",
+        cwd: "/tmp/project-a",
+        phase: "running",
+        atMs: 10,
+    });
+    recordCapturedCommand({
+        directory,
+        surfaceId: "22222222-2222-4222-8222-222222222222",
+        stableSurfaceId,
+        workspaceId: "44444444-4444-4444-8444-444444444444",
+        command: "printf moved",
+        cwd: "/tmp/project-b",
+        phase: "completed",
+        exitStatus: 0,
+        atMs: 20,
+    });
+    expect(loadCapturedCommands({ directory }).get(stableSurfaceId)).toMatchObject({
+        command: "printf moved",
+        cwd: "/tmp/project-b",
+    });
+    expect(loadCapturedCommands({ directory, beforeMs: 15 }).get(stableSurfaceId)).toMatchObject({
+        command: "tail -f service.log",
+        cwd: "/tmp/project-a",
+    });
+});
+
+test("the first command is linked after native autosave eventually supplies a stable identity", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-late-identity-"));
+    recordCapturedCommand({
+        directory,
+        surfaceId,
+        command: "tail -f service.log",
+        cwd: "/tmp/project",
+        phase: "running",
+        atMs: 1,
+    });
+    const stableSurfaceId = "55555555-5555-4555-8555-555555555555";
+    associateCapturedSurface({ directory, surfaceId, stableSurfaceId });
+    expect(loadCapturedCommands({ directory }).get(stableSurfaceId)?.command).toBe("tail -f service.log");
+});

--- a/src/cmux/lib/capture-journal.ts
+++ b/src/cmux/lib/capture-journal.ts
@@ -75,37 +75,81 @@ export function recordCapturedCommand(
     }
 }
 
+function journalLines(name: string, text: string): string[] {
+    if (!name.includes(".shell")) {
+        return text.split("\n");
+    }
+    const fields = text.split("\0");
+    const lines: string[] = [];
+    for (let index = 0; index + 9 < fields.length; index++) {
+        if (
+            fields[index] !== "1" ||
+            !z
+                .string()
+                .uuid()
+                .safeParse(fields[index + 1]).success ||
+            !["running", "completed"].includes(fields[index + 2])
+        ) {
+            continue;
+        }
+        const parsed = recordSchema.safeParse({
+            version: 1,
+            surfaceId: fields[index + 1],
+            phase: fields[index + 2],
+            cwd: fields[index + 3],
+            workspaceId: fields[index + 4] || undefined,
+            exitStatus: fields[index + 5] ? Number(fields[index + 5]) : undefined,
+            atMs: Number(fields[index + 6]) * 1000,
+            command: fields[index + 8],
+        });
+        if (parsed.success && Buffer.byteLength(parsed.data.command) === Number(fields[index + 7])) {
+            lines.push(SafeJSON.stringify(parsed.data));
+            index += 8;
+        }
+    }
+    return lines;
+}
+
 /** Cutoff prevents a reused surface from leaking a post-restart command into an old autosave. */
 export function loadCapturedCommands(
     options: { directory?: string; beforeMs?: number } = {}
 ): Map<string, CapturedCommand> {
     const directory = options.directory ?? captureJournalDirectory();
     const records = new Map<string, CapturedCommand>();
+    const aliases = new Map<string, string | undefined>();
 
     if (!existsSync(directory)) {
         return records;
     }
 
     for (const name of readdirSync(directory)
-        .filter((name) => /^[a-f\d-]+\.jsonl(?:\.previous)?$/.test(name))
+        .filter((name) => /^[a-f\d-]+\.(?:jsonl|shell)(?:\.previous)?$/.test(name))
         .sort()
         .reverse()) {
         const path = join(directory, name);
         try {
-            for (const line of readFileSync(path, "utf8").split("\n")) {
+            for (const line of journalLines(name, readFileSync(path, "utf8"))) {
                 if (!line) {
                     continue;
                 }
 
                 try {
                     const record = recordSchema.parse(SafeJSON.parse(line, { strict: true }));
-                    const alias = join(directory, `${record.surfaceId.toLowerCase()}.identity`);
-                    const storedIdentity =
-                        !record.stableSurfaceId && existsSync(alias)
-                            ? z.string().uuid().safeParse(readFileSync(alias, "utf8").trim())
-                            : undefined;
-                    const stableId =
-                        record.stableSurfaceId ?? (storedIdentity?.success ? storedIdentity.data : undefined);
+                    const runtimeId = record.surfaceId.toLowerCase();
+                    if (!record.stableSurfaceId && !aliases.has(runtimeId)) {
+                        aliases.set(runtimeId, undefined);
+                        const alias = join(directory, `${runtimeId}.identity`);
+                        try {
+                            const parsed = existsSync(alias)
+                                ? z.string().uuid().safeParse(readFileSync(alias, "utf8").trim())
+                                : undefined;
+                            aliases.set(runtimeId, parsed?.success ? parsed.data.toLowerCase() : undefined);
+                        } catch (error) {
+                            logger.debug({ error, alias }, "[cmux-capture] identity alias unavailable");
+                        }
+                    }
+                    const stableId = record.stableSurfaceId ?? aliases.get(runtimeId);
+                    record.stableSurfaceId = stableId;
                     for (const id of [stableId, record.surfaceId]) {
                         if (!id) {
                             continue;

--- a/src/cmux/lib/capture-journal.ts
+++ b/src/cmux/lib/capture-journal.ts
@@ -60,7 +60,15 @@ export function recordCapturedCommand(
 
     const fd = openSync(path, "a", 0o600);
     try {
-        writeSync(fd, encoded);
+        const bytes = Buffer.from(encoded);
+        let offset = 0;
+        while (offset < bytes.length) {
+            const written = writeSync(fd, bytes, offset, bytes.length - offset);
+            if (written === 0) {
+                throw new Error("Unable to append the complete capture record");
+            }
+            offset += written;
+        }
         fsyncSync(fd);
     } finally {
         closeSync(fd);

--- a/src/cmux/lib/capture-journal.ts
+++ b/src/cmux/lib/capture-journal.ts
@@ -1,0 +1,137 @@
+import {
+    closeSync,
+    existsSync,
+    fsyncSync,
+    mkdirSync,
+    openSync,
+    readdirSync,
+    readFileSync,
+    renameSync,
+    statSync,
+    writeFileSync,
+    writeSync,
+} from "node:fs";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { z } from "zod";
+
+const MAX_JOURNAL_BYTES = 1024 * 1024;
+const recordSchema = z.object({
+    version: z.literal(1),
+    surfaceId: z.string().uuid(),
+    stableSurfaceId: z.string().uuid().optional(),
+    workspaceId: z.string().uuid().optional(),
+    command: z.string().min(1).max(65536),
+    cwd: z.string().startsWith("/"),
+    phase: z.enum(["running", "completed"]),
+    exitStatus: z.number().int().min(0).max(255).optional(),
+    atMs: z.number().finite().nonnegative(),
+});
+
+export type CapturedCommand = z.infer<typeof recordSchema>;
+
+export function captureJournalDirectory(): string {
+    return join(env.tools.getHome(), ".genesis-tools", "cmux", "command-journal");
+}
+
+/** One owning shell per surface writes synchronously before the command starts. */
+export function recordCapturedCommand(
+    input: Omit<CapturedCommand, "version" | "atMs"> & {
+        atMs?: number;
+        directory?: string;
+    }
+): void {
+    const record = recordSchema.parse({ ...input, version: 1, atMs: input.atMs ?? Date.now() });
+    record.surfaceId = record.surfaceId.toLowerCase();
+    record.stableSurfaceId = record.stableSurfaceId?.toLowerCase();
+    const directory = input.directory ?? captureJournalDirectory();
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    if (record.stableSurfaceId) {
+        associateCapturedSurface({ directory, surfaceId: record.surfaceId, stableSurfaceId: record.stableSurfaceId });
+    }
+    const path = join(directory, `${record.stableSurfaceId ?? record.surfaceId}.jsonl`);
+    const encoded = `${SafeJSON.stringify(record)}\n`;
+
+    if (existsSync(path) && statSync(path).size + Buffer.byteLength(encoded) > MAX_JOURNAL_BYTES) {
+        renameSync(path, `${path}.previous`);
+    }
+
+    const fd = openSync(path, "a", 0o600);
+    try {
+        writeSync(fd, encoded);
+        fsyncSync(fd);
+    } finally {
+        closeSync(fd);
+    }
+}
+
+/** Cutoff prevents a reused surface from leaking a post-restart command into an old autosave. */
+export function loadCapturedCommands(
+    options: { directory?: string; beforeMs?: number } = {}
+): Map<string, CapturedCommand> {
+    const directory = options.directory ?? captureJournalDirectory();
+    const records = new Map<string, CapturedCommand>();
+
+    if (!existsSync(directory)) {
+        return records;
+    }
+
+    for (const name of readdirSync(directory)
+        .filter((name) => /^[a-f\d-]+\.jsonl(?:\.previous)?$/.test(name))
+        .sort()
+        .reverse()) {
+        const path = join(directory, name);
+        try {
+            for (const line of readFileSync(path, "utf8").split("\n")) {
+                if (!line) {
+                    continue;
+                }
+
+                try {
+                    const record = recordSchema.parse(SafeJSON.parse(line, { strict: true }));
+                    const alias = join(directory, `${record.surfaceId.toLowerCase()}.identity`);
+                    const storedIdentity =
+                        !record.stableSurfaceId && existsSync(alias)
+                            ? z.string().uuid().safeParse(readFileSync(alias, "utf8").trim())
+                            : undefined;
+                    const stableId =
+                        record.stableSurfaceId ?? (storedIdentity?.success ? storedIdentity.data : undefined);
+                    for (const id of [stableId, record.surfaceId]) {
+                        if (!id) {
+                            continue;
+                        }
+
+                        const key = id.toLowerCase();
+                        const prior = records.get(key);
+                        if (record.atMs <= (options.beforeMs ?? Infinity) && (!prior || record.atMs >= prior.atMs)) {
+                            records.set(key, record);
+                        }
+                    }
+                } catch (error) {
+                    logger.warn({ error, path }, "[cmux-capture] ignored invalid command journal entry");
+                }
+            }
+        } catch (error) {
+            logger.warn({ error, path }, "[cmux-capture] could not read command journal");
+        }
+    }
+
+    return records;
+}
+
+export function associateCapturedSurface(input: {
+    directory?: string;
+    surfaceId: string;
+    stableSurfaceId: string;
+}): void {
+    const surfaceId = z.string().uuid().parse(input.surfaceId).toLowerCase();
+    const stableId = z.string().uuid().parse(input.stableSurfaceId).toLowerCase();
+    const directory = input.directory ?? captureJournalDirectory();
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const alias = join(directory, `${surfaceId}.identity`);
+    if (!existsSync(alias) || readFileSync(alias, "utf8") !== stableId) {
+        writeFileSync(alias, stableId, { mode: 0o600 });
+    }
+}

--- a/src/cmux/lib/capture-runtime-logger.test.ts
+++ b/src/cmux/lib/capture-runtime-logger.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtempSync, readdirSync, statSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createCaptureRuntimeLogger } from "@app/cmux/lib/capture-runtime-logger";
@@ -20,4 +20,15 @@ test("standalone runtime diagnostics rotate within two bounded generations and s
     expect(readdirSync(directory).sort()).toEqual(["capture-runtime.log", "capture-runtime.log.previous"]);
     expect(statSync(path).size).toBeLessThanOrEqual(1024 * 1024);
     expect(statSync(`${path}.previous`).size).toBeLessThanOrEqual(1024 * 1024);
+});
+
+test("a failed diagnostic append can be retried with the same message", () => {
+    const root = mkdtempSync(join(tmpdir(), "cmux-log-retry-"));
+    const directory = join(root, "logs");
+    writeFileSync(directory, "blocking file");
+    const logger = createCaptureRuntimeLogger({ directory });
+    logger.debug({}, "retry this diagnostic");
+    renameSync(directory, join(root, "old-file"));
+    logger.debug({}, "retry this diagnostic");
+    expect(readFileSync(join(directory, "capture-runtime.log"), "utf8")).toContain("retry this diagnostic");
 });

--- a/src/cmux/lib/capture-runtime-logger.test.ts
+++ b/src/cmux/lib/capture-runtime-logger.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCaptureRuntimeLogger } from "@app/cmux/lib/capture-runtime-logger";
+
+test("standalone runtime diagnostics rotate within two bounded generations and suppress repeated messages", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-runtime-log-"));
+    const logger = createCaptureRuntimeLogger({ directory });
+    logger.debug({ state: "offline" }, "retaining cached output");
+    const path = join(directory, "capture-runtime.log");
+    const size = statSync(path).size;
+    logger.debug({ state: "offline" }, "retaining cached output");
+    expect(statSync(path).size).toBe(size);
+
+    for (let index = 0; index < 40; index++) {
+        logger.debug({ index, details: "x".repeat(60000) }, "fixture diagnostic");
+    }
+
+    expect(readdirSync(directory).sort()).toEqual(["capture-runtime.log", "capture-runtime.log.previous"]);
+    expect(statSync(path).size).toBeLessThanOrEqual(1024 * 1024);
+    expect(statSync(`${path}.previous`).size).toBeLessThanOrEqual(1024 * 1024);
+});

--- a/src/cmux/lib/capture-runtime-logger.ts
+++ b/src/cmux/lib/capture-runtime-logger.ts
@@ -1,0 +1,59 @@
+import { appendFileSync, existsSync, mkdirSync, renameSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+export function createCaptureRuntimeLogger(options: { directory?: string } = {}) {
+    let previous: string | undefined;
+    function writeDiagnostic(input: { level: "debug" | "warn" | "error"; context: object; message: string }): void {
+        const { level, context, message } = input;
+        const detail =
+            "error" in context && context.error instanceof Error
+                ? { ...context, error: { name: context.error.name, message: context.error.message } }
+                : context;
+        const signature = SafeJSON.stringify({ level, message, ...detail });
+        if (signature === previous) {
+            return;
+        }
+
+        previous = signature;
+        const directory = options.directory ?? join(env.tools.getHome(), ".genesis-tools/cmux");
+        let line = `${SafeJSON.stringify({ at: new Date().toISOString(), level, message, ...detail })}\n`;
+        if (Buffer.byteLength(line) > 65536) {
+            line = `${SafeJSON.stringify({ at: new Date().toISOString(), level, message: message.slice(0, 1024), detail: "oversized diagnostic omitted" })}\n`;
+        }
+
+        try {
+            mkdirSync(directory, { recursive: true, mode: 0o700 });
+            const path = join(directory, "capture-runtime.log");
+            if (existsSync(path) && statSync(path).size + Buffer.byteLength(line) > 1024 * 1024) {
+                renameSync(path, `${path}.previous`);
+            }
+
+            appendFileSync(path, line, { mode: 0o600 });
+        } catch (error) {
+            process.stderr.write(
+                `cmux capture diagnostic log failed: ${error instanceof Error ? error.message : String(error)}\n`
+            );
+        }
+
+        if (level !== "debug" && !process.argv.includes("--owner-token")) {
+            process.stderr.write(`${message}\n`);
+        }
+    }
+
+    return {
+        debug(context: object, message: string): void {
+            writeDiagnostic({ level: "debug", context, message });
+        },
+        warn(context: object, message: string): void {
+            writeDiagnostic({ level: "warn", context, message });
+        },
+        error(context: object, message: string): void {
+            writeDiagnostic({ level: "error", context, message });
+        },
+    };
+}
+
+/** Bundled recorder diagnostics avoid shared logger's dynamic package loading. */
+export const logger = createCaptureRuntimeLogger();

--- a/src/cmux/lib/capture-runtime-logger.ts
+++ b/src/cmux/lib/capture-runtime-logger.ts
@@ -16,7 +16,6 @@ export function createCaptureRuntimeLogger(options: { directory?: string } = {})
             return;
         }
 
-        previous = signature;
         const directory = options.directory ?? join(env.tools.getHome(), ".genesis-tools/cmux");
         let line = `${SafeJSON.stringify({ at: new Date().toISOString(), level, message, ...detail })}\n`;
         if (Buffer.byteLength(line) > 65536) {
@@ -31,6 +30,7 @@ export function createCaptureRuntimeLogger(options: { directory?: string } = {})
             }
 
             appendFileSync(path, line, { mode: 0o600 });
+            previous = signature;
         } catch (error) {
             process.stderr.write(
                 `cmux capture diagnostic log failed: ${error instanceof Error ? error.message : String(error)}\n`

--- a/src/cmux/lib/capture-shell.test.ts
+++ b/src/cmux/lib/capture-shell.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { loadCapturedCommands } from "@app/cmux/lib/capture-journal";
@@ -57,7 +57,7 @@ test("the journal exists before a short-lived command can observe the filesystem
         env: { PATH: "/bin:/usr/bin", HOME: directory, CMUX_SURFACE_ID: "11111111-1111-4111-8111-111111111111" },
     });
     proc.stdin.write(
-        `source '${hook}'\n[[ -s '${directory}/11111111-1111-4111-8111-111111111111.jsonl' ]] && printf CAPTURED_BEFORE_EXEC\n`
+        `source '${hook}'\n[[ -s '${directory}/11111111-1111-4111-8111-111111111111.shell' ]] && printf CAPTURED_BEFORE_EXEC\n`
     );
     proc.stdin.end();
     const [output, errors, code] = await Promise.all([
@@ -138,4 +138,54 @@ test("a user function with a similar name is still captured", async () => {
     expect(loadCapturedCommands({ directory }).get("11111111-1111-4111-8111-111111111111")?.command).toBe(
         "function _genesis_cmux_restore_internal_user { printf '%s' real; }; _genesis_cmux_restore_internal_user"
     );
+});
+
+test("the hook captures with no Bun or recorder executable in its command path", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-shell-no-bun-"));
+    const hook = join(directory, "hook.zsh");
+    await Bun.write(
+        hook,
+        renderCaptureShell({ directory, bunPath: "/missing-bun", recorderPath: "/missing-recorder" })
+    );
+    const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { PATH: "/bin:/usr/bin", HOME: directory, CMUX_SURFACE_ID: "11111111-1111-4111-8111-111111111111" },
+    });
+    proc.stdin.write(`source '${hook}'\nprintf '%s' lightweight\n`);
+    proc.stdin.end();
+    const [output, error, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    expect(code).toBe(0);
+    expect(error).not.toContain("capture failed");
+    expect(error).not.toContain("missing-bun");
+    expect(output).toContain("lightweight");
+    expect(loadCapturedCommands({ directory }).get("11111111-1111-4111-8111-111111111111")?.command).toBe(
+        "printf '%s' lightweight"
+    );
+});
+
+test("the lightweight shell spool rotates within two bounded generations", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-shell-rotate-"));
+    const hook = join(directory, "hook.zsh");
+    await Bun.write(hook, renderCaptureShell({ directory }));
+    const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { PATH: "/bin:/usr/bin", HOME: directory, CMUX_SURFACE_ID: "11111111-1111-4111-8111-111111111111" },
+    });
+    proc.stdin.write(`source '${hook}'\n` + `: '${"x".repeat(30000)}'\n`.repeat(40));
+    proc.stdin.end();
+    const [code] = await Promise.all([proc.exited, new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+    expect(code).toBe(0);
+    for (const suffix of [".shell", ".shell.previous"]) {
+        const stat = statSync(join(directory, `11111111-1111-4111-8111-111111111111${suffix}`));
+        expect(stat.size).toBeLessThan(1024 * 1024);
+        expect(stat.mode & 0o777).toBe(0o600);
+    }
 });

--- a/src/cmux/lib/capture-shell.test.ts
+++ b/src/cmux/lib/capture-shell.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { loadCapturedCommands } from "@app/cmux/lib/capture-journal";
+import { renderCaptureShell } from "@app/cmux/lib/capture-shell";
+
+test("zsh records a short-lived command before execution and preserves its exit status", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-shell-test-"));
+    const hook = join(directory, "hook.zsh");
+    await Bun.write(
+        hook,
+        renderCaptureShell({
+            bunPath: process.execPath,
+            recorderPath: resolve("src/cmux/capture-record.ts"),
+            directory,
+        })
+    );
+    const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { PATH: "/bin:/usr/bin", HOME: directory, CMUX_SURFACE_ID: "11111111-1111-4111-8111-111111111111" },
+    });
+    proc.stdin.write(`source '${hook}'\nprintf '%s' 'two words'; false\n`);
+    proc.stdin.end();
+    const [output, errors, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    expect(errors).not.toContain("command not found");
+    expect(output).toContain("two words");
+    expect(code).toBe(1);
+    expect(loadCapturedCommands({ directory }).get("11111111-1111-4111-8111-111111111111")).toMatchObject({
+        command: "printf '%s' 'two words'; false",
+        phase: "completed",
+        exitStatus: 1,
+    });
+});
+
+test("the journal exists before a short-lived command can observe the filesystem", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-before-exec-test-"));
+    const hook = join(directory, "hook.zsh");
+    await Bun.write(
+        hook,
+        renderCaptureShell({
+            bunPath: process.execPath,
+            recorderPath: resolve("src/cmux/capture-record.ts"),
+            directory,
+        })
+    );
+    const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { PATH: "/bin:/usr/bin", HOME: directory, CMUX_SURFACE_ID: "11111111-1111-4111-8111-111111111111" },
+    });
+    proc.stdin.write(
+        `source '${hook}'\n[[ -s '${directory}/11111111-1111-4111-8111-111111111111.jsonl' ]] && printf CAPTURED_BEFORE_EXEC\n`
+    );
+    proc.stdin.end();
+    const [output, errors, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    expect(errors).not.toContain("capture failed");
+    expect(code).toBe(0);
+    expect(output).toContain("CAPTURED_BEFORE_EXEC");
+});
+
+test("reserved restore setup leaves the last genuine command and its completion status intact", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-restore-exclusion-"));
+    const hook = join(directory, "hook.zsh");
+    await Bun.write(
+        hook,
+        renderCaptureShell({
+            bunPath: process.execPath,
+            recorderPath: resolve("src/cmux/capture-record.ts"),
+            directory,
+        })
+    );
+    const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { PATH: "/bin:/usr/bin", HOME: directory, CMUX_SURFACE_ID: "11111111-1111-4111-8111-111111111111" },
+    });
+    proc.stdin.write(
+        `source '${hook}'\nprintf '%s' genuine; false\nfunction _genesis_cmux_restore_internal { cd /; printf '%s' cmux-ready; }; _genesis_cmux_restore_internal; unfunction _genesis_cmux_restore_internal\n`
+    );
+    proc.stdin.end();
+    const [output, errors, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    expect(errors).not.toContain("capture failed");
+    expect(code).toBe(0);
+    expect(output).toContain("genuinecmux-ready");
+    expect(loadCapturedCommands({ directory }).get("11111111-1111-4111-8111-111111111111")).toMatchObject({
+        command: "printf '%s' genuine; false",
+        phase: "completed",
+        exitStatus: 1,
+    });
+});
+
+test("a user function with a similar name is still captured", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-restore-exclusion-control-"));
+    const hook = join(directory, "hook.zsh");
+    await Bun.write(
+        hook,
+        renderCaptureShell({
+            bunPath: process.execPath,
+            recorderPath: resolve("src/cmux/capture-record.ts"),
+            directory,
+        })
+    );
+    const proc = Bun.spawn(["/bin/zsh", "-dfi"], {
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { PATH: "/bin:/usr/bin", HOME: directory, CMUX_SURFACE_ID: "11111111-1111-4111-8111-111111111111" },
+    });
+    proc.stdin.write(
+        `source '${hook}'\nfunction _genesis_cmux_restore_internal_user { printf '%s' real; }; _genesis_cmux_restore_internal_user\n`
+    );
+    proc.stdin.end();
+    const [output, errors, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    expect(errors).not.toContain("capture failed");
+    expect(output).toContain("real");
+    expect(code).toBe(0);
+    expect(loadCapturedCommands({ directory }).get("11111111-1111-4111-8111-111111111111")?.command).toBe(
+        "function _genesis_cmux_restore_internal_user { printf '%s' real; }; _genesis_cmux_restore_internal_user"
+    );
+});

--- a/src/cmux/lib/capture-shell.ts
+++ b/src/cmux/lib/capture-shell.ts
@@ -1,0 +1,56 @@
+import { resolve } from "node:path";
+
+export function renderCaptureShell(
+    options: { bunPath?: string; recorderPath?: string; directory?: string; preferPathBun?: boolean } = {}
+): string {
+    const quote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;
+    const bunPath = options.bunPath ?? process.execPath;
+    const recorderPath = options.recorderPath ?? resolve(import.meta.dir, "../capture-record.ts");
+    const recorder = options.preferPathBun
+        ? `"$_GENESIS_CMUX_CAPTURE_BUN" ${quote(recorderPath)}`
+        : `${quote(bunPath)} ${quote(recorderPath)}`;
+    const selectBun = options.preferPathBun
+        ? `typeset -g _GENESIS_CMUX_CAPTURE_BUN="\${commands[bun]:-}"
+if [[ -z "$_GENESIS_CMUX_CAPTURE_BUN" ]]; then
+    _GENESIS_CMUX_CAPTURE_BUN=${quote(bunPath)}
+fi
+if [[ ! -x "$_GENESIS_CMUX_CAPTURE_BUN" ]]; then
+    print -u2 -- 'cmux capture requires Bun on PATH; reinstall capture after installing Bun'
+    return 0
+fi
+`
+        : "";
+    const directory = quote(options.directory ?? "");
+
+    return `# Synchronous cmux command capture. Source this from ~/.zshrc.
+[[ -o interactive && -n "$CMUX_SURFACE_ID" ]] || return 0
+[[ -z "$CMUX_CAPTURE_OWNER" || "$CMUX_CAPTURE_OWNER" = "$$" ]] || return 0
+${selectBun}export CMUX_CAPTURE_OWNER=$$
+autoload -Uz add-zsh-hook
+_genesis_cmux_capture_write() {
+    print -rn -- "$_GENESIS_CMUX_CAPTURE_COMMAND" | command ${recorder} "$1" "$CMUX_SURFACE_ID" "$_GENESIS_CMUX_CAPTURE_CWD" "$CMUX_WORKSPACE_ID" "$2" ${directory}
+}
+_genesis_cmux_capture_preexec() {
+    if [[ "$1" == 'function _genesis_cmux_restore_internal '* ]]; then
+        unset _GENESIS_CMUX_CAPTURE_COMMAND _GENESIS_CMUX_CAPTURE_CWD
+        return 0
+    fi
+    typeset -g _GENESIS_CMUX_CAPTURE_COMMAND="$1"
+    typeset -g _GENESIS_CMUX_CAPTURE_CWD="$PWD"
+    _genesis_cmux_capture_write running '' || print -u2 -- 'cmux command capture failed; this command may not be recoverable'
+    return 0
+}
+_genesis_cmux_capture_precmd() {
+    local command_status=$?
+    if [[ -n "$_GENESIS_CMUX_CAPTURE_COMMAND" ]]; then
+        _genesis_cmux_capture_write completed "$command_status" || print -u2 -- 'cmux command completion capture failed'
+        unset _GENESIS_CMUX_CAPTURE_COMMAND _GENESIS_CMUX_CAPTURE_CWD
+    fi
+    return 0
+}
+add-zsh-hook -d preexec _genesis_cmux_capture_preexec
+add-zsh-hook -d precmd _genesis_cmux_capture_precmd
+add-zsh-hook preexec _genesis_cmux_capture_preexec
+add-zsh-hook precmd _genesis_cmux_capture_precmd
+`;
+}

--- a/src/cmux/lib/capture-shell.ts
+++ b/src/cmux/lib/capture-shell.ts
@@ -4,31 +4,49 @@ export function renderCaptureShell(
     options: { bunPath?: string; recorderPath?: string; directory?: string; preferPathBun?: boolean } = {}
 ): string {
     const quote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;
-    const bunPath = options.bunPath ?? process.execPath;
-    const recorderPath = options.recorderPath ?? resolve(import.meta.dir, "../capture-record.ts");
-    const recorder = options.preferPathBun
-        ? `"$_GENESIS_CMUX_CAPTURE_BUN" ${quote(recorderPath)}`
-        : `${quote(bunPath)} ${quote(recorderPath)}`;
-    const selectBun = options.preferPathBun
-        ? `typeset -g _GENESIS_CMUX_CAPTURE_BUN="\${commands[bun]:-}"
-if [[ -z "$_GENESIS_CMUX_CAPTURE_BUN" ]]; then
-    _GENESIS_CMUX_CAPTURE_BUN=${quote(bunPath)}
-fi
-if [[ ! -x "$_GENESIS_CMUX_CAPTURE_BUN" ]]; then
-    print -u2 -- 'cmux capture requires Bun on PATH; reinstall capture after installing Bun'
-    return 0
-fi
-`
-        : "";
-    const directory = quote(options.directory ?? "");
-
-    return `# Synchronous cmux command capture. Source this from ~/.zshrc.
+    const bunPath = quote(options.bunPath ?? process.execPath);
+    const selectedBun = options.preferPathBun ? `\${commands[bun]:-${bunPath}}` : bunPath;
+    const recorderPath = quote(options.recorderPath ?? resolve(import.meta.dir, "../capture-record.ts"));
+    const directory = options.directory
+        ? quote(options.directory)
+        : '"${GENESIS_TOOLS_HOME:-$HOME}/.genesis-tools/cmux/command-journal"';
+    return `# Lightweight cmux command capture. Source this from ~/.zshrc.
 [[ -o interactive && -n "$CMUX_SURFACE_ID" ]] || return 0
 [[ -z "$CMUX_CAPTURE_OWNER" || "$CMUX_CAPTURE_OWNER" = "$$" ]] || return 0
-${selectBun}export CMUX_CAPTURE_OWNER=$$
+[[ "$CMUX_SURFACE_ID" =~ '^[a-fA-F0-9]{8}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}$' ]] || return 0
+export CMUX_CAPTURE_OWNER=$$
+zmodload zsh/datetime || return 0
+zmodload zsh/stat || return 0
+typeset -g _GENESIS_CMUX_CAPTURE_DIRECTORY=${directory}
+typeset -g _GENESIS_CMUX_CAPTURE_BUN=${selectedBun}
+typeset -g _GENESIS_CMUX_CAPTURE_ASSOCIATE_AT=\${_GENESIS_CMUX_CAPTURE_ASSOCIATE_AT:-0}
+(umask 077; command mkdir -p -- "$_GENESIS_CMUX_CAPTURE_DIRECTORY") || return 0
 autoload -Uz add-zsh-hook
+_genesis_cmux_capture_associate() {
+    local alias="$_GENESIS_CMUX_CAPTURE_DIRECTORY/\${CMUX_SURFACE_ID:l}.identity"
+    local identity=""
+    [[ -r "$alias" ]] && identity=$(<"$alias")
+    if [[ ! "$identity" =~ '^[a-fA-F0-9]{8}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}$' && -x "$_GENESIS_CMUX_CAPTURE_BUN" && -r ${recorderPath} ]] && (( EPOCHSECONDS - _GENESIS_CMUX_CAPTURE_ASSOCIATE_AT > 30 )); then
+        typeset -g _GENESIS_CMUX_CAPTURE_ASSOCIATE_AT=$EPOCHSECONDS
+        command "$_GENESIS_CMUX_CAPTURE_BUN" ${recorderPath} --associate "$CMUX_SURFACE_ID" "$_GENESIS_CMUX_CAPTURE_DIRECTORY" </dev/null >/dev/null 2>/dev/null &!
+    fi
+}
+_genesis_cmux_capture_associate
 _genesis_cmux_capture_write() {
-    print -rn -- "$_GENESIS_CMUX_CAPTURE_COMMAND" | command ${recorder} "$1" "$CMUX_SURFACE_ID" "$_GENESIS_CMUX_CAPTURE_CWD" "$CMUX_WORKSPACE_ID" "$2" ${directory}
+    setopt localoptions
+    unsetopt multibyte
+    local spool="$_GENESIS_CMUX_CAPTURE_DIRECTORY/\${CMUX_SURFACE_ID:l}.shell"
+    local -a spool_size
+    if [[ -f "$spool" ]]; then
+        zstat -A spool_size +size "$spool" || return 1
+        if (( spool_size[1] > 900000 )); then
+            command mv -f -- "$spool" "$spool.previous" || return 1
+        fi
+    fi
+    if (( \${#_GENESIS_CMUX_CAPTURE_COMMAND} > 65536 )); then
+        return 1
+    fi
+    (umask 077; print -rn -- $'\\0'"1"$'\\0'"$CMUX_SURFACE_ID"$'\\0'"$1"$'\\0'"$_GENESIS_CMUX_CAPTURE_CWD"$'\\0'"$CMUX_WORKSPACE_ID"$'\\0'"$2"$'\\0'"$EPOCHREALTIME"$'\\0'"\${#_GENESIS_CMUX_CAPTURE_COMMAND}"$'\\0'"$_GENESIS_CMUX_CAPTURE_COMMAND"$'\\0' >> "$spool")
 }
 _genesis_cmux_capture_preexec() {
     if [[ "$1" == 'function _genesis_cmux_restore_internal '* ]]; then
@@ -37,6 +55,7 @@ _genesis_cmux_capture_preexec() {
     fi
     typeset -g _GENESIS_CMUX_CAPTURE_COMMAND="$1"
     typeset -g _GENESIS_CMUX_CAPTURE_CWD="$PWD"
+    _genesis_cmux_capture_associate
     _genesis_cmux_capture_write running '' || print -u2 -- 'cmux command capture failed; this command may not be recoverable'
     return 0
 }

--- a/src/cmux/lib/capture-surface-identity.test.ts
+++ b/src/cmux/lib/capture-surface-identity.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recordCapturedCommand } from "@app/cmux/lib/capture-journal";
+import { resolveCapturedSurfaceIdentity, stableSurfaceIdForPanel } from "@app/cmux/lib/capture-surface-identity";
+
+const runtimeId = "11111111-1111-4111-8111-111111111111";
+const stableId = "22222222-2222-4222-8222-222222222222";
+
+test("a moved panel retains its persisted identity regardless of workspace placement", () => {
+    const panel = { id: runtimeId, stableSurfaceId: stableId, type: "terminal" };
+    const workspace = { layout: { type: "pane" as const, pane: { panelIds: [runtimeId] } }, panels: [panel] };
+    expect(stableSurfaceIdForPanel(runtimeId.toUpperCase(), [{ tabManager: { workspaces: [workspace] } }])).toBe(
+        stableId
+    );
+    expect(
+        stableSurfaceIdForPanel(runtimeId, [
+            { tabManager: { workspaces: [] } },
+            { tabManager: { workspaces: [workspace] } },
+        ])
+    ).toBe(stableId);
+    expect(
+        stableSurfaceIdForPanel("33333333-3333-4333-8333-333333333333", [{ tabManager: { workspaces: [workspace] } }])
+    ).toBeUndefined();
+});
+
+test("a shell with its old runtime ID retains its stable association after reparenting", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-id-alias-"));
+    recordCapturedCommand({
+        directory,
+        surfaceId: runtimeId,
+        stableSurfaceId: stableId,
+        command: "pwd",
+        cwd: "/tmp/project",
+        phase: "completed",
+    });
+    expect(
+        resolveCapturedSurfaceIdentity({
+            surfaceId: runtimeId,
+            journalDirectory: directory,
+            session: { path: "/fixture", savedAtMs: 1, windows: [] },
+        })
+    ).toBe(stableId);
+});

--- a/src/cmux/lib/capture-surface-identity.ts
+++ b/src/cmux/lib/capture-surface-identity.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { type AutosaveSession, type AutosaveWindow, readAutosaveSession } from "@app/cmux/lib/autosave";
+import { captureJournalDirectory } from "@app/cmux/lib/capture-journal";
+import { logger } from "@genesiscz/utils/logger";
+
+export function stableSurfaceIdForPanel(surfaceId: string, windows: AutosaveWindow[]): string | undefined {
+    const wanted = surfaceId.toLowerCase();
+    for (const window of windows) {
+        for (const workspace of window.tabManager.workspaces) {
+            const panel = workspace.panels.find(
+                (panel) => panel.id.toLowerCase() === wanted || panel.stableSurfaceId?.toLowerCase() === wanted
+            );
+            if (panel?.stableSurfaceId) {
+                return panel.stableSurfaceId.toLowerCase();
+            }
+        }
+    }
+
+    return undefined;
+}
+
+export function resolveCapturedSurfaceIdentity(input: {
+    surfaceId: string;
+    session?: AutosaveSession;
+    journalDirectory?: string;
+}): string | undefined {
+    const { surfaceId } = input;
+    try {
+        const stableId = stableSurfaceIdForPanel(surfaceId, (input.session ?? readAutosaveSession()).windows);
+        if (stableId) {
+            return stableId;
+        }
+    } catch (error) {
+        logger.debug({ error, surfaceId }, "[cmux-capture] native identity unavailable; checking saved association");
+    }
+
+    if (!/^[a-f\d]{8}(?:-[a-f\d]{4}){3}-[a-f\d]{12}$/i.test(surfaceId)) {
+        return undefined;
+    }
+
+    const alias = join(input.journalDirectory ?? captureJournalDirectory(), `${surfaceId.toLowerCase()}.identity`);
+    if (existsSync(alias)) {
+        const stableId = readFileSync(alias, "utf8").trim();
+        if (/^[a-f\d]{8}(?:-[a-f\d]{4}){3}-[a-f\d]{12}$/i.test(stableId)) {
+            return stableId.toLowerCase();
+        }
+    }
+
+    return undefined;
+}

--- a/src/cmux/lib/capture.move.live.test.ts
+++ b/src/cmux/lib/capture.move.live.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import { readAutosaveSession } from "@app/cmux/lib/autosave";
+import { loadCapturedCommands } from "@app/cmux/lib/capture-journal";
+import { stableSurfaceIdForPanel } from "@app/cmux/lib/capture-surface-identity";
+import { isShellPromptReady, waitForTerminalText } from "@app/cmux/lib/terminal-ready";
+import { runCmuxJSON, runCmuxOk, sendSurfaceText } from "@genesiscz/utils/cmux/lib/cli";
+import { paneList, workspaceCreate } from "@genesiscz/utils/cmux/lib/socket";
+import { env } from "@genesiscz/utils/env";
+
+test.skipIf(
+    env.getProcessEnv().RUN_LIVE !== "1" ||
+        !env.getProcessEnv().CMUX_TEST_WINDOW ||
+        !env.getProcessEnv().CMUX_TEST_CAPTURE_HOME
+)(
+    "installed capture follows a real terminal moved between temporary workspaces",
+    async () => {
+        const window = env.getProcessEnv().CMUX_TEST_WINDOW!;
+        const directory = join(
+            env.getProcessEnv().CMUX_TEST_CAPTURE_HOME!,
+            ".genesis-tools",
+            "cmux",
+            "command-journal"
+        );
+        const created: string[] = [];
+        try {
+            for (const suffix of ["source", "destination"]) {
+                const ws = await workspaceCreate({ window, name: `Capture move check ${suffix}`, cwd: "/private/tmp" });
+                created.push(ws.workspace_ref);
+            }
+            const sourcePane = (await paneList(created[0])).panes[0];
+            const destinationPane = (await paneList(created[1])).panes[0];
+            const listing = await runCmuxJSON<{ surfaces: Array<{ id: string; ref: string }> }>([
+                "--id-format",
+                "both",
+                "list-pane-surfaces",
+                "--workspace",
+                created[0],
+                "--pane",
+                sourcePane.ref,
+            ]);
+            const surface = listing.surfaces[0];
+            await runCmuxOk(["select-workspace", "--workspace", created[0]]);
+            await waitForTerminalText({
+                workspaceRef: created[0],
+                surfaceRef: surface.ref,
+                matches: isShellPromptReady,
+                description: "test shell",
+                activateOnUnavailable: true,
+            });
+            let stableId: string | undefined;
+            for (let i = 0; i < 120; i++) {
+                stableId = stableSurfaceIdForPanel(surface.id, readAutosaveSession().windows);
+                if (stableId) {
+                    break;
+                }
+                await Bun.sleep(100);
+            }
+            expect(stableId).toBeDefined();
+            await sendSurfaceText({ surfaceRef: surface.ref, text: "print -r -- CMUX_BEFORE_MOVE_PROOF\n" });
+            await waitForTerminalText({
+                workspaceRef: created[0],
+                surfaceRef: surface.ref,
+                matches: (t) => t.includes("CMUX_BEFORE_MOVE_PROOF") && isShellPromptReady(t),
+                description: "first probe",
+            });
+            await runCmuxOk([
+                "move-surface",
+                "--surface",
+                surface.ref,
+                "--workspace",
+                created[1],
+                "--pane",
+                destinationPane.ref,
+                "--focus",
+                "false",
+            ]);
+            await runCmuxOk(["select-workspace", "--workspace", created[1]]);
+            await sendSurfaceText({ surfaceRef: surface.ref, text: "print -r -- CMUX_AFTER_MOVE_PROOF\n" });
+            await waitForTerminalText({
+                workspaceRef: created[1],
+                surfaceRef: surface.ref,
+                matches: (t) => t.includes("CMUX_AFTER_MOVE_PROOF") && isShellPromptReady(t),
+                description: "moved probe",
+            });
+            let captured = loadCapturedCommands({ directory }).get(stableId!);
+            for (let i = 0; i < 30 && captured?.command !== "print -r -- CMUX_AFTER_MOVE_PROOF"; i++) {
+                await Bun.sleep(100);
+                captured = loadCapturedCommands({ directory }).get(stableId!);
+            }
+            expect(captured?.command).toBe("print -r -- CMUX_AFTER_MOVE_PROOF");
+            expect(captured?.stableSurfaceId).toBe(stableId);
+            expect(captured?.cwd).toBe("/private/tmp");
+        } finally {
+            const remaining = await runCmuxJSON<{ workspaces: Array<{ ref: string }> }>([
+                "list-workspaces",
+                "--window",
+                window,
+            ]);
+            for (const ref of created.filter((ref) => remaining.workspaces.some((ws) => ws.ref === ref))) {
+                await runCmuxOk(["close-workspace", "--workspace", ref]);
+            }
+        }
+    },
+    60_000
+);

--- a/src/cmux/lib/command-capture.test.ts
+++ b/src/cmux/lib/command-capture.test.ts
@@ -297,3 +297,15 @@ describe("etimeToSeconds", () => {
         expect(etimeToSeconds("garbage")).toBe(0);
     });
 });
+
+test("compound agent commands remain verbatim when a session is known", () => {
+    for (const original of [
+        "claude --model custom; printf done",
+        "grok && printf done",
+        "codex | cat",
+        "claude\nprintf done",
+        "claude > output.log",
+    ]) {
+        expect(deriveReplayCommand({ original, sessionId: "fixture-session" }).command).toBe(original);
+    }
+});

--- a/src/cmux/lib/command-capture.ts
+++ b/src/cmux/lib/command-capture.ts
@@ -101,10 +101,12 @@ export interface SurfaceSessionInfo {
 }
 
 /** surface uuid (CMUX_SURFACE_ID) → newest known claude session + account. */
-export async function loadSurfaceSessions(): Promise<Map<string, SurfaceSessionInfo>> {
+export async function loadSurfaceSessions(
+    options: { beforeMs?: number } = {}
+): Promise<Map<string, SurfaceSessionInfo>> {
     const out = new Map<string, { sessionId: string; account?: string; at: number }>();
     try {
-        const refs = loadAllSessionCmuxRefs();
+        const refs = loadAllSessionCmuxRefs(undefined, options);
         const pins = await loadPins({ readOnly: true });
 
         for (const entry of refs.values()) {
@@ -151,10 +153,40 @@ const CC_RUN_LAUNCHER = /^tools (?:cc|claude) run(?![\w-])/;
 const GROK_LAUNCHER = /^grok(?![\w-])/;
 const CODEX_LAUNCHER = /^codex(?![\w-])/;
 
+function isSimpleAgentCommand(command: string): boolean {
+    let quote: string | undefined;
+    for (let index = 0; index < command.length; index++) {
+        const char = command[index];
+        if (char === "\n" || char === "\r" || char === "`" || (char === "$" && command[index + 1] === "(")) {
+            return false;
+        }
+
+        if (char === "\\" && quote !== "'") {
+            index++;
+            continue;
+        }
+
+        if (quote) {
+            if (char === quote) {
+                quote = undefined;
+            }
+        } else if (char === "'" || char === '"') {
+            quote = char;
+        } else if (/[;&|<>()#]/.test(char)) {
+            return false;
+        }
+    }
+
+    return quote === undefined;
+}
+
 export function isAgentLauncher(command: string): boolean {
     const trimmed = command.trim();
 
-    return CLAUDE_LAUNCHER.test(trimmed) || GROK_LAUNCHER.test(trimmed) || CODEX_LAUNCHER.test(trimmed);
+    return (
+        isSimpleAgentCommand(command) &&
+        (CLAUDE_LAUNCHER.test(trimmed) || GROK_LAUNCHER.test(trimmed) || CODEX_LAUNCHER.test(trimmed))
+    );
 }
 
 export function agentKindFromLauncher(command: string): "claude" | "grok" | "codex" | undefined {
@@ -389,8 +421,8 @@ export function deriveReplayCommand(input: {
     account?: string;
 }): ReplayDerivation {
     const original = input.original.trim();
-    if (!input.sessionId) {
-        return { command: original, drift: [] };
+    if (!input.sessionId || !isAgentLauncher(input.original)) {
+        return { command: input.original, drift: [] };
     }
 
     if (GROK_LAUNCHER.test(original)) {

--- a/src/cmux/lib/offline-capture-journal.test.ts
+++ b/src/cmux/lib/offline-capture-journal.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { buildOfflinePanes } from "@app/cmux/lib/offline-snapshot";
+
+test("stable surface command journal restores a usage tab despite stale native agent metadata", () => {
+    const panes = buildOfflinePanes(
+        {
+            layout: { type: "pane", pane: { panelIds: ["new-id"] } },
+            panels: [
+                {
+                    id: "new-id",
+                    stableSurfaceId: "11111111-1111-4111-8111-111111111111",
+                    type: "terminal",
+                    title: "usage",
+                    directory: "/new cwd",
+                    terminal: { agent: { kind: "codex", sessionId: "stale" } },
+                },
+            ],
+        },
+        { x: 0, y: 0, width: 800, height: 600 },
+        {
+            ttyCommands: new Map(),
+            surfaceSessions: new Map(),
+            surfaceCommands: new Map([
+                [
+                    "11111111-1111-4111-8111-111111111111",
+                    {
+                        version: 1,
+                        surfaceId: "11111111-1111-4111-8111-111111111111",
+                        atMs: 100,
+                        command: "tools usage --name 'two words'",
+                        cwd: "/launch cwd",
+                        phase: "completed",
+                        exitStatus: 0,
+                    },
+                ],
+            ]),
+        }
+    );
+    expect(panes[0].surfaces[0]).toMatchObject({ command: "tools usage --name 'two words'", cwd: "/launch cwd" });
+});
+
+test("a shell capture is authoritative over another agent's stale native binding and title", () => {
+    const panes = buildOfflinePanes(
+        {
+            layout: { type: "pane", pane: { panelIds: ["11111111-1111-4111-8111-111111111111"] } },
+            panels: [
+                {
+                    id: "11111111-1111-4111-8111-111111111111",
+                    type: "terminal",
+                    title: "grok",
+                    terminal: {
+                        agent: { kind: "grok", sessionId: "wrong-agent-session", workingDirectory: "/wrong cwd" },
+                    },
+                },
+            ],
+        },
+        { x: 0, y: 0, width: 800, height: 600 },
+        {
+            ttyCommands: new Map(),
+            surfaceSessions: new Map(),
+            surfaceCommands: new Map([
+                [
+                    "11111111-1111-4111-8111-111111111111",
+                    {
+                        version: 1,
+                        surfaceId: "11111111-1111-4111-8111-111111111111",
+                        atMs: 100,
+                        command: "codex --model custom",
+                        cwd: "/launch cwd",
+                        phase: "running",
+                    },
+                ],
+            ]),
+        }
+    );
+    expect(panes[0].surfaces[0]).toMatchObject({ command: "codex --model custom", cwd: "/launch cwd" });
+});

--- a/src/cmux/lib/offline-snapshot.test.ts
+++ b/src/cmux/lib/offline-snapshot.test.ts
@@ -48,6 +48,89 @@ describe("flattenLayout", () => {
 });
 
 describe("buildOfflinePanes", () => {
+    test("uses stable surface journal IDs and terminal cwd even when the title is not a path", () => {
+        const ws = workspaceFixture();
+        ws.panels[0] = {
+            id: "a",
+            stableSurfaceId: "stable-a",
+            type: "terminal",
+            title: "✳ session",
+            terminal: { workingDirectory: "/tmp/project" },
+        };
+        const panes = buildOfflinePanes(ws, FRAME, {
+            ttyCommands: new Map(),
+            surfaceSessions: new Map([
+                ["stable-a", { sessionId: "11111111-aaaa-bbbb-cccc-222222222222", account: "work" }],
+            ]),
+        });
+        expect(panes[0].surfaces[0]).toMatchObject({
+            cwd: "/tmp/project",
+            command: expect.stringContaining("11111111-aaaa-bbbb-cccc-222222222222"),
+        });
+    });
+
+    test("restores native session metadata despite an uninformative title", () => {
+        const ws = workspaceFixture();
+        ws.panels[0] = {
+            id: "a",
+            type: "terminal",
+            title: "project",
+            directory: "/tmp/project",
+            terminal: {
+                agent: {
+                    kind: "codex",
+                    sessionId: "11111111-aaaa-bbbb-cccc-222222222222",
+                    launchCommand: { arguments: ["/opt/bin/codex", "--sandbox", "workspace-write"] },
+                },
+            },
+        };
+        const panes = buildOfflinePanes(ws, FRAME, { ttyCommands: new Map(), surfaceSessions: new Map() });
+        const surface = panes[0].surfaces[0];
+        expect(surface.type === "terminal" && surface.command).toContain("resume 11111111-aaaa-bbbb-cccc-222222222222");
+        expect(surface.type === "terminal" && surface.command).toContain("--sandbox workspace-write");
+    });
+
+    // Regression test: cmux restart verification, 2026-09-07 — agent cwd differs from the shell cwd.
+    test.each([
+        { agentCwd: "/tmp/agent-project", bindingCwd: "/tmp/binding-project", expected: "/tmp/agent-project" },
+        { agentCwd: undefined, bindingCwd: "/tmp/binding-project", expected: "/tmp/binding-project" },
+    ])("resumes native agents in their recorded directory: $expected", ({ agentCwd, bindingCwd, expected }) => {
+        const ws = workspaceFixture();
+        ws.panels[0].terminal = {
+            agent: {
+                kind: "codex",
+                sessionId: "11111111-aaaa-bbbb-cccc-222222222222",
+                workingDirectory: agentCwd,
+            },
+            resumeBinding: {
+                kind: "codex",
+                checkpointId: "11111111-aaaa-bbbb-cccc-222222222222",
+                cwd: bindingCwd,
+            },
+        };
+        const panes = buildOfflinePanes(ws, FRAME, { ttyCommands: new Map(), surfaceSessions: new Map() });
+        expect(panes[0].surfaces[0]).toMatchObject({ cwd: expected });
+    });
+
+    test("restores native resume bindings when the agent record is absent", () => {
+        const ws = workspaceFixture();
+        ws.panels[0] = {
+            id: "a",
+            type: "terminal",
+            title: "project",
+            directory: "/tmp/project",
+            terminal: {
+                resumeBinding: {
+                    kind: "codex",
+                    checkpointId: "11111111-aaaa-bbbb-cccc-222222222222",
+                    cwd: "/tmp/project",
+                },
+            },
+        };
+        expect(
+            buildOfflinePanes(ws, FRAME, { ttyCommands: new Map(), surfaceSessions: new Map() })[0].surfaces[0]
+        ).toMatchObject({ command: "codex resume 11111111-aaaa-bbbb-cccc-222222222222" });
+    });
     test("groups tabs per pane, keeps selection, joins commands via tty and enriches claude launchers", () => {
         const ws = workspaceFixture();
         const panes = buildOfflinePanes(ws, FRAME, {
@@ -124,4 +207,59 @@ describe("buildOfflinePanes", () => {
             expect(surface.command_source).toBe("offline");
         }
     });
+});
+
+test("offline recovery retains native terminal scrollback and a browser URL", () => {
+    const panes = buildOfflinePanes(
+        {
+            layout: { type: "pane", pane: { panelIds: ["shell", "web"], selectedPanelId: "shell" } },
+            panels: [
+                {
+                    id: "shell",
+                    type: "terminal",
+                    title: "Logs",
+                    directory: "/tmp/project",
+                    terminal: { scrollback: "➜  project tail -f app.log\nservice ready\n" },
+                },
+                { id: "web", type: "browser", title: "Reference", browser: { urlString: "https://example.test/docs" } },
+            ],
+        },
+        FRAME,
+        { ttyCommands: new Map(), surfaceSessions: new Map() }
+    );
+    expect(panes[0].surfaces[0]).toMatchObject({
+        screen: { text: "➜  project tail -f app.log\nservice ready", rows: 2 },
+        command: "tail -f app.log",
+    });
+    expect(panes[0].surfaces[1]).toMatchObject({ type: "browser", url: "https://example.test/docs" });
+});
+
+test("offline recovery finds cached viewport by persisted identity after a panel move", () => {
+    const panes = buildOfflinePanes(
+        {
+            layout: { type: "pane", pane: { panelIds: ["new-panel"] } },
+            panels: [
+                {
+                    id: "new-panel",
+                    stableSurfaceId: "22222222-2222-4222-8222-222222222222",
+                    type: "terminal",
+                    title: "Monitor",
+                    directory: "/tmp/project",
+                    terminal: { scrollback: "\u001b[0m  \n" },
+                },
+            ],
+        },
+        FRAME,
+        {
+            ttyCommands: new Map(),
+            surfaceSessions: new Map(),
+            surfaceScreens: new Map([
+                [
+                    "22222222-2222-4222-8222-222222222222",
+                    { surfaceId: "11111111-1111-4111-8111-111111111111", text: "CPU 2%\nMemory 40 MiB", atMs: 10 },
+                ],
+            ]),
+        }
+    );
+    expect(panes[0].surfaces[0]).toMatchObject({ screen: { text: "CPU 2%\nMemory 40 MiB", rows: 2 } });
 });

--- a/src/cmux/lib/offline-snapshot.test.ts
+++ b/src/cmux/lib/offline-snapshot.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { AutosaveWorkspace } from "@app/cmux/lib/autosave";
 import { flattenLayout } from "@app/cmux/lib/autosave";
-import { buildOfflinePanes } from "@app/cmux/lib/offline-snapshot";
+import { buildOfflinePanes, buildOfflineProfile } from "@app/cmux/lib/offline-snapshot";
 
 const FRAME = { x: 0, y: 0, width: 1000, height: 800 };
 
@@ -262,4 +262,29 @@ test("offline recovery finds cached viewport by persisted identity after a panel
         }
     );
     expect(panes[0].surfaces[0]).toMatchObject({ screen: { text: "CPU 2%\nMemory 40 MiB", rows: 2 } });
+});
+
+test("offline screen opt-out omits both cached and native terminal output", () => {
+    const workspace = workspaceFixture();
+    workspace.panels[0].terminal = { scrollback: "native fixture text" };
+    const session = { path: "/fixture", savedAtMs: 1, windows: [{ tabManager: { workspaces: [workspace] } }] };
+    const deps = {
+        ttyCommands: new Map<string, string>(),
+        surfaceSessions: new Map(),
+        surfaceScreens: new Map([
+            ["b", { surfaceId: "11111111-1111-4111-8111-111111111111", text: "cached fixture text", atMs: 1 }],
+        ]),
+    };
+    const enabled = buildOfflineProfile(session, deps, { name: "fixture", captureScreen: true });
+    expect(enabled.windows[0].workspaces[0].panes[0].surfaces[0]).toMatchObject({
+        screen: { text: "native fixture text" },
+    });
+    const disabled = buildOfflineProfile(session, deps, { name: "fixture", captureScreen: false });
+    for (const pane of disabled.windows[0].workspaces[0].panes) {
+        for (const surface of pane.surfaces) {
+            if (surface.type === "terminal") {
+                expect(surface.screen).toBeUndefined();
+            }
+        }
+    }
 });

--- a/src/cmux/lib/offline-snapshot.ts
+++ b/src/cmux/lib/offline-snapshot.ts
@@ -3,9 +3,20 @@ import {
     type AutosaveSession,
     type AutosaveWorkspace,
     flattenLayout,
+    panelWorkingDirectory,
     readAutosaveSession,
 } from "@app/cmux/lib/autosave";
-import { collectTtyLaunchCommands, loadSurfaceSessions, type SurfaceSessionInfo } from "@app/cmux/lib/command-capture";
+import { type CapturedCommand, loadCapturedCommands } from "@app/cmux/lib/capture-journal";
+import {
+    agentKindFromLauncher,
+    collectTtyLaunchCommands,
+    deriveReplayCommand,
+    isAgentLauncher,
+    loadSurfaceSessions,
+    type SurfaceSessionInfo,
+} from "@app/cmux/lib/command-capture";
+import { loadSavedScreens, preferredScreenText, type SavedSurfaceScreen } from "@app/cmux/lib/screen-cache";
+import { lastCommandFromCapture } from "@app/cmux/lib/shell-probe";
 import type { Pane, Profile, Surface, Window, Workspace } from "@app/cmux/lib/types";
 import { PROFILE_VERSION } from "@app/cmux/lib/types";
 import { logger } from "@genesiscz/utils/logger";
@@ -16,8 +27,8 @@ import { logger } from "@genesiscz/utils/logger";
  * with the process table and the claude session journals. This is the rescue
  * path for a UI-thread livelock, where every socket state command starves.
  *
- * Not captured offline: visible screen contents (needs `capture-pane`) and
- * browser URLs. Both degrade gracefully on restore.
+ * Native scrollback and browser URLs are preserved when the autosave contains
+ * them. No live UI activation is required for this recovery path.
  */
 
 const DEFAULT_CELL_WIDTH_PX = 8;
@@ -27,6 +38,8 @@ export interface OfflineCaptureDeps {
     ttyCommands: Map<string, string>;
     surfaceSessions: Map<string, SurfaceSessionInfo>;
     grokSessions?: ReplayCatalogSession[];
+    surfaceCommands?: Map<string, CapturedCommand>;
+    surfaceScreens?: Map<string, SavedSurfaceScreen>;
 }
 
 export interface OfflineCaptureOptions {
@@ -47,7 +60,17 @@ export async function captureOfflineProfile(options: OfflineCaptureOptions): Pro
     const [ttyCommands, surfaceSessions] = await Promise.all([collectTtyLaunchCommands(), loadSurfaceSessions()]);
     const grokSessions = loadGrokCatalog(cwds);
 
-    return buildOfflineProfile(session, { ttyCommands, surfaceSessions, grokSessions }, options);
+    return buildOfflineProfile(
+        session,
+        {
+            ttyCommands,
+            surfaceSessions,
+            grokSessions,
+            surfaceCommands: loadCapturedCommands(),
+            surfaceScreens: loadSavedScreens(),
+        },
+        options
+    );
 }
 
 export function buildOfflineProfile(
@@ -110,12 +133,77 @@ export function buildOfflinePanes(
             }
 
             if (panel.type === "browser") {
-                surfaces.push({ type: "browser", title: panel.title ?? "" });
+                surfaces.push({ type: "browser", title: panel.title ?? "", url: panel.browser?.urlString });
                 continue;
             }
 
-            const original = panel.ttyName ? deps.ttyCommands.get(panel.ttyName) : undefined;
-            const session = deps.surfaceSessions.get(panel.id);
+            const captured =
+                (panel.stableSurfaceId ? deps.surfaceCommands?.get(panel.stableSurfaceId.toLowerCase()) : undefined) ??
+                deps.surfaceCommands?.get(panel.id.toLowerCase());
+            const cachedScreen =
+                (panel.stableSurfaceId ? deps.surfaceScreens?.get(panel.stableSurfaceId.toLowerCase()) : undefined) ??
+                deps.surfaceScreens?.get(panel.id.toLowerCase());
+            const text = preferredScreenText(panel.terminal?.scrollback, cachedScreen?.text);
+            const screen = text ? { text, rows: text.split("\n").length } : undefined;
+            const original =
+                captured?.command ??
+                (panel.ttyName ? deps.ttyCommands.get(panel.ttyName) : undefined) ??
+                panel.terminal?.tmuxStartCommand ??
+                lastCommandFromCapture(text).value;
+            const session =
+                deps.surfaceSessions.get(panel.id) ??
+                (panel.stableSurfaceId ? deps.surfaceSessions.get(panel.stableSurfaceId) : undefined);
+            const cwd = captured?.cwd ?? panelWorkingDirectory(panel) ?? workspace.currentDirectory;
+
+            if (captured && !isAgentLauncher(captured.command)) {
+                surfaces.push({
+                    type: "terminal",
+                    title: panel.title ?? "",
+                    screen,
+                    cwd,
+                    command: captured.command,
+                    command_source: "shell-journal",
+                    drift: [
+                        `exact command recovered from shell journal (${captured.phase}${captured.exitStatus !== undefined ? `, exit ${captured.exitStatus}` : ""})`,
+                    ],
+                });
+                continue;
+            }
+            const agent = panel.terminal?.agent;
+            const binding = panel.terminal?.resumeBinding;
+            const nativeKind = agent?.kind ?? binding?.kind;
+            const nativeSessionId = agent?.sessionId ?? binding?.checkpointId;
+            const launchArgs = agent?.launchCommand?.arguments ?? [];
+            const headless = launchArgs.some((arg) =>
+                ["-p", "--prompt", "--prompt-file", "--output-format"].includes(arg)
+            );
+            if (
+                nativeKind &&
+                nativeSessionId &&
+                !headless &&
+                (!captured || agentKindFromLauncher(captured.command) === nativeKind)
+            ) {
+                const quote = (arg: string) =>
+                    /^[a-zA-Z0-9_./:=@+-]+$/.test(arg) ? arg : `'${arg.replace(/'/g, "'\\''")}'`;
+                const original = captured?.command ?? [nativeKind, ...launchArgs.slice(1)].map(quote).join(" ");
+                const derived = deriveReplayCommand({
+                    original,
+                    sessionId: nativeSessionId,
+                    account: session?.account,
+                });
+                surfaces.push({
+                    type: "terminal",
+                    title: panel.title ?? "",
+                    screen,
+                    cwd: captured?.cwd ?? agent?.workingDirectory ?? binding?.cwd ?? cwd,
+                    command: derived.command,
+                    command_source: captured ? "shell-journal" : "offline",
+                    command_original: captured && derived.command !== captured.command ? captured.command : undefined,
+                    resume: { kind: nativeKind, sessionId: nativeSessionId },
+                    drift: [`resume target recovered from cmux autosave (${nativeKind})`, ...derived.drift],
+                });
+                continue;
+            }
             // Always "claude": the surface-session journal only records Claude
             // sessions, so typing the kind from the tab title turned a claude
             // uuid into a `grok -r` argument on any pane whose title ends in
@@ -124,14 +212,19 @@ export function buildOfflinePanes(
                 ? {
                       kind: "claude",
                       sessionId: session.sessionId,
-                      cwd: panel.directory ?? "",
+                      cwd: cwd ?? "",
                       title: panel.title ?? "",
                       account: session.account,
                   }
                 : undefined;
 
             const derived = replayCommandForSurface(
-                { title: panel.title ?? "", cwd: panel.directory, command: original },
+                {
+                    title: panel.title ?? "",
+                    cwd,
+                    command: original,
+                    command_source: captured ? "shell-journal" : undefined,
+                },
                 { sessions: deps.grokSessions ?? [] },
                 preferred
             );
@@ -139,9 +232,10 @@ export function buildOfflinePanes(
             surfaces.push({
                 type: "terminal",
                 title: panel.title ?? "",
-                cwd: panel.directory,
+                screen,
+                cwd,
                 command: derived.command,
-                command_source: derived.command ? "offline" : undefined,
+                command_source: derived.command ? (captured ? "shell-journal" : "offline") : undefined,
                 command_original: derived.command && derived.command !== original ? original : undefined,
                 drift: derived.drift.length > 0 ? derived.drift : undefined,
             });

--- a/src/cmux/lib/offline-snapshot.ts
+++ b/src/cmux/lib/offline-snapshot.ts
@@ -40,11 +40,13 @@ export interface OfflineCaptureDeps {
     grokSessions?: ReplayCatalogSession[];
     surfaceCommands?: Map<string, CapturedCommand>;
     surfaceScreens?: Map<string, SavedSurfaceScreen>;
+    captureScreen?: boolean;
 }
 
 export interface OfflineCaptureOptions {
     name: string;
     note?: string;
+    captureScreen?: boolean;
 }
 
 export async function captureOfflineProfile(options: OfflineCaptureOptions): Promise<Profile> {
@@ -67,7 +69,7 @@ export async function captureOfflineProfile(options: OfflineCaptureOptions): Pro
             surfaceSessions,
             grokSessions,
             surfaceCommands: loadCapturedCommands(),
-            surfaceScreens: loadSavedScreens(),
+            surfaceScreens: options.captureScreen === false ? undefined : loadSavedScreens(),
         },
         options
     );
@@ -87,7 +89,11 @@ export function buildOfflineProfile(
             title: ws.customTitle || ws.processTitle || `workspace ${wsIndex + 1}`,
             selected: wsIndex === selectedIndex,
             current_directory: ws.currentDirectory,
-            panes: buildOfflinePanes(ws, { x: 0, y: 0, width: frame.width, height: frame.height }, deps),
+            panes: buildOfflinePanes(
+                ws,
+                { x: 0, y: 0, width: frame.width, height: frame.height },
+                { ...deps, captureScreen: options.captureScreen ?? deps.captureScreen }
+            ),
         }));
 
         return {
@@ -144,7 +150,7 @@ export function buildOfflinePanes(
                 (panel.stableSurfaceId ? deps.surfaceScreens?.get(panel.stableSurfaceId.toLowerCase()) : undefined) ??
                 deps.surfaceScreens?.get(panel.id.toLowerCase());
             const text = preferredScreenText(panel.terminal?.scrollback, cachedScreen?.text);
-            const screen = text ? { text, rows: text.split("\n").length } : undefined;
+            const screen = deps.captureScreen !== false && text ? { text, rows: text.split("\n").length } : undefined;
             const original =
                 captured?.command ??
                 (panel.ttyName ? deps.ttyCommands.get(panel.ttyName) : undefined) ??

--- a/src/cmux/lib/replay-input.test.ts
+++ b/src/cmux/lib/replay-input.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import { queueReplayCommand } from "@app/cmux/lib/replay-input";
+import * as cli from "@genesiscz/utils/cmux/lib/cli";
+
+afterEach(() => mock.restore());
+
+test("unsubmitted multiline and control input never reaches the terminal", async () => {
+    const send = spyOn(cli, "sendSurfaceText").mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    for (const command of ["echo first\necho second", "echo first\recho second", "echo first\u001b[200~"]) {
+        expect(await queueReplayCommand({ surfaceRef: "surface:1", command, enter: false })).toBe(false);
+    }
+    expect(send).not.toHaveBeenCalled();
+});
+
+test("explicit execution preserves multiline text and ordinary pretyping stays unsubmitted", async () => {
+    const send = spyOn(cli, "sendSurfaceText").mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    await queueReplayCommand({ surfaceRef: "surface:1", command: "echo first\necho second", enter: true });
+    expect(send).toHaveBeenLastCalledWith({ surfaceRef: "surface:1", text: "echo first\necho second\n" });
+    await queueReplayCommand({ surfaceRef: "surface:1", command: "echo safe", enter: false });
+    expect(send).toHaveBeenLastCalledWith({ surfaceRef: "surface:1", text: "echo safe" });
+});

--- a/src/cmux/lib/replay-input.ts
+++ b/src/cmux/lib/replay-input.ts
@@ -1,0 +1,18 @@
+import { sendSurfaceText } from "@genesiscz/utils/cmux/lib/cli";
+import { out } from "@genesiscz/utils/logger";
+
+export async function queueReplayCommand(input: {
+    surfaceRef: string;
+    command: string;
+    enter: boolean;
+}): Promise<boolean> {
+    if (!input.enter && [...input.command].some((char) => char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127)) {
+        out.log.warn(
+            `Skipped pretyping multiline/control input in ${input.surfaceRef}; use --enter to explicitly execute the saved command.`
+        );
+        return false;
+    }
+
+    await sendSurfaceText({ surfaceRef: input.surfaceRef, text: input.enter ? `${input.command}\n` : input.command });
+    return true;
+}

--- a/src/cmux/lib/restore-after-restart.test.ts
+++ b/src/cmux/lib/restore-after-restart.test.ts
@@ -121,4 +121,19 @@ describe("filterReplayByAgents", () => {
         expect(surfaces[0]).toMatchObject({ command: undefined });
         expect(surfaces[1]).toMatchObject({ command: "tail -f app.log" });
     });
+
+    test("agent filtering also recognizes relative executable paths", () => {
+        for (const command of ["./codex resume fixture", "~/bin/codex resume fixture", "bin/codex resume fixture"]) {
+            const input = structuredClone(profile);
+            input.windows[0].workspaces[0].panes[0].surfaces = [
+                { type: "terminal", title: "old - grok", command, command_source: "shell-journal" },
+            ];
+            expect(filterReplayByAgents(input, ["grok"]).windows[0].workspaces[0].panes[0].surfaces[0]).toMatchObject({
+                command: undefined,
+            });
+            expect(filterReplayByAgents(input, ["codex"]).windows[0].workspaces[0].panes[0].surfaces[0]).toMatchObject({
+                command,
+            });
+        }
+    });
 });

--- a/src/cmux/lib/restore-after-restart.test.ts
+++ b/src/cmux/lib/restore-after-restart.test.ts
@@ -87,4 +87,38 @@ describe("filterReplayByAgents", () => {
         expect(surfaces[0] && surfaces[0].type === "terminal" ? surfaces[0].command : "missing").toBeUndefined();
         expect(surfaces[1] && surfaces[1].type === "terminal" ? surfaces[1].command : "missing").toContain("claude");
     });
+
+    test("the actual executable wins over a stale grok title", () => {
+        const input = structuredClone(profile);
+        input.windows[0].workspaces[0].panes[0].surfaces = [
+            {
+                type: "terminal",
+                title: "Old task - grok",
+                command: "/opt/homebrew/bin/codex resume test-session",
+                command_source: "foreground",
+            },
+        ];
+        const filtered = filterReplayByAgents(input, ["grok"]);
+        expect(filtered.windows[0].workspaces[0].panes[0].surfaces[0]).toMatchObject({ command: undefined });
+        expect(filterReplayByAgents(input, ["codex"]).windows[0].workspaces[0].panes[0].surfaces[0]).toMatchObject({
+            command: "/opt/homebrew/bin/codex resume test-session",
+        });
+    });
+
+    test("never replays the restore command itself but retains other shell commands", () => {
+        const input = structuredClone(profile);
+        input.windows[0].workspaces[0].panes[0].surfaces = [
+            {
+                type: "terminal",
+                title: "Restore",
+                command: "tools cmux restore-after-restart --enter -y",
+                command_source: "foreground",
+            },
+            { type: "terminal", title: "Logs", command: "tail -f app.log", command_source: "foreground" },
+        ];
+        const surfaces = filterReplayByAgents(input, ["claude", "grok", "codex"]).windows[0].workspaces[0].panes[0]
+            .surfaces;
+        expect(surfaces[0]).toMatchObject({ command: undefined });
+        expect(surfaces[1]).toMatchObject({ command: "tail -f app.log" });
+    });
 });

--- a/src/cmux/lib/restore-after-restart.ts
+++ b/src/cmux/lib/restore-after-restart.ts
@@ -1,6 +1,5 @@
-import { inferLauncherFromTitle } from "@app/cmux/lib/agent-replay";
-import { agentKindFromLauncher, isAgentLauncher } from "@app/cmux/lib/command-capture";
-import type { Profile, TerminalSurface } from "@app/cmux/lib/types";
+import { agentKindFromLauncher, cleanLaunchCommand } from "@app/cmux/lib/command-capture";
+import type { Profile } from "@app/cmux/lib/types";
 import type { AgentKind } from "@genesiscz/utils/agent-sessions/types";
 
 export type RestoreRestartSource = "previous" | "live" | "profile";
@@ -48,12 +47,6 @@ export function parseAgentList(raw: string | undefined): AgentKind[] {
     return kinds;
 }
 
-function surfaceKind(surface: TerminalSurface): AgentKind | undefined {
-    return (
-        inferLauncherFromTitle(surface.title) ?? (surface.command ? agentKindFromLauncher(surface.command) : undefined)
-    );
-}
-
 /** Drop inferred resume commands for agents the user did not ask to restore. */
 export function filterReplayByAgents(profile: Profile, agents: AgentKind[]): Profile {
     const allowed = new Set(agents);
@@ -71,13 +64,27 @@ export function filterReplayByAgents(profile: Profile, agents: AgentKind[]): Pro
                             return surface;
                         }
 
-                        const kind = surfaceKind(surface);
-                        if (!kind || allowed.has(kind)) {
-                            return surface;
-                        }
-
-                        if (surface.command && isAgentLauncher(surface.command)) {
-                            return { ...surface, command: undefined, command_source: undefined };
+                        // Filter the prepared command that will actually run; the tab
+                        // title can still name an agent that ran here previously.
+                        const command = cleanLaunchCommand(surface.command ?? "").replace(
+                            /^\/\S*\/(?=(?:codex|claude|grok|tools)(?:\s|$))/,
+                            ""
+                        );
+                        const kind = agentKindFromLauncher(command);
+                        const restoresItself =
+                            /^tools\s+cmux\s+(?:restore-after-restart|profiles\s+restore)(?:\s|$)/.test(command);
+                        if (restoresItself || (kind && !allowed.has(kind))) {
+                            return {
+                                ...surface,
+                                command: undefined,
+                                command_source: undefined,
+                                command_original: surface.command,
+                                drift: [
+                                    restoresItself
+                                        ? "skipped restore command to avoid recursive restoration"
+                                        : `skipped ${kind}: agent not selected`,
+                                ],
+                            };
                         }
 
                         return surface;

--- a/src/cmux/lib/restore-after-restart.ts
+++ b/src/cmux/lib/restore-after-restart.ts
@@ -67,7 +67,7 @@ export function filterReplayByAgents(profile: Profile, agents: AgentKind[]): Pro
                         // Filter the prepared command that will actually run; the tab
                         // title can still name an agent that ran here previously.
                         const command = cleanLaunchCommand(surface.command ?? "").replace(
-                            /^\/\S*\/(?=(?:codex|claude|grok|tools)(?:\s|$))/,
+                            /^\S*\/(?=(?:codex|claude|grok|tools)(?:\s|$))/,
                             ""
                         );
                         const kind = agentKindFromLauncher(command);

--- a/src/cmux/lib/restore.browser.live.test.ts
+++ b/src/cmux/lib/restore.browser.live.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { restoreProfile } from "@app/cmux/lib/restore";
+import type { Profile } from "@app/cmux/lib/types";
+import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { paneList } from "@genesiscz/utils/cmux/lib/socket";
+import { env } from "@genesiscz/utils/env";
+
+test.skipIf(env.getProcessEnv().RUN_LIVE !== "1" || !env.getProcessEnv().CMUX_TEST_WINDOW)(
+    "restores a browser as the first tab instead of an empty terminal",
+    async () => {
+        const title = `Browser restore check ${crypto.randomUUID()}`;
+        const window = env.getProcessEnv().CMUX_TEST_WINDOW!;
+        const profile: Profile = {
+            version: 1,
+            name: "browser-check",
+            scope: "workspace",
+            captured_at: "2026-09-07T00:00:00Z",
+            cmux_version: "test",
+            windows: [
+                {
+                    ref: "window:source",
+                    title: "Example",
+                    container_frame: { width: 800, height: 600 },
+                    workspaces: [
+                        {
+                            ref: "workspace:source",
+                            title,
+                            selected: true,
+                            panes: [
+                                {
+                                    ref: "pane:source",
+                                    index: 0,
+                                    columns: 80,
+                                    rows: 24,
+                                    pixel_frame: { x: 0, y: 0, width: 800, height: 600 },
+                                    selected_surface_index: 0,
+                                    surfaces: [{ type: "browser", title: "Example", url: "about:blank" }],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+        try {
+            const outcome = await restoreProfile(profile, {
+                prefix: "",
+                replay: false,
+                enter: false,
+                yes: true,
+                dryRun: false,
+                window,
+            });
+            const ref = outcome.workspaces[0].ref;
+            const pane = (await paneList(ref)).panes[0];
+            const listing = await runCmuxJSON<{ surfaces: Array<{ type: string }> }>([
+                "list-pane-surfaces",
+                "--workspace",
+                ref,
+                "--pane",
+                pane.ref,
+            ]);
+            expect(listing.surfaces.map((s) => s.type)).toEqual(["browser"]);
+        } finally {
+            const listing = await runCmuxJSON<{ workspaces: Array<{ ref: string; title: string }> }>([
+                "list-workspaces",
+                "--window",
+                window,
+            ]);
+            for (const ws of listing.workspaces.filter((w) => w.title === title)) {
+                await runCmuxOk(["close-workspace", "--workspace", ws.ref]);
+            }
+        }
+    },
+    30_000
+);

--- a/src/cmux/lib/restore.continue.test.ts
+++ b/src/cmux/lib/restore.continue.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import { materializeWorkspace } from "@app/cmux/lib/restore";
+import type { Workspace } from "@app/cmux/lib/types";
+import * as socket from "@genesiscz/utils/cmux/lib/socket";
+import * as split from "@genesiscz/utils/cmux/split-tree";
+
+afterEach(() => mock.restore());
+
+test("an invalid browser anchor marks non-convergence and attempts later panes", async () => {
+    spyOn(split, "applySplitTree").mockResolvedValue(
+        new Map([
+            [0, "pane:1"],
+            [1, "pane:2"],
+        ])
+    );
+    spyOn(split, "measureCellDelta").mockResolvedValue(0);
+    const inspect = spyOn(socket, "paneList").mockResolvedValue({
+        workspace_ref: "workspace:1",
+        window_ref: "window:1",
+        container_frame: { width: 800, height: 600 },
+        panes: [
+            {
+                ref: "pane:1",
+                index: 0,
+                surface_count: 2,
+                surface_refs: ["surface:1", "surface:2"],
+                selected_surface_ref: "surface:1",
+                focused: false,
+                pixel_frame: { x: 0, y: 0, width: 400, height: 600 },
+            },
+        ],
+    });
+    const ws: Workspace = {
+        ref: "workspace:1",
+        title: "fixture",
+        selected: true,
+        panes: [0, 1].map((index) => ({
+            ref: `pane:${index + 1}`,
+            index,
+            columns: 40,
+            rows: 30,
+            selected_surface_index: 0,
+            pixel_frame: { x: index * 400, y: 0, width: 400, height: 600 },
+            surfaces: [{ type: "browser", title: "fixture", url: "https://example.com" }],
+        })),
+    };
+    const result = await materializeWorkspace(ws, "workspace:1", {
+        prefix: "",
+        replay: false,
+        enter: false,
+        yes: true,
+        dryRun: false,
+    });
+    expect(result.converged).toBe(false);
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0]).toMatchObject({
+        paneRef: "pane:1",
+        message: expect.stringContaining("fresh restore anchor"),
+    });
+    expect(inspect).toHaveBeenCalledTimes(2);
+});

--- a/src/cmux/lib/restore.order.live.test.ts
+++ b/src/cmux/lib/restore.order.live.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import { restoreProfile } from "@app/cmux/lib/restore";
+import type { Profile } from "@app/cmux/lib/types";
+import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { env } from "@genesiscz/utils/env";
+
+// Regression test: 2026-09-07 live audit — workspace insertion reverses the saved order.
+test.skipIf(env.getProcessEnv().RUN_LIVE !== "1" || !env.getProcessEnv().CMUX_TEST_WINDOW)(
+    "restores workspace order in the real cmux window",
+    async () => {
+        const created: string[] = [];
+        const profile: Profile = {
+            version: 1,
+            name: "restore-order-test",
+            scope: "window",
+            captured_at: "2026-09-07T00:00:00Z",
+            cmux_version: "test",
+            windows: [
+                {
+                    ref: "window:source",
+                    title: "test",
+                    container_frame: { width: 800, height: 600 },
+                    workspaces: ["first", "second", "third"].map((title, i) => ({
+                        ref: `workspace:source-${i}`,
+                        title: `Restore verification ${title}`,
+                        selected: i === 0,
+                        panes: [],
+                    })),
+                },
+            ],
+        };
+        try {
+            await restoreProfile(
+                profile,
+                {
+                    prefix: "",
+                    replay: false,
+                    enter: false,
+                    yes: true,
+                    dryRun: false,
+                    window: env.getProcessEnv().CMUX_TEST_WINDOW,
+                },
+                {
+                    onWorkspaceDone: ({ ref }) => {
+                        created.push(ref);
+                    },
+                }
+            );
+            const layout = await runCmuxJSON<{ window_ref: string }>(["list-panes", "--workspace", created[0]]);
+            const live = await runCmuxJSON<{ workspaces: Array<{ ref: string; index: number }> }>([
+                "list-workspaces",
+                "--window",
+                layout.window_ref,
+            ]);
+            expect(
+                live.workspaces
+                    .filter((ws) => created.includes(ws.ref))
+                    .sort((a, b) => a.index - b.index)
+                    .map((ws) => ws.ref)
+            ).toEqual(created);
+        } finally {
+            for (const ref of created) {
+                await runCmuxOk(["close-workspace", "--workspace", ref]);
+            }
+        }
+    },
+    30_000
+);

--- a/src/cmux/lib/restore.prompts.test.ts
+++ b/src/cmux/lib/restore.prompts.test.ts
@@ -19,6 +19,17 @@ describe("detectInteractivePrompt", () => {
         expect(detectInteractivePrompt(screen)).toContain("verify the highlighted session");
     });
 
+    // Regression test: 2026-09-07 live audit — failed resumes and cwd dialogs were reported as clear.
+    test.each([
+        ["ERROR: No saved session found with ID example", "resume failed"],
+        ["No conversation found with session ID: example", "resume failed"],
+        ["thread example already has an active writer (code -32600)", "already running"],
+        ["1. Use session directory (/tmp/project)\n2. Use current directory (/tmp/other)", "directory-choice"],
+        ["cmdand quote> %s%s", "shell continuation"],
+    ])("reports unresolved terminal state: %s", (screen, label) => {
+        expect(detectInteractivePrompt(screen)).toContain(label);
+    });
+
     test("returns undefined for a busy claude pane", () => {
         const screen = "✳ Cooking… (2m 3s · ↓ 1.2k tokens)\n  ⏵⏵ bypass permissions on";
         expect(detectInteractivePrompt(screen)).toBeUndefined();
@@ -50,4 +61,11 @@ describe("formatWaitingPanes", () => {
         expect(restore.slice(0, -1)).toEqual(rescue.slice(0, -1));
         expect(restore.at(-1)).toBe("  Restore does not auto-confirm these; answer each pane yourself.");
     });
+});
+
+// Regression test: 2026-09-07 panel audit — Codex is waiting before its session starts.
+test("reports the Codex directory trust prompt", () => {
+    expect(
+        detectInteractivePrompt("Do you trust the contents of this directory?\n1. Yes, continue\n2. No, quit")
+    ).toContain("directory-trust");
 });

--- a/src/cmux/lib/restore.replay.live.test.ts
+++ b/src/cmux/lib/restore.replay.live.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test";
+import { restoreProfile } from "@app/cmux/lib/restore";
+import { waitForTerminalText } from "@app/cmux/lib/terminal-ready";
+import type { Profile } from "@app/cmux/lib/types";
+import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { paneList } from "@genesiscz/utils/cmux/lib/socket";
+import { env } from "@genesiscz/utils/env";
+
+// Regression test: 2026-09-07 screenshot — exercise the real shell, transport, setup and replay.
+test.skipIf(env.getProcessEnv().RUN_LIVE !== "1" || !env.getProcessEnv().CMUX_TEST_WINDOW)(
+    "restores a shell without visible setup markers or broken quoting",
+    async () => {
+        const title = `Restore replay verification ${crypto.randomUUID()}`;
+        const profile: Profile = {
+            version: 1,
+            name: "replay-test",
+            scope: "workspace",
+            captured_at: "2026-09-07T00:00:00Z",
+            cmux_version: "offline (test autosave)",
+            windows: [
+                {
+                    ref: "window:source",
+                    title: "test",
+                    container_frame: { width: 800, height: 600 },
+                    workspaces: [
+                        {
+                            ref: "workspace:source",
+                            title,
+                            selected: true,
+                            current_directory: "/private/tmp",
+                            panes: [
+                                {
+                                    ref: "pane:source",
+                                    index: 0,
+                                    columns: 80,
+                                    rows: 24,
+                                    pixel_frame: { x: 0, y: 0, width: 800, height: 600 },
+                                    selected_surface_index: 0,
+                                    surfaces: [
+                                        {
+                                            type: "terminal",
+                                            title,
+                                            cwd: "/private/tmp",
+                                            command_source: "manual",
+                                            screen: { text: "SAVED_TRANSCRIPT_FOR_RESTORE\n", rows: 1 },
+                                            command: "printf 'CMUX_REPLAY_OK:%s\\n' 'a\\tb'; pwd",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+        try {
+            const result = await restoreProfile(profile, {
+                prefix: "",
+                replay: true,
+                enter: true,
+                yes: true,
+                dryRun: false,
+                window: env.getProcessEnv().CMUX_TEST_WINDOW,
+            });
+            expect(result.workspaces[0].maxCellDelta).toBeNull();
+            expect(result.workspaces[0].converged).toBe(false);
+            const workspaceRef = result.workspaces[0].ref;
+            const layout = await paneList(workspaceRef);
+            const surfaceRef = layout.panes[0].selected_surface_ref;
+            await waitForTerminalText({
+                workspaceRef,
+                surfaceRef,
+                description: "test command output",
+                matches: (text) => text.includes("CMUX_REPLAY_OK:a\\tb"),
+            });
+            const screen = await runCmuxOk(["read-screen", "--surface", surfaceRef]);
+            expect(screen.stdout).toContain("CMUX_REPLAY_OK:a\\tb");
+            expect(screen.stdout).toContain("/private/tmp");
+            expect(screen.stdout).toContain("SAVED_TRANSCRIPT_FOR_RESTORE");
+            expect(screen.stdout).not.toContain("quote>");
+            expect(screen.stdout).not.toContain("cmux-ready-");
+        } finally {
+            const live = await runCmuxJSON<{ workspaces: Array<{ ref: string; title: string }> }>([
+                "list-workspaces",
+                "--window",
+                env.getProcessEnv().CMUX_TEST_WINDOW!,
+            ]);
+            for (const workspace of live.workspaces.filter((ws) => ws.title === title)) {
+                await runCmuxOk(["close-workspace", "--workspace", workspace.ref]);
+            }
+        }
+    },
+    60_000
+);

--- a/src/cmux/lib/restore.scan.test.ts
+++ b/src/cmux/lib/restore.scan.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { scanForInteractivePrompts } from "@app/cmux/lib/restore";
+import * as cli from "@genesiscz/utils/cmux/lib/cli";
+import * as socket from "@genesiscz/utils/cmux/lib/socket";
+
+describe("restored prompt scan", () => {
+    afterEach(() => mock.restore());
+
+    function setup() {
+        spyOn(socket, "paneList").mockImplementation(async (workspaceRef) => ({
+            workspace_ref: workspaceRef,
+            window_ref: "window:2",
+            container_frame: { width: 800, height: 600 },
+            panes: [
+                {
+                    ref: "pane:10",
+                    index: 0,
+                    surface_count: 2,
+                    surface_refs: ["surface:36", "surface:40"],
+                    selected_surface_ref: "surface:36",
+                    focused: false,
+                    pixel_frame: { x: 0, y: 0, width: 800, height: 600 },
+                },
+            ],
+        }));
+        spyOn(cli, "runCmuxJSON").mockResolvedValue({
+            surfaces: [
+                { ref: "surface:36", type: "terminal" },
+                { ref: "surface:40", type: "browser" },
+            ],
+        });
+        return spyOn(cli, "runCmuxOk").mockResolvedValue({ code: 0, stdout: "Launch anyway?", stderr: "" });
+    }
+
+    test("reads only listed terminals and reports their prompts", async () => {
+        const read = setup();
+        const result = await scanForInteractivePrompts(["workspace:5"]);
+        expect(read.mock.calls).toEqual([[["read-screen", "--workspace", "workspace:5", "--surface", "surface:36"]]]);
+        expect(result).toEqual({
+            waiting: [
+                {
+                    workspaceRef: "workspace:5",
+                    surfaceRef: "surface:36",
+                    prompt: expect.stringContaining("account-headroom"),
+                },
+            ],
+            failures: [],
+        });
+    });
+
+    test("records read failures instead of claiming an empty successful scan", async () => {
+        setup().mockRejectedValue(new Error("surface closed"));
+        const result = await scanForInteractivePrompts(["workspace:5"]);
+        expect(result).toEqual({ waiting: [], failures: [expect.stringContaining("surface:36")] });
+    });
+
+    test("continues scanning later workspaces after a listing failure", async () => {
+        setup();
+        spyOn(socket, "paneList").mockRejectedValueOnce(new Error("workspace closed"));
+        const result = await scanForInteractivePrompts(["workspace:5", "workspace:6"]);
+        expect(result.failures).toHaveLength(1);
+        expect(result.waiting[0]?.workspaceRef).toBe("workspace:6");
+    });
+});

--- a/src/cmux/lib/restore.scan.test.ts
+++ b/src/cmux/lib/restore.scan.test.ts
@@ -7,7 +7,7 @@ describe("restored prompt scan", () => {
     afterEach(() => mock.restore());
 
     function setup() {
-        spyOn(socket, "paneList").mockImplementation(async (workspaceRef) => ({
+        const panes = spyOn(socket, "paneList").mockImplementation(async (workspaceRef) => ({
             workspace_ref: workspaceRef,
             window_ref: "window:2",
             container_frame: { width: 800, height: 600 },
@@ -29,11 +29,14 @@ describe("restored prompt scan", () => {
                 { ref: "surface:40", type: "browser" },
             ],
         });
-        return spyOn(cli, "runCmuxOk").mockResolvedValue({ code: 0, stdout: "Launch anyway?", stderr: "" });
+        return {
+            panes,
+            read: spyOn(cli, "runCmuxOk").mockResolvedValue({ code: 0, stdout: "Launch anyway?", stderr: "" }),
+        };
     }
 
     test("reads only listed terminals and reports their prompts", async () => {
-        const read = setup();
+        const { read } = setup();
         const result = await scanForInteractivePrompts(["workspace:5"]);
         expect(read.mock.calls).toEqual([[["read-screen", "--workspace", "workspace:5", "--surface", "surface:36"]]]);
         expect(result).toEqual({
@@ -49,14 +52,14 @@ describe("restored prompt scan", () => {
     });
 
     test("records read failures instead of claiming an empty successful scan", async () => {
-        setup().mockRejectedValue(new Error("surface closed"));
+        setup().read.mockRejectedValue(new Error("surface closed"));
         const result = await scanForInteractivePrompts(["workspace:5"]);
         expect(result).toEqual({ waiting: [], failures: [expect.stringContaining("surface:36")] });
     });
 
     test("continues scanning later workspaces after a listing failure", async () => {
-        setup();
-        spyOn(socket, "paneList").mockRejectedValueOnce(new Error("workspace closed"));
+        const { panes } = setup();
+        panes.mockRejectedValueOnce(new Error("workspace closed"));
         const result = await scanForInteractivePrompts(["workspace:5", "workspace:6"]);
         expect(result.failures).toHaveLength(1);
         expect(result.waiting[0]?.workspaceRef).toBe("workspace:6");

--- a/src/cmux/lib/restore.ts
+++ b/src/cmux/lib/restore.ts
@@ -1,9 +1,11 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { queueReplayCommand } from "@app/cmux/lib/replay-input";
+import { isShellPromptReady, waitForTerminalText } from "@app/cmux/lib/terminal-ready";
 import type { Pane, Profile, Surface, Workspace } from "@app/cmux/lib/types";
 import * as p from "@clack/prompts";
-import { runCmuxJSON, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { runCmuxJSON, runCmuxOk, sendSurfaceText } from "@genesiscz/utils/cmux/lib/cli";
 import { withFocusedWorkspace } from "@genesiscz/utils/cmux/lib/focus-guard";
 import { paneList, workspaceCreate } from "@genesiscz/utils/cmux/lib/socket";
 import { surfaceTargetArgs } from "@genesiscz/utils/cmux/lib/target";
@@ -22,6 +24,8 @@ export interface RestoreOptions {
     enter: boolean;
     yes: boolean;
     dryRun: boolean;
+    /** Explicit destination; otherwise cmux uses the current window. */
+    window?: string;
 }
 
 export interface RestorePlanWorkspace {
@@ -40,8 +44,8 @@ export interface RestoreOutcome {
         ref: string;
         title: string;
         converged: boolean;
-        /** Largest |saved - actual| over all panes / dimensions, in terminal cells. */
-        maxCellDelta: number;
+        /** Null when the source autosave had estimated rather than measured cell sizes. */
+        maxCellDelta: number | null;
     }>;
 }
 
@@ -81,6 +85,7 @@ export async function restoreProfile(
     events: RestoreEvents = {}
 ): Promise<RestoreOutcome> {
     const outcome: RestoreOutcome = { workspaces: [] };
+    const previousWorkspaceByWindow = new Map<string, string>();
     const totalWorkspaces = playable.windows.reduce((acc, w) => acc + w.workspaces.length, 0);
     let visited = 0;
 
@@ -90,7 +95,26 @@ export async function restoreProfile(
             const targetTitle = `${opts.prefix}${ws.title}`;
             events.onWorkspaceStart?.({ title: targetTitle, index: visited, total: totalWorkspaces });
 
-            const created = await workspaceCreate({ name: targetTitle });
+            const created = await workspaceCreate({
+                name: targetTitle,
+                window: opts.window,
+                cwd: ws.current_directory,
+            });
+            const previousWorkspace = previousWorkspaceByWindow.get(created.window_ref);
+            if (previousWorkspace) {
+                await runCmuxOk([
+                    "reorder-workspace",
+                    "--workspace",
+                    created.workspace_ref,
+                    "--after",
+                    previousWorkspace,
+                    "--window",
+                    created.window_ref,
+                ]);
+            }
+
+            previousWorkspaceByWindow.set(created.window_ref, created.workspace_ref);
+
             // workspace.create's name param is best-effort; cmux often overrides it with an
             // auto-generated user@host:cwd title. Force the desired title explicitly.
             try {
@@ -108,8 +132,8 @@ export async function restoreProfile(
             outcome.workspaces.push({
                 ref: created.workspace_ref,
                 title: targetTitle,
-                converged: result.converged,
-                maxCellDelta: result.maxCellDelta,
+                converged: !playable.cmux_version.startsWith("offline ") && result.converged,
+                maxCellDelta: playable.cmux_version.startsWith("offline ") ? null : result.maxCellDelta,
             });
             events.onWorkspaceDone?.({ ref: created.workspace_ref, title: targetTitle });
         }
@@ -241,6 +265,25 @@ async function populatePane(
         throw new Error(`Pane ${paneRef} disappeared mid-restore`);
     }
     const surfaceRefs = [...current.surface_refs];
+    const firstSurface = savedPane.surfaces[0];
+    if (firstSurface.type === "browser") {
+        if (surfaceRefs.length !== 1) {
+            throw new Error(`Expected one fresh restore anchor in ${paneRef}; refusing to replace existing tabs`);
+        }
+
+        const args = ["new-surface", "--workspace", workspaceRef, "--pane", paneRef, "--type", "browser"];
+        if (firstSurface.url) {
+            args.push("--url", firstSurface.url);
+        }
+
+        const browser = await runCmuxJSON<{ surface_ref: string; pane_ref: string }>(args);
+        if (browser.pane_ref !== paneRef) {
+            throw new Error(`Browser restore landed in ${browser.pane_ref}, expected ${paneRef}`);
+        }
+
+        await runCmuxOk(["close-surface", "--surface", surfaceRefs[0]]);
+        surfaceRefs[0] = browser.surface_ref;
+    }
 
     while (surfaceRefs.length < expectedCount) {
         const nextSavedSurface = savedPane.surfaces[surfaceRefs.length];
@@ -292,28 +335,29 @@ async function populatePane(
     // restored explicitly even when it is the first tab.
     const selectedIndex = savedPane.selected_surface_index;
 
-    if (surfaceRefs.length > 1 && selectedIndex >= 0 && selectedIndex < surfaceRefs.length) {
-        await reorder(surfaceRefs[selectedIndex], selectedIndex, true);
-    }
-
-    // Rename + replay
-    for (let i = 0; i < expectedCount; i += 1) {
-        const savedSurface = savedPane.surfaces[i];
-        const surfaceRef = surfaceRefs[i];
-        if (savedSurface.title) {
-            await runCmuxOk([
-                "rename-tab",
-                "--workspace",
-                workspaceRef,
-                "--surface",
-                surfaceRef,
-                savedSurface.title,
-            ]).catch((error) => {
-                logger.debug({ error, surfaceRef }, "[restore] rename-tab failed");
-            });
+    try {
+        for (let i = 0; i < expectedCount; i += 1) {
+            const savedSurface = savedPane.surfaces[i];
+            const surfaceRef = surfaceRefs[i];
+            if (savedSurface.title) {
+                await runCmuxOk([
+                    "rename-tab",
+                    "--workspace",
+                    workspaceRef,
+                    "--surface",
+                    surfaceRef,
+                    savedSurface.title,
+                ]).catch((error) => {
+                    logger.debug({ error, surfaceRef }, "[restore] rename-tab failed");
+                });
+            }
+            if (savedSurface.type === "terminal") {
+                await replayTerminal(savedSurface, workspaceRef, surfaceRef, opts);
+            }
         }
-        if (savedSurface.type === "terminal") {
-            await replayTerminal(savedSurface, workspaceRef, surfaceRef, opts);
+    } finally {
+        if (selectedIndex >= 0 && selectedIndex < surfaceRefs.length) {
+            await reorder(surfaceRefs[selectedIndex], selectedIndex, true);
         }
     }
 }
@@ -328,6 +372,14 @@ function shellQuote(path: string): string {
  * panes are waiting so the user confirms each one deliberately.
  */
 const INTERACTIVE_PROMPT_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+    { pattern: /Do you trust the contents of this directory\?/, label: "directory-trust prompt" },
+    {
+        pattern: /No saved session found|No conversation found with session ID|Failed to resume session/,
+        label: "resume failed; inspect the terminal error",
+    },
+    { pattern: /already has an active writer/, label: "session already running in another terminal" },
+    { pattern: /Use session directory[\s\S]*Use current directory/, label: "directory-choice dialog" },
+    { pattern: /(?:cmdand )?quote>/, label: "shell continuation or malformed replay text" },
     { pattern: /Launch anyway\?/, label: "account-headroom gate (weekly limit spent — Launch anyway?)" },
     { pattern: /Resume full session as-is/, label: "resume-mode dialog (summary vs full session)" },
     { pattern: /NAME\s+BRANCH\s+AGE/, label: "session picker (verify the highlighted session before Enter!)" },
@@ -351,20 +403,56 @@ export interface WaitingPane {
 }
 
 /** Scan the restored workspaces for panes stopped at an interactive prompt. Read-only. */
-export async function scanForInteractivePrompts(workspaceRefs: string[]): Promise<WaitingPane[]> {
+export async function scanForInteractivePrompts(workspaceRefs: string[]): Promise<PromptScanResult> {
     const waiting: WaitingPane[] = [];
+    const failures: string[] = [];
 
     for (const workspaceRef of workspaceRefs) {
-        const layout = await paneList(workspaceRef);
+        const layout = await paneList(workspaceRef).catch((error) => {
+            logger.debug({ error, workspaceRef }, "[restore] prompt scan pane listing failed");
+            failures.push(workspaceRef);
+            return undefined;
+        });
+        if (!layout) {
+            continue;
+        }
+
         for (const pane of layout.panes) {
-            for (const surfaceRef of pane.surface_refs) {
+            const listing = await runCmuxJSON<{ surfaces: Array<{ ref: string; type: string }> }>([
+                "list-pane-surfaces",
+                "--workspace",
+                workspaceRef,
+                "--pane",
+                pane.ref,
+            ]).catch((error) => {
+                logger.debug(
+                    { error, workspaceRef, paneRef: pane.ref },
+                    "[restore] prompt scan surface listing failed"
+                );
+                failures.push(`${workspaceRef} ${pane.ref}`);
+                return undefined;
+            });
+            if (!listing) {
+                continue;
+            }
+
+            for (const surface of listing.surfaces) {
+                if (surface.type !== "terminal") {
+                    continue;
+                }
+
+                const surfaceRef = surface.ref;
                 const result = await runCmuxOk([
                     "read-screen",
                     "--workspace",
                     workspaceRef,
                     "--surface",
                     surfaceRef,
-                ]).catch(() => undefined);
+                ]).catch((error) => {
+                    logger.debug({ error, workspaceRef, surfaceRef }, "[restore] prompt scan screen read failed");
+                    failures.push(`${workspaceRef} ${surfaceRef}`);
+                    return undefined;
+                });
                 if (!result) {
                     continue;
                 }
@@ -377,7 +465,12 @@ export async function scanForInteractivePrompts(workspaceRefs: string[]): Promis
         }
     }
 
-    return waiting;
+    return { waiting, failures };
+}
+
+export interface PromptScanResult {
+    waiting: WaitingPane[];
+    failures: string[];
 }
 
 /**
@@ -392,18 +485,26 @@ export async function reportWaitingPrompts(workspaceRefs: string[], actor: "Resc
     // The replayed commands need a moment to draw whatever they are going to ask.
     await new Promise((resolve) => setTimeout(resolve, 4000));
 
-    let waiting: WaitingPane[];
+    let result: PromptScanResult;
     try {
-        waiting = await scanForInteractivePrompts(workspaceRefs);
+        result = await scanForInteractivePrompts(workspaceRefs);
     } catch (error) {
         // Reporting "nothing is waiting" here would be a lie: the scan never ran.
         logger.debug({ error, actor }, "[cmux] waiting-prompt scan failed");
+        p.log.warn("Could not check restored terminals for interactive prompts. Check them manually.");
 
         return;
     }
 
+    const { waiting, failures } = result;
+    if (failures.length > 0) {
+        p.log.warn(`Prompt scan incomplete. Could not check: ${failures.join(", ")}. Check these manually.`);
+    }
+
     if (waiting.length === 0) {
-        p.log.info("No panes are waiting at an interactive prompt.");
+        if (failures.length === 0) {
+            p.log.info("No recognized interactive prompts found in the restored terminals.");
+        }
 
         return;
     }
@@ -419,38 +520,37 @@ export function formatWaitingPanes(waiting: WaitingPane[], actor: "Rescue" | "Re
     return lines;
 }
 
+function internalRestoreCommand(parts: string[]): string {
+    return `function _genesis_cmux_restore_internal { ${parts.join(" && ")}; }; _genesis_cmux_restore_internal; unfunction _genesis_cmux_restore_internal\n`;
+}
+
 async function replayTerminal(
     surface: Surface & { type: "terminal" },
     workspaceRef: string,
     surfaceRef: string,
     opts: RestoreOptions
 ): Promise<void> {
+    await waitForTerminalText({
+        workspaceRef,
+        surfaceRef,
+        matches: isShellPromptReady,
+        description: "shell prompt",
+        activateOnUnavailable: true,
+    });
     if (!opts.replay) {
         if (surface.cwd) {
-            await runCmuxOk([
-                "send",
-                ...surfaceTargetArgs(surfaceRef, workspaceRef),
-                `cd -- ${shellQuote(surface.cwd)}\n`,
-            ]);
+            await sendSurfaceText({ surfaceRef, text: internalRestoreCommand([`cd -- ${shellQuote(surface.cwd)}`]) });
         }
         return;
     }
 
-    // Build a single shell pipeline that:
-    //   1. cd's to the saved cwd (silently — failures don't abort)
-    //   2. clears the screen AND scrollback (\033[2J\033[3J\033[H), erasing both the
-    //      shell's startup banner and the typed-input echo of this very command
-    //   3. cats the saved screen contents from a temp file, faithfully reproducing
-    //      what the pane looked like when the profile was saved. The content goes
-    //      through a file, NOT inline base64 — a full pane screen inlined into one
-    //      typed line exceeds the pty input limit and the shell echoes the mangled
-    //      command as garbage instead of executing it.
-    // Then, after the trailing newline, the saved last-typed command is sent (without
-    // a newline) so it sits queued at the fresh prompt for the user to confirm — this
-    // is what re-launches `claude --resume <id>`, `vim file`, etc.
+    // Acknowledge directory setup before replay. Render saved output only after
+    // clearing the setup text, so the readiness marker is not left on screen and
+    // the saved transcript survives the redraw.
     const parts: string[] = [];
+    const screenParts: string[] = [];
     if (surface.cwd) {
-        parts.push(`cd -- ${shellQuote(surface.cwd)} 2>/dev/null`);
+        parts.push(`cd -- ${shellQuote(surface.cwd)}`);
     }
     // The screen text can hold tokens and private output, so it goes into a fresh
     // 0700 mkdtemp dir (unpredictable path, unreadable by other local users). The
@@ -461,20 +561,33 @@ async function replayTerminal(
         screenDir = await mkdtemp(join(tmpdir(), "cmux-restore-screen-"));
         const screenFile = join(screenDir, `${surfaceRef.replace(/[^A-Za-z0-9]/g, "-")}.txt`);
         await Bun.write(screenFile, surface.screen.text);
-        parts.push("printf '\\033[2J\\033[3J\\033[H'");
-        parts.push(`cat -- ${shellQuote(screenFile)}`);
-        parts.push(`rm -rf -- ${shellQuote(screenDir)}`);
+        screenParts.push("printf '\\033[2J\\033[H'");
+        screenParts.push(`cat -- ${shellQuote(screenFile)}`);
+        screenParts.push(`rm -rf -- ${shellQuote(screenDir)}`);
     }
-    let payload = parts.length > 0 ? `${parts.join("; ")}\n` : "";
-    if (surface.command && surface.command_source && surface.command_source !== "none") {
-        payload += opts.enter ? `${surface.command}\n` : surface.command;
-    }
-    if (!payload) {
-        return;
-    }
-
     try {
-        await runCmuxOk(["send", ...surfaceTargetArgs(surfaceRef, workspaceRef), payload]);
+        if (parts.length > 0) {
+            const marker = `cmux-ready-${crypto.randomUUID()}`;
+            // Split the marker across printf arguments so input echo cannot acknowledge setup.
+            parts.push(`printf '\\n%s%s\\n' 'cmux-ready-' '${marker.slice("cmux-ready-".length)}'`);
+            await sendSurfaceText({ surfaceRef, text: internalRestoreCommand(parts) });
+            await waitForTerminalText({
+                workspaceRef,
+                surfaceRef,
+                matches: (text) => text.split("\n").some((line) => line.trim() === marker) && isShellPromptReady(text),
+                description: "working-directory and screen setup",
+            });
+        }
+
+        await runCmuxOk(["send-key", ...surfaceTargetArgs(surfaceRef, workspaceRef), "ctrl-l"]);
+
+        if (screenParts.length > 0) {
+            await sendSurfaceText({ surfaceRef, text: internalRestoreCommand(screenParts) });
+        }
+
+        if (surface.command && surface.command_source && surface.command_source !== "none") {
+            await queueReplayCommand({ surfaceRef, command: surface.command, enter: opts.enter });
+        }
     } catch (error) {
         if (screenDir) {
             // The pipeline never reached the pane, so nothing will consume the file.

--- a/src/cmux/lib/restore.ts
+++ b/src/cmux/lib/restore.ts
@@ -46,7 +46,14 @@ export interface RestoreOutcome {
         converged: boolean;
         /** Null when the source autosave had estimated rather than measured cell sizes. */
         maxCellDelta: number | null;
+        failures: Array<{ paneRef: string; message: string }>;
     }>;
+}
+
+export function restoreFailureMessages(outcome: RestoreOutcome): string[] {
+    return outcome.workspaces.flatMap((workspace) =>
+        workspace.failures.map((failure) => `${workspace.title} / ${failure.paneRef}: ${failure.message}`)
+    );
 }
 
 export interface RestoreEvents {
@@ -139,6 +146,7 @@ export async function restoreProfile(
                 title: targetTitle,
                 converged: !playable.cmux_version.startsWith("offline ") && result.converged,
                 maxCellDelta: playable.cmux_version.startsWith("offline ") ? null : result.maxCellDelta,
+                failures: result.failures,
             });
             events.onWorkspaceDone?.({ ref: created.workspace_ref, title: targetTitle });
         }
@@ -148,17 +156,18 @@ export async function restoreProfile(
 
 interface MaterializeResult {
     converged: boolean;
+    failures: Array<{ paneRef: string; message: string }>;
     /** Largest |saved - actual| over all panes / dimensions, in terminal cells. */
     maxCellDelta: number;
 }
 
-async function materializeWorkspace(
+export async function materializeWorkspace(
     ws: Workspace,
     workspaceRef: string,
     opts: RestoreOptions
 ): Promise<MaterializeResult> {
     if (ws.panes.length === 0) {
-        return { converged: true, maxCellDelta: 0 };
+        return { converged: true, maxCellDelta: 0, failures: [] };
     }
 
     const paneRefByIndex = await applySplitTree(buildSplitTree(ws.panes), workspaceRef);
@@ -173,15 +182,25 @@ async function materializeWorkspace(
         paneRefByIndex
     );
 
+    const failures: MaterializeResult["failures"] = [];
     for (const savedPane of ws.panes) {
         const paneRef = paneRefByIndex.get(savedPane.index);
         if (!paneRef) {
+            failures.push({ paneRef: `saved pane ${savedPane.index}`, message: "No restored pane mapping" });
             continue;
         }
-        await populatePane(savedPane, paneRef, workspaceRef, opts);
+        try {
+            await populatePane(savedPane, paneRef, workspaceRef, opts);
+        } catch (error) {
+            failures.push({ paneRef, message: error instanceof Error ? error.message : String(error) });
+            logger.warn(
+                { error, paneRef, workspaceRef },
+                "[restore] pane population failed; continuing with remaining panes"
+            );
+        }
     }
 
-    return { converged: maxDelta <= 1, maxCellDelta: maxDelta };
+    return { converged: failures.length === 0 && maxDelta <= 1, maxCellDelta: maxDelta, failures };
 }
 
 export interface RectPane {

--- a/src/cmux/lib/restore.ts
+++ b/src/cmux/lib/restore.ts
@@ -110,7 +110,12 @@ export async function restoreProfile(
                     previousWorkspace,
                     "--window",
                     created.window_ref,
-                ]);
+                ]).catch((error) => {
+                    logger.warn(
+                        { error, workspaceRef: created.workspace_ref },
+                        "[restore] workspace reorder failed; continuing restore"
+                    );
+                });
             }
 
             previousWorkspaceByWindow.set(created.window_ref, created.workspace_ref);
@@ -521,7 +526,7 @@ export function formatWaitingPanes(waiting: WaitingPane[], actor: "Rescue" | "Re
 }
 
 function internalRestoreCommand(parts: string[]): string {
-    return `function _genesis_cmux_restore_internal { ${parts.join(" && ")}; }; _genesis_cmux_restore_internal; unfunction _genesis_cmux_restore_internal\n`;
+    return `function _genesis_cmux_restore_internal { ${parts.join(" && ")}; }; _genesis_cmux_restore_internal; unset -f _genesis_cmux_restore_internal\n`;
 }
 
 async function replayTerminal(

--- a/src/cmux/lib/screen-cache.test.ts
+++ b/src/cmux/lib/screen-cache.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    advanceScreenEpoch,
+    loadSavedScreens,
+    preferredScreenText,
+    pruneSavedScreens,
+    saveSurfaceScreen,
+} from "@app/cmux/lib/screen-cache";
+
+const surfaceId = "11111111-1111-4111-8111-111111111111";
+const stableSurfaceId = "22222222-2222-4222-8222-222222222222";
+
+test("saved output survives restart and later output updates with a historical cutoff", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-screen-test-"));
+    advanceScreenEpoch({ directory, epoch: "before" });
+    saveSurfaceScreen({ directory, surfaceId, stableSurfaceId, text: "service ready", atMs: 10 });
+    advanceScreenEpoch({ directory, epoch: "after" });
+    for (let i = 20; i <= 50; i += 10) {
+        saveSurfaceScreen({ directory, surfaceId, stableSurfaceId, text: `new output ${i}`, atMs: i });
+    }
+    expect(loadSavedScreens({ directory, beforeMs: 15 }).get(stableSurfaceId)?.text).toBe("service ready");
+    expect(loadSavedScreens({ directory }).get(surfaceId)?.text).toBe("new output 50");
+    expect(loadSavedScreens({ directory, beforeMs: 5 }).size).toBe(0);
+});
+
+test("screen cache refuses a path-like identity before writing", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-screen-invalid-"));
+    expect(() => saveSurfaceScreen({ directory, surfaceId: "../outside", text: "example", atMs: 1 })).toThrow();
+    expect(loadSavedScreens({ directory }).size).toBe(0);
+});
+
+test("unchanged viewports do not rewrite the cache and retention obeys its byte budget", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-screen-budget-"));
+    expect(saveSurfaceScreen({ directory, surfaceId, text: "a".repeat(2000), atMs: 10 })).toBe(true);
+    expect(saveSurfaceScreen({ directory, surfaceId, text: "a".repeat(2000), atMs: 20 })).toBe(false);
+    expect(loadSavedScreens({ directory }).get(surfaceId)?.atMs).toBe(10);
+    saveSurfaceScreen({ directory, surfaceId, text: "b".repeat(2000), atMs: 30 });
+    pruneSavedScreens({ directory, maxBytes: 2500 });
+    const bytes = readdirSync(directory)
+        .filter((p) => p.endsWith(".json"))
+        .reduce((total, p) => total + statSync(join(directory, p)).size, 0);
+    expect(bytes).toBeLessThanOrEqual(2500);
+    expect(loadSavedScreens({ directory }).get(surfaceId)?.text).toBe("b".repeat(2000));
+});
+
+test("a malformed current entry is repaired without archiving its damaged bytes", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-screen-repair-"));
+    writeFileSync(join(directory, `${surfaceId}.json`), "{broken");
+    expect(saveSurfaceScreen({ directory, surfaceId, text: "fresh output", atMs: 10 })).toBe(true);
+    expect(loadSavedScreens({ directory }).get(surfaceId)?.text).toBe("fresh output");
+    expect(existsSync(join(directory, `${surfaceId}.previous.json`))).toBe(false);
+});
+
+test("live and offline viewport selection falls back only when native text is empty", () => {
+    for (const native of [undefined, "", "  \n", "\u001b[0m\n"]) {
+        expect(preferredScreenText(native, "cached output\n")).toBe("cached output");
+    }
+    expect(preferredScreenText("native output\n", "cached output")).toBe("native output");
+});

--- a/src/cmux/lib/screen-cache.ts
+++ b/src/cmux/lib/screen-cache.ts
@@ -1,0 +1,161 @@
+import {
+    copyFileSync,
+    existsSync,
+    mkdirSync,
+    readdirSync,
+    readFileSync,
+    renameSync,
+    rmSync,
+    statSync,
+    unlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { stripAnsi } from "@genesiscz/utils/string";
+import { z } from "zod";
+
+const schema = z.object({
+    surfaceId: z.string().uuid(),
+    stableSurfaceId: z.string().uuid().optional(),
+    text: z.string().max(200_000),
+    atMs: z.number().finite().nonnegative(),
+});
+export type SavedSurfaceScreen = z.infer<typeof schema>;
+
+export function preferredScreenText(nativeText: string | undefined, cachedText: string | undefined): string {
+    return stripAnsi(nativeText ?? "").trimEnd() || stripAnsi(cachedText ?? "").trimEnd();
+}
+
+export function screenCacheDirectory(): string {
+    return join(env.tools.getHome(), ".genesis-tools", "cmux", "screens");
+}
+
+function writeAtomic(path: string, text: string): void {
+    const temporary = `${path}.${process.pid}.tmp`;
+    writeFileSync(temporary, text, { mode: 0o600 });
+    renameSync(temporary, path);
+}
+
+function screenFiles(directory: string): string[] {
+    return existsSync(directory)
+        ? readdirSync(directory).filter((name) => /^[a-f\d-]+(?:\.previous)?\.json$/.test(name))
+        : [];
+}
+
+export function advanceScreenEpoch({
+    directory = screenCacheDirectory(),
+    epoch,
+}: {
+    directory?: string;
+    epoch: string;
+}): void {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const marker = join(directory, "epoch");
+    const prior = existsSync(marker) ? readFileSync(marker, "utf8") : undefined;
+    if (prior === epoch) {
+        return;
+    }
+
+    if (prior !== undefined) {
+        const archive = join(directory, "previous-session");
+        if (existsSync(archive)) {
+            rmSync(archive, { recursive: true });
+        }
+
+        mkdirSync(archive, { mode: 0o700 });
+        for (const name of screenFiles(directory)) {
+            copyFileSync(join(directory, name), join(archive, name));
+        }
+    }
+
+    writeAtomic(marker, epoch);
+}
+
+export function saveSurfaceScreen(input: SavedSurfaceScreen & { directory?: string }): boolean {
+    const record = schema.parse(input);
+    record.surfaceId = record.surfaceId.toLowerCase();
+    record.stableSurfaceId = record.stableSurfaceId?.toLowerCase();
+    const directory = input.directory ?? screenCacheDirectory();
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const key = record.stableSurfaceId ?? record.surfaceId;
+    const path = join(directory, `${key}.json`);
+    if (existsSync(path)) {
+        let previous: SavedSurfaceScreen | undefined;
+        try {
+            previous = schema.parse(SafeJSON.parse(readFileSync(path, "utf8"), { strict: true }));
+        } catch (error) {
+            logger.warn({ error, path }, "[cmux-screens] replacing unreadable cache entry");
+        }
+
+        if (previous?.text === record.text && previous.surfaceId === record.surfaceId) {
+            return false;
+        }
+
+        if (previous) {
+            copyFileSync(path, join(directory, `${key}.previous.json`));
+        }
+    }
+
+    writeAtomic(path, SafeJSON.stringify(record));
+    return true;
+}
+
+export function loadSavedScreens(
+    options: { directory?: string; beforeMs?: number } = {}
+): Map<string, SavedSurfaceScreen> {
+    const directory = options.directory ?? screenCacheDirectory();
+    const result = new Map<string, SavedSurfaceScreen>();
+    for (const root of [join(directory, "previous-session"), directory]) {
+        for (const name of screenFiles(root)) {
+            try {
+                const record = schema.parse(SafeJSON.parse(readFileSync(join(root, name), "utf8"), { strict: true }));
+                if (record.atMs > (options.beforeMs ?? Infinity)) {
+                    continue;
+                }
+
+                for (const id of [record.stableSurfaceId, record.surfaceId]) {
+                    if (!id) {
+                        continue;
+                    }
+
+                    const key = id.toLowerCase();
+                    if (!result.has(key) || result.get(key)!.atMs < record.atMs) {
+                        result.set(key, record);
+                    }
+                }
+            } catch (error) {
+                logger.debug({ error, path: join(root, name) }, "[cmux-screens] ignored unreadable cache entry");
+            }
+        }
+    }
+
+    return result;
+}
+
+export function pruneSavedScreens(options: { directory?: string; maxBytes?: number } = {}): number {
+    const directory = options.directory ?? screenCacheDirectory();
+    const maxBytes = options.maxBytes ?? 64 * 1024 * 1024;
+    const files = [join(directory, "previous-session"), directory]
+        .flatMap((root) =>
+            screenFiles(root).map((name) => {
+                const path = join(root, name);
+                const stat = statSync(path);
+                return { path, bytes: stat.size, at: stat.mtimeMs, previous: name.includes(".previous.") };
+            })
+        )
+        .sort((a, b) => a.at - b.at || Number(b.previous) - Number(a.previous));
+    let bytes = files.reduce((sum, file) => sum + file.bytes, 0);
+    for (const file of files) {
+        if (bytes <= maxBytes) {
+            break;
+        }
+
+        unlinkSync(file.path);
+        bytes -= file.bytes;
+    }
+
+    return bytes;
+}

--- a/src/cmux/lib/screen-collector.test.ts
+++ b/src/cmux/lib/screen-collector.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadSavedScreens } from "@app/cmux/lib/screen-cache";
+import { collectTerminalScreens } from "@app/cmux/lib/screen-collector";
+
+test("collector reads terminals only, keeps stable identity and survives a dormant terminal", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cmux-collector-test-"));
+    const visited: string[] = [];
+    const result = await collectTerminalScreens({
+        directory,
+        session: {
+            path: "/fixture",
+            savedAtMs: 1,
+            windows: [
+                {
+                    tabManager: {
+                        workspaces: [
+                            {
+                                layout: { type: "pane", pane: { panelIds: [] } },
+                                panels: [
+                                    {
+                                        id: "11111111-1111-4111-8111-111111111111",
+                                        stableSurfaceId: "22222222-2222-4222-8222-222222222222",
+                                        type: "terminal",
+                                    },
+                                    { id: "33333333-3333-4333-8333-333333333333", type: "terminal" },
+                                    { id: "44444444-4444-4444-8444-444444444444", type: "browser" },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+        readText: async (surfaceId) => {
+            visited.push(surfaceId);
+            if (surfaceId.startsWith("3333")) {
+                throw new Error("Failed to read terminal text");
+            }
+            return "example output";
+        },
+    });
+    expect(visited).toEqual(["11111111-1111-4111-8111-111111111111", "33333333-3333-4333-8333-333333333333"]);
+    expect(result).toMatchObject({ saved: 1, unavailable: 1 });
+    expect(loadSavedScreens({ directory }).get("22222222-2222-4222-8222-222222222222")?.text).toBe("example output");
+});

--- a/src/cmux/lib/screen-collector.ts
+++ b/src/cmux/lib/screen-collector.ts
@@ -24,11 +24,18 @@ export async function collectTerminalScreens(input: {
 
         try {
             if (panel.stableSurfaceId && input.journalDirectory) {
-                associateCapturedSurface({
-                    directory: input.journalDirectory,
-                    surfaceId: panel.id,
-                    stableSurfaceId: panel.stableSurfaceId,
-                });
+                try {
+                    associateCapturedSurface({
+                        directory: input.journalDirectory,
+                        surfaceId: panel.id,
+                        stableSurfaceId: panel.stableSurfaceId,
+                    });
+                } catch (error) {
+                    logger.warn(
+                        { error, surfaceId: panel.id },
+                        "[cmux-screens] identity association failed; continuing viewport capture"
+                    );
+                }
             }
             const text = stripAnsi(await input.readText(panel.id))
                 .trimEnd()

--- a/src/cmux/lib/screen-collector.ts
+++ b/src/cmux/lib/screen-collector.ts
@@ -1,0 +1,69 @@
+import type { AutosaveSession } from "@app/cmux/lib/autosave";
+import { associateCapturedSurface } from "@app/cmux/lib/capture-journal";
+import { saveSurfaceScreen } from "@app/cmux/lib/screen-cache";
+import { logger } from "@genesiscz/utils/logger";
+import { stripAnsi } from "@genesiscz/utils/string";
+
+export async function collectTerminalScreens(input: {
+    session: AutosaveSession;
+    journalDirectory?: string;
+    directory: string;
+    readText: (surfaceId: string) => Promise<string>;
+    shouldContinue?: () => boolean;
+}): Promise<{ saved: number; written: number; unavailable: number; empty: number; stopped: boolean }> {
+    const result = { saved: 0, written: 0, unavailable: 0, empty: 0, stopped: false };
+    for (const panel of input.session.windows.flatMap((w) => w.tabManager.workspaces.flatMap((ws) => ws.panels))) {
+        if (panel.type !== "terminal") {
+            continue;
+        }
+
+        if (input.shouldContinue?.() === false) {
+            result.stopped = true;
+            break;
+        }
+
+        try {
+            if (panel.stableSurfaceId && input.journalDirectory) {
+                associateCapturedSurface({
+                    directory: input.journalDirectory,
+                    surfaceId: panel.id,
+                    stableSurfaceId: panel.stableSurfaceId,
+                });
+            }
+            const text = stripAnsi(await input.readText(panel.id))
+                .trimEnd()
+                .slice(-200_000);
+            if (input.shouldContinue?.() === false) {
+                result.stopped = true;
+                break;
+            }
+
+            if (!text) {
+                result.empty++;
+                continue;
+            }
+
+            const written = saveSurfaceScreen({
+                directory: input.directory,
+                surfaceId: panel.id,
+                stableSurfaceId: panel.stableSurfaceId,
+                text,
+                atMs: Date.now(),
+            });
+            result.saved++;
+            result.written += Number(written);
+        } catch (error) {
+            result.unavailable++;
+            logger.debug(
+                { error, surfaceId: panel.id },
+                "[cmux-screens] terminal unavailable; no activation attempted"
+            );
+            if (error instanceof Error && /timed out|ECONNREFUSED|ENOENT/.test(error.message)) {
+                result.stopped = true;
+                break;
+            }
+        }
+    }
+
+    return result;
+}

--- a/src/cmux/lib/snapshot.journal.test.ts
+++ b/src/cmux/lib/snapshot.journal.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test";
+import type { AutosaveSession } from "@app/cmux/lib/autosave";
+import type { CapturedCommand } from "@app/cmux/lib/capture-journal";
+import { buildTerminalSurfaceSnapshot, capturedCommandsByPanelId } from "@app/cmux/lib/snapshot";
+
+const stableId = "11111111-1111-4111-8111-111111111111";
+const journal: CapturedCommand = {
+    version: 1,
+    surfaceId: stableId,
+    command: "tools usage --name 'two words'",
+    cwd: "/launch cwd",
+    phase: "completed",
+    atMs: 100,
+    exitStatus: 0,
+};
+
+test("live capture joins stable native IDs and preserves exact command syntax over foreground processes", () => {
+    const autosave: AutosaveSession = {
+        path: "/fixture",
+        savedAtMs: 200,
+        windows: [
+            {
+                tabManager: {
+                    workspaces: [
+                        {
+                            layout: { type: "pane", pane: { panelIds: ["native-panel"] } },
+                            panels: [{ id: "native-panel", stableSurfaceId: stableId, type: "terminal" }],
+                        },
+                    ],
+                },
+            },
+        ],
+    };
+    const captured = buildTerminalSurfaceSnapshot({
+        entry: { ref: "surface:1", id: "NATIVE-PANEL", type: "terminal", title: "grok", index: 0 },
+        captureCwd: true,
+        captured: { command: { value: "echo stale", source: "scrollback" } },
+        capture: {
+            ttyCommands: new Map([["ttys001", "some unrelated child process"]]),
+            panelTty: new Map([["native-panel", "ttys001"]]),
+            panelCwd: new Map([["native-panel", "/wrong cwd"]]),
+            surfaceSessions: new Map(),
+            replayCatalog: { sessions: [] },
+            surfaceCommands: capturedCommandsByPanelId(autosave, new Map([[stableId, journal]])),
+        },
+    });
+    expect(captured).toMatchObject({
+        command: "tools usage --name 'two words'",
+        command_source: "shell-journal",
+        cwd: "/launch cwd",
+    });
+});
+
+test("live capture pins a known Claude session without losing the journal's launcher flags", () => {
+    const captured = buildTerminalSurfaceSnapshot({
+        entry: { ref: "surface:1", id: stableId, type: "terminal", title: "grok", index: 0 },
+        captureCwd: true,
+        captured: { command: { value: undefined, source: "none" } },
+        capture: {
+            ttyCommands: new Map(),
+            panelTty: new Map(),
+            panelCwd: new Map(),
+            replayCatalog: { sessions: [] },
+            surfaceSessions: new Map([[stableId, { sessionId: "known-session" }]]),
+            surfaceCommands: new Map([[stableId, { ...journal, command: "claude --model custom" }]]),
+        },
+    });
+    expect(captured).toMatchObject({
+        command: "claude --model custom --resume known-session",
+        command_original: "claude --model custom",
+        command_source: "shell-journal",
+        cwd: "/launch cwd",
+    });
+});
+
+test("live capture still falls back to the foreground process when no shell journal exists", () => {
+    const captured = buildTerminalSurfaceSnapshot({
+        entry: { ref: "surface:1", id: stableId, type: "terminal", title: "usage", index: 0 },
+        captureCwd: true,
+        captured: { command: { value: "echo stale", source: "scrollback" } },
+        capture: {
+            ttyCommands: new Map([["ttys001", "tail -f /tmp/log"]]),
+            panelTty: new Map([[stableId, "ttys001"]]),
+            panelCwd: new Map([[stableId, "/cwd"]]),
+            replayCatalog: { sessions: [] },
+            surfaceSessions: new Map(),
+        },
+    });
+    expect(captured).toMatchObject({ command: "tail -f /tmp/log", command_source: "foreground", cwd: "/cwd" });
+});
+
+test("live save uses native saved output when a dormant terminal cannot be read", () => {
+    const capture = {
+        ttyCommands: new Map<string, string>(),
+        panelTty: new Map<string, string>(),
+        panelCwd: new Map([[stableId, "/tmp/project"]]),
+        surfaceSessions: new Map(),
+        replayCatalog: { sessions: [] },
+        panelScreens: new Map([[stableId, { text: "➜  project tail -f app.log\nready", rows: 2 }]]),
+    };
+    const input = {
+        entry: { ref: "surface:99", id: stableId, type: "terminal" as const, title: "Logs", index: 0 },
+        captureCwd: true,
+        captured: { command: { value: undefined, source: "none" as const } },
+        capture,
+    };
+    expect(buildTerminalSurfaceSnapshot(input)).toMatchObject({
+        screen: { text: "➜  project tail -f app.log\nready" },
+        command: "tail -f app.log",
+        command_source: "scrollback",
+    });
+    const noContent = buildTerminalSurfaceSnapshot({ ...input, captureScreen: false, captureHistory: false });
+    expect(noContent).toMatchObject({ type: "terminal", cwd: "/tmp/project" });
+    expect(noContent.type === "terminal" && noContent.screen).toBeUndefined();
+    expect(noContent.type === "terminal" && noContent.command).toBeUndefined();
+});

--- a/src/cmux/lib/snapshot.ts
+++ b/src/cmux/lib/snapshot.ts
@@ -4,10 +4,22 @@ import {
     type ReplayCatalogSession,
     replayCommandForSurface,
 } from "@app/cmux/lib/agent-replay";
-import { panelsById, readAutosaveSession } from "@app/cmux/lib/autosave";
-import { collectTtyLaunchCommands, loadSurfaceSessions, type SurfaceSessionInfo } from "@app/cmux/lib/command-capture";
-import { captureSurfaceState, cwdFromTitle } from "@app/cmux/lib/shell-probe";
-import type { Pane, Profile, ProfileScope, Surface, Window, Workspace } from "@app/cmux/lib/types";
+import { type AutosaveSession, panelsById, panelWorkingDirectory, readAutosaveSession } from "@app/cmux/lib/autosave";
+import { type CapturedCommand, loadCapturedCommands } from "@app/cmux/lib/capture-journal";
+import {
+    collectTtyLaunchCommands,
+    isAgentLauncher,
+    loadSurfaceSessions,
+    type SurfaceSessionInfo,
+} from "@app/cmux/lib/command-capture";
+import { loadSavedScreens, preferredScreenText } from "@app/cmux/lib/screen-cache";
+import {
+    captureSurfaceState,
+    cwdFromTitle,
+    lastCommandFromCapture,
+    type SurfaceCaptureResult,
+} from "@app/cmux/lib/shell-probe";
+import type { Pane, Profile, ProfileScope, ScreenSnapshot, Surface, Window, Workspace } from "@app/cmux/lib/types";
 import { PROFILE_VERSION } from "@app/cmux/lib/types";
 import { runCmux, runCmuxJSON } from "@genesiscz/utils/cmux/lib/cli";
 import { withFocusedWorkspace } from "@genesiscz/utils/cmux/lib/focus-guard";
@@ -39,23 +51,78 @@ interface SurfaceListEntry {
  * per tty), cmux's autosave (surface uuid → tty), and the claude session journals
  * (surface uuid → session id + account). All readable without the cmux socket.
  */
-interface CommandCaptureContext {
+export interface CommandCaptureContext {
     ttyCommands: Map<string, string>;
     panelTty: Map<string, string>;
+    panelCwd: Map<string, string>;
     surfaceSessions: Map<string, SurfaceSessionInfo>;
     replayCatalog: ReplayCatalog;
+    surfaceCommands?: Map<string, CapturedCommand>;
+    panelScreens?: Map<string, ScreenSnapshot>;
+    panelBrowserUrls?: Map<string, string>;
 }
 
-export async function buildCommandCaptureContext(): Promise<CommandCaptureContext> {
-    const [ttyCommands, surfaceSessions] = await Promise.all([collectTtyLaunchCommands(), loadSurfaceSessions()]);
+export function capturedCommandsByPanelId(
+    autosave: AutosaveSession,
+    commands: Map<string, CapturedCommand>
+): Map<string, CapturedCommand> {
+    const aliases = new Map([...commands].map(([id, command]) => [id.toLowerCase(), command]));
 
+    for (const [id, panel] of panelsById(autosave)) {
+        const command =
+            (panel.stableSurfaceId ? commands.get(panel.stableSurfaceId.toLowerCase()) : undefined) ??
+            commands.get(panel.id.toLowerCase());
+
+        if (command) {
+            aliases.set(id.toLowerCase(), command);
+        }
+    }
+
+    return aliases;
+}
+
+export async function buildCommandCaptureContext(options: { commands?: boolean } = {}): Promise<CommandCaptureContext> {
+    const [ttyCommands, surfaceSessions] =
+        options.commands === false
+            ? [new Map<string, string>(), new Map<string, SurfaceSessionInfo>()]
+            : await Promise.all([collectTtyLaunchCommands(), loadSurfaceSessions()]);
+
+    let surfaceCommands = options.commands === false ? new Map<string, CapturedCommand>() : loadCapturedCommands();
     const panelTty = new Map<string, string>();
+    const panelCwd = new Map<string, string>();
+    const panelScreens = new Map<string, ScreenSnapshot>();
+    const cachedScreens = loadSavedScreens();
+    const panelBrowserUrls = new Map<string, string>();
     const grokCwds: string[] = [];
     try {
         const session = readAutosaveSession();
+        surfaceCommands = capturedCommandsByPanelId(session, surfaceCommands);
         for (const [id, panel] of panelsById(session)) {
+            const cached =
+                (panel.stableSurfaceId ? cachedScreens.get(panel.stableSurfaceId.toLowerCase()) : undefined) ??
+                cachedScreens.get(panel.id.toLowerCase());
+            const text = preferredScreenText(panel.terminal?.scrollback, cached?.text);
+            if (text) {
+                panelScreens.set(id.toLowerCase(), { text, rows: text.split("\n").length });
+            }
+
+            if (panel.browser?.urlString) {
+                panelBrowserUrls.set(id.toLowerCase(), panel.browser.urlString);
+            }
+            const surfaceSession =
+                (panel.stableSurfaceId ? surfaceSessions.get(panel.stableSurfaceId) : undefined) ??
+                surfaceSessions.get(panel.id);
+
+            if (surfaceSession) {
+                surfaceSessions.set(id.toLowerCase(), surfaceSession);
+            }
+
+            const cwd = panelWorkingDirectory(panel);
+            if (cwd) {
+                panelCwd.set(id.toLowerCase(), cwd);
+            }
             if (panel.ttyName) {
-                panelTty.set(id, panel.ttyName);
+                panelTty.set(id.toLowerCase(), panel.ttyName);
             }
         }
 
@@ -76,7 +143,16 @@ export async function buildCommandCaptureContext(): Promise<CommandCaptureContex
         logger.debug({ error }, "[snapshot] autosave unavailable — foreground command capture degraded");
     }
 
-    return { ttyCommands, panelTty, surfaceSessions, replayCatalog: { sessions: loadGrokCatalog(grokCwds) } };
+    return {
+        ttyCommands,
+        panelTty,
+        panelCwd,
+        surfaceSessions,
+        surfaceCommands,
+        panelScreens,
+        panelBrowserUrls,
+        replayCatalog: { sessions: options.commands === false ? [] : loadGrokCatalog(grokCwds) },
+    };
 }
 
 interface ListPaneSurfacesResponse {
@@ -112,7 +188,10 @@ export async function captureProfile(options: SnapshotOptions, progress: Snapsho
     const allWorkspaces = await collectAllWorkspaces(allWindows);
 
     const ctx = await getIdentifyContext();
-    const capture = options.captureHistory ? await buildCommandCaptureContext() : undefined;
+    const capture =
+        options.captureHistory || options.captureScreen || options.captureCwd
+            ? await buildCommandCaptureContext({ commands: options.captureHistory })
+            : undefined;
     const targetWorkspaces = filterWorkspaces(allWorkspaces, options, ctx.focusedWorkspaceRef);
     const targetWindowRefs = new Set(targetWorkspaces.map((ws) => ws.window_ref));
     const targetWindows = allWindows.filter((w) => targetWindowRefs.has(w.ref));
@@ -327,10 +406,13 @@ async function captureSurface(
     const title = entry.title ?? "";
     if (entry.type === "browser") {
         const url = await browserUrl(entry.ref);
-        return { type: "browser", title, url: url ?? undefined };
+        return {
+            type: "browser",
+            title,
+            url: url ?? (entry.id ? capture?.panelBrowserUrls?.get(entry.id.toLowerCase()) : undefined),
+        };
     }
 
-    const cwd = options.captureCwd ? cwdFromTitle(title) : undefined;
     // Skip screen capture for the surface running this very save command — its
     // visible content is dominated by the `tools cmux profiles save` invocation
     // and the running clack prompts, which would replay back into the restored
@@ -344,13 +426,63 @@ async function captureSurface(
         history: options.captureHistory,
     });
 
+    return buildTerminalSurfaceSnapshot({
+        entry,
+        captureCwd: options.captureCwd,
+        captureScreen: options.captureScreen && !isCaller,
+        captureHistory: options.captureHistory,
+        captured,
+        capture,
+    });
+}
+
+export function buildTerminalSurfaceSnapshot(input: {
+    entry: SurfaceListEntry;
+    captureCwd: boolean;
+    captureScreen?: boolean;
+    captureHistory?: boolean;
+    captured: SurfaceCaptureResult;
+    capture?: CommandCaptureContext;
+}): Surface {
+    const { entry, captureCwd, captured, capture } = input;
+    const title = entry.title ?? "";
+    const id = entry.id?.toLowerCase();
+    const journal = id ? capture?.surfaceCommands?.get(id) : undefined;
+    const fallbackScreen = id ? capture?.panelScreens?.get(id) : undefined;
+    const screen = input.captureScreen !== false ? (captured.screen ?? fallbackScreen) : undefined;
+    const cwd = captureCwd
+        ? (journal?.cwd ?? (id ? capture?.panelCwd.get(id) : undefined) ?? cwdFromTitle(title))
+        : undefined;
+
+    if (input.captureHistory === false) {
+        return { type: "terminal", title, cwd, screen };
+    }
+
+    if (journal && !isAgentLauncher(journal.command)) {
+        return {
+            type: "terminal",
+            title,
+            cwd,
+            screen,
+            command: journal.command,
+            command_source: "shell-journal",
+            drift: [
+                `exact command recovered from shell journal (${journal.phase}${journal.exitStatus !== undefined ? `, exit ${journal.exitStatus}` : ""})`,
+            ],
+        };
+    }
+
     // The foreground process on the pane's tty beats scrollback parsing: a pane
     // running a fullscreen TUI (claude, grok, vim) shows no shell prompt to parse,
     // but its launch command is right there in the process table.
-    const tty = capture && entry.id ? capture.panelTty.get(entry.id) : undefined;
+    const tty = id ? capture?.panelTty.get(id) : undefined;
     const foreground = tty ? capture?.ttyCommands.get(tty) : undefined;
-    const original = foreground ?? captured.command.value;
-    const session = capture && entry.id ? capture.surfaceSessions.get(entry.id) : undefined;
+    const textCommand = captured.command.value ? captured.command : lastCommandFromCapture(fallbackScreen?.text);
+    const original = journal?.command ?? foreground ?? textCommand.value;
+    const session =
+        capture && entry.id
+            ? (capture.surfaceSessions.get(id ?? entry.id) ?? capture.surfaceSessions.get(entry.id))
+            : undefined;
     // Always "claude": this id comes from the Claude cmux-refs journal and
     // nowhere else. Typing it from the tab title made any pane whose title ends
     // in the word "grok" (including a shell in a directory named grok) replay
@@ -365,21 +497,27 @@ async function captureSurface(
           }
         : undefined;
     const derived = replayCommandForSurface(
-        { title, cwd, command: original },
+        { title, cwd, command: original, command_source: journal ? "shell-journal" : undefined },
         capture?.replayCatalog ?? { sessions: [] },
         preferred
     );
     if (!derived.command) {
-        return { type: "terminal", title, cwd, screen: captured.screen };
+        return { type: "terminal", title, cwd, screen };
     }
 
     return {
         type: "terminal",
         title,
         cwd,
-        screen: captured.screen,
+        screen,
         command: derived.command,
-        command_source: foreground ? "foreground" : derived.command !== original ? "inferred" : captured.command.source,
+        command_source: journal
+            ? "shell-journal"
+            : foreground
+              ? "foreground"
+              : derived.command !== original
+                ? "inferred"
+                : textCommand.source,
         command_original: derived.command !== original ? original : undefined,
         drift: derived.drift.length > 0 ? derived.drift : undefined,
     };

--- a/src/cmux/lib/snapshot.ts
+++ b/src/cmux/lib/snapshot.ts
@@ -409,7 +409,7 @@ async function captureSurface(
         return {
             type: "browser",
             title,
-            url: url ?? (entry.id ? capture?.panelBrowserUrls?.get(entry.id.toLowerCase()) : undefined),
+            url: url || (entry.id ? capture?.panelBrowserUrls?.get(entry.id.toLowerCase()) : undefined),
         };
     }
 

--- a/src/cmux/lib/socket.test.ts
+++ b/src/cmux/lib/socket.test.ts
@@ -1,7 +1,38 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import * as cli from "@genesiscz/utils/cmux/lib/cli";
 import * as socket from "@genesiscz/utils/cmux/lib/socket";
 
 describe("cmux socket RPC params", () => {
+    test("paneList uses the workspace-scoped CLI and preserves geometry", async () => {
+        const layout = {
+            workspace_ref: "workspace:5",
+            window_ref: "window:2",
+            panes: [],
+            container_frame: { width: 100, height: 80 },
+        };
+        const cliSpy = spyOn(cli, "runCmuxJSON").mockResolvedValue(layout);
+        const rpcSpy = spyOn(socket, "rpc").mockResolvedValue({ ...layout, workspace_ref: "workspace:1" });
+        try {
+            expect(await socket.paneList("workspace:5")).toEqual(layout);
+            expect(cliSpy).toHaveBeenCalledWith(["list-panes", "--workspace", "workspace:5"]);
+            expect(rpcSpy).not.toHaveBeenCalled();
+        } finally {
+            cliSpy.mockRestore();
+            rpcSpy.mockRestore();
+        }
+    });
+
+    test("paneList rejects a response for another workspace", async () => {
+        const layout = { workspace_ref: "workspace:1", panes: [] };
+        const cliSpy = spyOn(cli, "runCmuxJSON").mockResolvedValue(layout);
+        const rpcSpy = spyOn(socket, "rpc").mockResolvedValue(layout);
+        try {
+            await expect(socket.paneList("workspace:5")).rejects.toThrow("workspace:1");
+        } finally {
+            cliSpy.mockRestore();
+            rpcSpy.mockRestore();
+        }
+    });
     afterEach(() => {
         socket.resetSocketPathCache();
     });

--- a/src/cmux/lib/terminal-ready.test.ts
+++ b/src/cmux/lib/terminal-ready.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import { isShellPromptReady, waitForTerminalText } from "@app/cmux/lib/terminal-ready";
+import * as cli from "@genesiscz/utils/cmux/lib/cli";
+
+afterEach(() => mock.restore());
+
+test("startup banners and agent input boxes are not a ready shell", () => {
+    expect(isShellPromptReady("Last login: today\nYou have mail.\n")).toBe(false);
+    expect(isShellPromptReady("Claude Code\n❯ \n")).toBe(false);
+    expect(isShellPromptReady("➜  repo git:(main) ✗ \n")).toBe(true);
+    expect(isShellPromptReady("➜  repo git:(main) ✗ command still running\n")).toBe(false);
+});
+
+test("waits through empty, unready, and unavailable screens before accepting the prompt", async () => {
+    const read = spyOn(cli, "runCmux")
+        .mockResolvedValueOnce({ code: 1, stdout: "", stderr: "starting" })
+        .mockResolvedValueOnce({ code: 0, stdout: "Last login: today", stderr: "" })
+        .mockResolvedValue({ code: 0, stdout: "➜  repo ", stderr: "" });
+    await waitForTerminalText({
+        workspaceRef: "workspace:5",
+        surfaceRef: "surface:40",
+        matches: isShellPromptReady,
+        description: "shell prompt",
+        intervalMs: 1,
+        timeoutMs: 1000,
+    });
+    expect(read).toHaveBeenCalledTimes(3);
+});
+
+test("times out without sending any command when the shell never becomes ready", async () => {
+    spyOn(cli, "runCmux").mockResolvedValue({ code: 0, stdout: "Starting…", stderr: "" });
+    const send = spyOn(cli, "runCmuxOk").mockRejectedValue(new Error("must not send"));
+    await expect(
+        waitForTerminalText({
+            workspaceRef: "workspace:5",
+            surfaceRef: "surface:40",
+            matches: isShellPromptReady,
+            description: "shell prompt",
+            intervalMs: 1,
+            timeoutMs: 5,
+        })
+    ).rejects.toThrow("surface:40");
+    expect(send).not.toHaveBeenCalled();
+});
+
+// Regression test: 2026-09-07 user report — unreadable dormant tabs start only on activation.
+test("restore can activate a dormant terminal once before retrying its read", async () => {
+    let active = false;
+    spyOn(cli, "runCmux").mockImplementation(async () =>
+        active
+            ? { code: 0, stdout: "➜  repo ", stderr: "" }
+            : { code: 1, stdout: "", stderr: "internal_error: Failed to read terminal text" }
+    );
+    const activate = spyOn(cli, "runCmuxOk").mockImplementation(async () => {
+        active = true;
+        return { code: 0, stdout: "", stderr: "" };
+    });
+    await waitForTerminalText({
+        workspaceRef: "workspace:5",
+        surfaceRef: "surface:40",
+        matches: isShellPromptReady,
+        description: "shell prompt",
+        intervalMs: 1,
+        timeoutMs: 100,
+        activateOnUnavailable: true,
+    });
+    expect(activate).toHaveBeenCalledTimes(1);
+    expect(activate.mock.calls[0]?.[0]).toEqual(["rpc", "surface.focus", '{"surface_id":"surface:40"}']);
+});
+
+test("read-only waits never activate a terminal with unavailable text", async () => {
+    spyOn(cli, "runCmux").mockResolvedValue({ code: 1, stdout: "", stderr: "Failed to read terminal text" });
+    const activate = spyOn(cli, "runCmuxOk").mockRejectedValue(new Error("must not activate"));
+    await expect(
+        waitForTerminalText({
+            workspaceRef: "workspace:5",
+            surfaceRef: "surface:40",
+            matches: isShellPromptReady,
+            description: "shell prompt",
+            intervalMs: 1,
+            timeoutMs: 5,
+        })
+    ).rejects.toThrow("Timed out");
+    expect(activate).not.toHaveBeenCalled();
+});
+
+test("ordinary default and two-line shell prompts are recognized", () => {
+    for (const prompt of ["host% ", "$ ", "# ", "project on main\n❯ ", "user@host ~/project\n$ "]) {
+        expect(isShellPromptReady(prompt)).toBe(true);
+    }
+});

--- a/src/cmux/lib/terminal-ready.test.ts
+++ b/src/cmux/lib/terminal-ready.test.ts
@@ -61,7 +61,7 @@ test("restore can activate a dormant terminal once before retrying its read", as
         matches: isShellPromptReady,
         description: "shell prompt",
         intervalMs: 1,
-        timeoutMs: 100,
+        timeoutMs: 2000,
         activateOnUnavailable: true,
     });
     expect(activate).toHaveBeenCalledTimes(1);
@@ -101,8 +101,16 @@ test("a failed optional focus RPC does not abort readiness polling", async () =>
         matches: isShellPromptReady,
         description: "shell",
         intervalMs: 1,
-        timeoutMs: 100,
+        timeoutMs: 2000,
         activateOnUnavailable: true,
     });
     expect(activate).toHaveBeenCalledTimes(1);
+});
+
+test("agent-screen rejection applies to every supported prompt shape", () => {
+    for (const prompt of ["➜ repo", "[status]#", "user@host:path$", "host%", "❯"]) {
+        expect(isShellPromptReady(`Claude Code\n${prompt}`)).toBe(false);
+    }
+    expect(isShellPromptReady("100%")).toBe(false);
+    expect(isShellPromptReady("➜ grok")).toBe(true);
 });

--- a/src/cmux/lib/terminal-ready.test.ts
+++ b/src/cmux/lib/terminal-ready.test.ts
@@ -89,3 +89,20 @@ test("ordinary default and two-line shell prompts are recognized", () => {
         expect(isShellPromptReady(prompt)).toBe(true);
     }
 });
+
+test("a failed optional focus RPC does not abort readiness polling", async () => {
+    spyOn(cli, "runCmux")
+        .mockResolvedValueOnce({ code: 1, stdout: "", stderr: "Failed to read terminal text" })
+        .mockResolvedValue({ code: 0, stdout: "host% ", stderr: "" });
+    const activate = spyOn(cli, "runCmuxOk").mockRejectedValue(new Error("focus unavailable"));
+    await waitForTerminalText({
+        workspaceRef: "workspace:5",
+        surfaceRef: "surface:40",
+        matches: isShellPromptReady,
+        description: "shell",
+        intervalMs: 1,
+        timeoutMs: 100,
+        activateOnUnavailable: true,
+    });
+    expect(activate).toHaveBeenCalledTimes(1);
+});

--- a/src/cmux/lib/terminal-ready.ts
+++ b/src/cmux/lib/terminal-ready.ts
@@ -4,6 +4,9 @@ import { logger } from "@genesiscz/utils/logger";
 import { stripAnsi } from "@genesiscz/utils/string";
 
 export function isShellPromptReady(text: string): boolean {
+    if (/Claude Code|OpenAI Codex|(?:^|\n)\s*Grok(?:\s+CLI|\s+v?\d|\s*$)/i.test(stripAnsi(text))) {
+        return false;
+    }
     const last =
         stripAnsi(text)
             .split("\n")
@@ -14,8 +17,8 @@ export function isShellPromptReady(text: string): boolean {
         /^➜\s+\S+(?:\s+git:\([^)]*\))?(?:\s+✗)?\s*$/u.test(last) ||
         /^\[[^\]]+\]\s*[$#%]\s*$/u.test(last) ||
         /^[\w.-]+@[\w.-]+:\S*[$#%]\s*$/u.test(last) ||
-        /^[\w.-]+[%#$]\s*$/u.test(last) ||
-        (/^\s*[$#%❯]\s*$/u.test(last) && !/Claude Code|OpenAI Codex|Grok/i.test(stripAnsi(text)))
+        /^[a-zA-Z_][\w.-]*[%#$]\s*$/u.test(last) ||
+        /^\s*[$#%❯]\s*$/u.test(last)
     );
 }
 

--- a/src/cmux/lib/terminal-ready.ts
+++ b/src/cmux/lib/terminal-ready.ts
@@ -56,8 +56,15 @@ export async function waitForTerminalText({
             result.code !== 0 &&
             result.stderr.includes("Failed to read terminal text")
         ) {
-            await runCmuxOk(["rpc", "surface.focus", SafeJSON.stringify({ surface_id: surfaceRef })]);
             activated = true;
+            try {
+                await runCmuxOk(["rpc", "surface.focus", SafeJSON.stringify({ surface_id: surfaceRef })]);
+            } catch (error) {
+                logger.warn(
+                    { error, surfaceRef },
+                    "[restore] optional terminal activation failed; continuing readiness polling"
+                );
+            }
         }
 
         await Bun.sleep(intervalMs);

--- a/src/cmux/lib/terminal-ready.ts
+++ b/src/cmux/lib/terminal-ready.ts
@@ -1,0 +1,67 @@
+import { runCmux, runCmuxOk } from "@genesiscz/utils/cmux/lib/cli";
+import { SafeJSON } from "@genesiscz/utils/json";
+import { logger } from "@genesiscz/utils/logger";
+import { stripAnsi } from "@genesiscz/utils/string";
+
+export function isShellPromptReady(text: string): boolean {
+    const last =
+        stripAnsi(text)
+            .split("\n")
+            .map((line) => line.trimEnd())
+            .filter(Boolean)
+            .at(-1) ?? "";
+    return (
+        /^➜\s+\S+(?:\s+git:\([^)]*\))?(?:\s+✗)?\s*$/u.test(last) ||
+        /^\[[^\]]+\]\s*[$#%]\s*$/u.test(last) ||
+        /^[\w.-]+@[\w.-]+:\S*[$#%]\s*$/u.test(last) ||
+        /^[\w.-]+[%#$]\s*$/u.test(last) ||
+        (/^\s*[$#%❯]\s*$/u.test(last) && !/Claude Code|OpenAI Codex|Grok/i.test(stripAnsi(text)))
+    );
+}
+
+export async function waitForTerminalText({
+    workspaceRef,
+    surfaceRef,
+    matches,
+    description,
+    timeoutMs = 30_000,
+    intervalMs = 200,
+    activateOnUnavailable = false,
+}: {
+    workspaceRef: string;
+    surfaceRef: string;
+    matches: (text: string) => boolean;
+    description: string;
+    timeoutMs?: number;
+    intervalMs?: number;
+    activateOnUnavailable?: boolean;
+}): Promise<void> {
+    const started = Date.now();
+    let activated = false;
+    while (Date.now() - started < timeoutMs) {
+        const result = await runCmux(["read-screen", "--workspace", workspaceRef, "--surface", surfaceRef], {
+            timeoutMs: Math.max(1, timeoutMs - (Date.now() - started)),
+        });
+        if (result.code === 0 && matches(result.stdout)) {
+            logger.debug(
+                { workspaceRef, surfaceRef, description, elapsedMs: Date.now() - started },
+                "[restore] terminal ready"
+            );
+            return;
+        }
+
+        if (
+            activateOnUnavailable &&
+            !activated &&
+            result.code !== 0 &&
+            result.stderr.includes("Failed to read terminal text")
+        ) {
+            await runCmuxOk(["rpc", "surface.focus", SafeJSON.stringify({ surface_id: surfaceRef })]);
+            activated = true;
+        }
+
+        await Bun.sleep(intervalMs);
+    }
+
+    throw new Error(`Timed out waiting for ${description} in ${workspaceRef} ${surfaceRef}; command was not replayed`);
+}

--- a/src/cmux/lib/types.ts
+++ b/src/cmux/lib/types.ts
@@ -2,7 +2,7 @@ export const PROFILE_VERSION = 1;
 
 export type ProfileScope = "all" | "window" | "workspace";
 
-export type CommandSource = "scrollback" | "foreground" | "offline" | "manual" | "inferred" | "none";
+export type CommandSource = "scrollback" | "foreground" | "offline" | "shell-journal" | "manual" | "inferred" | "none";
 
 export interface ScreenSnapshot {
     /** Raw rendered text returned by `cmux capture-pane` at save time. ANSI-stripped. */
@@ -41,6 +41,8 @@ export interface TerminalSurface {
      */
     command?: string;
     command_source?: CommandSource;
+    /** Exact native autosave binding; survives title-based inference on later restores. */
+    resume?: { kind: "claude" | "grok" | "codex"; sessionId: string };
     /**
      * The command as originally captured, before any enrichment (account added,
      * `-- --resume <sessionId>` appended). Present only when `command` differs.

--- a/src/utils/cmux/lib/cli.ts
+++ b/src/utils/cmux/lib/cli.ts
@@ -163,3 +163,14 @@ export async function runCmuxOk(args: string[], opts: CmuxTimeoutOpt = {}): Prom
     }
     return result;
 }
+
+/** Send shell code verbatim; `cmux send` interprets backslash escapes as keystrokes. */
+export async function sendSurfaceText({
+    surfaceRef,
+    text,
+}: {
+    surfaceRef: string;
+    text: string;
+}): Promise<CmuxRunResult> {
+    return runCmuxOk(["rpc", "surface.send_text", SafeJSON.stringify({ surface_id: surfaceRef, text })]);
+}

--- a/src/utils/cmux/lib/send-text.test.ts
+++ b/src/utils/cmux/lib/send-text.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { chmod, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+import { SafeJSON } from "@genesiscz/utils/json";
+
+// Regression test: 2026-09-07 restore screenshot — cmux send turns shell escapes into Enter keys.
+test("literal terminal transport preserves backslashes and the final Enter", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "cmux-literal-test-"));
+    const executable = join(dir, "cmux");
+    await Bun.write(executable, "#!/bin/sh\nprintf '%s\\n' \"$@\"\n");
+    await chmod(executable, 0o755);
+    const modulePath = join(import.meta.dir, "cli.ts");
+    const payload = "printf '%s\\n' 'a\\tb\\rc'\n";
+    const source = `
+        import { sendSurfaceText } from ${SafeJSON.stringify(modulePath)};
+        const result = await sendSurfaceText({ surfaceRef: "surface:42", text: ${SafeJSON.stringify(payload)} });
+        process.stdout.write(result.stdout);
+    `;
+    const proc = Bun.spawn([process.execPath, "-e", source], {
+        env: { ...env.getProcessEnv(), PATH: `${dir}:${env.getProcessEnv().PATH ?? ""}` },
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [stdout, stderr, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+    ]);
+    expect({ code, stderr }).toMatchObject({ code: 0 });
+    const [command, method, params] = stdout.trimEnd().split("\n");
+    expect(command).toBe("rpc");
+    expect(method).toBe("surface.send_text");
+    expect(SafeJSON.parse(params)).toEqual({ surface_id: "surface:42", text: payload });
+});

--- a/src/utils/cmux/lib/socket.ts
+++ b/src/utils/cmux/lib/socket.ts
@@ -134,7 +134,14 @@ export interface PaneListResponse {
 }
 
 export async function paneList(workspaceRef: string): Promise<PaneListResponse> {
-    return rpc<PaneListResponse>("pane.list", { workspace: workspaceRef });
+    // Raw pane.list can ignore workspace and return the focused workspace. The
+    // CLI honors the target and now preserves the geometry used by restore.
+    const layout = await runCmuxJSON<PaneListResponse>(["list-panes", "--workspace", workspaceRef]);
+    if (workspaceRef.startsWith("workspace:") && layout.workspace_ref !== workspaceRef) {
+        throw new Error(`cmux returned ${layout.workspace_ref} when asked for ${workspaceRef}`);
+    }
+
+    return layout;
 }
 
 export interface WindowEntry {

--- a/src/zsh/index.ts
+++ b/src/zsh/index.ts
@@ -2,6 +2,7 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { registerCaptureLifecycleCommands } from "@app/cmux/commands/capture-install";
 import * as p from "@clack/prompts";
 import { runTool } from "@genesiscz/utils/cli";
 import { env } from "@genesiscz/utils/env";
@@ -36,6 +37,10 @@ program
     .description("Shell enhancement manager with toggleable features")
     .version("1.0.0")
     .showHelpAfterError(true);
+
+registerCaptureLifecycleCommands(
+    program.command("cmux").description("Install and inspect durable cmux command capture")
+);
 
 program
     .command("install")


### PR DESCRIPTION
Cmux restart recovery could lose completed shell commands, depend on the originating checkout, leave dormant terminals unreadable, and recreate tabs in the wrong order. This adds portable capture installation and generic terminal recovery, with bounded viewport snapshots rather than full scrollback recording.

- One installer core behind `tools cmux capture install|status|uninstall` and `tools zsh cmux install|status|uninstall`. It backs up shell configuration and installs self-contained runtimes that survive removal of the generating checkout.
- Exact commands are recorded before execution and retained after completion. Persisted surface identities and runtime aliases keep history attached when a panel moves; numbered `surface:N` handles are not used as durable keys.
- An optional read-only collector samples current viewport text roughly every 15 seconds. It skips unchanged writes and unavailable terminals, retains pre-restart output, and enforces a 64 MiB viewport-cache budget. `--no-screens` enables command capture alone.
- Live/offline saves consume available native text, browser URLs and cached viewports. Restore initializes only its new unavailable terminals, preserves selection/order, and sends shell text without interpreting backslash escapes. Browser-first panes are restored as browsers.
- The README documents covered examples and limits: process memory, unsaved buffers, shell-local state and agent authentication/confirmation flows are not reconstructed.

Validation:
- 263 tests passed in the combined cmux/zsh/shared-cmux suite; four live tests are gated in the ordinary run.
- Four isolated live tests passed separately: shell replay, workspace order, browser-first restore, and installed capture following a terminal moved between temporary workspaces.
- Relocation tests execute the installed recorder after renaming away its generating checkout. Installer tests cover idempotence, both aliases, rc preservation, collector ownership and bounded logs.
- Full TypeScript and repository rule checks passed. The local personal-data probe checked 813 patterns with no matches.
- Observed collector sample over 218 seconds: 1.10 CPU seconds, about 0.5% of one core; viewport cache approximately 712 KiB for the live collection. This is a local measurement, not a fixed resource guarantee.

The PR is based on `feat/2026-09-04-enhancements`; the rewritten base history has been excluded. No unrelated main-checkout work is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable cmux shell-command and terminal-screen capture with install, status, uninstall, and dry-run controls.
  - Added offline restoration of terminal content, browser URLs, working directories, and captured commands.
  - Added capture support for cmux and zsh workflows, including stable pane identity tracking and cached screen history.
  - Added explicit restore destination window selection and improved terminal readiness handling.

- **Bug Fixes**
  - Improved historical session selection and prevented replay of restore commands or unsafe multiline input.
  - Preserved original non-agent commands and improved browser, workspace-order, and prompt restoration.

- **Documentation**
  - Expanded offline capture setup, lifecycle, retention, supported scenarios, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->