### PR TITLE
feat: 2026-09-07 enhancements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.54",
+    "version": "1.0.55",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.54",
+            "version": "1.0.55",
             "author": {
                 "name": "GenesisTools"
             },

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ It registers **27 tools across 4 capability groups**:
 | Capability | Tools | Purpose |
 |------------|-------|---------|
 | `question_answer` | `question_answer` | Capture a question and your complete answer to the local question store, reviewable later with `tools question log` / `tools question tail`. |
-| `handoff` | `handoff_post`, `handoff_get`, `handoff_list`, `handoff_action` | Cross-agent task handoff: post a task list, claim it, check items off with proof, finish. |
+| `handoff` | `handoff_post`, `handoff_get`, `handoff_list`, `handoff_action` | Cross-agent task handoff: post a task list, address it to a session or a harness (`target.agent`: claude / codex / grok / copilot), fetch it by id or readable name, claim it, check items off with proof, finish. A session that is not the intended recipient gets a warning, never a block. |
 | `annotate` | `annotate_image` | Annotate an image (arrows, boxes, labels) for review. |
 | `boards` | 21 `boards_*` tools | Dev-dashboard annotation boards: create and compose boards, push screenshot sets, list and answer work, wait for new annotations. |
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -29,6 +29,9 @@ preload = [
     # every sqlite-vec suite fail with "no such module: vec0" whenever another
     # test file in the same worker had opened a Database first.
     "./src/utils/search/stores/sqlite-vec-preload.ts",
+    # One temp root per test process, removed on a green exit, so fixtures that never clean
+    # up cannot fill the temp folder. Before the sandbox preload, whose home lands inside it.
+    "./src/utils/bun/preload-test-tmpdir.ts",
     "./src/utils/bun/preload-test-sandbox.ts",
     "./src/utils/bun/preload-test-keyring.ts",
     "./src/utils/bun/preload-test-process-exit.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ],
     "scripts": {
         "prepare": "git config core.hooksPath .githooks",
-        "typecheck:all": "tsgo --noEmit && tsgo -p src/claude-history-dashboard/tsconfig.json --noEmit && tsgo -p src/spotify/ui/tsconfig.json --noEmit && tsgo -p src/monitor/ui/tsconfig.json --noEmit && tsgo -p src/clarity/ui/tsconfig.json --noEmit",
+        "typecheck:all": "tsgo --noEmit && tsgo -p src/claude-history-dashboard/tsconfig.json --noEmit && tsgo -p src/spotify/ui/tsconfig.json --noEmit && tsgo -p src/monitor/ui/tsconfig.json --noEmit && tsgo -p src/clarity/ui/tsconfig.json --noEmit && tsgo -p plugins/genesis-tools/skills/fable-replace/scripts/tsconfig.json --noEmit",
         "tsgo": "tsgo --noEmit",
         "tsc": "tsgo --noEmit",
         "lint": "bun run lint:biome && bun run lint:rules",

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.54",
+    "version": "1.0.55",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/skills/chrome-devtools/SKILL.md
+++ b/plugins/genesis-tools/skills/chrome-devtools/SKILL.md
@@ -29,7 +29,9 @@ tools chrome-devtools open --browser chrome --port 9223 --fresh <url>
 Ask which before quitting anything. Losing their tab set without warning is the one thing
 they will be annoyed about. Do not `osascript quit` + `open -a`: `open -a` reuses the live
 process and ignores the flag. ⚠️ Chrome ≥136 refuses the flag on the DEFAULT profile dir;
-`restart` detects that and suggests the `--fresh` fallback.
+`restart` detects that and suggests two fallbacks: `open --fresh` (throwaway, log in every
+time) and `open --user-data-dir ~/.genesis-tools/chrome-devtools/profile` (a persistent
+separate profile, logins survive between runs; the only way to keep sessions on Chrome ≥136).
 
 ## Start here, every time
 

--- a/plugins/genesis-tools/skills/fable-replace/SKILL.md
+++ b/plugins/genesis-tools/skills/fable-replace/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: fable-replace
+description: Verified, transactional find/replace for code and docs. Use INSTEAD of sed, perl, python s.replace() or repeated Edit calls whenever you change text in a file: one literal edit, a rename across 50 files, an insert under a line, a new file, a comment sweep. Every op is checked (a needle must match exactly as declared), the batch is all-or-nothing with a backup, and a MISS tells you which line to re-read. Triggers on "replace", "rename everywhere", "sweep", "batch edit", "mass replace", "insert after", "fable replace", and on any edit you were about to do with a shell one-liner.
+---
+
+# fable-replace — verified editing, from a heredoc or a script
+
+## The one rule
+
+**Never edit text with `sed`, `perl -pi`, `python -c "s.replace(...)"` or a Bash heredoc that
+rewrites a whole file.** They do not verify: a needle that does not match is a silent no-op,
+a needle that matches twice edits both, and nothing tells you. Use the CLI below. It is one
+call, needs no code, and refuses to write anything unless every op matched exactly as declared.
+
+The Edit tool is fine for ONE edit in ONE file you have just read. From two edits up, the CLI
+is fewer calls and the only option that verifies.
+
+## Quick path: the CLI (use this 90% of the time)
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" <<'FRSPEC'
+@@ src/foo/widget.ts
+<<<
+const gate = getLinkGate(link);
+===
+const gate = getActionDisabledState(link);
+>>>
+<<< after
+import React from "react";
+===
+import { thing } from "pkg";
+>>>
+@@ src/foo/new-file.ts
+<<< create
+export const fresh = 1;
+>>>
+FRSPEC
+```
+
+The harness substitutes `${CLAUDE_PLUGIN_ROOT}` at load time; if you see the placeholder
+unsubstituted, build the path from the "Base directory for this skill" line printed when this
+skill loaded. Keep the quotes: an install path can contain spaces.
+
+- `@@ path` starts a file section (relative to cwd, or absolute).
+- `<<<` … `===` … `>>>` is one op: the exact current text, then the replacement. Bodies are
+  raw lines; there is NO escaping, which is why a quoted heredoc is the right carrier. Only a
+  line that is exactly `===` or `>>>` is special inside a block.
+- ⚠️ Pick a heredoc delimiter that cannot appear in the bodies (`FRSPEC`, not `EOF`): a body
+  line equal to the delimiter ends the heredoc early and zsh rejects the whole command.
+- Bodies are literal, line for line. An empty last line in an `after`/`before`/`append` body
+  is a real blank line in the file (the usual "insert this block, then a gap"). A multi-line
+  anchor for `after` inserts below the anchor's LAST line; `before` inserts above its FIRST.
+- Compose big specs programmatically when the replacement text already exists somewhere:
+  `{ echo '@@ f.ts'; echo '<<< after'; echo 'anchor'; echo '==='; git show ref:f.ts | sed -n '10,40p'; echo '>>>'; } | bun cli.ts`
+  keeps placement and verification in the tool while the text comes from the source of truth.
+- Default contract: the needle occurs **exactly once**. Twice is a MISS (ambiguous), zero is a
+  MISS (stale). Modifiers on the `<<<` line change it:
+
+| marker | meaning |
+|---|---|
+| `<<<` | literal replace, exactly once |
+| `<<< count=all` / `count=3` | every occurrence / exactly three |
+| `<<< optional` | SKIP instead of MISS when absent; use for re-runnable specs |
+| `<<< label=free text` | name shown in the report (rest of the line, so put it LAST; a modifier written after it is a spec error, and `label="…"` keeps a word like `regex` as text) |
+| `<<< regex flags=gi count=2` | body 1 is a JS regex source, body 2 may use `$1`; `count` pins the match count |
+| `<<< fuzzy` | whitespace-insensitive literal |
+| `<<< after` (anchor `===` lines) | insert whole lines after the line holding the unique anchor |
+| `<<< before` (anchor `===` lines) | same, before it |
+| `<<< append` (lines) | append at end of file |
+| `<<< delete` (lines) | remove these lines, newline included |
+| `<<< block` (from `===` to `===` replacement) | replace the region between two anchors; empty replacement deletes it |
+| `<<< create` (content) | create a new file; refuses to overwrite an existing one |
+
+Per-file post-conditions go between `@@` and the first op: `expect: text` (must be present
+afterwards), `absent: text` (must be gone). Both repeatable. `# comments` and blank lines are
+allowed outside blocks.
+
+`block` is the only op with THREE bodies: the from-anchor, the to-anchor, then what replaces
+the whole region. Leave the third body empty to delete it.
+
+```
+@@ src/foo/widget.ts
+<<< block label=drop the legacy branch
+// ── Legacy parity ──
+===
+// ── end legacy ──
+===
+>>>
+```
+
+The region includes both anchors. ⚠️ An EMPTY third body is one empty line, not nothing, so
+the five lines above collapse to a single blank line rather than vanishing. That is usually
+what you want between two declarations; when it is not, put the following line in the third
+body instead, or use `delete`. `block` is no more markdown-aware than `append` is, so read
+the `--dry --diff` output before the real run.
+
+Flags: `--dry` (preview diffs, write nothing), `--diff` (show diffs on a real run too),
+`--verify "bun run test src/x.test.ts"` (runs after writing, captured and trimmed: a pass shows
+its last 5 lines, a fail shows the first 40 and last 60 and saves the whole output as
+`verify-output.txt` in the backup dir; a red check NEVER rolls the sweep back, see exit 3 below;
+a `|`, a `;` chain or a background `&` outside quotes is refused before anything is written;
+⚠️ in a scratch tree `bunx tsgo --noEmit` reports `Cannot find module 'bun:test'` on perfectly
+correct code, because the copy has no bun-types or tsconfig: scope tsgo to the non-test files,
+or verify with a `bun -e 'import("./x.ts")'` smoke import instead),
+`--cwd <dir>`, `--partial`, `--quiet`, `--spec <file>` (the spec from a file instead of stdin:
+use it whenever a heredoc is refused by a sandbox hook or gets long), `--rollback <backupDir>
+[--force]` (undo the sweep whose backup dir a run printed), `--api [query]`, `--help`.
+
+Exit 0: everything landed, or the dry run is clean. Exit 1: at least one MISS (**nothing was
+written**, also on `--dry`; a `--partial` run with misses is 1 too). Exit 2: malformed spec,
+unknown flag, missing file, `--dry` together with `--verify`. **Exit 3: the sweep IS written**,
+and something after the write is unhappy: the verify failed (or could not be measured: a
+timeout, a signal), or `leftoversCheck` found stale prose. An unknown or misspelled flag is an
+error, so `--dyr` can never turn a preview into a real write.
+
+After `SWEEP WRITTEN, VERIFY FAILED`: the files hold the sweep, so do NOT re-send the spec (it
+would MISS: the needles are gone). Read the head and tail it printed, send a SMALL follow-up
+spec for the fix, and run the check again. To undo everything instead, run the exact
+`--rollback <dir>` line it printed.
+
+Rules that the spec format does not say out loud:
+
+- **`before` and `after` keep the anchor line.** Never repeat it inside the body; the report
+  flags a body that starts or ends with the anchor line, because it would appear twice.
+- **A body line that must be exactly `===` or `>>>` is written `\===` or `\>>>`.** A bare
+  `>>>` closes the block early; a bare `===` starts an extra body (the error names its line).
+  For content full of such lines, use the JSON form: a top-level array of FileEdit objects.
+- **Ops apply in order, each sees the previous op's output.** Converting call sites AND the
+  declaration in one spec: put the declaration edit last, or write a regex that cannot match
+  the already converted line, or the syntax check will stop you with a parse error.
+- **Regex replacements follow JavaScript rules:** `$1` is a group, `$&` the whole match, `$$`
+  a literal dollar. A literal `$` in the replacement body must be `$$`.
+- **`fuzzy` forgives whitespace on the FIND side only.** The replacement lands exactly as
+  typed, indentation and line endings included.
+- **Build spec text with `printf '%s\n'`, never `echo`,** when a shell loop writes it: zsh's
+  `echo` turns `\b` into a backspace byte, and the parser now refuses control characters
+  with that hint instead of reporting "regex matched nothing" 62 times.
+- **`append` is not markdown-aware:** it adds no separating blank line. End the previous
+  content with a blank line in the body when the file needs one.
+
+### Reading a MISS
+
+Every MISS says why, and where to look. The hints, in order of what the runner tries:
+
+- *the REPLACEMENT is already in the file* — the edit was applied before. Re-running is not an
+  error in itself; add `optional` if the spec must be re-runnable.
+- *matches when ALL whitespace is ignored (first at line N)* — indentation, tabs or a line
+  break differ. Re-read line N and paste the exact text, or use `fuzzy`.
+  ⚠️ A literal needle is a SUBSTRING match, so this fires only when your needle carries MORE
+  whitespace than the file. A needle with LESS leading indentation than the file line still
+  matches silently, and the file's own indentation survives, because only the matched span is
+  replaced. So "it matched" does not prove you copied the line exactly.
+- *matches when case AND whitespace are ignored (line N)* — a letter-case typo in the needle.
+- *matches after Unicode normalization (line N)* — the file and the needle spell an accented
+  word with different code points (NFC vs NFD). Copy the text from the file, or use `fuzzy`.
+- *anchor occurs N× but never at the start of a line* — an indented `after`/`before` anchor
+  carries its indentation on purpose; copy the leading whitespace exactly.
+  An anchor that does NOT start with whitespace is matched anywhere in the line, mid-line
+  included; it must still be unique, and the insert lands on its own line above or below.
+- *"from" anchor occurs N× (lines …)* — a `block` needs a unique start; add context.
+- *first line found at line N, text diverges at line M: file has "…", needle has "…"* — your
+  copy of the file is stale from line M on.
+- *expected exactly 1 occurrence(s), found 3 at line(s) 12, 40, 77* — add surrounding
+  context, or say `count=3` when all three are meant.
+- *no line of the file contains the needle's first line* — wrong file, or the text is gone.
+
+A MISS is not a failure of the tool. It is the tool telling you your model of the file is
+wrong, before anything was written. Re-read, fix the op, re-run.
+
+## When you need a script instead
+
+Use the TypeScript API when the CLI cannot express it: recon (find the files first, count the
+occurrences), a rename across many files with a pinned count per file, comment sweeps, a
+replacer FUNCTION, file delete/rename in the same transaction.
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" --api     # every function + params + docs
+```
+
+Every function with more than two inputs takes ONE object, so `--api` shows every field and
+its doc next to the signature (`--api rename` narrows it). Contract of the script API:
+
+- **`run()` throws a `FableReplaceError`** (its `code` is the exit code: 1 misses or a
+  partial write; 2 pre-flight; 3 written but the verify failed or stale prose survived, with
+  the captured verdict in `err.report.verify`) instead of exiting your process. Catch it if
+  you want to continue; an uncaught one still ends the script non-zero. `throwOnFailure: false`
+  restores the exit behaviour.
+- **A red `verifyCommand` keeps the files written**, exactly like the CLI. A script with no
+  model in the loop that wants the old atomic behaviour writes it in three lines:
+  `catch (err) { rollback({ backupDir }); throw err; }`. `rollback` is exported.
+- **Unknown option keys are a pre-flight error** with a "did you mean" hint: `dry: true` is
+  not `dryRun: true`, and used to be a silent real write.
+- **`partial: true` still fails when anything missed:** the clean files are written, then the
+  error is thrown. `report.ok` is false.
+- **The thrown error carries the report:** `err.report` is the same `RunReport` a green run
+  returns, so a catch reads `err.report.written` / `.missCount` / `.files` instead of parsing
+  the message. A pre-flight refusal (code 2) happens before any file is planned, so there
+  `err.report` is undefined.
+- **`findFiles` needs `containing`:** it is the content filter, not an option. Omitting it
+  throws rather than returning `[]`, which used to read as "no file holds the symbol".
+- **`renameSymbolAcross` refuses a file that both imports and declares the symbol** (a local
+  wrapper) unless `includeShadowed: true`; `countMatches` prints the same split, and
+  `shadowedFiles({ files, name })` returns it.
+- **`findFiles` roots may be plain files** (`README.md`, `CLAUDE.md`) as well as directories.
+- **`insertAfter` is same-line and verbatim** (add your own space or newline);
+  `insertLinesAfter` inserts whole lines under the anchor's line.
+
+The shapes you will use most:
+
+```ts
+import { countMatches, findFiles, leftovers, renameSymbolAcross, run, scratchDir } from "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/replace-utils";
+
+const files = findFiles({ roots: ["src"], containing: /\boldName\b/ });
+const counts = countMatches({ files, pattern: "oldName" }); // per-file numbers, zero-match and shadowing warnings
+
+await run({
+  edits: [
+    { file: "src/a.ts", ops: [{ find: "old", replace: "new" }], absentAfter: ["old"] },
+    ...renameSymbolAcross({ files: counts, oldName: "oldName", newName: "newName" }), // counts pinned per file
+  ],
+  backupDir: scratchDir("rename-oldName"),
+  verifyCommand: "bunx tsgo --noEmit",
+  leftoversCheck: { names: ["oldName"], dirs: ["."] },
+});
+```
+
+`scripts/example.ts` is a fuller template. `--dry` on argv previews. The modules, if you need
+to read one: `types.ts` (every shape), `edit-one-file.ts` (ops), `comments.ts` (comment and
+line sweeps), `rename-symbols.ts`, `recon.ts`, `sweep-many-files.ts` (the runner),
+`backup-and-rollback.ts`, `spec.ts` (the CLI format). `replace-utils.ts` re-exports all.
+
+## Recon before a sweep
+
+Ops are literal. Copy the text verbatim from the file, indentation included; a MISS means your
+mental model of the file is stale, which is the point. Traps that each cost a wasted round:
+
+- **Match the thing, not the statement shape.** Hunting import specifiers with a pattern
+  anchored on `import … from` misses multi-line imports, `export … from` barrels, dynamic
+  `import("…")` and type-only positions. Match the quoted specifier itself.
+- **One grep shape is never the whole picture.** The same module is imported as
+  `"@pkg/format"`, `"@pkg/format.ts"` and `"./format"` in one repo.
+- 🛑 **Never pipe recon through `head`/`tail` on its way to a file.** `head` exits early,
+  SIGPIPE kills `tee` and `rg`, and the file is truncated. A trial captured 109 of 411 matches
+  this way. Redirect to the file first, then read it.
+- 🛑 **`--type tsx` is not a ripgrep type.** `rg -l foo --type ts --type tsx` matches nothing
+  and exits 0. Use `-g '*.ts' -g '*.tsx'`. Treat any surprisingly empty recon as broken
+  instrumentation, not an answer.
+- 🛑 **Never count with `rg --heading … | wc -l`.** Heading mode adds a filename line and a
+  blank per file. Use `countMatches`, or `rg -o … | wc -l`.
+- **`countMatches` prints the `expect:` numbers** and warns about zero-match files (a
+  guaranteed MISS) and files that DECLARE a symbol of the same name (renaming those changes an
+  unrelated helper). Do not transcribe counts by hand.
+
+## 🛑 Every op OK does not mean the sweep is complete
+
+The report only proves the ops you DECLARED matched. It cannot know about a call site your
+recon never found. A 50-file rename once reported zero MISS and was still broken. So:
+
+- **Put the project's own check in `--verify` / `verifyCommand`** on every real sweep. A red
+  check keeps the sweep written, exits 3 and prints the undo command; fix forward with a small
+  follow-up spec. Write the BARE command: a `|`, a `;` chain or a background `&` outside quotes
+  is refused in pre-flight (exit 2, nothing written), because both `/bin/sh` and `pipefail` lie
+  about a pipeline's exit code, and the CLI trims the output itself. `&&`, `||` and redirects
+  are fine; `2>/dev/null` only warns. The escape hatch names the risk in the command:
+  `--verify "bash -c 'set -o pipefail; bun run test | tail -3'"`. A pipe inside `$( )` is
+  refused too: the check is a quote scanner, not a shell parser. The same rule applies to a
+  check you run AFTER the CLI: never `cli.ts … ; bun run test | tail -3` in one Bash call,
+  because the `;` and the pipe hide the test's exit code from you as well.
+- **A green check does not mean the sweep was RIGHT.** A blanket rename across 71 files
+  typechecked while renaming three unrelated local helpers that shared the name. Read the diff
+  (`--dry` first, `--diff` on the real run).
+- **`expectAfter` / `expect:` and `absentAfter` / `absent:` are plain substring checks**, not
+  word-boundary matches. They cannot see structure; a dropped brace passes them. That is what
+  the built-in syntax check is for: every edited `.ts/.tsx/.js/.jsx` is parsed after the ops,
+  and a file that stopped parsing fails the batch with the line number.
+- **A rename is not finished when the code is green.** Sweep README, CLAUDE.md, docs and plans
+  that name the symbol. `leftoversCheck` (script) fails the run when the old name survives in
+  prose while leaving the verified code written; `leftovers({ names, dirs })` is the manual form.
+
+## Renames: the two forks
+
+- **Renaming a PUBLIC API:** the `export { old }` barrel line is in scope, rename it and its
+  consumers, the old name should disappear.
+- **Renaming an INTERNAL helper that a barrel still publishes as `old`:** alias on the way in
+  (`import { newName as old }`), keep `export { old }` exactly, leave the barrel's consumers
+  untouched. A blanket regex rename silently breaks this contract.
+
+The two look identical in a grep and want opposite edits. Grep for `export {` before any
+blanket rename, and say in the sweep which fork you chose. If the brief does not say, ask.
+
+Several symbols in overlapping file sets: build one file list per symbol from `countMatches`
+(a listed file that lacks the symbol is a MISS), and wrap the batch in `mergeFileEdits` so a
+shared file is not "listed twice". `sameOpsAcross` carries ONE op list and therefore ONE
+`expect`; the moment per-file counts differ, build the edits from the counts map instead.
+
+## Guards that fire before anything is written
+
+- `node_modules` paths are refused (`allowNodeModules` overrides).
+- Generated files are refused: `*.gen.ts`, `dist/`, `build/`, or a header comment saying
+  `@generated` / `DO NOT EDIT` (only a real comment counts; a module that EMITS such text is
+  not itself generated). Fix the generator. `allowGenerated: true` per file overrides.
+- Syntax check on every edited script, with the line that broke.
+- `renameTo` refuses an existing target, a target claimed twice, or a target also edited.
+- A reused `backupDir` is refused (the CLI always makes a fresh one).
+- Two sweeps racing into ONE `backupDir` are refused: the manifest is created exclusively, so
+  the loser aborts before writing instead of overwriting the winner's manifest and silently
+  losing its own undo.
+- A file that is not valid UTF-8 is refused. The whole file is read as text and written back,
+  so one stray cp1252 byte would silently become U+FFFD far from your edit.
+- A file that changed on disk between the read and the write is refused and the batch rolls
+  back: the ops were computed against a snapshot, and writing anyway erases whoever wrote in
+  between while still reporting OK.
+- A file listed twice in one batch is refused; merge the ops.
+
+## Rollback
+
+`backupDir` (the CLI prints it) holds the originals plus a manifest with a hash of what was
+written. Undo from the shell:
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" --rollback /var/folders/…/fable-replace-cli-1234-AbCdEf
+```
+
+or `rollback({ backupDir })` in a script. Both restore byte-for-byte and SKIP any file that
+changed after the sweep wrote it, reporting it as drifted; `--force` / `force: true` restores
+those too. A file that is already back at its original content is reported as such, not as
+drift. Stacked sweeps unwind newest-first or refuse. `backupOverwrite: true` is a one-way
+door: the original content in the old snapshot becomes unrecoverable. 🛑 Never
+`git checkout --` as the undo; it destroys uncommitted work.
+
+A restore that the filesystem itself blocks (a file some later command chmod'd read-only, a
+full disk) never stops the others: each entry is restored inside its own guard, the survivors
+come back, and the blocked ones land in `report.failed` plus the thrown error's message. Those
+files still hold the SWEPT content, so fix the cause and re-run the rollback; the backup is
+intact.
+
+## Recipe: positional arguments to one object
+
+```
+<<< regex count=6 label=call sites first, declaration last
+(?<!function )describeMail\(\s*([^,]+?)\s*,\s*([^,]+?)\s*,\s*([^)]+?)\s*\)
+===
+describeMail({ subject: $1, sender: $2, mailbox: $3 })
+>>>
+<<<
+function describeMail(subject: string, sender: string, mailbox: string): string {
+===
+function describeMail({ subject, sender, mailbox }: { subject: string; sender: string; mailbox: string }): string {
+>>>
+```
+
+`\s*,\s*` survives a call that wraps its arguments over several lines; a literal `, ` does
+not. `count=6` was measured first (`countMatches`, or a deliberately wrong count whose MISS
+reports the real number and the lines).
+
+🛑 **The lookbehind is not optional.** A three-parameter DECLARATION has the same comma and
+paren shape as a three-argument CALL, so the call-site regex matches the declaration too and
+the count comes out one too high. Reordering the ops does not help: the already-destructured
+declaration still matches the same naive pattern. If your count is exactly one above what
+`countMatches` reported, this is why. Keep `(?<!function )`, and add the declaration's own
+prefix (`(?<!const )`, a method name) when it is not a plain `function`. Never "fix" the
+mismatch by raising `count`: that rewrites the declaration with the call-site template and
+produces garbage.
+
+## Comment sweeps (script only)
+
+`dropComments` (`containing` or `matching`): the COMMENT goes, code on the same line stays;
+string, template and regex aware, and it knows the JSX tag shapes `</Foo>` and `<Foo />`. It
+does not model JSX TEXT: a comment-shaped run inside rendered text (`<p>/* note */</p>`, a
+URL in a paragraph) counts as a comment, so on .tsx files keep the predicate narrow and read
+`--dry --diff`. `deleteLines`: the WHOLE line goes. For
+`}, [onConfirm]); // eslint-disable-line` the first keeps the statement, the second deletes it.
+Both refuse to run without a predicate.
+
+## Housekeeping
+
+- 🛑 `/tmp` is shared machine-wide. Two agents sweeping in parallel overwrote each other's
+  log at `/tmp/sweep-dry.log`. The CLI uses `scratchDir()`; scripts must too. Every scratch
+  and backup dir lives under `<tmp>/fable-replace/`, and every CLI run prunes that root:
+  age-only (older than 12 h), manifest-gated (only a dir this tool created and finished, or
+  an empty one), at most 50 per run, never the current run's dir. `--prune` runs it now. A
+  reboot empties the temp folder anyway; the prune matters on machines that stay up for weeks.
+- One spec or script per logical sweep, so the report maps to one reviewable change.
+- Every real CLI run, rollback and prune is journaled to `~/.genesis-tools/fable-replace/journal.jsonl`
+  (a `--dry` run writes nothing at all, not even the journal, and never prunes)
+  (`GENESIS_TOOLS_HOME` or `FABLE_REPLACE_HOME` move it). The spec text is never stored there,
+  only its size and hash; the text goes to `<backupDir>/spec.frspec`. `--history [N]` lists the
+  last runs with outcome, tokens and backup dir; `--stats [days]` sums outcomes, tokens written
+  and read back, the tokens wasted on failed runs (no dollar figure: multiply by your model's
+  output rate), and the top MISS reasons.
+- Literal ops match RAW BYTES: a find that spans a string-concatenation boundary in the source
+  can never match. Split it per line.
+- `bun scripts/selftest.ts` after touching anything under `scripts/`; it must end with
+  `ALL SELFTESTS PASSED`. It pins every op kind, the spec parser, the CLI end to end, the
+  transaction, every guard and the rollback contract.

--- a/plugins/genesis-tools/skills/fable-replace/scripts/api.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/api.ts
@@ -1,0 +1,176 @@
+/**
+ * fable-replace — PRINT THE TYPED API. `bun cli.ts --api` dumps every exported
+ * function signature, interface and type alias together with its JSDoc, straight
+ * from the source, so an agent gets the full parameter types without reading the
+ * modules. Nothing here is hand-maintained; if it is exported, it is listed.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const MODULES = [
+    "types.ts",
+    "spec.ts",
+    "sweep-many-files.ts",
+    "edit-one-file.ts",
+    "comments.ts",
+    "rename-symbols.ts",
+    "recon.ts",
+    "backup-and-rollback.ts",
+    "verify-command.ts",
+];
+
+interface ApiEntry {
+    module: string;
+    name: string;
+    doc: string;
+    signature: string;
+}
+
+/** Text of the JSDoc block that ends right above `lineIdx`, or "". */
+const docAbove = (lines: string[], lineIdx: number): string => {
+    let j = lineIdx - 1;
+    if (j < 0 || !lines[j].trim().endsWith("*/")) {
+        return "";
+    }
+    const end = j;
+    while (j >= 0 && !lines[j].trim().startsWith("/**")) {
+        j -= 1;
+    }
+    if (j < 0) {
+        return "";
+    }
+    return lines
+        .slice(j, end + 1)
+        .map((l) =>
+            l
+                .trim()
+                .replace(/^\/\*\*\s?/, "")
+                .replace(/^\*\/?\s?/, "")
+                .replace(/\*\/$/, "")
+        )
+        .join("\n")
+        .trim();
+};
+
+/**
+ * Text from `start` up to the line where the depth opened by `open` on that line
+ * returns to zero, plus the character offset of that closing bracket. Nothing past
+ * it: a function BODY is not part of its signature.
+ */
+const balancedSpan = ({
+    lines,
+    start,
+    open,
+    close,
+}: {
+    lines: string[];
+    start: number;
+    open: string;
+    close: string;
+}): { text: string; closeAt: number } => {
+    let depth = 0;
+    let seen = false;
+    let offset = 0;
+    for (let i = start; i < lines.length; i += 1) {
+        const line = lines[i];
+        for (let c = 0; c < line.length; c += 1) {
+            const ch = line[c];
+            if (ch === open) {
+                depth += 1;
+                seen = true;
+            } else if (ch === close) {
+                depth -= 1;
+                if (seen && depth === 0) {
+                    return { text: lines.slice(start, i + 1).join("\n"), closeAt: offset + c };
+                }
+            }
+        }
+        offset += line.length + 1;
+    }
+    return { text: lines[start], closeAt: lines[start].length };
+};
+
+/** `export const name = (params): Return => …` reduced to `name = (params): Return`. */
+const arrowSignature = ({ lines, start }: { lines: string[]; start: number }): string => {
+    const span = balancedSpan({ lines, start, open: "(", close: ")" });
+    const arrow = span.text.indexOf("=>", span.closeAt);
+    const head = arrow === -1 ? span.text : span.text.slice(0, arrow).trimEnd();
+    return head.replace(/^export const /, "");
+};
+
+const declarationSignature = ({ lines, start }: { lines: string[]; start: number }): string => {
+    const first = lines[start];
+    if (first.includes("{")) {
+        return balancedSpan({ lines, start, open: "{", close: "}" }).text.replace(/^export /, "");
+    }
+    // `type X = A | B;` possibly continued on following lines until the terminating `;`
+    const out: string[] = [];
+    for (let i = start; i < lines.length; i += 1) {
+        out.push(lines[i]);
+        if (lines[i].trimEnd().endsWith(";")) {
+            break;
+        }
+    }
+    return out.join("\n").replace(/^export /, "");
+};
+
+export const collectApi = (dir: string): ApiEntry[] => {
+    const entries: ApiEntry[] = [];
+    for (const module of MODULES) {
+        const file = path.join(dir, module);
+        if (!fs.existsSync(file)) {
+            continue;
+        }
+        const lines = fs.readFileSync(file, "utf8").split("\n");
+        for (let i = 0; i < lines.length; i += 1) {
+            const l = lines[i];
+            const fn = l.match(/^export const (\w+) = (?:async )?\(/);
+            const decl = l.match(/^export (interface|type|class) (\w+)/);
+            if (fn !== null) {
+                entries.push({
+                    module,
+                    name: fn[1],
+                    doc: docAbove(lines, i),
+                    signature: arrowSignature({ lines, start: i }),
+                });
+            } else if (decl !== null) {
+                entries.push({
+                    module,
+                    name: decl[2],
+                    doc: docAbove(lines, i),
+                    signature: declarationSignature({ lines, start: i }),
+                });
+            }
+        }
+    }
+    return entries;
+};
+
+/** Print the API, optionally only the entries whose name or module contains `query` (case-insensitive). */
+export const printApi = ({ dir, query }: { dir: string; query?: string }): void => {
+    const q = query?.toLowerCase();
+    const entries = collectApi(dir).filter(
+        (e) => q === undefined || e.name.toLowerCase().includes(q) || e.module.toLowerCase().includes(q)
+    );
+    console.log(
+        `fable-replace API — ${entries.length} entr${entries.length === 1 ? "y" : "ies"}${q === undefined ? " (narrow with --api <query>)" : ` matching "${query}"`}`
+    );
+    // The "## module" headings below name the file that DEFINES a symbol. That is not the
+    // import path: everything is re-exported from the barrel, so a script written from this
+    // dump imports one specifier and never has to track which module moved.
+    console.log(
+        `import { … } from "${path.join(dir, "replace-utils")}";  // every symbol below; ## headings name the defining file, not the import path`
+    );
+    let lastModule = "";
+    for (const entry of entries) {
+        if (entry.module !== lastModule) {
+            console.log(`\n## ${entry.module}\n`);
+            lastModule = entry.module;
+        }
+        if (entry.doc.length > 0) {
+            console.log(`/** ${entry.doc.replace(/\n/g, "\n    ")} */`);
+        }
+        console.log(`${entry.signature}\n`);
+    }
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/backup-and-rollback.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/backup-and-rollback.ts
@@ -1,0 +1,370 @@
+/**
+ * fable-replace — BACKUP AND ROLLBACK. The undo story.
+ *
+ * `backupDir` snapshots every file the sweep is about to touch, plus a manifest,
+ * BEFORE anything is written. After the write phase the manifest also records a
+ * hash of what the sweep produced.
+ *
+ * `rollback(dir)` restores byte-for-byte — but SKIPS any file whose content changed
+ * after the sweep wrote it (a hand edit, a formatter, a later sweep) and reports it
+ * as drifted, because restoring it would destroy work the snapshot never saw. Pass
+ * `force: true` to restore those too. A side effect worth knowing: stacked
+ * sweeps therefore refuse to unwind out of order.
+ *
+ * Never point two sweeps at one backupDir — the second overwrites the first
+ * snapshot. The runner refuses this in pre-flight.
+ */
+
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { FableReplaceError } from "./internal";
+import { parseJson, stringifyJson } from "./json";
+import type { PruneParams, PruneReport, RollbackParams, RollbackReport, WriteBackupParams } from "./types";
+
+interface BackupManifestEntry {
+    /** Absolute original path. */
+    original: string;
+    /** File name inside the backup dir, or null when the file did not exist (created/renamed targets). */
+    stored: string | null;
+    /**
+     * sha256 of what the sweep WROTE to `original`, filled in after the write phase
+     * (null when the sweep deleted the file). `rollback()` compares against it, so an
+     * edit made by hand after the sweep is never silently overwritten.
+     */
+    hashAfter?: string | null;
+}
+
+const MANIFEST_NAME = "fable-replace-manifest.json";
+
+const hashOf = (file: string): string | null => {
+    if (!fs.existsSync(file)) {
+        return null;
+    }
+    return createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+};
+
+/** Is `dir` already holding a manifest from an earlier sweep? */
+export const backupDirInUse = (dir: string): string | null => {
+    const manifestPath = path.join(dir, MANIFEST_NAME);
+    if (!fs.existsSync(manifestPath)) {
+        return null;
+    }
+    try {
+        return (
+            (parseJson(fs.readFileSync(manifestPath, "utf8")) as { createdAt?: string }).createdAt ?? "an earlier run"
+        );
+    } catch {
+        return "an unreadable earlier manifest";
+    }
+};
+
+export const writeBackup = ({ dir, files, overwrite = false }: WriteBackupParams): void => {
+    fs.mkdirSync(dir, { recursive: true });
+    const manifestPath = path.join(dir, MANIFEST_NAME);
+    const createdAt = new Date().toISOString();
+    // Reserve the dir BEFORE any byte is copied. The stored names are deterministic
+    // (0000-<name>), so a second writer that copied first would overwrite the first
+    // snapshot's originals and only then fail on the manifest. "wx" fails when the manifest
+    // already exists, and the pre-flight `backupDirInUse` check cannot cover two sweeps
+    // racing past it. The loser fails loudly here, with the winner's snapshot intact.
+    try {
+        fs.writeFileSync(manifestPath, stringifyJson({ createdAt, entries: [] }, 2), { flag: overwrite ? "w" : "wx" });
+    } catch (err) {
+        throw new FableReplaceError(
+            `backup dir ${dir} gained a manifest while this sweep was starting: another sweep is using it. Give this run its own backupDir (scratchDir("my-sweep")). Nothing was written. (${String(err)})`,
+            2
+        );
+    }
+
+    const entries: BackupManifestEntry[] = [];
+    let i = 0;
+    for (const file of files) {
+        if (fs.existsSync(file)) {
+            const stored = `${String(i).padStart(4, "0")}-${path.basename(file)}`;
+            fs.copyFileSync(file, path.join(dir, stored));
+            entries.push({ original: file, stored });
+        } else {
+            entries.push({ original: file, stored: null });
+        }
+        i += 1;
+    }
+    fs.writeFileSync(manifestPath, stringifyJson({ createdAt, entries }, 2));
+};
+
+/**
+ * Record what the sweep actually wrote, so `rollback()` can detect a file that
+ * changed again afterwards. Called once, after the write phase succeeds.
+ */
+export const recordPostWriteHashes = (dir: string): void => {
+    const manifestPath = path.join(dir, MANIFEST_NAME);
+    if (!fs.existsSync(manifestPath)) {
+        return;
+    }
+    const manifest = parseJson(fs.readFileSync(manifestPath, "utf8")) as {
+        createdAt: string;
+        entries: BackupManifestEntry[];
+    };
+    for (const entry of manifest.entries) {
+        try {
+            entry.hashAfter = hashOf(entry.original);
+        } catch (err) {
+            // A verify command may have turned the path into a directory or made it
+            // unreadable. Without a hash the rollback restores it with no drift check, the
+            // right default for a path this run can no longer describe.
+            entry.hashAfter = undefined;
+            console.error(
+                `⚠ could not hash ${entry.original} after the write (${String(err)}); its rollback skips the drift check`
+            );
+        }
+    }
+    fs.writeFileSync(manifestPath, stringifyJson(manifest, 2));
+};
+
+/**
+ * Restore every file recorded in a backup dir's manifest byte-for-byte.
+ * Files that did not exist at backup time are deleted if they exist now.
+ *
+ * A file that changed AFTER the sweep wrote it (someone edited it by hand, a
+ * formatter ran, a later sweep touched it) is reported as drifted and SKIPPED —
+ * restoring it would destroy work the backup never saw. Pass `force: true`
+ * to restore those too.
+ */
+export const rollback = ({ backupDir, force = false, only }: RollbackParams): RollbackReport => {
+    const manifestPath = path.join(backupDir, MANIFEST_NAME);
+    if (!fs.existsSync(manifestPath)) {
+        throw new Error(`No ${MANIFEST_NAME} in ${backupDir} — not a fable-replace backup dir`);
+    }
+    const manifest = parseJson(fs.readFileSync(manifestPath, "utf8")) as { entries: BackupManifestEntry[] };
+    const report: RollbackReport = { restored: [], drifted: [], failed: [] };
+    const wanted = only === undefined ? null : new Set(only.map((file) => path.resolve(file)));
+    for (const entry of manifest.entries) {
+        if (wanted !== null && !wanted.has(path.resolve(entry.original))) {
+            continue;
+        }
+
+        // Every entry is inspected AND restored inside its OWN guard. The obstruction that
+        // broke the sweep (a read-only file, a full disk) usually blocks the restore of the
+        // SAME file, and an uncaught throw here used to abandon every LATER entry with the
+        // rejected sweep content still live, under an exit code that read as a routine
+        // failure. The drift check reads the file too: a path that became unreadable, or a
+        // directory, threw before the guard and stranded the rest the same way.
+        try {
+            if (
+                entry.hashAfter !== undefined &&
+                force &&
+                fs.existsSync(entry.original) &&
+                hashOf(entry.original) !== entry.hashAfter
+            ) {
+                // `force` still overwrites, but never silently. The content here is neither what
+                // the sweep wrote nor the snapshot, so this file is not simply "drifted": a
+                // hand-edited manifest pointing somewhere else looks exactly the same, and the
+                // tool's own drift message invites the user to run `--force` next.
+                console.error(`⚠ FORCING over content this sweep never wrote: ${entry.original}`);
+            }
+
+            if (entry.hashAfter !== undefined && !force) {
+                const now = hashOf(entry.original);
+                if (now !== entry.hashAfter) {
+                    // Already back at the snapshot (a previous rollback, or a hand revert) is
+                    // not drift: nothing would be lost by restoring, and nothing needs doing.
+                    const original = entry.stored === null ? null : hashOf(path.join(backupDir, entry.stored));
+                    if (now === original) {
+                        console.log(`· already at its original content: ${entry.original}`);
+                        report.restored.push(entry.original);
+                        continue;
+                    }
+                    report.drifted.push(entry.original);
+                    console.log(`⚠ SKIPPED, changed since the sweep: ${entry.original}`);
+                    continue;
+                }
+            }
+
+            if (entry.stored === null) {
+                if (fs.existsSync(entry.original)) {
+                    fs.rmSync(entry.original);
+                    console.log(`↩ deleted (did not exist at backup time): ${entry.original}`);
+                }
+            } else {
+                const stored = path.join(backupDir, entry.stored);
+                if (fs.existsSync(entry.original) && hashOf(entry.original) === hashOf(stored)) {
+                    // Byte-identical already: copying would only bump the mtime and wake
+                    // every file watcher and incremental build cache for nothing.
+                    console.log(`· already at its original content: ${entry.original}`);
+                    report.restored.push(entry.original);
+                    continue;
+                }
+
+                fs.mkdirSync(path.dirname(entry.original), { recursive: true });
+                fs.copyFileSync(stored, entry.original);
+                console.log(`↩ restored: ${entry.original}`);
+            }
+        } catch (err) {
+            report.failed.push({ file: entry.original, error: String(err) });
+            console.error(`✗ COULD NOT RESTORE, still holds the swept content: ${entry.original} — ${String(err)}`);
+            continue;
+        }
+
+        report.restored.push(entry.original);
+    }
+    console.log(
+        `Rollback complete: ${report.restored.length} restored, ${report.drifted.length} skipped as changed, ${report.failed.length} FAILED, from ${backupDir}`
+    );
+    if (report.drifted.length > 0) {
+        console.log(
+            `  re-run with rollback({ backupDir, force: true }) to overwrite the ${report.drifted.length} changed file(s) too.`
+        );
+    }
+    if (report.failed.length > 0) {
+        console.error(`🛑 ${report.failed.length} file(s) still hold the swept content and could NOT be restored:`);
+        for (const f of report.failed) {
+            console.error(`   ${f.file}`);
+        }
+        console.error(
+            `   Fix the cause (permissions, disk space), then re-run the rollback: the backup at ${backupDir} is intact.`
+        );
+    }
+    return report;
+};
+
+/** One root for every scratch and backup dir, so a listing and a prune stay cheap and scoped. */
+export const scratchRoot = (): string => path.join(os.tmpdir(), "fable-replace");
+
+/**
+ * A collision-proof scratch directory under `<tmp>/fable-replace/`.
+ *
+ * /tmp is shared machine-wide. Two agents running similar sweeps in parallel both
+ * reached for `/tmp/sweep-dry.log` and one silently overwrote the other's evidence,
+ * so a log read back from disk described a different sweep entirely. Never hard-code
+ * a generic /tmp path for a backupDir or a log.
+ */
+export const scratchDir = (label: string): string => {
+    const root = scratchRoot();
+    fs.mkdirSync(root, { recursive: true });
+    // mkdtemp, not a timestamp: two calls in the same millisecond must not collide.
+    return fs.mkdtempSync(path.join(root, `${label}-${process.pid}-`));
+};
+
+/** Longer than any session's need for its undo trail, shorter than a typical uptime, so it fires. */
+export const PRUNE_TTL_MS = 12 * 60 * 60 * 1000;
+const PRUNE_MAX_REMOVALS = 50;
+/** The layout before the single root: dirs directly under the temp dir, swept by the same gate. */
+const LEGACY_PREFIX = "fable-replace-";
+
+/**
+ * Only a dir this tool created AND finished writing (it holds the manifest), or an empty
+ * one. A name pattern could match someone else's dir; a manifest cannot. That is also
+ * what protects scratch dirs without one, such as a selftest's own.
+ */
+const isPrunable = (dir: string): boolean => {
+    try {
+        const entries = fs.readdirSync(dir);
+        return entries.length === 0 || entries.includes(MANIFEST_NAME);
+    } catch {
+        // Vanished between the listing and this read: another prune got it first.
+        return false;
+    }
+};
+
+const dirBytes = (dir: string): number => {
+    let bytes = 0;
+    try {
+        for (const name of fs.readdirSync(dir)) {
+            try {
+                const stat = fs.statSync(path.join(dir, name));
+                if (stat.isFile()) {
+                    bytes += stat.size;
+                }
+            } catch {
+                // A file removed under us costs nothing to skip.
+            }
+        }
+    } catch {
+        // The dir itself vanished: nothing to count.
+    }
+    return bytes;
+};
+
+const listDirs = (dir: string, filter: (name: string) => boolean): string[] => {
+    try {
+        return fs
+            .readdirSync(dir)
+            .filter(filter)
+            .map((name) => path.join(dir, name));
+    } catch (err) {
+        if ((err as { code?: string }).code === "ENOENT") {
+            return [];
+        }
+
+        throw err;
+    }
+};
+
+/**
+ * Remove stale scratch dirs. Age-only (never count- or size-based, so a live run's young
+ * dir is safe and two prunes at once are benign), manifest-gated, capped per run, and the
+ * dirs in `keep` are never touched. Only the temp dir this process writes to is swept
+ * (`os.tmpdir()`, so TMPDIR decides), never another root. Legacy `fable-replace-*`
+ * entries directly under it fall under the same gate.
+ *
+ * On a machine that reboots often this rarely fires: a reboot empties the temp folder
+ * first. It pays off on machines that stay up for weeks.
+ */
+export const pruneScratch = ({
+    ttlMs = PRUNE_TTL_MS,
+    maxRemovals = PRUNE_MAX_REMOVALS,
+    keep = [],
+    now = Date.now(),
+}: PruneParams = {}): PruneReport => {
+    // One root only: the temp dir THIS process writes to. A launchd job with no TMPDIR has
+    // os.tmpdir() === /tmp and prunes /tmp itself. Sweeping /tmp from every process as well
+    // made a TMPDIR-redirected run (the selftest, a sandbox) delete backups it never wrote.
+    const temp = os.tmpdir();
+    const candidates = [
+        ...listDirs(path.join(temp, "fable-replace"), () => true),
+        ...listDirs(temp, (name) => name.startsWith(LEGACY_PREFIX)),
+    ];
+
+    const keepSet = new Set(keep.map((dir) => path.resolve(dir)));
+    const report: PruneReport = {
+        scanned: candidates.length,
+        removed: 0,
+        bytes: 0,
+        roots: [path.join(temp, "fable-replace")],
+    };
+    for (const dir of candidates) {
+        if (report.removed >= maxRemovals) {
+            break;
+        }
+
+        if (keepSet.has(path.resolve(dir))) {
+            continue;
+        }
+
+        let stat: fs.Stats;
+        try {
+            stat = fs.statSync(dir);
+        } catch {
+            // Gone already: a concurrent prune or the OS sweep.
+            continue;
+        }
+
+        if (!stat.isDirectory() || now - stat.mtimeMs < ttlMs || !isPrunable(dir)) {
+            continue;
+        }
+
+        const bytes = dirBytes(dir);
+        try {
+            fs.rmSync(dir, { recursive: true, force: true });
+        } catch {
+            // Refused by the filesystem: leave it, the next run tries again.
+            continue;
+        }
+
+        report.removed += 1;
+        report.bytes += bytes;
+    }
+
+    return report;
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/cli.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/cli.ts
@@ -1,0 +1,365 @@
+#!/usr/bin/env bun
+/**
+ * fable-replace — THE CLI. One call, zero ceremony, verified and transactional:
+ *
+ *   bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" <<'EOF'
+ *   @@ src/foo.ts
+ *   <<<
+ *   const gate = getLinkGate(link);
+ *   ===
+ *   const gate = getActionDisabledState(link);
+ *   >>>
+ *   EOF
+ *
+ * Reads the spec from stdin (or --spec <file>), applies every op in memory, writes
+ * only when ALL of them matched, backs up first, prints one OK/MISS line per op and
+ * a hint on every MISS. Exit 0 = everything landed. Exit 1 = nothing written.
+ * Exit 3 = written, but the verify failed (the sweep stays; the undo command is printed).
+ *
+ * Flags: --dry (preview, write nothing) · --diff (print diffs on a real run too)
+ *        --verify "<cmd>" (run after writing, captured and trimmed; red keeps the files) · --cwd <dir>
+ *        --partial (write the files that fully passed) · --quiet (MISS/SKIP only)
+ *        --no-backup · --spec <file> · --api (print the typed library API) · --help
+ */
+
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { format } from "node:util";
+import { printApi } from "./api";
+import { pruneScratch, rollback, scratchDir, scratchRoot } from "./backup-and-rollback";
+import { FableReplaceError } from "./internal";
+import { appendJournal, estimateTokens, type JournalEntry, printHistory, printStats } from "./journal";
+import { parseSpec } from "./spec";
+import { run } from "./sweep-many-files";
+import type { RunReport, VerifyResult } from "./types";
+
+const HELP = `fable-replace CLI — verified, transactional find/replace from a heredoc or a spec file.
+
+usage: bun cli.ts [--dry] [--diff] [--verify "<cmd>"] [--cwd <dir>] [--partial] [--quiet] [--no-backup] < spec
+       bun cli.ts --spec <file> …        # same, spec from a file (use this when a heredoc is refused or long)
+       bun cli.ts --rollback <backupDir> [--force]   # undo a sweep from the backup dir a run printed
+       bun cli.ts --api [query]          # every exported function/type with its docs; query narrows
+       bun cli.ts --help
+
+housekeeping (below the fold on purpose):
+       bun cli.ts --history [N]          # the last N journaled runs (default 20): outcome, tokens, verify, backup dir
+       bun cli.ts --stats [days]         # counts per outcome, tokens written and read back, tokens wasted on failed runs
+       bun cli.ts --prune                # remove backup dirs older than 12 h under <tmp>/fable-replace/ (every sweep does this too)
+       Every real run (never --dry), rollback and prune is journaled to ~/.genesis-tools/fable-replace/journal.jsonl
+       (GENESIS_TOOLS_HOME or FABLE_REPLACE_HOME move it). The spec text is saved beside the backup, never there.
+
+exit 0  everything landed (or the dry run is clean)     exit 1  a MISS: nothing written (a partial write with misses is 1 too)
+exit 2  bad spec, unknown flag, a --verify with | ; or &   exit 3  the sweep IS written, but the verify failed or stale prose survived
+An unknown flag is an ERROR: "--dyr" never becomes a real write. After exit 3, fix forward with a small
+follow-up spec, or run the --rollback line the failure printed; never re-send the same spec.
+
+spec (git-marker shaped, no escaping, heredoc-friendly; pick a delimiter that cannot appear in bodies, e.g. FRSPEC):
+
+  @@ path/to/file.ts            start a file section
+  expect: text                  optional: must be present after the ops (repeatable)
+  absent: text                  optional: must be absent after the ops (repeatable)
+  <<<                           literal replace, exactly once (the workhorse)
+  old text (verbatim, indentation included)
+  ===
+  new text
+  >>>
+  <<< count=all | count=3 | optional | label=free text
+  <<< regex flags=gi            find is a JS regex; replace may use $1 ($$ for a literal $, $& is the match); count=N pins matches
+  <<< fuzzy                     whitespace-insensitive FIND; the replacement is written verbatim
+  <<< after   (anchor === lines)   insert whole lines after the line holding the unique anchor; the anchor line stays, never repeat it
+  <<< before  (anchor === lines)   same, above it
+  <<< append  (lines)              append at end of file
+  <<< delete  (lines)              remove these lines, newline included
+  <<< block   (from === to === replacement)   replace a region; empty replacement deletes it
+  <<< create  (whole file content) create a new file; refuses an existing one
+
+Bodies are raw, line for line. Only a line that is exactly === or >>> is special inside a block:
+write such a line as \\=== or \\>>>. Ops apply in order, each sees the previous op's output.
+Build spec text with printf '%s\\n', never echo (zsh echo turns \\b into a backspace byte).
+Nothing is written unless every required op matches. Backups go to a fresh temp dir (printed).
+A MISS names the line to re-read; a spec error names the spec line.
+`;
+
+const VALUE_FLAGS = ["--verify", "--cwd", "--spec", "--rollback"];
+const OPTIONAL_VALUE_FLAGS = ["--api", "--history", "--stats"];
+const BOOL_FLAGS = ["--dry", "--diff", "--partial", "--quiet", "--no-backup", "--force", "--prune", "--help", "-h"];
+const argv = process.argv.slice(2);
+const values = new Map<string, string>();
+const flags = new Set<string>();
+
+for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (VALUE_FLAGS.includes(arg)) {
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith("--")) {
+            console.error(`${arg} needs a value. Run with --help.`);
+            process.exit(2);
+        }
+        values.set(arg, next);
+        i += 1;
+    } else if (OPTIONAL_VALUE_FLAGS.includes(arg)) {
+        flags.add(arg);
+        if (argv[i + 1] !== undefined && !argv[i + 1].startsWith("--")) {
+            values.set(arg, argv[i + 1]);
+            i += 1;
+        }
+    } else if (BOOL_FLAGS.includes(arg)) {
+        flags.add(arg);
+    } else {
+        // Silently ignoring "--dyr" once turned a preview into a real write.
+        console.error(
+            `unknown argument "${arg}". Known flags: ${[...BOOL_FLAGS, ...VALUE_FLAGS, "--api [query]", "--history [N]", "--stats [days]"].join(" ")}. Nothing was done.`
+        );
+        process.exit(2);
+    }
+}
+
+const flag = (name: string): boolean => flags.has(name);
+const value = (name: string): string | undefined => values.get(name);
+
+// Everything the CLI prints is what a model reads back, so count it for the journal. Bun's
+// console writes natively and never passes through process.stdout.write, so the console
+// methods themselves are wrapped; each still calls the original, nothing else changes.
+let printedChars = 0;
+for (const name of ["log", "error", "warn", "info"] as const) {
+    const original = console[name].bind(console);
+    console[name] = (...args: unknown[]): void => {
+        printedChars += format(...args).length + 1;
+        original(...args);
+    };
+}
+
+// One journal line per run or rollback, written on exit whatever path got there. The
+// exit hook is the single place, so a spec error, a pre-flight refusal and a MISS are
+// recorded by the same code as a green sweep. Help, --api, --history and --stats skip it.
+const startedAt = Date.now();
+const entry: JournalEntry = {
+    ts: new Date(startedAt).toISOString(),
+    runId: `${startedAt.toString(36)}-${process.pid}`,
+    pid: process.pid,
+    cwd: process.cwd(),
+    kind: "run",
+    outcome: "error",
+};
+let journalThisRun = false;
+process.on("exit", () => {
+    // A dry run is a preview: it writes nothing, not even the journal, and it never prunes.
+    if (!journalThisRun || flag("--dry")) {
+        return;
+    }
+
+    entry.durationMs = Date.now() - startedAt;
+    entry.resultChars = printedChars;
+    entry.tokensEst = { spec: estimateTokens(entry.spec?.chars ?? 0), result: estimateTokens(printedChars) };
+    appendJournal(entry);
+
+    // Housekeeping rides on every run: age-only, manifest-gated, capped, this run's own
+    // backup dir excluded. Silent unless it removed something.
+    const pruned = pruneScratch({ keep: entry.backupDir === undefined ? [] : [entry.backupDir] });
+    if (pruned.removed > 0) {
+        console.log(`pruned ${pruned.removed} stale scratch dir(s) older than 12 h under ${scratchRoot()}`);
+        appendJournal({
+            ...entry,
+            kind: "prune",
+            outcome: "prune",
+            prune: { removed: pruned.removed, bytes: pruned.bytes },
+        });
+    }
+});
+
+const journalVerify = (verify: VerifyResult | undefined): JournalEntry["verify"] =>
+    verify === undefined
+        ? undefined
+        : {
+              cmd: verify.command,
+              status: verify.status,
+              exit: verify.exitCode,
+              ms: verify.ms,
+              outputChars: verify.outputChars,
+              shownLines: verify.shown.length,
+              timedOut: verify.timedOut,
+              buffered: verify.buffered,
+          };
+
+const missReasons = (report: RunReport | undefined): string[] =>
+    (report?.files ?? []).flatMap((file) => [
+        ...file.ops.filter((op) => op.status === "MISS").map((op) => `${file.file}: ${op.desc}: ${op.reason ?? ""}`),
+        ...file.postConditionFailures.map((failure) => `${file.file}: ${failure}`),
+    ]);
+
+if (flag("--help") || flag("-h")) {
+    console.log(HELP);
+    process.exit(0);
+}
+if (flag("--api")) {
+    printApi({ dir: path.dirname(fileURLToPath(import.meta.url)), query: value("--api") });
+    process.exit(0);
+}
+if (flag("--history")) {
+    printHistory(Number(value("--history") ?? 20) || 20);
+    process.exit(0);
+}
+if (flag("--stats")) {
+    printStats(Number(value("--stats") ?? 7) || 7);
+    process.exit(0);
+}
+if (flag("--prune")) {
+    const report = pruneScratch();
+    console.log(
+        `pruned ${report.removed} stale scratch dir(s), ${Math.round(report.bytes / 1024)} KB, older than 12 h, under ${report.roots.join(" and ")} (${report.scanned} scanned)`
+    );
+    appendJournal({
+        ...entry,
+        kind: "prune",
+        outcome: "prune",
+        prune: { removed: report.removed, bytes: report.bytes },
+    });
+    process.exit(0);
+}
+
+const rollbackDir = value("--rollback");
+if (rollbackDir !== undefined) {
+    entry.kind = "rollback";
+    entry.backupDir = rollbackDir;
+    entry.flags = [...flags];
+    journalThisRun = true;
+    try {
+        const report = rollback({ backupDir: rollbackDir, force: flag("--force") });
+        entry.outcome = "rollback";
+        entry.rollback = {
+            restored: report.restored.length,
+            drifted: report.drifted.length,
+            failed: report.failed.length,
+        };
+        process.exit(report.drifted.length > 0 || report.failed.length > 0 ? 1 : 0);
+    } catch (err) {
+        entry.message = err instanceof Error ? err.message : String(err);
+        console.error(`ROLLBACK ERROR: ${entry.message}`);
+        process.exit(2);
+    }
+}
+
+const specPath = value("--spec");
+// Journal from here on: a spec that cannot be read, or an empty one, is a failed run too,
+// and used to leave no trace in --history.
+entry.flags = [...flags, ...values.keys()];
+journalThisRun = true;
+let text: string;
+try {
+    text = fs.readFileSync(specPath ?? 0, "utf8");
+} catch (err) {
+    entry.outcome = "spec-error";
+    entry.message = `cannot read ${specPath ?? "stdin"}: ${err instanceof Error ? err.message : String(err)}`;
+    console.error(`SPEC ERROR: ${entry.message}`);
+    process.exit(2);
+}
+if (text.trim().length === 0) {
+    entry.outcome = "spec-error";
+    entry.message = "no spec on stdin and no --spec file";
+    console.error("no spec on stdin and no --spec file. Run with --help for the format.");
+    process.exit(2);
+}
+entry.spec = {
+    files: 0,
+    ops: 0,
+    chars: text.length,
+    hash: createHash("sha256").update(text).digest("hex").slice(0, 12),
+};
+
+let edits: ReturnType<typeof parseSpec>;
+try {
+    edits = parseSpec({ text, onWarning: (message) => console.error(`WARNING: ${message}`) });
+} catch (err) {
+    entry.outcome = "spec-error";
+    entry.specError = err instanceof Error ? err.message : String(err);
+    console.error(`SPEC ERROR: ${entry.specError}`);
+    process.exit(2);
+}
+
+const cwd = value("--cwd") ?? process.cwd();
+
+const opCount = edits.reduce((sum, e) => sum + (e.ops?.length ?? 0), 0);
+entry.spec.files = edits.length;
+entry.spec.ops = opCount;
+const creates = edits.filter((e) => e.createWith !== undefined).length;
+console.log(
+    `spec: ${edits.length} file(s), ${opCount} op(s)${creates > 0 ? `, ${creates} create` : ""}${flag("--dry") ? " — DRY RUN" : ""}`
+);
+
+try {
+    const report = await run({
+        edits,
+        cwd,
+        dryRun: flag("--dry"),
+        showDiff: flag("--diff"),
+        verbose: !flag("--quiet"),
+        partial: flag("--partial"),
+        backupDir: flag("--no-backup") || flag("--dry") ? undefined : scratchDir("cli"),
+        verifyCommand: value("--verify"),
+        throwOnFailure: true,
+        onWritten: ({ written, backupDir }) => {
+            if (backupDir !== undefined) {
+                // The ephemeral place for the spec text: collected with the originals it edited.
+                try {
+                    fs.writeFileSync(path.join(backupDir, "spec.frspec"), text);
+                } catch (err) {
+                    console.error(`could not save the spec beside the backup: ${String(err)}`);
+                }
+            }
+
+            if (value("--verify") !== undefined) {
+                // A check the Bash tool kills mid-run never reaches the exit hook; this line proves
+                // the sweep landed before it started.
+                appendJournal({
+                    ...entry,
+                    outcome: "written",
+                    written: written.length,
+                    backupDir,
+                    durationMs: Date.now() - startedAt,
+                    resultChars: printedChars,
+                });
+            }
+        },
+    });
+    entry.outcome = flag("--dry") ? "dry-ok" : "ok";
+    entry.written = report.written.length;
+    entry.backupDir = report.backupDir;
+    entry.verify = journalVerify(report.verify);
+} catch (err) {
+    if (err instanceof FableReplaceError) {
+        const report = err.report;
+        entry.written = report?.written.length;
+        entry.backupDir = report?.backupDir;
+        entry.missCount = report?.missCount;
+        entry.reasons = missReasons(report);
+        entry.verify = journalVerify(report?.verify);
+        entry.message = err.message;
+        if (err.code === 2) {
+            entry.outcome = "pre-flight";
+        } else if (err.code === 3) {
+            const verifyStatus = report?.verify?.status;
+            entry.outcome =
+                verifyStatus === "unknown"
+                    ? "verify-unknown"
+                    : verifyStatus === "fail"
+                      ? "verify-failed"
+                      : err.message.includes("backup manifest not updated")
+                        ? "written"
+                        : "stale-prose";
+        } else if (flag("--dry")) {
+            entry.outcome = "dry-miss";
+        } else if (err.message.startsWith("fable-replace: write failed")) {
+            entry.outcome = "write-failed";
+        } else if (flag("--partial") && (report?.written.length ?? 0) > 0) {
+            entry.outcome = "partial";
+        } else {
+            entry.outcome = "miss";
+        }
+        process.exit(err.code);
+    }
+    entry.message = err instanceof Error ? err.message : String(err);
+    console.error(`ERROR: ${entry.message}`);
+    process.exit(1);
+}

--- a/plugins/genesis-tools/skills/fable-replace/scripts/comments.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/comments.ts
@@ -1,0 +1,396 @@
+/**
+ * fable-replace — COMMENT AND LINE SWEEPS on a single file's text.
+ *
+ * `scanComments` is a real tokenizer: it tracks '…', "…", `…` (with ${} nesting),
+ * escapes, regex literals, and the two JSX tag shapes that look like operators
+ * (`</Foo>`, `<Foo />`), so "//" inside a string or a regex is never mistaken for a
+ * comment. That matters — a naive scanner corrupted 0.95% of a real 5252-file repo
+ * before the regex/JSX handling was added.
+ *
+ * It does NOT model JSX text. A comment-shaped run inside rendered text
+ * (`<p>/* note *\/</p>`, `<a>https://…</a>`) is scanned as a comment, because telling
+ * `<` as a tag from `<` as a comparison needs a parser this dependency-free script does
+ * not have. On .tsx/.jsx files keep the predicate narrow and read `--dry --diff`.
+ *
+ * Use `dropComments` when the COMMENT must go but code on the same line must stay.
+ * Use `deleteLines` when the WHOLE line must go. Getting that pair the wrong way
+ * round is the commonest mistake in a comment sweep.
+ */
+
+import { FableReplaceError, stateless } from "./internal";
+import type { CommentSpan, DeleteLinesOp, DropCommentsOp, DropCommentsOptions, OpResult } from "./types";
+
+export const scanComments = (src: string): CommentSpan[] => {
+    const spans: CommentSpan[] = [];
+    let i = 0;
+    let line = 1;
+    // stack of template-literal contexts: each entry is the ${}-depth inside that template
+    const templateStack: number[] = [];
+    const n = src.length;
+
+    // Previous significant code character, and the identifier ending on it. This is
+    // the only way to tell a regex literal `/re/` from a division `a / b`. Without
+    // it a literal such as /[&<>"']/g reads as a string opener and desyncs the rest
+    // of the file, which corrupted 0.95% of a real 5252-file repo before this fix.
+    const REGEX_OK_AFTER = new Set([
+        "return",
+        "typeof",
+        "instanceof",
+        "in",
+        "of",
+        "new",
+        "delete",
+        "void",
+        "throw",
+        "case",
+        "do",
+        "else",
+        "yield",
+        "await",
+    ]);
+    let prevChar = "";
+    let prevWord = "";
+    let wordBroke = true;
+    const noteChar = (ch: string): void => {
+        if (/\s/.test(ch)) {
+            wordBroke = true;
+            return;
+        }
+        if (/[\w$]/.test(ch)) {
+            prevWord = wordBroke || !/[\w$]/.test(prevChar) ? ch : prevWord + ch;
+        } else {
+            prevWord = "";
+        }
+        prevChar = ch;
+        wordBroke = false;
+    };
+    /** A string, template or regex literal just closed, so a value ended here. */
+    const noteValueEnd = (): void => {
+        prevChar = ")";
+        prevWord = "";
+        wordBroke = false;
+    };
+    const regexAllowedHere = (): boolean => {
+        if (prevChar === "") {
+            return true;
+        }
+        // "<" means a JSX closing tag (</Foo>), not a regex.
+        if (prevChar === ")" || prevChar === "]" || prevChar === "<") {
+            return false;
+        }
+        if (/[\w$]/.test(prevChar)) {
+            return REGEX_OK_AFTER.has(prevWord);
+        }
+        return true;
+    };
+    /** Consume a regex literal so its slashes and quotes never reach the comment checks. */
+    const skipRegexLiteral = (): void => {
+        i += 1;
+        let inClass = false;
+        while (i < n) {
+            const ch = src[i];
+            if (ch === "\\") {
+                i += 2;
+                continue;
+            }
+            if (ch === "\n") {
+                return;
+            }
+            if (ch === "[") {
+                inClass = true;
+            } else if (ch === "]") {
+                inClass = false;
+            } else if (ch === "/" && !inClass) {
+                i += 1;
+                while (i < n && /[a-z]/.test(src[i] ?? "")) {
+                    i += 1;
+                }
+                noteValueEnd();
+                return;
+            }
+            i += 1;
+        }
+    };
+
+    const skipString = (quote: string): void => {
+        i += 1; // past the opening quote
+        while (i < n) {
+            const c = src[i];
+            if (c === "\\") {
+                i += 2;
+                continue;
+            }
+            if (c === "\n") {
+                line += 1;
+            }
+            if (c === quote) {
+                i += 1;
+                return;
+            }
+            i += 1;
+        }
+    };
+
+    while (i < n) {
+        const c = src[i];
+        const next = src[i + 1];
+
+        if (c === "\n") {
+            line += 1;
+            i += 1;
+            continue;
+        }
+
+        // inside a template literal body?
+        if (templateStack.length > 0 && templateStack[templateStack.length - 1] === 0) {
+            if (c === "\\") {
+                i += 2;
+                continue;
+            }
+            if (c === "`") {
+                templateStack.pop();
+                noteValueEnd();
+                i += 1;
+                continue;
+            }
+            if (c === "$" && next === "{") {
+                templateStack[templateStack.length - 1] = 1; // entering an interpolation
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+
+        // in code (top level, or inside a ${…} interpolation)
+        if (templateStack.length > 0) {
+            if (c === "{") {
+                templateStack[templateStack.length - 1] += 1;
+            } else if (c === "}") {
+                templateStack[templateStack.length - 1] -= 1;
+            }
+        }
+
+        if (c === '"' || c === "'") {
+            skipString(c);
+            noteValueEnd();
+            continue;
+        }
+        if (c === "`") {
+            templateStack.push(0);
+            i += 1;
+            continue;
+        }
+        // next === ">" is a JSX self-close (<Foo />), never a regex.
+        if (c === "/" && next !== "/" && next !== "*" && next !== ">" && regexAllowedHere()) {
+            skipRegexLiteral();
+            continue;
+        }
+        if (c === "/" && next === "/") {
+            const start = i;
+            const startLine = line;
+            let end = src.indexOf("\n", i);
+            if (end === -1) {
+                end = n;
+            }
+            spans.push({ start, end, text: src.slice(start, end), type: "line", line: startLine });
+            i = end;
+            continue;
+        }
+        if (c === "/" && next === "*") {
+            const start = i;
+            const startLine = line;
+            let end = src.indexOf("*/", i + 2);
+            end = end === -1 ? n : end + 2;
+            line += (src.slice(start, end).match(/\n/g) ?? []).length;
+            spans.push({ start, end, text: src.slice(start, end), type: "block", line: startLine });
+            i = end;
+            continue;
+        }
+        noteChar(c);
+        i += 1;
+    }
+    return spans;
+};
+
+/**
+ * Remove a set of spans from the source. When removing a span leaves its line(s)
+ * as pure whitespace, the whole line (including the newline) is removed too — so
+ * dropping a full-line comment doesn't leave a blank hole.
+ */
+/** Neighbours that never fuse with a token, so no separator is needed beside them. */
+const NEVER_FUSES = /[()[\]{},;:]/;
+
+export const removeSpans = (src: string, spans: Array<{ start: number; end: number }>): string => {
+    let out = src;
+    const sorted = [...spans].sort((a, b) => b.start - a.start);
+    for (const span of sorted) {
+        let { start, end } = span;
+        const lineStart = out.lastIndexOf("\n", start - 1) + 1;
+        let lineEnd = out.indexOf("\n", end);
+        lineEnd = lineEnd === -1 ? out.length : lineEnd + 1;
+        const remainder = out.slice(lineStart, start) + out.slice(end, lineEnd);
+        if (remainder.trim() === "") {
+            start = lineStart;
+            end = lineEnd;
+        } else if (out.slice(end, lineEnd).trim() === "") {
+            // span ends the line (e.g. trailing comment) — eat the whitespace before it too
+            while (start > lineStart && (out[start - 1] === " " || out[start - 1] === "\t")) {
+                start -= 1;
+            }
+        }
+        // An inline comment is lexical whitespace: `return/*legacy*/value` must not fuse
+        // into `returnvalue`, and `x/*c*//y` must not become a line comment. One space stays
+        // when both neighbours are non-blank, unless one is a bracket, a comma, a semicolon
+        // or a colon. A whole-line or trailing removal has a line break on one side.
+        const before = out[start - 1] ?? "";
+        const after = out[end] ?? "";
+        const glue =
+            /\S/.test(before) && /\S/.test(after) && !NEVER_FUSES.test(before) && !NEVER_FUSES.test(after) ? " " : "";
+        out = out.slice(0, start) + glue + out.slice(end);
+    }
+    return out;
+};
+
+/**
+ * Drop comments matching a predicate — string-aware (never touches "//" inside
+ * strings), and removes the whole line when the comment was alone on it.
+ * Returns the new content and how many comments were dropped.
+ */
+export const dropComments = (
+    src: string,
+    options: DropCommentsOptions
+): { content: string; dropped: number; lines: number[] } => {
+    const scope = options.scope ?? "both";
+    // "" is not a predicate: every text includes it. Treated as absent, so it can neither
+    // select every comment on its own nor widen a regex it is combined with.
+    const containing = options.containing === "" ? undefined : options.containing;
+    const matching = options.matching === undefined ? undefined : stateless(options.matching);
+    const targets = scanComments(src).filter((span) => {
+        if (scope !== "both" && span.type !== scope) {
+            return false;
+        }
+        if (containing !== undefined && !span.text.includes(containing)) {
+            return false;
+        }
+        if (matching !== undefined && !matching.test(span.text)) {
+            return false;
+        }
+        return containing !== undefined || matching !== undefined;
+    });
+    if (options.expect !== undefined && targets.length !== options.expect) {
+        // The direct call used to ignore `expect` and remove whatever matched; only the op
+        // form checked it. The contract lives here now, for both doors.
+        const where = targets.length > 0 ? ` at line(s) ${targets.map((span) => span.line).join(", ")}` : "";
+        throw new FableReplaceError(
+            `dropComments: expected ${options.expect} comment(s), found ${targets.length}${where} — nothing removed`,
+            1
+        );
+    }
+
+    return { content: removeSpans(src, targets), dropped: targets.length, lines: targets.map((span) => span.line) };
+};
+
+export const deleteLines = (src: string, op: DeleteLinesOp): { content: string; removed: number; lines: number[] } => {
+    const lines = src.split("\n");
+    const kept: string[] = [];
+    // "" is not a predicate: every line includes it, so OR-ed with a regex it deleted the
+    // whole file and reported OK. Treated as absent.
+    const containing = op.containing === "" ? undefined : op.containing;
+    const matching = op.matching === undefined ? undefined : stateless(op.matching);
+    const hitLines: number[] = [];
+    for (const [idx, l] of lines.entries()) {
+        const hit = (containing !== undefined && l.includes(containing)) || matching?.test(l);
+        if (hit) {
+            hitLines.push(idx + 1);
+        } else {
+            kept.push(l);
+        }
+    }
+    if (op.expect !== undefined && hitLines.length !== op.expect) {
+        // The direct call used to ignore `expect`; only the op form checked it. Same
+        // contract as dropComments: enforced here, for both doors.
+        const where = hitLines.length > 0 ? ` at line(s) ${hitLines.join(", ")}` : "";
+        throw new FableReplaceError(
+            `deleteLines: expected ${op.expect} line(s), found ${hitLines.length}${where} — nothing removed`,
+            1
+        );
+    }
+
+    return { content: kept.join("\n"), removed: hitLines.length, lines: hitLines };
+};
+
+export const applyDropComments = (content: string, op: DropCommentsOp): { content: string; result: OpResult } => {
+    const desc = op.label ?? `dropComments ${op.containing ? `containing "${op.containing}"` : String(op.matching)}`;
+    // An EMPTY `containing` is not a predicate: "".includes("") is true for every comment,
+    // so it silently dropped all of them and reported OK. Same guard recon.ts uses.
+    if ((op.containing === undefined || op.containing === "") && op.matching === undefined) {
+        return {
+            content,
+            result: {
+                status: "MISS",
+                desc,
+                reason: "dropComments needs a non-empty `containing` or a `matching` regex — refusing to drop ALL comments",
+            },
+        };
+    }
+    let outcome: { content: string; dropped: number; lines: number[] };
+    try {
+        outcome = dropComments(content, op);
+    } catch (err) {
+        // The shared function enforces `expect`; the op form reports it as a MISS.
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: err instanceof Error ? err.message : String(err),
+            },
+        };
+    }
+    const { content: next, dropped, lines } = outcome;
+    if (dropped === 0) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: "no comment matched", found: 0 },
+        };
+    }
+    return { content: next, result: { status: "OK", desc, found: dropped, expected: op.expect, lines } };
+};
+
+export const applyDeleteLines = (content: string, op: DeleteLinesOp): { content: string; result: OpResult } => {
+    const desc = op.label ?? `deleteLines ${op.containing ? `containing "${op.containing}"` : String(op.matching)}`;
+    // An empty `containing` matches every line: it used to wipe the file and report OK.
+    if ((op.containing === undefined || op.containing === "") && op.matching === undefined) {
+        return {
+            content,
+            result: {
+                status: "MISS",
+                desc,
+                reason: "deleteLines needs a non-empty `containing` or a `matching` regex — refusing to delete EVERY line",
+            },
+        };
+    }
+    let outcome: { content: string; removed: number; lines: number[] };
+    try {
+        outcome = deleteLines(content, op);
+    } catch (err) {
+        // The shared function enforces `expect`; the op form reports it as a MISS.
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: err instanceof Error ? err.message : String(err),
+            },
+        };
+    }
+    const { content: next, removed, lines } = outcome;
+    if (removed === 0) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: "no line matched", found: 0 },
+        };
+    }
+    return { content: next, result: { status: "OK", desc, found: removed, expected: op.expect, lines } };
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/edit-one-file.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/edit-one-file.ts
@@ -1,0 +1,578 @@
+/**
+ * fable-replace — EDITING THE TEXT OF ONE FILE. Everything here is pure: string in,
+ * string out, no filesystem.
+ *
+ * These are the ops you put in a FileEdit's `ops` array: literal (the workhorse),
+ * regex, deleteBlock/replaceBlock, insertBefore/insertAfter, fuzzy. Every op is
+ * VERIFIED — a literal op with the default `count: 1` requires the needle exactly
+ * once, so a stale assumption is a loud MISS, never a silent no-op.
+ *
+ * Prefer literal over regex. Paste the exact current text, indentation included.
+ */
+
+import { applyDeleteLines, applyDropComments } from "./comments";
+import {
+    countOccurrences,
+    dominantEol,
+    escapeRegex,
+    lineStartOffsets,
+    matchLines,
+    nthIndexOf,
+    opDesc,
+    preview,
+    replaceAllLiteral,
+    replaceNLiteral,
+} from "./internal";
+import type {
+    AppendOp,
+    DeleteBlockOp,
+    DropJsdocParams,
+    DropParams,
+    FuzzyOp,
+    InsertLinesOp,
+    InsertOp,
+    LiteralOp,
+    LiteralSugarParams,
+    NearestHintParams,
+    Op,
+    OpResult,
+    RegexOp,
+    ReplaceBlockOp,
+} from "./types";
+
+/** What the ops before this one did to the buffer, so a MISS can tell "re-run" from "consumed". */
+interface BatchContext {
+    original: string;
+    producedBy?: { index: number; desc: string };
+}
+
+/** Splice `replacement` over `length` characters at each offset, from the end so offsets stay valid. */
+const replaceAtOffsets = ({
+    content,
+    offsets,
+    length,
+    replacement,
+}: {
+    content: string;
+    offsets: number[];
+    length: number;
+    replacement: string;
+}): string => {
+    let out = content;
+    for (const at of [...offsets].reverse()) {
+        out = out.slice(0, at) + replacement + out.slice(at + length);
+    }
+    return out;
+};
+
+const applyLiteral = (content: string, op: LiteralOp, batch?: BatchContext): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    // `wholeLines` (what `<<< delete` compiles to) counts only occurrences that start a
+    // line: "foo" inside "notfoo" used to match, report OK, and leave "not" behind.
+    const atLineStarts = op.wholeLines === true ? lineStartOffsets(content, op.find) : null;
+    const found = atLineStarts === null ? countOccurrences(content, op.find) : atLineStarts.length;
+    const want = op.count ?? 1;
+
+    if (op.find === op.replace) {
+        return { content, result: { status: "MISS", desc, reason: "find === replace (no-op edit)", found } };
+    }
+
+    if (found === 0) {
+        const midLine = atLineStarts === null ? 0 : countOccurrences(content, op.find);
+        const where =
+            midLine > 0
+                ? `needle occurs ${midLine}× but never at the start of a line (a delete body must be whole lines).`
+                : `needle not found. ${nearestHint({
+                      content,
+                      needle: op.find,
+                      replacement: op.replace,
+                      original: batch?.original,
+                      producedBy: batch?.producedBy,
+                  })}`;
+        return { content, result: { status: op.optional ? "SKIP" : "MISS", desc, reason: where, found } };
+    }
+
+    if (want === "all") {
+        return {
+            content:
+                atLineStarts === null
+                    ? replaceAllLiteral(content, op.find, op.replace)
+                    : replaceAtOffsets({
+                          content,
+                          offsets: atLineStarts,
+                          length: op.find.length,
+                          replacement: op.replace,
+                      }),
+            result: { status: "OK", desc, found, expected: want },
+        };
+    }
+
+    if (found !== want) {
+        const lines =
+            atLineStarts === null
+                ? matchLines({ content, needle: op.find })
+                : atLineStarts.map((at) => content.slice(0, at).split("\n").length).join(", ");
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: `expected exactly ${want} occurrence(s), found ${found} at line(s) ${lines} — add surrounding context to disambiguate, or set count to ${found}`,
+                found,
+            },
+        };
+    }
+
+    return {
+        content:
+            atLineStarts === null
+                ? replaceNLiteral(content, op.find, op.replace, want)
+                : replaceAtOffsets({
+                      content,
+                      offsets: atLineStarts.slice(0, want),
+                      length: op.find.length,
+                      replacement: op.replace,
+                  }),
+        result: { status: "OK", desc, found, expected: want },
+    };
+};
+
+const applyRegex = (content: string, op: RegexOp): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    const global = op.find.global ? op.find : new RegExp(op.find.source, `${op.find.flags}g`);
+    const found = (content.match(global) ?? []).length;
+
+    if (found === 0) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: "regex matched nothing", found },
+        };
+    }
+
+    if (op.expect !== undefined && found !== op.expect) {
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: `expected ${op.expect} match(es), found ${found} at line(s) ${matchLines({ content, needle: op.find })}`,
+                found,
+            },
+        };
+    }
+
+    const next =
+        typeof op.replace === "string"
+            ? content.replace(global, op.replace)
+            : content.replace(global, op.replace as (substring: string, ...args: unknown[]) => string);
+
+    return { content: next, result: { status: "OK", desc, found, expected: op.expect } };
+};
+
+/**
+ * A block anchor written with LF against a CRLF file. The literal form is tried first, so
+ * a mixed-ending file keeps matching exactly what it did; only an absent LF anchor is
+ * retried in its CRLF spelling. `dropJsdocStarting` closes on the JSDoc terminator plus
+ * "\n", which no CRLF file contains.
+ */
+const eolAnchor = (content: string, anchor: string): string => {
+    if (content.includes(anchor) || !anchor.includes("\n") || anchor.includes("\r") || !content.includes("\r\n")) {
+        return anchor;
+    }
+
+    return anchor.replace(/\n/g, "\r\n");
+};
+
+const locateBlock = (
+    content: string,
+    op: DeleteBlockOp | ReplaceBlockOp
+): { start: number; end: number } | { error: string } => {
+    const from = eolAnchor(content, op.from);
+    const to = eolAnchor(content, op.to);
+    if (op.occurrence === undefined) {
+        // Acting on the FIRST of several matching anchors silently leaves the others
+        // alone and still reports OK. Ambiguity is a MISS, like every other op.
+        const fromCount = countOccurrences(content, from);
+        if (fromCount > 1) {
+            return {
+                error: `"from" anchor occurs ${fromCount}× (lines ${matchLines({ content, needle: from })}); add context to make it unique, or set occurrence`,
+            };
+        }
+    }
+    const fromIdx = nthIndexOf({ haystack: content, needle: from, n: op.occurrence ?? 1 });
+    if (fromIdx === -1) {
+        return {
+            error: `"from" anchor not found (occurrence ${op.occurrence ?? 1}). ${nearestHint({ content, needle: from })}`,
+        };
+    }
+    const searchFrom = fromIdx + from.length;
+    const toIdx = content.indexOf(to, searchFrom);
+    if (toIdx === -1) {
+        return { error: `"to" anchor not found after "from"` };
+    }
+    const start = op.keepFrom ? fromIdx + from.length : fromIdx;
+    const end = op.keepTo ? toIdx : toIdx + to.length;
+    return { start, end };
+};
+
+const applyBlock = (content: string, op: DeleteBlockOp | ReplaceBlockOp): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    const loc = locateBlock(content, op);
+    if ("error" in loc) {
+        return { content, result: { status: op.optional ? "SKIP" : "MISS", desc, reason: loc.error } };
+    }
+    const substitute = op.kind === "replaceBlock" ? op.replace : "";
+    return {
+        content: content.slice(0, loc.start) + substitute + content.slice(loc.end),
+        result: { status: "OK", desc },
+    };
+};
+
+const applyInsert = (content: string, op: InsertOp): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    const idx = nthIndexOf({ haystack: content, needle: op.anchor, n: op.occurrence ?? 1 });
+    if (idx === -1) {
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: `anchor not found (occurrence ${op.occurrence ?? 1})`,
+            },
+        };
+    }
+    const at = op.kind === "insertBefore" ? idx : idx + op.anchor.length;
+    return { content: content.slice(0, at) + op.text + content.slice(at), result: { status: "OK", desc } };
+};
+
+/**
+ * Offset in `content` where `needle` starts once EVERY whitespace character is
+ * removed from both sides, or -1. "two=2" finds "two = 2" and vice versa, which a
+ * whitespace-run-tolerant regex cannot do (it needs at least one space on both sides).
+ */
+const squashedIndexOf = ({ content, needle }: { content: string; needle: string }): number => {
+    const map: number[] = [];
+    let squashed = "";
+    for (let i = 0; i < content.length; i += 1) {
+        if (!/\s/.test(content[i])) {
+            squashed += content[i];
+            map.push(i);
+        }
+    }
+    const target = needle.replace(/\s+/g, "");
+    if (target.length === 0) {
+        return -1;
+    }
+    const at = squashed.indexOf(target);
+    return at === -1 ? -1 : map[at];
+};
+/** 1-based line number of the line that contains offset `at`. */
+const lineAt = (content: string, at: number): number => content.slice(0, at).split("\n").length;
+
+/**
+ * Why did a literal needle miss? Say something a reader can act on: the file
+ * already holds the replacement, the needle matches once whitespace is ignored
+ * (so it is an indentation problem, use `fuzzy`), or the needle's first line
+ * exists at line N and the text diverges from line N+k. A bare "not found" made
+ * agents guess; this points at the line to re-read.
+ */
+export const nearestHint = ({ content, needle, replacement, original, producedBy }: NearestHintParams): string => {
+    if (replacement !== undefined && replacement.length > 0 && content.includes(replacement)) {
+        if (original !== undefined && !original.includes(replacement)) {
+            // The text is there because THIS batch put it there: an earlier op consumed the
+            // needle. "Make it optional" would hide an ordering mistake, so it is not offered.
+            const who =
+                producedBy === undefined
+                    ? "an earlier op in this batch"
+                    : `op ${producedBy.index + 1} of this batch (${producedBy.desc})`;
+            return `the REPLACEMENT is present only because ${who} produced it: that op consumed this needle before this one ran. This is not a re-run. Reorder or merge the two ops, or drop this one.`;
+        }
+
+        return "the REPLACEMENT is already in the file: this edit was probably applied before (make the op optional to allow re-runs).";
+    }
+    const noSpace = squashedIndexOf({ content, needle });
+    if (noSpace !== -1) {
+        return `matches when ALL whitespace is ignored (first at line ${lineAt(content, noSpace)}): the difference is spaces, tabs, indentation or line breaks. Copy the exact text, or use kind "fuzzy".`;
+    }
+    const noCase = squashedIndexOf({ content: content.toLowerCase(), needle: needle.toLowerCase() });
+    if (noCase !== -1) {
+        return `matches when case AND whitespace are ignored (first at line ${lineAt(content, noCase)}): the needle has a letter-case typo somewhere. Re-read that line.`;
+    }
+    const nfcAt = content.normalize("NFC").indexOf(needle.normalize("NFC"));
+    if (nfcAt !== -1) {
+        return `matches after Unicode normalization (line ${lineAt(content.normalize("NFC"), nfcAt)}): the file and the needle spell the same accented text with different code points (NFC vs NFD). Copy the text from the file itself, or use kind "fuzzy".`;
+    }
+    const needleLines = needle.split("\n");
+    const firstLine = needleLines.find((l) => l.trim().length > 0)?.trim() ?? "";
+    if (firstLine.length === 0) {
+        return "the needle is blank.";
+    }
+    const contentLines = content.split("\n");
+    const candidates = contentLines.map((l, i) => ({ i, l })).filter(({ l }) => l.includes(firstLine));
+    if (candidates.length === 0) {
+        const probe = firstLine.slice(0, Math.max(12, Math.floor(firstLine.length / 2)));
+        const probeLower = probe.toLowerCase();
+        const partial = contentLines.findIndex((l) => l.toLowerCase().includes(probeLower));
+        return partial === -1
+            ? "no line of the file contains the needle's first line. Re-read the file: the text is different, or it lives in another file."
+            : `the needle's first line is not in the file, but line ${partial + 1} starts the same way: "${preview(contentLines[partial].trim(), 70)}". Re-read from there.`;
+    }
+    for (const { i } of candidates) {
+        for (let k = 1; k < needleLines.length; k += 1) {
+            const actual = contentLines[i + k];
+            if (actual === undefined || actual.trim() !== needleLines[k].trim()) {
+                return `first line found at line ${i + 1}, text diverges at line ${i + k + 1}: file has "${preview((actual ?? "<end of file>").trim(), 70)}", needle has "${preview(needleLines[k].trim(), 70)}".`;
+            }
+        }
+    }
+    return `the needle's first line is at line ${candidates[0].i + 1} but the exact text is not. Check trailing spaces and tabs.`;
+};
+
+const lineBounds = (content: string, at: number): { start: number; end: number } => {
+    const start = content.lastIndexOf("\n", at - 1) + 1;
+    const nl = content.indexOf("\n", at);
+    return { start, end: nl === -1 ? content.length : nl };
+};
+
+/**
+ * Every offset where `anchor` occurs. An anchor that starts with whitespace carries its
+ * indentation on purpose, so it only counts where it begins a line: "    foo" must not
+ * match inside "        foo", or a wrong indentation would land the insert anyway.
+ */
+const anchorOffsets = ({ content, anchor }: { content: string; anchor: string }): number[] => {
+    const offsets: number[] = [];
+    if (anchor === "") {
+        return offsets;
+    }
+
+    let idx = content.indexOf(anchor);
+    while (idx !== -1) {
+        if (!/^\s/.test(anchor) || idx === 0 || content[idx - 1] === "\n") {
+            offsets.push(idx);
+        }
+        idx = content.indexOf(anchor, idx + 1);
+    }
+    return offsets;
+};
+
+const applyInsertLines = (content: string, op: InsertLinesOp): { content: string; result: OpResult } => {
+    const offsets = anchorOffsets({ content, anchor: op.anchor });
+    const found = offsets.length;
+    const raw = countOccurrences(content, op.anchor);
+    const anchorLine = op.anchor.split("\n");
+    const textLines = op.text.replace(/\n$/, "").split("\n");
+    const repeatsAnchor =
+        textLines[0] === anchorLine[anchorLine.length - 1] || textLines[textLines.length - 1] === anchorLine[0];
+    const desc = repeatsAnchor
+        ? `${opDesc(op)} ⚠ the inserted text starts or ends with the anchor line; before/after KEEP the anchor, so it will appear twice`
+        : opDesc(op);
+    if (found !== 1) {
+        const reason =
+            found === 0 && raw > 0
+                ? `anchor occurs ${raw}× but never at the start of a line: its indentation is wrong. Re-read line ${matchLines({ content, needle: op.anchor })} and copy the leading whitespace exactly`
+                : found === 0
+                  ? `anchor not found. ${nearestHint({ content, needle: op.anchor })}`
+                  : `anchor occurs ${found}× (lines ${matchLines({ content, needle: op.anchor })}), must be unique: add surrounding context`;
+        return { content, result: { status: op.optional ? "SKIP" : "MISS", desc, reason, found } };
+    }
+    // `text` is inserted line for line. A trailing "\n" is a real blank line, because
+    // that is what an agent means when it leaves an empty last line in a spec body
+    // ("insert this block, then a gap"). Stripping it once made a helper land glued to
+    // the next declaration.
+    // Inserted lines take the file's own line ending. Hardcoding "\n" spliced a lone LF
+    // line into an otherwise all-CRLF file, which every later diff then shows as noise.
+    const eol = dominantEol(content);
+    const text = op.text.replace(/\r?\n/g, eol);
+    // A multi-line anchor starts on one line and ends on another: "before" goes above
+    // the line where it STARTS, "after" goes below the line where it ENDS. Inserting
+    // after the first line of a two-line anchor once nested a new object key inside
+    // the previous one, and the result still parsed.
+    const anchorAt = offsets[0];
+    const { start } = lineBounds(content, anchorAt);
+    const bounds = lineBounds(content, anchorAt + op.anchor.length - 1);
+    // lineBounds stops before the "\n" but AFTER a "\r", so on a CRLF file inserting at
+    // `end` would leave the anchor line ending in a bare "\r" and split the pair.
+    const end = content[bounds.end - 1] === "\r" ? bounds.end - 1 : bounds.end;
+    const next =
+        op.kind === "insertLinesBefore"
+            ? `${content.slice(0, start)}${text}${eol}${content.slice(start)}`
+            : `${content.slice(0, end)}${eol}${text}${content.slice(end)}`;
+    return { content: next, result: { status: "OK", desc, found, expected: 1 } };
+};
+
+const applyAppend = (content: string, op: AppendOp): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    // Same rule as insertLines: the text is literal, it takes the file's line ending, and
+    // the file ends with a newline.
+    const eol = dominantEol(content);
+    const body = op.text.replace(/\r?\n/g, eol);
+    const text = body.endsWith(eol) ? body : `${body}${eol}`;
+    const glue = content.length === 0 || content.endsWith("\n") ? "" : eol;
+    return { content: `${content}${glue}${text}`, result: { status: "OK", desc } };
+};
+
+const applyFuzzy = (content: string, op: FuzzyOp): { content: string; result: OpResult } => {
+    const desc = op.label ?? `fuzzy "${op.find.replace(/\s+/g, " ").slice(0, 48)}"`;
+    const rx = fuzzyWhitespaceRegex(op.find);
+    const found = (content.match(rx) ?? []).length;
+    const want = op.count ?? 1;
+    if (found === 0) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: "no whitespace-tolerant match", found },
+        };
+    }
+    if (want !== "all" && found !== want) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: `expected ${want}, found ${found}`, found },
+        };
+    }
+    return { content: content.replace(rx, () => op.replace), result: { status: "OK", desc, found } };
+};
+
+/**
+ * Build a regex that matches `needle` treating every run of whitespace as "any
+ * whitespace". Lets a literal op survive reindentation/reformatting drift:
+ * pass `fuzzy: true` on a LiteralOp when an exact match keeps missing on
+ * whitespace grounds only.
+ */
+export const fuzzyWhitespaceRegex = (needle: string): RegExp => {
+    const parts = needle
+        .split(/\s+/)
+        .filter((p) => p.length > 0)
+        .map(escapeRegex);
+    return new RegExp(parts.join("\\s+"), "g");
+};
+
+/**
+ * An empty needle is never a match: `indexOf("")` succeeds at every offset, so the offset
+ * scan of a line insert never terminated, a same-line insert or a block landed at offset
+ * 0 and reported OK, and an empty fuzzy or regex needle matched between every character
+ * and wrote the replacement everywhere. The marker parser refuses these earlier; this
+ * guards the JSON and script doors.
+ */
+const emptyNeedle = (op: Op): string | null => {
+    switch (op.kind) {
+        case "fuzzy":
+            return op.find.trim() === "" ? "fuzzy needle is empty or whitespace-only" : null;
+        case "regex":
+            return op.find.source === "(?:)" ? "regex is empty: it would match between every character" : null;
+        case "insertBefore":
+        case "insertAfter":
+        case "insertLinesBefore":
+        case "insertLinesAfter":
+            return op.anchor === "" ? "anchor is empty: the anchor must hold the line to anchor on" : null;
+        case "deleteBlock":
+        case "replaceBlock":
+            if (op.from === "") {
+                return '"from" anchor is empty';
+            }
+
+            return op.to === "" ? '"to" anchor is empty' : null;
+        default:
+            return null;
+    }
+};
+
+/** Apply a list of ops to a string. Pure — no filesystem access. */
+export const applyOps = (content: string, ops: Op[]): { content: string; results: OpResult[] } => {
+    let current = content;
+    const results: OpResult[] = [];
+    let producedBy: BatchContext["producedBy"];
+    for (const op of ops) {
+        let outcome: { content: string; result: OpResult };
+        const empty = emptyNeedle(op);
+        if (empty !== null) {
+            const optional = "optional" in op && op.optional === true;
+            results.push({ status: optional ? "SKIP" : "MISS", desc: opDesc(op), reason: empty });
+            continue;
+        }
+
+        switch (op.kind) {
+            case "regex":
+                outcome = applyRegex(current, op);
+                break;
+            case "deleteBlock":
+            case "replaceBlock":
+                outcome = applyBlock(current, op);
+                break;
+            case "insertBefore":
+            case "insertAfter":
+                outcome = applyInsert(current, op);
+                break;
+            case "insertLinesBefore":
+            case "insertLinesAfter":
+                outcome = applyInsertLines(current, op);
+                break;
+            case "append":
+                outcome = applyAppend(current, op);
+                break;
+            case "dropComments":
+                outcome = applyDropComments(current, op);
+                break;
+            case "deleteLines":
+                outcome = applyDeleteLines(current, op);
+                break;
+            case "fuzzy":
+                outcome = applyFuzzy(current, op);
+                break;
+            default: {
+                // The script door: a misspelled kind is not a literal op.
+                const kind = (op as { kind?: string }).kind;
+                if (kind !== undefined && kind !== "replace") {
+                    outcome = {
+                        content: current,
+                        result: { status: "MISS", desc: opDesc(op), reason: `unknown op kind "${kind}"` },
+                    };
+                    break;
+                }
+
+                outcome = applyLiteral(current, op as LiteralOp, { original: content, producedBy });
+                break;
+            }
+        }
+        if (outcome.result.status === "OK" && outcome.content !== current) {
+            producedBy = { index: results.length, desc: outcome.result.desc };
+        }
+
+        current = outcome.content;
+        results.push(outcome.result);
+    }
+    return { content: current, results };
+};
+
+/** Literal op with count:"all" — replace every occurrence in the file. */
+export const all = ({ find, replace, label }: LiteralSugarParams): LiteralOp => ({
+    find,
+    replace,
+    count: "all",
+    label,
+});
+
+/** Literal op that is allowed to not match (idempotent re-runs, optional cleanups). */
+export const maybe = ({ find, replace, label }: LiteralSugarParams): LiteralOp => ({
+    find,
+    replace,
+    optional: true,
+    label,
+});
+
+/** Delete an exact literal chunk (must occur exactly once). */
+export const drop = ({ find, label }: DropParams): LiteralOp => ({
+    find,
+    replace: "",
+    label: label ?? `drop "${preview(find, 44)}"`,
+});
+
+/**
+ * Delete a whole /** … *\/ JSDoc (or any block) that STARTS with the given prefix.
+ * Sugar over deleteBlock with the closing anchor defaulted to the end of a JSDoc
+ * plus its trailing newline.
+ */
+export const dropJsdocStarting = ({ fromPrefix, label }: DropJsdocParams): DeleteBlockOp => ({
+    kind: "deleteBlock",
+    from: fromPrefix,
+    to: " */\n",
+    label: label ?? `dropJsdoc "${preview(fromPrefix, 40)}"`,
+});

--- a/plugins/genesis-tools/skills/fable-replace/scripts/example.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/example.ts
@@ -1,0 +1,105 @@
+/**
+ * Template for a throwaway sweep SCRIPT. You rarely need one: for literal edits,
+ * inserts, appends and new files the CLI is one call with no code at all —
+ *
+ *   bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" <<'EOF'
+ *   @@ src/foo.ts
+ *   <<<
+ *   old text
+ *   ===
+ *   new text
+ *   >>>
+ *   EOF
+ *
+ * Reach for a script when you need recon (findFiles / countMatches / grepPreview),
+ * a cross-file rename with pinned counts, comment sweeps, or a replacer FUNCTION.
+ * Every multi-input function takes ONE object; `bun cli.ts --api` prints every
+ * signature with its docs.
+ *
+ *   bun <your-script>.ts --dry   # preview diffs, writes nothing
+ *   bun <your-script>.ts         # transactional apply (all-or-nothing)
+ *
+ * 🛑 Never a hard-coded generic /tmp path for backupDir or logs: /tmp is shared
+ * machine-wide and two parallel agents overwrote each other's evidence. scratchDir().
+ */
+import {
+    all,
+    countMatches,
+    drop,
+    dropJsdocStarting,
+    findFiles,
+    grepPreview,
+    leftovers,
+    maybe,
+    mergeFileEdits,
+    renameSymbolAcross,
+    run,
+    sameOpsAcross,
+    scratchDir,
+} from "./replace-utils";
+
+// A copy of this template that lives elsewhere imports from
+// "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/replace-utils" instead.
+
+const scratch = scratchDir("my-sweep");
+
+// ── recon, entirely inside the API ───────────────────────────────────────────
+const targets = findFiles({ roots: ["src"], containing: /\boldName\b/ });
+const EXPECT = countMatches({ files: targets, pattern: "oldName" }); // paste-ready counts + zero-match and shadowing warnings
+grepPreview({ files: targets.slice(0, 3), pattern: /oldName(?=\()/, context: 2 });
+
+await run({
+    edits: [
+        {
+            file: "src/some/File.ts",
+            ops: [
+                { find: `const x = oldName(y);`, replace: `const x = newName(y);` }, // exactly once (default)
+                all({ find: "oldName(", replace: "newName(" }), // every occurrence
+                dropJsdocStarting({ fromPrefix: "/**\n * Legacy parity" }), // delete a JSDoc by its opening lines
+                maybe({ find: "// TODO remove me\n", replace: "" }), // fine if already gone on a re-run
+                { kind: "regex", find: /useFoo\(([^)]*)\)/g, replace: "useBar($1)", expect: 3 }, // pinned match count
+                {
+                    kind: "insertLinesAfter",
+                    anchor: `import React from "react";`,
+                    text: `import { thing } from "pkg";`,
+                },
+                { kind: "append", text: "export {};" },
+            ],
+            expectAfter: ["newName"],
+            absentAfter: ["oldName"],
+        },
+
+        // Comment sweep: the COMMENT goes, code on the same line stays (deleteLines would
+        // delete the whole statement). One expect per file, from the countMatches map.
+        ...Object.entries(EXPECT).map(([file, n]) => ({
+            file,
+            ops: [{ kind: "dropComments" as const, containing: "eslint-disable", expect: n }],
+        })),
+
+        // Identical counts → one shared op list is safe:
+        ...sameOpsAcross({
+            files: ["src/a.tsx", "src/b.tsx"],
+            ops: [{ kind: "deleteLines", containing: "console.debug(" }],
+        }),
+
+        // Cross-file identifier rename, word-boundary anchored. Pass the countMatches map
+        // to pin every count; mergeFileEdits lets two renames share files.
+        ...mergeFileEdits([
+            ...renameSymbolAcross({ files: EXPECT, oldName: "oldName", newName: "newName" }),
+            ...renameSymbolAcross({
+                files: findFiles({ roots: ["src"], containing: /\botherName\b/ }),
+                oldName: "otherName",
+                newName: "renamedOther",
+            }),
+        ]),
+
+        { file: "src/dead/Orphan.ts", delete: true },
+        { file: "src/old/Path.ts", renameTo: "src/new/Path.ts" },
+        { file: "src/two.ts", ops: [drop({ find: "// old comment\n" })] },
+    ],
+    backupDir: scratch, // one per sweep, never reused; the scratch dir ITSELF, so the age prune can reclaim it
+    verifyCommand: "bunx tsgo --noEmit", // proves completeness; red keeps the writes and throws code 3 (rollback({ backupDir }) undoes)
+    leftoversCheck: { names: ["oldName"], dirs: ["."] }, // a rename is not done while docs still say oldName
+});
+
+leftovers({ names: ["oldName"], dirs: ["src", "docs", "README.md"] });

--- a/plugins/genesis-tools/skills/fable-replace/scripts/internal.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/internal.ts
@@ -1,0 +1,211 @@
+/**
+ * fable-replace — private helpers shared by the other modules. Not part of the
+ * story a sweep script needs; nothing here decides policy.
+ */
+
+import * as fs from "node:fs";
+import type { LiteralOp, NthIndexOfParams, Op, RunReport } from "./types";
+
+/**
+ * Every failure `run()` / `rollback()` / `renameSymbolAcross()` raises. `code` mirrors
+ * the CLI exit code: 1 = misses or a partial write (nothing, or not everything, landed);
+ * 2 = pre-flight / spec; 3 = the sweep IS written, but the verify failed or stale prose
+ * survived. Three is the one a reader must never mistake for one.
+ *
+ * `report` carries the same RunReport a successful `run()` returns, so a catch can read
+ * `err.report.files` / `.written` / `.missCount` instead of parsing the message. It is
+ * set on the MISS and stale-prose failures, where a report exists; a pre-flight refusal
+ * happens before any file is planned, so there it stays undefined.
+ */
+export class FableReplaceError extends Error {
+    readonly code: 1 | 2 | 3;
+
+    readonly report?: RunReport;
+
+    constructor(message: string, code: 1 | 2 | 3, report?: RunReport) {
+        super(message);
+        this.name = "FableReplaceError";
+        this.code = code;
+        this.report = report;
+    }
+}
+
+/** 1-based line numbers where `needle` (string or RegExp) matches, capped, for MISS reasons. */
+export const matchLines = ({
+    content,
+    needle,
+    cap = 12,
+}: {
+    content: string;
+    needle: string | RegExp;
+    cap?: number;
+}): string => {
+    const lines: number[] = [];
+    if (typeof needle === "string") {
+        let idx = content.indexOf(needle);
+        while (idx !== -1 && lines.length <= cap) {
+            lines.push(content.slice(0, idx).split("\n").length);
+            idx = content.indexOf(needle, idx + Math.max(1, needle.length));
+        }
+    } else {
+        const rx = new RegExp(needle.source, needle.flags.includes("g") ? needle.flags : `${needle.flags}g`);
+        for (const m of content.matchAll(rx)) {
+            lines.push(content.slice(0, m.index ?? 0).split("\n").length);
+            if (lines.length > cap) {
+                break;
+            }
+        }
+    }
+    const shown = lines.slice(0, cap).join(", ");
+    return lines.length > cap ? `${shown}, …` : shown;
+};
+
+/**
+ * A regex carrying `g` or `y` keeps `lastIndex` between `.test()` calls, so one
+ * instance tested against many strings silently skips every other match. Every
+ * predicate use goes through this stateless clone instead.
+ */
+export const stateless = (rx: RegExp): RegExp =>
+    rx.global || rx.sticky ? new RegExp(rx.source, rx.flags.replace(/[gy]/g, "")) : rx;
+
+export const preview = (s: string, max = 60): string => {
+    const flat = s.replace(/\n/g, "\\n").replace(/\t/g, "\\t");
+    return flat.length <= max ? flat : `${flat.slice(0, max)}…`;
+};
+
+export const countOccurrences = (haystack: string, needle: string): number => {
+    if (needle.length === 0) {
+        return 0;
+    }
+    let count = 0;
+    let idx = haystack.indexOf(needle);
+    while (idx !== -1) {
+        count += 1;
+        idx = haystack.indexOf(needle, idx + needle.length);
+    }
+    return count;
+};
+
+/** Offsets where `needle` STARTS a line (offset 0 or right after "\n"), non-overlapping. */
+export const lineStartOffsets = (haystack: string, needle: string): number[] => {
+    const offsets: number[] = [];
+    if (needle.length === 0) {
+        return offsets;
+    }
+    let idx = haystack.indexOf(needle);
+    while (idx !== -1) {
+        if (idx === 0 || haystack[idx - 1] === "\n") {
+            offsets.push(idx);
+            idx = haystack.indexOf(needle, idx + needle.length);
+        } else {
+            idx = haystack.indexOf(needle, idx + 1);
+        }
+    }
+    return offsets;
+};
+
+/**
+ * The line ending the file already uses, so inserted lines match their neighbours.
+ * A file holding any CRLF at all is treated as CRLF: splicing one LF line into a CRLF
+ * file is what later shows up as phantom diff noise.
+ */
+export const dominantEol = (content: string): string => (content.includes("\r\n") ? "\r\n" : "\n");
+
+/** Index of the 1-based n-th occurrence of `needle`, or -1. */
+export const nthIndexOf = ({ haystack, needle, n }: NthIndexOfParams): number => {
+    // Non-overlapping, the same walk `countOccurrences` does: "aa" in "aaaa" has two
+    // occurrences, so the 2nd starts at 2, not 1. Advancing one character at a time
+    // disagreed with the count `locateBlock` had just used to prove the anchor unique.
+    let idx = -1;
+    let from = 0;
+    for (let i = 0; i < n; i += 1) {
+        idx = haystack.indexOf(needle, from);
+        if (idx === -1) {
+            return -1;
+        }
+        from = idx + Math.max(1, needle.length);
+    }
+    return idx;
+};
+
+export const replaceAllLiteral = (haystack: string, needle: string, replacement: string): string =>
+    haystack.split(needle).join(replacement);
+
+export const replaceNLiteral = (haystack: string, needle: string, replacement: string, n: number): string => {
+    // The offsets are collected against the ORIGINAL string, non-overlapping (the same
+    // walk `countOccurrences` does), and spliced in from the END. Searching the MUTATED
+    // string on each pass meant a replacement that CONTAINS the needle re-matched itself:
+    // count=2 of "oldName" → "wrapper(oldName)" wrapped the first call site twice, never
+    // touched the second, and still reported "OK ×2 of 2 declared".
+    const offsets: number[] = [];
+    let idx = haystack.indexOf(needle);
+    while (idx !== -1 && offsets.length < n) {
+        offsets.push(idx);
+        idx = haystack.indexOf(needle, idx + needle.length);
+    }
+
+    let out = haystack;
+    for (const at of offsets.reverse()) {
+        out = out.slice(0, at) + replacement + out.slice(at + needle.length);
+    }
+
+    return out;
+};
+
+export const opDesc = (op: Op): string => {
+    if (op.label) {
+        return op.label;
+    }
+    switch (op.kind) {
+        case "regex":
+            return `regex ${String(op.find)}`;
+        case "deleteBlock":
+            return `deleteBlock "${preview(op.from, 40)}" → "${preview(op.to, 24)}"`;
+        case "replaceBlock":
+            return `replaceBlock "${preview(op.from, 40)}" → "${preview(op.to, 24)}"`;
+        case "insertBefore":
+        case "insertAfter":
+        case "insertLinesBefore":
+        case "insertLinesAfter":
+            return `${op.kind} "${preview(op.anchor, 40)}"`;
+        case "append":
+            return `append "${preview(op.text, 40)}"`;
+        default:
+            return `replace "${preview((op as LiteralOp).find, 48)}"`;
+    }
+};
+
+export const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * A JavaScript identifier on its own. `\b` is a WORD boundary and `$` is not a word
+ * character, so `\bfoo\b` also matched inside `$foo`, and `\b$foo\b` never matched a
+ * declaration of `$foo`.
+ */
+export const identifierPattern = (name: string): string => `(?<![\\w$])${escapeRegex(name)}(?![\\w$])`;
+
+export const COLORS = {
+    ok: "\x1b[32m",
+    miss: "\x1b[31m",
+    skip: "\x1b[33m",
+    dim: "\x1b[2m",
+    bold: "\x1b[1m",
+    reset: "\x1b[0m",
+};
+
+const useColor = process.stdout.isTTY === true;
+
+export const paint = (code: string, s: string): string => (useColor ? `${code}${s}${COLORS.reset}` : s);
+
+/**
+ * Did `abs` change since the sweep read it? The whole file is read into memory at plan
+ * time; writing without this check silently destroyed a concurrent write and still
+ * reported OK. A file that vanished counts as changed.
+ */
+export const changedOnDisk = ({ abs, expected }: { abs: string; expected: string }): boolean => {
+    if (!fs.existsSync(abs)) {
+        return true;
+    }
+
+    return fs.readFileSync(abs, "utf8") !== expected;
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/journal.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/journal.ts
@@ -1,0 +1,257 @@
+/**
+ * fable-replace — THE JOURNAL. One JSON line per CLI run, rollback and prune, so "which
+ * sweeps failed this week", "what did that failure cost" and "which spec trap costs the
+ * most" have an answer without re-reading session transcripts.
+ *
+ * Lives beside the other GenesisTools data, `<home>/.genesis-tools/fable-replace/journal.jsonl`,
+ * where home is FABLE_REPLACE_HOME, else GENESIS_TOOLS_HOME (the repo's test sandbox sets it,
+ * so `bun test` never writes the real file), else the user's home. Plain appends, no lock:
+ * eight processes appending 250 lines each produced 2,000 well-formed lines at 400-byte and
+ * 90 KB payloads. That holds for a local filesystem, never a network share. The writer never
+ * throws: a failed append is one stderr line and the run's exit code stands.
+ *
+ * The spec text is never journaled (the file is durable, specs are source). Its size and
+ * hash are. The text itself goes beside the backup, the ephemeral place.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseJson, stringifyJson } from "./json";
+
+export type JournalOutcome =
+    | "ok"
+    | "miss"
+    | "spec-error"
+    | "pre-flight"
+    | "write-failed"
+    | "written"
+    | "verify-failed"
+    | "verify-unknown"
+    | "stale-prose"
+    | "dry-ok"
+    | "dry-miss"
+    | "partial"
+    | "rollback"
+    | "prune"
+    | "error";
+
+export interface JournalEntry {
+    ts: string;
+    runId: string;
+    pid: number;
+    cwd: string;
+    kind: "run" | "rollback" | "prune";
+    outcome: JournalOutcome;
+    spec?: { files: number; ops: number; chars: number; hash: string };
+    flags?: string[];
+    missCount?: number;
+    /** The first three MISS reasons, truncated: what aggregates into "which trap costs the most". */
+    reasons?: string[];
+    specError?: string;
+    written?: number;
+    backupDir?: string;
+    verify?: {
+        cmd: string;
+        status: string;
+        exit: number | null;
+        ms: number;
+        outputChars: number;
+        shownLines: number;
+        timedOut: boolean;
+        buffered: boolean;
+    };
+    durationMs?: number;
+    /** Everything the CLI printed: the tokens a model reads back. */
+    resultChars?: number;
+    tokensEst?: { spec: number; result: number };
+    rollback?: { restored: number; drifted: number; failed: number };
+    prune?: { removed: number; bytes: number };
+    message?: string;
+}
+
+/**
+ * Tokens only, never dollars: this script cannot reach the shared price catalog, and a
+ * second rate table goes stale silently. A reader multiplies the spec tokens by the output
+ * rate of the model that wrote them. The divisor is the measured average for code and specs.
+ */
+export const TOKEN_ESTIMATE = {
+    charsPerToken: 3.7,
+};
+
+/** One archive at the cap; the second rotation discards the first archive. About 30 heavy sessions. */
+export const JOURNAL_MAX_BYTES = 5 * 1024 * 1024;
+const MAX_FIELD_CHARS = 300;
+const MAX_REASON_CHARS = 80;
+
+export const journalHome = (): string => {
+    const home = process.env.FABLE_REPLACE_HOME ?? process.env.GENESIS_TOOLS_HOME ?? os.homedir();
+    return path.join(home, ".genesis-tools", "fable-replace");
+};
+
+export const journalPath = (): string => path.join(journalHome(), "journal.jsonl");
+
+const archivePath = (): string => path.join(journalHome(), "journal.1.jsonl");
+
+export const estimateTokens = (chars: number): number => Math.round(chars / TOKEN_ESTIMATE.charsPerToken);
+
+const clipField = (text: string, max = MAX_FIELD_CHARS): string =>
+    text.length <= max ? text : `${text.slice(0, max)}…`;
+
+/** Append one line. Never throws. Long fields are clipped so a runaway command string cannot bloat every line. */
+export const appendJournal = (entry: JournalEntry): void => {
+    const file = journalPath();
+    try {
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        const clipped: JournalEntry = {
+            ...entry,
+            specError: entry.specError === undefined ? undefined : clipField(entry.specError),
+            reasons: entry.reasons?.slice(0, 3).map((reason) => clipField(reason, MAX_REASON_CHARS)),
+            verify: entry.verify === undefined ? undefined : { ...entry.verify, cmd: clipField(entry.verify.cmd) },
+            message: entry.message === undefined ? undefined : clipField(entry.message),
+        };
+        try {
+            if (fs.statSync(file).size > JOURNAL_MAX_BYTES) {
+                fs.renameSync(file, archivePath());
+            }
+        } catch (err) {
+            if ((err as { code?: string }).code !== "ENOENT") {
+                throw err;
+            }
+        }
+        fs.appendFileSync(file, `${stringifyJson(clipped)}\n`);
+    } catch (err) {
+        console.error(`journal: could not append to ${file}: ${String(err)}`);
+    }
+};
+
+/** Every parseable line, archive first, oldest to newest. Malformed lines are counted, never fatal. */
+export const readJournal = ({ limit, sinceMs }: { limit?: number; sinceMs?: number } = {}): JournalEntry[] => {
+    const entries: JournalEntry[] = [];
+    let malformed = 0;
+    for (const file of [archivePath(), journalPath()]) {
+        if (!fs.existsSync(file)) {
+            continue;
+        }
+
+        for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+            if (line.trim() === "") {
+                continue;
+            }
+
+            try {
+                entries.push(parseJson(line) as JournalEntry);
+            } catch {
+                malformed += 1;
+            }
+        }
+    }
+    if (malformed > 0) {
+        console.error(`journal: skipped ${malformed} malformed line(s)`);
+    }
+
+    const since = sinceMs === undefined ? entries : entries.filter((entry) => Date.parse(entry.ts) >= sinceMs);
+    return limit === undefined ? since : since.slice(-limit);
+};
+
+const compact = (n: number): string => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n));
+
+export const printHistory = (limit: number): void => {
+    const entries = readJournal({ limit });
+    if (entries.length === 0) {
+        console.log(`journal is empty: ${journalPath()}`);
+        return;
+    }
+
+    console.log(`last ${entries.length} entries from ${journalPath()}`);
+    for (const entry of entries) {
+        const when = entry.ts.slice(0, 16).replace("T", " ");
+        const spec = entry.spec === undefined ? "" : `${entry.spec.files}f/${entry.spec.ops}op`;
+        const tokens =
+            entry.tokensEst === undefined
+                ? ""
+                : `spec ${compact(entry.tokensEst.spec)} result ${compact(entry.tokensEst.result)} tok`;
+        const verify =
+            entry.verify === undefined
+                ? ""
+                : `verify ${entry.verify.status}${entry.verify.exit === null ? "" : ` (exit ${entry.verify.exit})`}`;
+        const extra =
+            entry.rollback !== undefined
+                ? `restored ${entry.rollback.restored}, drifted ${entry.rollback.drifted}, failed ${entry.rollback.failed}`
+                : entry.prune !== undefined
+                  ? `removed ${entry.prune.removed} dir(s), ${compact(entry.prune.bytes)} B`
+                  : "";
+        const backup = entry.backupDir === undefined ? "" : `backup ${entry.backupDir}`;
+        console.log(
+            [when, entry.outcome.padEnd(14), spec.padEnd(9), tokens, verify, extra, backup]
+                .filter((s) => s !== "")
+                .join("  ")
+        );
+        if (entry.reasons !== undefined && entry.reasons.length > 0) {
+            console.log(`                 ↳ ${entry.reasons.join(" | ")}`);
+        }
+    }
+};
+
+/** Outcomes whose spec had to be re-sent: the text cost that a better spec would have avoided. */
+const WASTED = new Set<JournalOutcome>(["miss", "spec-error", "pre-flight", "write-failed", "dry-miss", "error"]);
+
+export const printStats = (days: number): void => {
+    const raw = readJournal({ sinceMs: Date.now() - days * 86_400_000 }).filter((entry) => entry.kind === "run");
+    // The CLI writes a "written" breadcrumb before a verify and a terminal line after it,
+    // both under one runId. A run counts once: the terminal line wins, and the breadcrumb
+    // survives only for a run that never reached its terminal line (killed mid-verify).
+    const byRun = new Map<string, JournalEntry>();
+    for (const entry of raw) {
+        const seen = byRun.get(entry.runId);
+        if (seen === undefined || seen.outcome === "written") {
+            byRun.set(entry.runId, entry);
+        }
+    }
+    const entries = [...byRun.values()];
+    if (entries.length === 0) {
+        console.log(`no runs in the last ${days} day(s) in ${journalPath()}`);
+        return;
+    }
+
+    const byOutcome = new Map<string, number>();
+    const reasons = new Map<string, number>();
+    let specTokens = 0;
+    let resultTokens = 0;
+    let wastedTokens = 0;
+    let wastedRuns = 0;
+    for (const entry of entries) {
+        byOutcome.set(entry.outcome, (byOutcome.get(entry.outcome) ?? 0) + 1);
+        specTokens += entry.tokensEst?.spec ?? 0;
+        resultTokens += entry.tokensEst?.result ?? 0;
+        if (WASTED.has(entry.outcome)) {
+            wastedTokens += entry.tokensEst?.spec ?? 0;
+            wastedRuns += 1;
+        }
+        for (const reason of entry.reasons ?? []) {
+            const key = reason.replace(/\d+/g, "N").slice(0, 60);
+            reasons.set(key, (reasons.get(key) ?? 0) + 1);
+        }
+    }
+
+    const { charsPerToken } = TOKEN_ESTIMATE;
+    console.log(`fable-replace runs, last ${days} day(s): ${entries.length} (${journalPath()})`);
+    for (const [outcome, count] of [...byOutcome.entries()].sort((a, b) => b[1] - a[1])) {
+        console.log(`  ${outcome.padEnd(14)} ${count}`);
+    }
+    console.log(
+        `tokens (chars ÷ ${charsPerToken}): spec ${compact(specTokens)} written by the model, result ${compact(resultTokens)} read back`
+    );
+    console.log(
+        `wasted on ${wastedRuns} failed run(s) whose spec had to be re-sent: ${compact(wastedTokens)} spec tokens`
+    );
+    console.log(
+        "no price here: multiply the spec tokens by the output rate of the model that wrote them. Round trips cost more than text: each failed run also bought one."
+    );
+    if (reasons.size > 0) {
+        console.log("top MISS reasons:");
+        for (const [reason, count] of [...reasons.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5)) {
+            console.log(`  ${count}× ${reason}`);
+        }
+    }
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/json.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/json.ts
@@ -1,0 +1,15 @@
+/**
+ * fable-replace — JSON without the bare global. The repo's lint denies `JSON` so that
+ * application code goes through SafeJSON; a standalone plugin script cannot import it,
+ * so the two calls live here, once, instead of one ignore per call site.
+ */
+
+export const parseJson = (text: string): unknown => {
+    // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+    return JSON.parse(text);
+};
+
+export const stringifyJson = (value: unknown, indent?: number): string => {
+    // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+    return JSON.stringify(value, null, indent);
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/recon.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/recon.ts
@@ -1,0 +1,301 @@
+/**
+ * fable-replace — RECON. Look before you declare an op.
+ *
+ * `grepPreview` takes a JS RegExp (so lookahead/lookbehind work, unlike plain
+ * ripgrep) or a literal string, and prints every match with context.
+ *
+ * When you are hunting import specifiers, match the QUOTED SPECIFIER itself, not
+ * the statement shape. A pattern anchored on `import … from` silently undercounts:
+ * it misses multi-line import statements, `export … from`, dynamic `import("…")`
+ * and type-only `import("…").Type` positions.
+ */
+
+import * as fs from "node:fs";
+import { escapeRegex, FableReplaceError, identifierPattern, stateless } from "./internal";
+import { stringifyJson } from "./json";
+import type {
+    CountMatchesParams,
+    FindFilesParams,
+    GrepPreviewParams,
+    LeftoversParams,
+    ShadowedFilesParams,
+} from "./types";
+
+/**
+ * Recon helper: print every match of `pattern` across files with `context`
+ * lines around it. Use INSIDE a sweep script before committing to ops, or in a
+ * quick `bun -e` — keeps the recon and the edit in one reviewable place.
+ */
+export const grepPreview = ({ files, pattern, context = 2 }: GrepPreviewParams): number => {
+    const rx = typeof pattern === "string" ? new RegExp(escapeRegex(pattern)) : stateless(pattern);
+    let total = 0;
+    for (const file of files) {
+        if (!fs.existsSync(file)) {
+            console.log(`?? ${file} (missing)`);
+            continue;
+        }
+        const lines = fs.readFileSync(file, "utf8").split("\n");
+        lines.forEach((l, idx) => {
+            if (rx.test(l)) {
+                total += 1;
+                console.log(`\n${file}:${idx + 1}`);
+                for (let j = Math.max(0, idx - context); j <= Math.min(lines.length - 1, idx + context); j += 1) {
+                    console.log(`${j === idx ? ">" : " "} ${String(j + 1).padStart(4)}| ${lines[j]}`);
+                }
+            }
+        });
+    }
+    console.log(`\n${total} match(es) across ${files.length} file(s)`);
+    return total;
+};
+
+const CODE_EXT_RE = /\.(m|c)?(ts|js)x?$/;
+// Tested against each directory NAME while descending, never against the root the
+// caller passed in — a root under .worktrees/ must still be scannable.
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git", "dist", "build", "coverage", ".next"]);
+
+const walk = (dir: string, out: string[]): void => {
+    // A fable-replace backup dir holds pre-sweep copies, so it ALWAYS contains the old
+    // name. Reporting it as a survivor is pure noise.
+    if (fs.existsSync(`${dir}/fable-replace-manifest.json`)) {
+        return;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = `${dir}/${entry.name}`;
+        if (entry.isDirectory()) {
+            if (SKIP_DIR_NAMES.has(entry.name)) {
+                continue;
+            }
+            walk(full, out);
+        } else if (entry.isFile()) {
+            out.push(full);
+        }
+    }
+};
+
+export interface LeftoverReport {
+    /** Matches in code — usually legitimate aliases and re-exports, but check them. */
+    code: string[];
+    /** Matches in prose (markdown, text). A rename that skipped these left the docs lying. */
+    docs: string[];
+}
+
+/**
+ * After a rename, find every place the OLD name still appears. Three of five trial
+ * sweeps shipped green code while leaving README/CLAUDE.md naming a symbol that no
+ * longer existed, so this splits code hits (often legitimate aliases) from prose hits
+ * (almost never legitimate).
+ */
+export const leftovers = ({ names: needles, dirs, quiet = false }: LeftoversParams): LeftoverReport => {
+    const report: LeftoverReport = { code: [], docs: [] };
+    const files: string[] = [];
+    for (const entry of dirs) {
+        if (!fs.existsSync(entry)) {
+            continue;
+        }
+        // A plain file is a legitimate target — the docs' own example passes README.md,
+        // and readdirSync on it used to throw ENOTDIR.
+        if (fs.statSync(entry).isDirectory()) {
+            walk(entry, files);
+        } else {
+            files.push(entry);
+        }
+    }
+    for (const file of files) {
+        let content: string;
+        try {
+            content = fs.readFileSync(file, "utf8");
+        } catch {
+            continue;
+        }
+        for (const needle of needles) {
+            const rx = needleRegex(needle);
+            if (!rx.test(content)) {
+                continue;
+            }
+            const lines = content
+                .split("\n")
+                .flatMap((l, i) => (rx.test(l) ? [`${file}:${i + 1}: ${l.trim().slice(0, 100)}`] : []));
+            const bucket = CODE_EXT_RE.test(file) ? report.code : report.docs;
+            for (const hit of lines) {
+                // one line matching two needles is ONE surviving line, not two
+                if (!bucket.includes(hit)) {
+                    bucket.push(hit);
+                }
+            }
+        }
+    }
+    if (!quiet && report.docs.length > 0) {
+        console.log(
+            `\n⚠ ${report.docs.length} PROSE mention(s) of ${needles.join(", ")} survive the sweep — the docs now name something that does not exist:`
+        );
+        for (const hit of report.docs.slice(0, 20)) {
+            console.log(`  ${hit}`);
+        }
+    }
+    if (!quiet && report.docs.length === 0 && report.code.length === 0) {
+        console.log(`leftovers: 0 hit(s) for ${needles.join(", ")} — nothing survives.`);
+    }
+    if (!quiet && report.code.length > 0) {
+        console.log(
+            `\n${report.code.length} code mention(s) remain (aliases and re-exports are legitimate — confirm each):`
+        );
+        for (const hit of report.code.slice(0, 10)) {
+            console.log(`  ${hit}`);
+        }
+    }
+    return report;
+};
+
+const IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/;
+
+/**
+ * Word-boundary anchoring is right for an identifier and WRONG for anything else.
+ * `\b@genesiscz/utils/Stopwatch\b` matches nothing at all, because the characters
+ * either side of the needle are already non-word — so a leftover import path silently
+ * reported zero hits, which is the worst possible failure in a safety check.
+ */
+const needleRegex = (needle: string, flags = ""): RegExp =>
+    new RegExp(IDENTIFIER_RE.test(needle) ? identifierPattern(needle) : escapeRegex(needle), flags);
+
+/**
+ * Occurrences per file, ready to paste into `expect:` / `count:`. Two independent
+ * trial runs hand-rolled `grep -o … | wc -l` loops for exactly this, then transcribed
+ * the numbers by hand — which is a silent-error step in the one place the whole
+ * verification contract rests on.
+ *
+ * A string pattern that looks like an identifier is matched on word boundaries (what
+ * you want for a symbol rename); any other string is matched literally. A RegExp is
+ * used as given, with the `g` flag forced on.
+ */
+export const countMatches = ({ files, pattern, quiet = false }: CountMatchesParams): Record<string, number> => {
+    const rx =
+        typeof pattern === "string"
+            ? needleRegex(pattern, "g")
+            : new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`);
+    const counts: Record<string, number> = {};
+    for (const file of files) {
+        if (!fs.existsSync(file)) {
+            console.log(`?? ${file} (missing)`);
+            continue;
+        }
+        counts[file] = (fs.readFileSync(file, "utf8").match(rx) ?? []).length;
+    }
+    // A file that DECLARES the same bare name matters, but not always the same way:
+    //  - it declares AND imports the name  -> a local wrapper shadowing the shared one.
+    //    Renaming its declaration changes an unrelated helper. Keep it out of the bucket.
+    //  - it declares and does NOT import it -> the definition you are probably renaming,
+    //    or an independent implementation. Only you can tell which.
+    // Reporting both as "unrelated" cried wolf on the source module itself.
+    const split =
+        typeof pattern === "string" && IDENTIFIER_RE.test(pattern)
+            ? shadowedFiles({ files: Object.keys(counts), name: pattern })
+            : { shadows: [], declarers: [] };
+    const { shadows, declarers } = split;
+    if (!quiet) {
+        const entries = Object.entries(counts);
+        const total = entries.reduce((sum, [, n]) => sum + n, 0);
+        const zero = entries.filter(([, n]) => n === 0);
+        console.log(`\ncountMatches ${String(rx)} — ${total} occurrence(s) in ${entries.length} file(s):`);
+        console.log(`const EXPECT: Record<string, number> = {`);
+        for (const [file, n] of entries) {
+            console.log(`\t${stringifyJson(file)}: ${n},`);
+        }
+        console.log(`};`);
+        if (shadows.length > 0) {
+            console.log(
+                `⚠ ${shadows.length} file(s) both IMPORT and DECLARE "${String(pattern)}" — a local wrapper. Renaming its declaration changes an unrelated helper:`
+            );
+            for (const file of shadows) {
+                console.log(`  ${file}`);
+            }
+        }
+        if (declarers.length > 0) {
+            console.log(
+                `· ${declarers.length} file(s) DECLARE "${String(pattern)}" without importing it — the definition you are renaming, or an independent implementation. Decide per file:`
+            );
+            for (const file of declarers) {
+                console.log(`  ${file}`);
+            }
+        }
+        if (zero.length > 0) {
+            console.log(
+                `⚠ ${zero.length} file(s) contain ZERO matches — a non-optional op on those is a guaranteed MISS:`
+            );
+            for (const [file] of zero) {
+                console.log(`  ${file}`);
+            }
+        }
+    }
+    return counts;
+};
+
+/**
+ * Split `files` by how they relate to the identifier `name`: `shadows` both import AND
+ * declare it (a local wrapper: renaming its declaration changes an unrelated helper),
+ * `declarers` declare it without importing it (the definition, or an independent one).
+ * countMatches prints this; renameSymbolAcross refuses the shadows unless told otherwise.
+ */
+export const shadowedFiles = ({ files, name }: ShadowedFilesParams): { shadows: string[]; declarers: string[] } => {
+    const shadows: string[] = [];
+    const declarers: string[] = [];
+    const declRe = new RegExp(`\\b(?:function|class|const|let|var|interface|type)\\s+${identifierPattern(name)}`);
+    const importRe = new RegExp(`import[^;]*${identifierPattern(name)}[^;]*from`, "s");
+    for (const file of files) {
+        let src: string;
+        try {
+            src = fs.readFileSync(file, "utf8");
+        } catch {
+            continue;
+        }
+        if (!declRe.test(src)) {
+            continue;
+        }
+        (importRe.test(src) ? shadows : declarers).push(file);
+    }
+    return { shadows, declarers };
+};
+
+/**
+ * Every file under `roots` whose CONTENT matches — the recon step that has to happen
+ * BEFORE countMatches/grepPreview, which both take an already-known file list.
+ *
+ * Without this you cannot start inside the documented API: you shell out to ripgrep
+ * for the file list first, which is exactly what the docs tell you not to do. Skips
+ * node_modules, build output, and fable-replace backup dirs.
+ */
+export const findFiles = ({ roots, containing, exts = [".ts", ".tsx"] }: FindFilesParams): string[] => {
+    // Without this, a forgotten `containing` returns [] — which reads as "no file holds
+    // the symbol" and quietly turns the whole sweep into a no-op.
+    if (containing === undefined || containing === "") {
+        throw new FableReplaceError(
+            'findFiles: "containing" is required (a literal string or a RegExp); it is the content filter, not an option',
+            2
+        );
+    }
+
+    const rx = typeof containing === "string" ? new RegExp(escapeRegex(containing)) : stateless(containing);
+    const all: string[] = [];
+    for (const root of roots) {
+        if (!fs.existsSync(root)) {
+            continue;
+        }
+        // A plain file is a legitimate root too (README.md, CLAUDE.md): readdirSync on
+        // it used to throw a bare ENOTDIR.
+        if (fs.statSync(root).isFile()) {
+            all.push(root);
+        } else {
+            walk(root, all);
+        }
+    }
+    return all
+        .filter((file) => exts.length === 0 || exts.some((ext) => file.endsWith(ext)))
+        .filter((file) => {
+            try {
+                return rx.test(fs.readFileSync(file, "utf8"));
+            } catch {
+                return false;
+            }
+        })
+        .sort();
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/rename-symbols.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/rename-symbols.ts
@@ -1,0 +1,75 @@
+/**
+ * fable-replace — RENAMING AN IDENTIFIER ACROSS MANY FILES.
+ *
+ *   renameSymbolAcross({ files, oldName: "oldName", newName: "newName" })
+ *
+ * The rename is word-boundary anchored, so `oldName` never matches inside
+ * `_oldName` or `oldNameSuffix`. Every listed file MUST contain the symbol: a file
+ * that does not is a MISS. When you are renaming several symbols that live in
+ * OVERLAPPING but different file sets, bucket the files per symbol rather than
+ * passing one list for all of them.
+ *
+ * A rename is not finished when the code is green. Sweep the markdown that names
+ * the symbol too (README, CLAUDE.md, docs), or you leave the docs lying.
+ */
+
+import { FableReplaceError, identifierPattern } from "./internal";
+import { shadowedFiles } from "./recon";
+import type { FileEdit, RegexOp, RenameSymbolAcrossParams, RenameSymbolParams, SameOpsAcrossParams } from "./types";
+
+/** Same set of ops applied to many files (e.g. rename a symbol across call sites). */
+export const sameOpsAcross = ({ files, ops, extra = {} }: SameOpsAcrossParams): FileEdit[] =>
+    files.map((file) => ({ file, ops, ...extra }));
+
+export const renameSymbol = ({ oldName, newName, expect }: RenameSymbolParams): RegexOp => ({
+    kind: "regex",
+    find: new RegExp(identifierPattern(oldName), "g"),
+    // A function, so a `$` in the new name is literal: as a replacement STRING, "$$foo"
+    // would have been written as "$foo".
+    replace: () => newName,
+    expect,
+    label: `rename ${oldName} → ${newName}`,
+});
+
+/**
+ * Word-boundary rename of an identifier in one file's ops form. Use with
+ * sameOpsAcross() for a cross-file rename:
+ *   sameOpsAcross({ files, ops: [renameSymbol({ oldName: "getLinkGate", newName: "getActionDisabledState" })] })
+ */
+/**
+ * The commonest sweep of all, in one call:
+ *   renameSymbolAcross({ files, oldName: "oldName", newName: "newName" })
+ * Equivalent to sameOpsAcross({ files, ops: [renameSymbol({ oldName, newName })] }). Every listed file
+ * MUST contain the symbol — a file that does not is a MISS, so bucket your file
+ * list by which symbol it actually holds rather than passing one list for several
+ * renames.
+ */
+export const renameSymbolAcross = ({
+    files,
+    oldName,
+    newName,
+    extra = {},
+    includeShadowed = false,
+}: RenameSymbolAcrossParams): FileEdit[] => {
+    // countMatches only WARNS about local wrappers; a caller piping its map straight in
+    // renamed one anyway. Refusing here makes the warning binding.
+    if (!includeShadowed) {
+        const candidates = Array.isArray(files) ? files : Object.keys(files);
+        const { shadows } = shadowedFiles({ files: candidates, name: oldName });
+        if (shadows.length > 0) {
+            throw new FableReplaceError(
+                `renameSymbolAcross: ${shadows.length} file(s) both import AND declare "${oldName}" (a local wrapper; renaming its declaration changes an unrelated helper):\n  ${shadows.join("\n  ")}\nDrop them from the file list, or pass includeShadowed: true on purpose.`,
+                2
+            );
+        }
+    }
+    // Accept the countMatches() map directly: zero-match files are dropped (they would
+    // MISS) and each file's expected count is pinned from the number you already
+    // measured, instead of being transcribed by hand.
+    if (Array.isArray(files)) {
+        return sameOpsAcross({ files, ops: [renameSymbol({ oldName, newName })], extra });
+    }
+    return Object.entries(files)
+        .filter(([, n]) => n > 0)
+        .map(([file, n]) => ({ file, ops: [renameSymbol({ oldName, newName, expect: n })], ...extra }));
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/replace-utils.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/replace-utils.ts
@@ -1,0 +1,59 @@
+/**
+ * fable-replace — verified, transactional batch editing utilities.
+ *
+ * This file is the BARREL. One import line still gets you everything:
+ *
+ *   import { run, renameSymbolAcross } from "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/replace-utils";
+ *
+ * The implementation is split by concern, so you can read the 200 lines that
+ * matter instead of all 1400. What is where:
+ *
+ *   types.ts               every op / edit / result shape. The vocabulary.
+ *   edit-one-file.ts       ops that transform ONE file's text: literal, regex,
+ *                          deleteBlock/replaceBlock, insert, fuzzy, applyOps.
+ *   comments.ts            comment and line sweeps: scanComments, dropComments
+ *                          (comment goes, code on the line stays), deleteLines
+ *                          (whole line goes).
+ *   rename-symbols.ts      cross-file identifier renames: renameSymbolAcross,
+ *                          renameSymbol, sameOpsAcross.
+ *   sweep-many-files.ts    the runner: run(), pre-flight guards, transaction,
+ *                          verifyCommand, dry-run diff.
+ *   backup-and-rollback.ts backupDir snapshots, drift-aware rollback().
+ *   recon.ts               grepPreview — look before you declare an op.
+ *   internal.ts            private helpers. Nothing to see.
+ *
+ * Design contract (the reason this exists instead of sed):
+ *  - Every operation is VERIFIED: a literal op with the default `count: 1` requires
+ *    the needle EXACTLY once; regex ops can pin an expected match count; block ops
+ *    require both anchors. Anything that does not hold is a MISS, never a silent
+ *    no-op.
+ *  - The batch is TRANSACTIONAL: everything is applied in memory and checked first
+ *    (including that every edited script still parses). A single required MISS
+ *    aborts the whole run and writes nothing.
+ *  - `dryRun` prints diffs and writes nothing.
+ *  - `backupDir` snapshots originals + a manifest before writing; `rollback(dir)`
+ *    restores byte-for-byte and refuses to clobber anything edited since.
+ *
+ * Runtime: bun (TypeScript directly). No dependencies outside node builtins.
+ */
+
+export {
+    backupDirInUse,
+    pruneScratch,
+    recordPostWriteHashes,
+    rollback,
+    scratchDir,
+    scratchRoot,
+    writeBackup,
+} from "./backup-and-rollback";
+export { applyDeleteLines, applyDropComments, deleteLines, dropComments, removeSpans, scanComments } from "./comments";
+export { all, applyOps, drop, dropJsdocStarting, fuzzyWhitespaceRegex, maybe, nearestHint } from "./edit-one-file";
+export { changedOnDisk, countOccurrences, FableReplaceError, nthIndexOf } from "./internal";
+export type { LeftoverReport } from "./recon";
+export { countMatches, findFiles, grepPreview, leftovers, shadowedFiles } from "./recon";
+export { renameSymbol, renameSymbolAcross, sameOpsAcross } from "./rename-symbols";
+export type { ParseSpecParams } from "./spec";
+export { parseSpec } from "./spec";
+export { looksGenerated, mergeFileEdits, run, simpleDiff } from "./sweep-many-files";
+export * from "./types";
+export { checkVerifyCommand, runVerifyCommand, trimOutput, verifyUnknownReason } from "./verify-command";

--- a/plugins/genesis-tools/skills/fable-replace/scripts/selftest.test.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/selftest.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The selftest is a standalone script so it can run from any checkout with plain `bun`.
+// This wrapper is what puts it under `bun run test` and CI. The two variables keep it
+// hermetic even if the lines inside selftest.ts that set them are ever moved.
+describe("fable-replace selftest", () => {
+    test("bun selftest.ts exits 0 and ends with ALL SELFTESTS PASSED", () => {
+        const root = join(tmpdir(), "fable-replace");
+        mkdirSync(root, { recursive: true });
+        const scratch = mkdtempSync(join(root, "selftest-wrapper-"));
+        try {
+            const result = spawnSync("bun", [join(import.meta.dir, "selftest.ts")], {
+                encoding: "utf8",
+                env: { ...process.env, GENESIS_TOOLS_HOME: scratch, TMPDIR: scratch },
+                timeout: 120_000,
+            });
+            if (result.status !== 0) {
+                console.error(result.stdout);
+                console.error(result.stderr);
+            }
+            expect(result.status).toBe(0);
+            expect(result.stdout.trim().split("\n").at(-1)).toBe("ALL SELFTESTS PASSED");
+        } finally {
+            rmSync(scratch, { recursive: true, force: true });
+        }
+    });
+});

--- a/plugins/genesis-tools/skills/fable-replace/scripts/selftest.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/selftest.ts
@@ -1,0 +1,3388 @@
+/**
+ * Self-test for replace-utils.ts. Run: bun selftest.ts
+ * Exercises every op kind, transactional abort, partial mode, dry-run,
+ * post-conditions, backup + rollback, delete/rename/create — against scratch
+ * files in a fresh temp dir. Must end with "ALL SELFTESTS PASSED".
+ */
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { collectApi } from "./api";
+import { writeBackup } from "./backup-and-rollback";
+import type { JournalEntry } from "./journal";
+import { parseJson, stringifyJson } from "./json";
+import * as barrel from "./replace-utils";
+import {
+    all,
+    applyOps,
+    changedOnDisk,
+    checkVerifyCommand,
+    countMatches,
+    countOccurrences,
+    deleteLines,
+    drop,
+    dropComments,
+    dropJsdocStarting,
+    FableReplaceError,
+    findFiles,
+    fuzzyWhitespaceRegex,
+    grepPreview,
+    leftovers,
+    looksGenerated,
+    maybe,
+    mergeFileEdits,
+    nearestHint,
+    nthIndexOf,
+    parseSpec,
+    pruneScratch,
+    renameSymbol,
+    renameSymbolAcross,
+    rollback,
+    run,
+    scanComments,
+    scratchDir,
+    scratchRoot,
+    shadowedFiles,
+    simpleDiff,
+} from "./replace-utils";
+import type { Op } from "./types";
+
+let failures = 0;
+const check = (name: string, cond: boolean, detail = ""): void => {
+    if (cond) {
+        console.log(`  ✓ ${name}`);
+    } else {
+        failures += 1;
+        console.error(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`);
+    }
+};
+
+// Hermetic: every CLI this file spawns resolves its journal home and its scratch root from
+// these two variables, so neither the standalone run nor `bun run test` can touch the real
+// ~/.genesis-tools or the real temp folder. Set before `tmp` below, which reads os.tmpdir().
+const hermeticRoot = scratchDir("selftest-home");
+process.env.GENESIS_TOOLS_HOME = hermeticRoot;
+process.env.TMPDIR = hermeticRoot;
+// Bun does not forward process.env mutations to spawned children (measured: a child of a
+// process that set X after startup sees X empty), so every CLI this file spawns gets the
+// hermetic env explicitly. Three standalone runs once wrote 48 lines into the real journal.
+const hermeticEnv = { ...process.env };
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fable-replace-selftest-"));
+const f = (name: string): string => path.join(tmp, name);
+const write = (name: string, content: string): string => {
+    fs.writeFileSync(f(name), content);
+    return f(name);
+};
+const read = (name: string): string => fs.readFileSync(f(name), "utf8");
+
+console.log(`scratch dir: ${tmp}\n`);
+
+// ── unit: helpers ────────────────────────────────────────────────────────────
+console.log("helpers");
+check("countOccurrences", countOccurrences("aXbXcX", "X") === 3);
+check("countOccurrences empty needle", countOccurrences("abc", "") === 0);
+check("nthIndexOf 2nd", nthIndexOf({ haystack: "aXbXc", needle: "X", n: 2 }) === 3);
+check("nthIndexOf missing", nthIndexOf({ haystack: "aXbXc", needle: "X", n: 3 }) === -1);
+check(
+    "simpleDiff shows change",
+    simpleDiff({ before: "a\nb\nc", after: "a\nB\nc" }).includes("- b") &&
+        simpleDiff({ before: "a\nb\nc", after: "a\nB\nc" }).includes("+ B")
+);
+
+// ── unit: applyOps ───────────────────────────────────────────────────────────
+console.log("applyOps");
+{
+    const r = applyOps("hello world", [{ find: "world", replace: "there" }]);
+    check("literal exact-once", r.content === "hello there" && r.results[0].status === "OK");
+}
+{
+    const r = applyOps("x x x", [{ find: "x", replace: "y" }]);
+    check("ambiguous literal is MISS", r.results[0].status === "MISS" && r.content === "x x x");
+}
+{
+    const r = applyOps("x x x", [all({ find: "x", replace: "y" })]);
+    check("count:all replaces every occurrence", r.content === "y y y");
+}
+{
+    const r = applyOps("x x x", [{ find: "x", replace: "y", count: 3 }]);
+    check("count:n exact", r.content === "y y y");
+}
+{
+    const r = applyOps("x x x", [{ find: "x", replace: "y", count: 2 }]);
+    check("count:n mismatch is MISS", r.results[0].status === "MISS");
+}
+{
+    const r = applyOps("abc", [maybe({ find: "zzz", replace: "q" })]);
+    check("optional non-match is SKIP", r.results[0].status === "SKIP" && r.content === "abc");
+}
+{
+    const r = applyOps("abc", [{ find: "abc", replace: "abc" }]);
+    check("no-op edit (find===replace) is MISS", r.results[0].status === "MISS");
+}
+{
+    const r = applyOps("useFoo(1) useFoo(2)", [
+        { kind: "regex", find: /useFoo\((\d)\)/g, replace: "useBar($1)", expect: 2 },
+    ]);
+    check("regex with expect", r.content === "useBar(1) useBar(2)");
+}
+{
+    const r = applyOps("useFoo(1)", [{ kind: "regex", find: /useFoo\((\d)\)/g, replace: "useBar($1)", expect: 2 }]);
+    check("regex expect mismatch is MISS", r.results[0].status === "MISS");
+}
+{
+    const r = applyOps("keep\n/**\n * junk\n * junk2\n */\nrest", [dropJsdocStarting({ fromPrefix: "/**\n * junk" })]);
+    check("dropJsdocStarting removes the block", r.content === "keep\nrest");
+}
+{
+    const r = applyOps("a START mid END b", [
+        { kind: "deleteBlock", from: "START", to: "END", keepFrom: true, keepTo: true },
+    ]);
+    check("deleteBlock keepFrom+keepTo (region between anchors goes, spaces included)", r.content === "a STARTEND b");
+}
+{
+    const r = applyOps("x A1x A2x", [{ kind: "deleteBlock", from: "A", to: "x", occurrence: 2 }]);
+    check("deleteBlock occurrence:2", r.content === "x A1x ");
+}
+{
+    const r = applyOps("head body", [{ kind: "replaceBlock", from: "head", to: "body", replace: "ALL" }]);
+    check("replaceBlock", r.content === "ALL");
+}
+{
+    const r = applyOps("import a;\ncode", [{ kind: "insertAfter", anchor: "import a;\n", text: "import b;\n" }]);
+    check("insertAfter", r.content === "import a;\nimport b;\ncode");
+}
+{
+    const r = applyOps("one two", [{ kind: "insertBefore", anchor: "two", text: "1.5 " }]);
+    check("insertBefore", r.content === "one 1.5 two");
+}
+{
+    const r = applyOps("a b", [
+        { find: "a", replace: "A" },
+        { find: "A b", replace: "A B" },
+    ]);
+    check("ops chain (later ops see earlier output)", r.content === "A B");
+}
+
+// ── integration: run() happy path with backup, then rollback ────────────────
+console.log("run(): happy path + rollback");
+{
+    write("one.ts", "const gate = getLinkGate(link);\ngetLinkGate(x);\n");
+    write("two.ts", "// old comment\nkeep();\n");
+    const backupDir = path.join(tmp, "backup1");
+    const report = await run({
+        edits: [
+            {
+                file: f("one.ts"),
+                ops: [all({ find: "getLinkGate(", replace: "getActionDisabledState(" })],
+                expectAfter: ["getActionDisabledState"],
+                absentAfter: ["getLinkGate"],
+            },
+            { file: f("two.ts"), ops: [drop({ find: "// old comment\n" })] },
+        ],
+        backupDir,
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("run ok", report.ok && report.written.length === 2);
+    check(
+        "one.ts rewritten",
+        read("one.ts") === "const gate = getActionDisabledState(link);\ngetActionDisabledState(x);\n"
+    );
+    check("two.ts comment dropped", read("two.ts") === "keep();\n");
+    rollback({ backupDir: backupDir });
+    check("rollback restored one.ts", read("one.ts").includes("getLinkGate(link)"));
+    check("rollback restored two.ts", read("two.ts") === "// old comment\nkeep();\n");
+}
+
+// ── integration: transactional abort — one MISS writes NOTHING ──────────────
+console.log("run(): transactional abort");
+{
+    write("a.ts", "alpha\n");
+    write("b.ts", "beta\n");
+    let threw = false;
+    try {
+        await run({
+            edits: [
+                { file: f("a.ts"), ops: [{ find: "alpha", replace: "ALPHA" }] },
+                { file: f("b.ts"), ops: [{ find: "DOES-NOT-EXIST", replace: "x" }] },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("aborted run throws", threw);
+    check("a.ts untouched despite its op being OK", read("a.ts") === "alpha\n");
+    check("b.ts untouched", read("b.ts") === "beta\n");
+}
+
+// ── integration: partial mode writes the clean files ────────────────────────
+console.log("run(): partial mode");
+{
+    let partialError: unknown = null;
+    try {
+        await run({
+            edits: [
+                { file: f("a.ts"), ops: [{ find: "alpha", replace: "ALPHA" }] },
+                { file: f("b.ts"), ops: [{ find: "DOES-NOT-EXIST", replace: "x" }] },
+            ],
+            verbose: false,
+            partial: true,
+            throwOnFailure: true,
+        });
+    } catch (err) {
+        partialError = err;
+    }
+    check(
+        "partial mode with a MISS still fails, code 1, after writing",
+        partialError instanceof FableReplaceError &&
+            partialError.code === 1 &&
+            partialError.message.includes("partial mode wrote 1 file(s)"),
+        String(partialError)
+    );
+    check("clean file written in partial mode", read("a.ts") === "ALPHA\n");
+    check("missed file untouched in partial mode", read("b.ts") === "beta\n");
+}
+
+// ── integration: dry run writes nothing ─────────────────────────────────────
+console.log("run(): dry run");
+{
+    write("dry.ts", "dry content\n");
+    const report = await run({
+        edits: [{ file: f("dry.ts"), ops: [{ find: "dry", replace: "wet" }] }],
+        dryRun: true,
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("dry run ok", report.ok && report.written.length === 0);
+    check("dry run wrote nothing", read("dry.ts") === "dry content\n");
+}
+
+// ── integration: post-condition failure aborts ──────────────────────────────
+console.log("run(): post-conditions");
+{
+    write("post.ts", "foo bar\n");
+    let threw = false;
+    try {
+        await run({
+            edits: [{ file: f("post.ts"), ops: [{ find: "foo", replace: "baz" }], absentAfter: ["bar"] }],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("absentAfter violation aborts", threw && read("post.ts") === "foo bar\n");
+}
+
+// ── integration: create, rename, delete ─────────────────────────────────────
+console.log("run(): file lifecycle");
+{
+    write("victim.ts", "bye\n");
+    const backupDir = path.join(tmp, "backup2");
+    const report = await run({
+        edits: [
+            {
+                file: f("new.ts"),
+                createWith: 'export const created = "FIND";\n',
+                ops: [{ find: "FIND", replace: "content" }],
+            },
+            { file: f("one.ts"), renameTo: f("renamed.ts") },
+            { file: f("victim.ts"), delete: true },
+        ],
+        backupDir,
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("lifecycle run ok", report.ok);
+    check("createWith + ops", read("new.ts") === 'export const created = "content";\n');
+    check("rename moved the file", !fs.existsSync(f("one.ts")) && fs.existsSync(f("renamed.ts")));
+    check("delete removed the file", !fs.existsSync(f("victim.ts")));
+    rollback({ backupDir: backupDir });
+    check("rollback deletes created file", !fs.existsSync(f("new.ts")));
+    check("rollback restores renamed source", fs.existsSync(f("one.ts")));
+}
+
+// ── comment scanner + higher-level ops ──────────────────────────────────────
+console.log("comment scanner + high-level ops");
+{
+    const src = `const a = "// not a comment";\n// real line comment\nconst b = \`tpl // still string \${x /* real block in interpolation */}\`;\n/* block\n comment */\ncode();\n`;
+    const spans = scanComments(src);
+    check(
+        "scanner skips comment-lookalikes in strings",
+        spans.every((s2) => !s2.text.includes("not a comment") && !s2.text.includes("still string"))
+    );
+    check(
+        "scanner finds line + block + interpolation comments",
+        spans.filter((s2) => s2.type === "line").length === 1 && spans.filter((s2) => s2.type === "block").length === 2
+    );
+}
+{
+    const src = "keep();\n// TODO old marker\nmore(); // trailing TODO old\n";
+    const r = dropComments(src, { containing: "TODO old" });
+    check(
+        "dropComments removes full-line comment incl. its line",
+        r.dropped === 2 && r.content === "keep();\nmore();\n"
+    );
+}
+{
+    const r = applyOps("a();\n// noise 1\nb();\n// noise 2\n", [
+        { kind: "dropComments", containing: "noise", expect: 2 },
+    ]);
+    check("dropComments op with expect", r.results[0].status === "OK" && r.content === "a();\nb();\n");
+}
+{
+    const r = applyOps("code();\n", [{ kind: "dropComments" } as never]);
+    check("dropComments without predicate refuses (never drop ALL)", r.results[0].status === "MISS");
+}
+{
+    const r = applyOps("keep\ndebugLog(1)\nkeep2\ndebugLog(2)\n", [
+        { kind: "deleteLines", containing: "debugLog", expect: 2 },
+    ]);
+    check("deleteLines", r.content === "keep\nkeep2\n");
+}
+{
+    const r = applyOps("if (x) {\n\t\tdoThing( a,  b );\n}", [
+        { kind: "fuzzy", find: "doThing( a, b );", replace: "doOther(a, b);" },
+    ]);
+    check("fuzzy whitespace-tolerant literal", r.content.includes("doOther(a, b);"));
+    check("fuzzyWhitespaceRegex matches across reindentation", fuzzyWhitespaceRegex("a b").test("a\n\t b"));
+}
+{
+    const r = applyOps("getFoo(); notGetFoo(); getFoo();", [
+        renameSymbol({ oldName: "getFoo", newName: "getBar", expect: 2 }),
+    ]);
+    check("renameSymbol respects word boundaries", r.content === "getBar(); notGetFoo(); getBar();");
+}
+
+// ── verifyCommand keeps the sweep on red ────────────────────────────────────
+console.log("run(): verifyCommand");
+{
+    write("vc.ts", "verify me\n");
+    const backupDir = path.join(tmp, "backup3");
+    const red = await run({
+        edits: [{ file: f("vc.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir,
+        verifyCommand: "exit 1",
+        verbose: false,
+        throwOnFailure: true,
+    }).catch((e: FableReplaceError) => e);
+    check("failing verifyCommand throws code 3", red instanceof FableReplaceError && red.code === 3, String(red));
+    check("failing verifyCommand keeps the sweep written", read("vc.ts") === "verified\n", read("vc.ts"));
+    check(
+        "the thrown error says the sweep is written and carries the verdict",
+        red instanceof FableReplaceError &&
+            red.message.includes("sweep WRITTEN") &&
+            red.report?.verify?.status === "fail" &&
+            red.report.verify.exitCode === 1,
+        String(red)
+    );
+    const undo = rollback({ backupDir });
+    check(
+        "the printed rollback restores it without --force",
+        undo.restored.length === 1 && read("vc.ts") === "verify me\n"
+    );
+
+    const ok = await run({
+        edits: [{ file: f("vc.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: path.join(tmp, "backup4"),
+        verifyCommand: "exit 0",
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("passing verifyCommand keeps the write", ok.ok && read("vc.ts") === "verified\n");
+    check("a passing verify is reported on the run", ok.verify?.status === "pass" && ok.verify.exitCode === 0);
+
+    // A check that rewrites files (a formatter) must not make the undo command fail with drift.
+    write("vc2.ts", "verify me\n");
+    const fmtDir = path.join(tmp, "backup-fmt");
+    const fmt = await run({
+        edits: [{ file: f("vc2.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: fmtDir,
+        verifyCommand: `printf 'formatted\\n' > ${f("vc2.ts")} && exit 1`,
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    const fmtUndo = rollback({ backupDir: fmtDir });
+    check(
+        "the undo works after a verify that rewrote the file",
+        fmt instanceof FableReplaceError &&
+            fmt.code === 3 &&
+            fmtUndo.drifted.length === 0 &&
+            read("vc2.ts") === "verify me\n",
+        `${String(fmt)} | drifted=${fmtUndo.drifted.length} | ${stringifyJson(read("vc2.ts"))}`
+    );
+
+    // Output limits: a pass shows a five-line tail, a fail shows head and tail, both save the rest.
+    write("vc3.ts", "verify me\n");
+    const tailDir = path.join(tmp, "backup-tail");
+    const long = await run({
+        edits: [{ file: f("vc3.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: tailDir,
+        verifyCommand: "seq 1 12",
+        verbose: false,
+    });
+    check(
+        "a passing verify shows only its last 5 lines plus a suppressed-count line",
+        long.verify?.shown.length === 6 &&
+            long.verify.shown[0].includes("7 earlier line(s) suppressed") &&
+            long.verify.shown[5] === "12",
+        stringifyJson(long.verify?.shown)
+    );
+    check(
+        "the whole verify output is saved beside the backup",
+        fs.readFileSync(path.join(tailDir, "verify-output.txt"), "utf8").trim().split("\n").length === 12
+    );
+    write("vc4.ts", "verify me\n");
+    const both = await run({
+        edits: [{ file: f("vc4.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: path.join(tmp, "backup-both"),
+        verifyCommand: "seq 1 200 && exit 1",
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    const bothShown = both instanceof FableReplaceError ? (both.report?.verify?.shown ?? []) : [];
+    check(
+        "a failing verify shows the first 40 and last 60 lines around an omitted marker",
+        bothShown.length === 101 &&
+            bothShown[0] === "1" &&
+            bothShown[40].includes("100 line(s) omitted") &&
+            bothShown[100] === "200",
+        `${bothShown.length} lines, [40]=${bothShown[40] ?? ""}`
+    );
+
+    // More output than the default 1 MB buffer must not read as a failure.
+    write("vc5.ts", "verify me\n");
+    const big = await run({
+        edits: [{ file: f("vc5.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: path.join(tmp, "backup-big"),
+        verifyCommand: `bun -e "process.stdout.write('a'.repeat(3000000))"`,
+        verbose: false,
+    });
+    check(
+        "3 MB of verify output is a pass, not ENOBUFS",
+        big.ok && big.verify?.status === "pass" && big.verify.outputChars === 3000000,
+        stringifyJson(big.verify?.status)
+    );
+
+    // A check that never returns is "unknown": still exit 3, never a test failure.
+    write("vc6.ts", "verify me\n");
+    const slow = await run({
+        edits: [{ file: f("vc6.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: path.join(tmp, "backup-slow"),
+        verifyCommand: "sleep 5",
+        verifyTimeoutMs: 300,
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a verify timeout is its own outcome: code 3, status unknown, timedOut",
+        slow instanceof FableReplaceError &&
+            slow.code === 3 &&
+            slow.report?.verify?.status === "unknown" &&
+            slow.report.verify.timedOut &&
+            slow.message.includes("could not be measured"),
+        String(slow)
+    );
+    check("the timed-out sweep stays written", read("vc6.ts") === "verified\n");
+
+    // A partial run with misses never reaches the check: exit 3 must mean everything declared landed.
+    write("vc7.ts", "verify me\n");
+    write("vc8.ts", "nothing here\n");
+    const part = await run({
+        edits: [
+            { file: f("vc7.ts"), ops: [{ find: "verify me", replace: "verified" }] },
+            { file: f("vc8.ts"), ops: [{ find: "absent needle", replace: "x" }] },
+        ],
+        backupDir: path.join(tmp, "backup-part"),
+        partial: true,
+        verifyCommand: "exit 1",
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a partial run with a MISS skips the verify and exits 1",
+        part instanceof FableReplaceError &&
+            part.code === 1 &&
+            part.report?.verify === undefined &&
+            read("vc7.ts") === "verified\n",
+        String(part)
+    );
+
+    // dryRun with a verify is refused before anything happens.
+    const dryVerify = await run({
+        edits: [{ file: f("vc7.ts"), ops: [{ find: "verified", replace: "verify me" }] }],
+        dryRun: true,
+        verifyCommand: "exit 0",
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "dryRun with a verifyCommand is a pre-flight error",
+        dryVerify instanceof FableReplaceError &&
+            dryVerify.code === 2 &&
+            dryVerify.message.includes("nothing to verify"),
+        String(dryVerify)
+    );
+}
+
+// ── verifyCommand refuses status-hiding shell operators ─────────────────────
+console.log("run(): verify command scanner");
+{
+    const refused = (cmd: string): string => checkVerifyCommand(cmd).refusal ?? "";
+    check("a pipe is refused", refused("bun run test | tail -3").includes("contains a pipe"));
+    check("a ; chain is refused", refused("bun run test; echo done").includes("chain"));
+    check("a newline is refused", refused("bun run test\necho done").includes("more than one line"));
+    check("a background & is refused", refused("bun run test &").includes("background"));
+    check("&& and || are allowed", refused("a && b || c") === "");
+    check("redirects are allowed", refused("bun run test 2>&1 >out.txt <in.txt &>all.txt") === "");
+    check(
+        "$( ), backticks and env prefixes are allowed",
+        refused("FOO=1 bun run test $(git rev-parse HEAD) `date`") === ""
+    );
+    check(
+        "a pipe inside single quotes is allowed",
+        refused("bash -c 'set -o pipefail; bun run test | tail -3'") === ""
+    );
+    check("a pipe inside double quotes is allowed", refused('bun test -t "a|b"') === "");
+    check("an escaped quote does not open a quoted region", refused('echo \\"x | cat').includes("contains a pipe"));
+    check(
+        "/dev/null warns instead of refusing",
+        checkVerifyCommand("bun run test 2>/dev/null").warning?.includes("/dev/null") === true &&
+            refused("bun run test 2>/dev/null") === ""
+    );
+    write("scan.ts", "scan me\n");
+    const piped = await run({
+        edits: [{ file: f("scan.ts"), ops: [{ find: "scan me", replace: "scanned" }] }],
+        backupDir: path.join(tmp, "backup-scan"),
+        verifyCommand: "exit 1 | cat",
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a piped verifyCommand is a pre-flight error and nothing is written",
+        piped instanceof FableReplaceError &&
+            piped.code === 2 &&
+            piped.message.includes("contains a pipe") &&
+            read("scan.ts") === "scan me\n",
+        String(piped)
+    );
+}
+
+// ── guard rails ─────────────────────────────────────────────────────────────
+console.log("guard rails");
+{
+    let threw = false;
+    try {
+        await run({
+            edits: [{ file: path.join(tmp, "node_modules", "x.ts"), ops: [{ find: "a", replace: "b" }] }],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("node_modules refused", threw);
+}
+{
+    let threw = false;
+    try {
+        await run({ edits: [{ file: f("a.ts") }], verbose: false, throwOnFailure: true });
+    } catch {
+        threw = true;
+    }
+    check("empty edit refused", threw);
+}
+{
+    let threw = false;
+    try {
+        await run({
+            edits: [
+                { file: f("a.ts"), ops: [maybe({ find: "q", replace: "r" })] },
+                { file: f("a.ts"), ops: [maybe({ find: "s", replace: "t" })] },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("duplicate file in batch refused", threw);
+}
+
+// ── regressions: the four defects found by the 2026-09-03 stress test ───────
+console.log("regressions (stress-test defects)");
+{
+    // 1. a /g predicate regex used to skip every other match (lastIndex carry-over)
+    const src4 = "log(1)\nlog(2)\nlog(3)\nlog(4)\nkeep\n";
+    const dl = deleteLines(src4, { kind: "deleteLines", matching: /log\(/g });
+    check("deleteLines with a /g regex removes EVERY match", dl.removed === 4, `removed ${dl.removed}`);
+    const dc = dropComments("// a1\nx;\n// a2\ny;\n// a3\nz;\n// a4\n", { matching: /a\d/g });
+    check("dropComments with a /g regex drops EVERY match", dc.dropped === 4, `dropped ${dc.dropped}`);
+    const shared = /DEBUG/g;
+    const across = [0, 1, 2, 3].map(
+        () => deleteLines("k\nDEBUG a\nDEBUG b\n", { kind: "deleteLines", matching: shared }).removed
+    );
+    check(
+        "one shared /g regex behaves the same across files",
+        across.every((n) => n === 2),
+        across.join(",")
+    );
+}
+{
+    // 2. renameTo used to clobber an unrelated existing file with no warning
+    write("rn-src.ts", "SOURCE\n");
+    write("rn-dst.ts", "PRECIOUS\n");
+    let threw = false;
+    try {
+        await run({
+            edits: [{ file: f("rn-src.ts"), ops: [{ find: "SOURCE", replace: "SRC" }], renameTo: f("rn-dst.ts") }],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("renameTo onto an existing file is refused", threw && read("rn-dst.ts") === "PRECIOUS\n", read("rn-dst.ts"));
+    await run({
+        edits: [
+            {
+                file: f("rn-src.ts"),
+                ops: [{ find: "SOURCE", replace: "SRC" }],
+                renameTo: f("rn-dst.ts"),
+                overwrite: true,
+            },
+        ],
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("overwrite:true allows it", read("rn-dst.ts") === "SRC\n" && !fs.existsSync(f("rn-src.ts")));
+    write("rn-a.ts", "A\n");
+    write("rn-b.ts", "B\n");
+    let threw2 = false;
+    try {
+        await run({
+            edits: [
+                { file: f("rn-a.ts"), ops: [{ find: "A", replace: "A2" }], renameTo: f("rn-x.ts") },
+                { file: f("rn-b.ts"), ops: [{ find: "B", replace: "B2" }], renameTo: f("rn-x.ts") },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw2 = true;
+    }
+    check("two edits renaming to the same path are refused", threw2);
+}
+{
+    // 3. an I/O failure mid-batch used to leave the batch half applied
+    for (let i = 0; i < 6; i += 1) {
+        write(`io${i}.ts`, `const v = "old";\n`);
+    }
+    fs.chmodSync(f("io3.ts"), 0o444);
+    let threw = false;
+    try {
+        await run({
+            edits: [0, 1, 2, 3, 4, 5].map((i) => ({
+                file: f(`io${i}.ts`),
+                ops: [{ find: `"old"`, replace: `"new"` }],
+            })),
+            verbose: false,
+            throwOnFailure: true,
+            backupDir: path.join(tmp, "iobk"),
+        });
+    } catch {
+        threw = true;
+    }
+    fs.chmodSync(f("io3.ts"), 0o644);
+    const allOld = [0, 1, 2, 3, 4, 5].every((i) => read(`io${i}.ts`).includes(`"old"`));
+    check(
+        "a failing write rolls the whole batch back",
+        threw && allOld,
+        [0, 1, 2, 3, 4, 5].map((i) => (read(`io${i}.ts`).includes("new") ? "new" : "old")).join(",")
+    );
+}
+{
+    // 4. regex literals used to desync the comment scanner for the rest of the file
+    const rx = "const RE = /\\/usr\\/bin\\//;\nconst keep = 1;\n";
+    check(
+        "a regex literal containing // is not a comment",
+        scanComments(rx).length === 0,
+        stringifyJson(scanComments(rx).map((s) => s.text))
+    );
+    const quoted = `const esc = /[&<>"']/g;\nconst u = new URL(h, "https://x/").href; // real\n`;
+    const spans = scanComments(quoted);
+    check(
+        "a regex literal containing a quote does not desync the file",
+        spans.length === 1 && spans[0].text === "// real",
+        stringifyJson(spans.map((s) => s.text))
+    );
+    const jsx = 'const d = mount(<Tabs t={t} />, "http://x/demo"); // tail\n';
+    check(
+        "JSX self-close is not a regex",
+        scanComments(jsx).length === 1,
+        stringifyJson(scanComments(jsx).map((s) => s.text))
+    );
+    const close = 'const d = <div>x</div>; const u = "http://x/"; // tail\n';
+    check(
+        "JSX closing tag is not a regex",
+        scanComments(close).length === 1,
+        stringifyJson(scanComments(close).map((s) => s.text))
+    );
+    const div = "const avg = total / count / 2; // ok\n";
+    check("division is still division", scanComments(div).length === 1);
+    const ret = "function f(s) { return /a\\/b/.test(s); } // ok\n";
+    check(
+        "a regex literal after `return` is skipped",
+        scanComments(ret).length === 1,
+        stringifyJson(scanComments(ret).map((s) => s.text))
+    );
+}
+
+// ── rollback safety (2026-09-03 edge-case pass) ─────────────────────────────
+console.log("rollback safety");
+{
+    // a hand edit made AFTER the sweep must never be silently overwritten
+    write("rb-hand.ts", "ORIGINAL\n");
+    const bd = path.join(tmp, "rb-hand-bk");
+    await run({
+        edits: [{ file: f("rb-hand.ts"), ops: [{ find: "ORIGINAL", replace: "SWEPT" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    fs.writeFileSync(f("rb-hand.ts"), "SWEPT\n// hand-written note\n");
+    const drifted = rollback({ backupDir: bd });
+    check(
+        "rollback skips a file changed after the sweep",
+        drifted.drifted.length === 1 && drifted.restored.length === 0 && read("rb-hand.ts").includes("hand-written"),
+        stringifyJson(read("rb-hand.ts"))
+    );
+    const forced = rollback({ backupDir: bd, force: true });
+    check(
+        "rollback({force:true}) restores it anyway",
+        forced.restored.length === 1 && read("rb-hand.ts") === "ORIGINAL\n",
+        stringifyJson(read("rb-hand.ts"))
+    );
+}
+{
+    // only the drifted file is skipped; its neighbours still roll back
+    write("rb-a.ts", "A\n");
+    write("rb-b.ts", "B\n");
+    const bd = path.join(tmp, "rb-pair-bk");
+    await run({
+        edits: [
+            { file: f("rb-a.ts"), ops: [{ find: "A", replace: "A2" }] },
+            { file: f("rb-b.ts"), ops: [{ find: "B", replace: "B2" }] },
+        ],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    fs.writeFileSync(f("rb-a.ts"), "A2 then hand-edited\n");
+    const rep = rollback({ backupDir: bd });
+    check(
+        "a drifted file does not block its neighbours",
+        rep.drifted.length === 1 &&
+            rep.restored.length === 1 &&
+            read("rb-b.ts") === "B\n" &&
+            read("rb-a.ts") === "A2 then hand-edited\n"
+    );
+}
+{
+    // reusing a backupDir would destroy the first snapshot — refuse before writing
+    write("rb-reuse.ts", "V1\n");
+    const bd = path.join(tmp, "rb-reuse-bk");
+    await run({
+        edits: [{ file: f("rb-reuse.ts"), ops: [{ find: "V1", replace: "V2" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    let threw = false;
+    try {
+        await run({
+            edits: [{ file: f("rb-reuse.ts"), ops: [{ find: "V2", replace: "V3" }] }],
+            verbose: false,
+            throwOnFailure: true,
+            backupDir: bd,
+        });
+    } catch {
+        threw = true;
+    }
+    check("a reused backupDir is refused in pre-flight", threw && read("rb-reuse.ts") === "V2\n", read("rb-reuse.ts"));
+    await run({
+        edits: [{ file: f("rb-reuse.ts"), ops: [{ find: "V2", replace: "V3" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+        backupOverwrite: true,
+    });
+    check("backupOverwrite:true allows deliberate reuse", read("rb-reuse.ts") === "V3\n");
+}
+{
+    // byte fidelity across CRLF / missing trailing newline / unicode
+    const shapes = {
+        "rb-crlf.ts": "a\r\nDROP\r\nb\r\n",
+        "rb-nonl.ts": "no trailing newline DROP",
+        "rb-uni.ts": "emoji 👍 DROP ünïcødé\n",
+    };
+    const bd = path.join(tmp, "rb-bytes-bk");
+    const before = Object.entries(shapes).map(([n, c]) => {
+        write(n, c);
+        return [n, fs.readFileSync(f(n))] as const;
+    });
+    await run({
+        edits: Object.keys(shapes).map((n) => ({ file: f(n), ops: [{ find: "DROP", replace: "X" }] })),
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    rollback({ backupDir: bd });
+    check(
+        "rollback is byte-exact across CRLF / no-newline / unicode",
+        before.every(([n, buf]) => buf.equals(fs.readFileSync(f(n))))
+    );
+}
+{
+    // the executable bit must survive a sweep and its rollback
+    const p = write("rb-exec.sh", "#!/bin/sh\necho old\n");
+    fs.chmodSync(p, 0o755);
+    const bd = path.join(tmp, "rb-exec-bk");
+    await run({
+        edits: [{ file: p, ops: [{ find: "echo old", replace: "echo new" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    rollback({ backupDir: bd });
+    check(
+        "the executable bit survives sweep + rollback",
+        (fs.statSync(p).mode & 0o777) === 0o755,
+        (fs.statSync(p).mode & 0o777).toString(8)
+    );
+}
+
+{
+    // two stacked sweeps must unwind newest-first; the wrong order is caught as drift
+    write("rb-stack.ts", "V1\n");
+    const bkA = path.join(tmp, "rb-stack-a");
+    const bkB = path.join(tmp, "rb-stack-b");
+    await run({
+        edits: [{ file: f("rb-stack.ts"), ops: [{ find: "V1", replace: "V2" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bkA,
+    });
+    await run({
+        edits: [{ file: f("rb-stack.ts"), ops: [{ find: "V2", replace: "V3" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bkB,
+    });
+    const wrongOrder = rollback({ backupDir: bkA });
+    check(
+        "rolling back the older sweep first is refused",
+        wrongOrder.drifted.length === 1 && read("rb-stack.ts") === "V3\n",
+        read("rb-stack.ts")
+    );
+    rollback({ backupDir: bkB });
+    rollback({ backupDir: bkA });
+    check("newest-first unwinds both sweeps to the original", read("rb-stack.ts") === "V1\n", read("rb-stack.ts"));
+}
+
+// ── leftovers(): a rename is not finished when the code is green ────────────
+console.log("leftovers");
+{
+    fs.mkdirSync(f("lo/src"), { recursive: true });
+    fs.mkdirSync(f("lo/node_modules"), { recursive: true });
+    fs.writeFileSync(f("lo/src/code.ts"), 'export { newName as oldName } from "./x";\n');
+    fs.writeFileSync(f("lo/README.md"), "Call `oldName(x)` to format.\n");
+    fs.writeFileSync(f("lo/node_modules/noise.ts"), "const oldName = 1;\n");
+    const rep = leftovers({ names: ["oldName"], dirs: [f("lo")], quiet: true });
+    check(
+        "leftovers finds the prose mention",
+        rep.docs.length === 1 && rep.docs[0].includes("README.md"),
+        stringifyJson(rep.docs)
+    );
+    check(
+        "leftovers separates the legitimate code alias",
+        rep.code.length === 1 && rep.code[0].includes("code.ts"),
+        stringifyJson(rep.code)
+    );
+    check("leftovers skips node_modules", !rep.code.concat(rep.docs).some((h) => h.includes("node_modules")));
+    check(
+        "leftovers respects word boundaries",
+        leftovers({ names: ["oldNam"], dirs: [f("lo")], quiet: true }).docs.length === 0
+    );
+    // the root the caller passes may itself sit under a directory name we skip while
+    // descending (a git worktree, a build output). It must still be scannable.
+    fs.mkdirSync(f("lo/build/nested"), { recursive: true });
+    fs.writeFileSync(f("lo/build/nested/code.ts"), "const oldName = 1;\n");
+    check(
+        "a skipped directory name is skipped while descending",
+        leftovers({ names: ["oldName"], dirs: [f("lo")], quiet: true }).code.length === 1
+    );
+    check(
+        "but that same directory is scannable as an explicit root",
+        leftovers({ names: ["oldName"], dirs: [f("lo/build")], quiet: true }).code.length === 1
+    );
+}
+
+// ── countMatches(): the numbers `expect:` rests on ─────────────────────────
+console.log("countMatches");
+{
+    write("cm-a.ts", "oldName(1); oldName(2);\nconst x = _oldName;\n");
+    write("cm-b.ts", "nothing here\n");
+    const counts = countMatches({ files: [f("cm-a.ts"), f("cm-b.ts")], pattern: "oldName", quiet: true });
+    check("identifier pattern is word-boundary matched", counts[f("cm-a.ts")] === 2, String(counts[f("cm-a.ts")]));
+    check("a zero-match file is reported as zero, not omitted", counts[f("cm-b.ts")] === 0, stringifyJson(counts));
+    write("cm-c.ts", "a.b.c and a.b.c\n");
+    check(
+        "a non-identifier string is matched literally",
+        countMatches({ files: [f("cm-c.ts")], pattern: "a.b.c", quiet: true })[f("cm-c.ts")] === 2
+    );
+    check(
+        "a non-global RegExp still counts every match",
+        countMatches({ files: [f("cm-a.ts")], pattern: /oldName/, quiet: true })[f("cm-a.ts")] === 3
+    );
+}
+
+// ── dry-run diff output is bounded across the WHOLE run ────────────────────
+console.log("dry-run diff budget");
+{
+    const files = [0, 1, 2, 3, 4].map((i) => {
+        write(
+            `dd${i}.ts`,
+            `${Array.from({ length: 60 }, (_, n) => `const v${n} = ${i};`).join("\n")}\nconst TARGET = "old";\n`
+        );
+        return f(`dd${i}.ts`);
+    });
+    const logged: string[] = [];
+    const realLog = console.log;
+    console.log = (...args: unknown[]): void => {
+        logged.push(args.join(" "));
+    };
+    try {
+        await run({
+            edits: files.map((file) => ({ file, ops: [{ find: `"old"`, replace: `"new"` }] })),
+            verbose: false,
+            dryRun: true,
+            throwOnFailure: true,
+            maxTotalDiffLines: 12,
+        });
+    } finally {
+        console.log = realLog;
+    }
+    const joined = logged.join("\n");
+    check(
+        "the total diff budget suppresses later diffs",
+        joined.includes("diffs for") && joined.includes("suppressed"),
+        joined.slice(-200)
+    );
+    check("the dry-run verdict still prints after suppression", joined.includes("DRY RUN — nothing written"));
+    check(
+        "suppression wrote nothing",
+        files.every((p) => fs.readFileSync(p, "utf8").includes('"old"'))
+    );
+}
+
+// ── the documented two-symbol overlapping rename must actually RUN ─────────
+console.log("mergeFileEdits / overlapping renames");
+{
+    write("mf-both.ts", "renderCliKeyRow(); renderCliSection();\n");
+    write("mf-a.ts", "renderCliKeyRow();\n");
+    write("mf-b.ts", "renderCliSection();\n");
+    const both = [f("mf-both.ts")];
+    // exactly the shape SKILL.md documents — without the merge this is "listed twice"
+    let threwUnmerged = false;
+    try {
+        await run({
+            edits: [
+                ...renameSymbolAcross({
+                    files: [...both, f("mf-a.ts")],
+                    oldName: "renderCliKeyRow",
+                    newName: "renderCliKeyValueRow",
+                }),
+                ...renameSymbolAcross({
+                    files: [...both, f("mf-b.ts")],
+                    oldName: "renderCliSection",
+                    newName: "renderCliSectionHeader",
+                }),
+            ],
+            verbose: false,
+            throwOnFailure: true,
+            dryRun: true,
+        });
+    } catch {
+        threwUnmerged = true;
+    }
+    check("concatenating two renameSymbolAcross calls with an overlap is refused", threwUnmerged);
+    let mergedThrew = "";
+    try {
+        await run({
+            edits: mergeFileEdits([
+                ...renameSymbolAcross({
+                    files: [...both, f("mf-a.ts")],
+                    oldName: "renderCliKeyRow",
+                    newName: "renderCliKeyValueRow",
+                }),
+                ...renameSymbolAcross({
+                    files: [...both, f("mf-b.ts")],
+                    oldName: "renderCliSection",
+                    newName: "renderCliSectionHeader",
+                }),
+            ]),
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch (err) {
+        mergedThrew = String(err).split("\n")[0];
+    }
+    check("the merged batch runs without a pre-flight refusal", mergedThrew === "", mergedThrew);
+    check(
+        "mergeFileEdits makes the documented pattern run",
+        read("mf-both.ts") === "renderCliKeyValueRow(); renderCliSectionHeader();\n",
+        read("mf-both.ts")
+    );
+    check(
+        "the non-overlapping files renamed too",
+        read("mf-a.ts").includes("renderCliKeyValueRow") && read("mf-b.ts").includes("renderCliSectionHeader")
+    );
+    check(
+        "merge unions post-conditions",
+        mergeFileEdits([
+            { file: "x.ts", ops: [maybe({ find: "a", replace: "b" })], expectAfter: ["p"] },
+            { file: "x.ts", ops: [maybe({ find: "c", replace: "d" })], absentAfter: ["q"] },
+        ])[0].expectAfter?.length === 1
+    );
+    check(
+        "merge concatenates ops in order",
+        mergeFileEdits([
+            { file: "x.ts", ops: [maybe({ find: "a", replace: "b" })] },
+            { file: "x.ts", ops: [maybe({ find: "c", replace: "d" })] },
+        ])[0].ops?.length === 2
+    );
+    let conflicted = false;
+    try {
+        mergeFileEdits([
+            { file: "x.ts", ops: [maybe({ find: "a", replace: "b" })], renameTo: "y.ts" },
+            { file: "x.ts", ops: [maybe({ find: "c", replace: "d" })], renameTo: "z.ts" },
+        ]);
+    } catch {
+        conflicted = true;
+    }
+    check("merge refuses conflicting renameTo rather than guessing", conflicted);
+    let deleteConflict = false;
+    try {
+        mergeFileEdits([
+            { file: "x.ts", delete: true },
+            { file: "x.ts", ops: [maybe({ find: "a", replace: "b" })] },
+        ]);
+    } catch {
+        deleteConflict = true;
+    }
+    check("merge refuses a delete beside ops", deleteConflict);
+}
+
+// ── generated-file guard: catches output, not files that EMIT the marker ───
+console.log("generated-file guard");
+{
+    write(
+        "gen-real.ts",
+        "// This file was automatically generated by a tool.\n// You should NOT make any changes in this file.\nexport const routes = 1;\n"
+    );
+    write(
+        "gen-emitter.ts",
+        'export const header = "# my shell hook — auto-generated, do not edit";\nexport const x = 1;\n'
+    );
+    write("gen-plain.ts", "export const x = 1;\n");
+    fs.mkdirSync(f("gensub"), { recursive: true });
+    fs.writeFileSync(f("gensub/routeTree.gen.ts"), "export const t = 1;\n");
+    check(
+        "a real generated header is caught",
+        looksGenerated(f("gen-real.ts")) !== null,
+        String(looksGenerated(f("gen-real.ts")))
+    );
+    check("a *.gen.ts path is caught", looksGenerated(f("gensub/routeTree.gen.ts")) !== null);
+    check(
+        "a file that merely EMITS the marker in a string is NOT flagged",
+        looksGenerated(f("gen-emitter.ts")) === null,
+        String(looksGenerated(f("gen-emitter.ts")))
+    );
+    check("an ordinary file is not flagged", looksGenerated(f("gen-plain.ts")) === null);
+    let refused = false;
+    try {
+        await run({
+            edits: [
+                {
+                    file: f("gen-real.ts"),
+                    ops: [{ find: "export const routes = 1;", replace: "export const routes = 2;" }],
+                },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        refused = true;
+    }
+    check("the runner refuses a generated file", refused && read("gen-real.ts").includes("routes = 1"));
+    let overrideErr = "";
+    try {
+        await run({
+            edits: [
+                {
+                    file: f("gen-real.ts"),
+                    ops: [{ find: "export const routes = 1;", replace: "export const routes = 2;" }],
+                    allowGenerated: true,
+                },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch (err) {
+        overrideErr = String(err).split("\n")[0];
+    }
+    check(
+        "per-file allowGenerated overrides it without disarming the batch",
+        overrideErr === "" && read("gen-real.ts").includes("routes = 2"),
+        overrideErr || read("gen-real.ts")
+    );
+    // the per-file flag must NOT leak to a sibling edit in the same batch
+    write("gen-real2.ts", "// automatically generated, do not edit\nexport const q = 1;\n");
+    let siblingRefused = false;
+    try {
+        await run({
+            edits: [
+                { file: f("gen-real.ts"), ops: [{ find: "routes = 2", replace: "routes = 3" }], allowGenerated: true },
+                { file: f("gen-real2.ts"), ops: [{ find: "q = 1", replace: "q = 2" }] },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        siblingRefused = true;
+    }
+    check(
+        "one file's allowGenerated does not disarm the guard for its siblings",
+        siblingRefused && read("gen-real2.ts").includes("q = 1")
+    );
+}
+
+// ── post-flight leftover gate + recon shadow warning ───────────────────────
+console.log("leftovers gate / shadow warning");
+{
+    fs.mkdirSync(f("lg/src"), { recursive: true });
+    fs.writeFileSync(f("lg/src/a.ts"), "export const oldName = 1;\n");
+    fs.writeFileSync(f("lg/README.md"), "Call `oldName()` first.\n");
+    let gated = "";
+    let gatedCode = 0;
+    try {
+        await run({
+            edits: renameSymbolAcross({ files: [f("lg/src/a.ts")], oldName: "oldName", newName: "newName" }),
+            verbose: false,
+            throwOnFailure: true,
+            backupDir: path.join(tmp, "lg-bk"),
+            leftoversCheck: { names: ["oldName"], dirs: [f("lg")] },
+        });
+    } catch (err) {
+        gated = String(err);
+        gatedCode = err instanceof FableReplaceError ? err.code : 0;
+    }
+    check("a stale prose mention fails the run", gated.includes("stale prose mention"), gated);
+    check("stale prose after a green sweep exits 3, because the code IS written", gatedCode === 3, String(gatedCode));
+    check("but the verified code is still written", fs.readFileSync(f("lg/src/a.ts"), "utf8").includes("newName"));
+    fs.writeFileSync(f("lg/README.md"), "Call `newName()` first.\n");
+    fs.writeFileSync(f("lg/src/b.ts"), "export const oldName = 2;\n");
+    const rep = await run({
+        edits: renameSymbolAcross({ files: [f("lg/src/b.ts")], oldName: "oldName", newName: "newName" }),
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: path.join(tmp, "lg-bk2"),
+        leftoversCheck: { names: ["oldName"], dirs: [f("lg")] },
+    });
+    check("clean docs pass the gate", rep.ok === true);
+    check(
+        "the backup dir is not scanned as a survivor",
+        leftovers({ names: ["oldName"], dirs: [path.join(tmp, "lg-bk")], quiet: true }).code.length === 0
+    );
+}
+{
+    // countMatches must flag a file that DECLARES the same bare name
+    write("sh-consumer.ts", "import { fmt } from './x';\nfmt(); oldName();\n");
+    write("sh-owner.ts", "function oldName() { return 1; }\noldName();\n");
+    const counts = countMatches({ files: [f("sh-consumer.ts"), f("sh-owner.ts")], pattern: "oldName", quiet: true });
+    check("both files counted", counts[f("sh-consumer.ts")] === 1 && counts[f("sh-owner.ts")] === 2);
+    const printed: string[] = [];
+    const realLog = console.log;
+    console.log = (...a: unknown[]): void => {
+        printed.push(a.join(" "));
+    };
+    try {
+        countMatches({ files: [f("sh-consumer.ts"), f("sh-owner.ts")], pattern: "oldName" });
+    } finally {
+        console.log = realLog;
+    }
+    const joined = printed.join("\n");
+    // sh-owner declares but does not import, so it lands in the "decide per file"
+    // bucket rather than the wrapper bucket — see the declaration-split test below.
+    check(
+        "a locally-declaring file is surfaced during recon",
+        joined.includes("without importing it") && joined.includes("sh-owner.ts"),
+        joined.slice(-200)
+    );
+    check(
+        "a plain consumer is not surfaced as a declarer",
+        !joined.split("without importing it")[1]?.includes("sh-consumer.ts")
+    );
+}
+{
+    const a = scratchDir("x");
+    const b = scratchDir("x");
+    check("scratchDir returns a unique path per call", a !== b && fs.existsSync(a) && fs.existsSync(b));
+}
+
+// ── findFiles(): recon must be able to START inside the API ────────────────
+console.log("findFiles");
+{
+    fs.mkdirSync(f("ff/src/deep"), { recursive: true });
+    fs.mkdirSync(f("ff/src/node_modules/pkg"), { recursive: true });
+    fs.writeFileSync(f("ff/src/hit.ts"), "export const oldName = 1;\n");
+    fs.writeFileSync(f("ff/src/deep/hit.tsx"), "oldName();\n");
+    fs.writeFileSync(f("ff/src/miss.ts"), "export const other = 1;\n");
+    fs.writeFileSync(f("ff/src/notes.md"), "oldName is documented here\n");
+    fs.writeFileSync(f("ff/src/node_modules/pkg/hit.ts"), "oldName();\n");
+    const hits = findFiles({ roots: [f("ff")], containing: /\boldName\b/ });
+    check(
+        "findFiles finds matching .ts and .tsx",
+        hits.length === 2,
+        stringifyJson(hits.map((h) => h.split("/").pop()))
+    );
+    check("findFiles skips node_modules", !hits.some((h) => h.includes("node_modules")));
+    check("findFiles excludes non-listed extensions by default", !hits.some((h) => h.endsWith(".md")));
+    const withMd = findFiles({ roots: [f("ff")], containing: /\boldName\b/, exts: [".md"] });
+    check("findFiles honours an explicit extension list", withMd.length === 1 && withMd[0].endsWith("notes.md"));
+    check("findFiles accepts a literal string", findFiles({ roots: [f("ff")], containing: "oldName" }).length === 2);
+    check(
+        "findFiles output feeds countMatches",
+        countMatches({
+            files: findFiles({ roots: [f("ff")], containing: "oldName" }),
+            pattern: "oldName",
+            quiet: true,
+        })[f("ff/src/hit.ts")] === 1
+    );
+}
+
+// ── recon fixes found by the grok round ────────────────────────────────────
+console.log("recon: leftovers on files, needle anchoring, declaration split");
+{
+    fs.mkdirSync(f("gk/src"), { recursive: true });
+    fs.writeFileSync(f("gk/README.md"), "oldName is documented here\n");
+    fs.writeFileSync(f("gk/src/imp.ts"), 'import x from "@pkg/utils/Stopwatch";\n');
+    // a FILE path must be accepted — the docs' own example passes README.md
+    let viaFile: { code: string[]; docs: string[] } = { code: [], docs: [] };
+    let viaFileErr = "";
+    try {
+        viaFile = leftovers({ names: ["oldName"], dirs: [f("gk/src"), f("gk/README.md")], quiet: true });
+    } catch (err) {
+        viaFileErr = String(err).split("\n")[0];
+    }
+    check(
+        "leftovers accepts a file path, not just a directory",
+        viaFileErr === "" && viaFile.docs.length === 1,
+        viaFileErr || stringifyJson(viaFile.docs)
+    );
+    // a non-identifier needle must NOT be word-boundary wrapped, or it silently finds nothing
+    const viaPath = leftovers({ names: ["@pkg/utils/Stopwatch"], dirs: [f("gk/src")], quiet: true });
+    check("a non-identifier needle matches literally", viaPath.code.length === 1, stringifyJson(viaPath.code));
+    // one line matching two needles is ONE surviving line
+    fs.writeFileSync(f("gk/src/two.ts"), "aaa(); bbb();\n");
+    check(
+        "a line matching two needles is counted once",
+        leftovers({ names: ["aaa", "bbb"], dirs: [f("gk/src/two.ts")], quiet: true }).code.length === 1
+    );
+}
+{
+    // the declaration warning must not cry wolf on the definition being renamed
+    write("dw-wrapper.ts", 'import { fmt as _fmt } from "./x";\nfunction fmt() { return _fmt(); }\nfmt();\n');
+    write("dw-source.ts", "export function fmt() { return 1; }\n");
+    const printed: string[] = [];
+    const realLog = console.log;
+    console.log = (...a: unknown[]): void => {
+        printed.push(a.join(" "));
+    };
+    try {
+        countMatches({ files: [f("dw-wrapper.ts"), f("dw-source.ts")], pattern: "fmt" });
+    } finally {
+        console.log = realLog;
+    }
+    const joined = printed.join("\n");
+    const wrapperLine = joined.split("both IMPORT and DECLARE")[1]?.split("·")[0] ?? "";
+    const sourceLine = joined.split("without importing it")[1] ?? "";
+    check(
+        "a file that imports AND declares is flagged as a wrapper",
+        wrapperLine.includes("dw-wrapper.ts") && !wrapperLine.includes("dw-source.ts"),
+        wrapperLine.trim()
+    );
+    check(
+        "a file that only declares is reported separately, not as a shadow",
+        sourceLine.includes("dw-source.ts"),
+        sourceLine.trim()
+    );
+}
+{
+    // renameSymbolAcross must accept the countMatches map and drop zero-match files
+    write("rm-a.ts", "oldName(); oldName();\n");
+    write("rm-b.ts", "nothing\n");
+    const counts = countMatches({ files: [f("rm-a.ts"), f("rm-b.ts")], pattern: "oldName", quiet: true });
+    const edits = renameSymbolAcross({ files: counts, oldName: "oldName", newName: "newName" });
+    check(
+        "a counts map drops zero-match files",
+        edits.length === 1 && edits[0].file === f("rm-a.ts"),
+        stringifyJson(edits.map((e) => e.file))
+    );
+    await run({ edits, verbose: false, throwOnFailure: true });
+    check("and the pinned count applies", read("rm-a.ts") === "newName(); newName();\n", read("rm-a.ts"));
+}
+
+// ── line-oriented inserts and append ─────────────────────────────────────────
+console.log("insertLines / append");
+{
+    const r = applyOps("a\nb\nc\n", [{ kind: "insertLinesAfter", anchor: "b", text: "b2\nb3" }]);
+    check(
+        "insertLinesAfter puts whole lines under the anchor line",
+        r.content === "a\nb\nb2\nb3\nc\n",
+        stringifyJson(r.content)
+    );
+    const r2 = applyOps("a\n  b = 1;\nc\n", [{ kind: "insertLinesBefore", anchor: "= 1", text: "  // note" }]);
+    check(
+        "insertLinesBefore ignores where on the line the anchor sits",
+        r2.content === "a\n  // note\n  b = 1;\nc\n",
+        stringifyJson(r2.content)
+    );
+    const r2b = applyOps("a\nb\n", [{ kind: "insertLinesAfter", anchor: "a", text: "x\n" }]);
+    check(
+        "a trailing newline in the text is a real blank line (spec bodies rely on it)",
+        r2b.content === "a\nx\n\nb\n",
+        stringifyJson(r2b.content)
+    );
+    const r3 = applyOps("a\nb\nb\n", [{ kind: "insertLinesAfter", anchor: "b", text: "x" }]);
+    check(
+        "insertLines needs a unique anchor",
+        r3.results[0].status === "MISS" && (r3.results[0].reason ?? "").includes("2×")
+    );
+    const r6 = applyOps("a\nb\nc\nd\n", [{ kind: "insertLinesAfter", anchor: "b\nc", text: "X" }]);
+    check(
+        "insertLinesAfter with a multi-line anchor goes below the anchor's LAST line",
+        r6.content === "a\nb\nc\nX\nd\n",
+        stringifyJson(r6.content)
+    );
+    const r7 = applyOps("a\nb\nc\nd\n", [{ kind: "insertLinesBefore", anchor: "b\nc", text: "X" }]);
+    check(
+        "insertLinesBefore with a multi-line anchor goes above the anchor's FIRST line",
+        r7.content === "a\nX\nb\nc\nd\n",
+        stringifyJson(r7.content)
+    );
+    const r4 = applyOps("a", [{ kind: "append", text: "z" }]);
+    check("append adds the newline between and at the end", r4.content === "a\nz\n", stringifyJson(r4.content));
+    const r5 = applyOps("a\n", [{ kind: "append", text: "z\n" }]);
+    check("append never doubles a newline", r5.content === "a\nz\n", stringifyJson(r5.content));
+}
+
+// ── nearestHint: a MISS says where to look ──────────────────────────────────
+console.log("nearestHint");
+{
+    const src = "one\n    two = 2;\nthree\n";
+    check(
+        "already applied",
+        nearestHint({ content: src, needle: "two = 1;", replacement: "two = 2;" }).includes("already")
+    );
+    check("whitespace-only drift → fuzzy hint", nearestHint({ content: src, needle: "two=2;" }).includes("whitespace"));
+    check("case typo → case hint", nearestHint({ content: src, needle: "    Two = 2;" }).includes("case"));
+    check("divergence line named", nearestHint({ content: src, needle: "one\nnope" }).includes("diverges at line 2"));
+    check(
+        "zero-vs-some whitespace still counts as whitespace drift",
+        nearestHint({ content: "a = b;", needle: "a=b;" }).includes("whitespace")
+    );
+    check("nothing similar → re-read", nearestHint({ content: src, needle: "zebra crossing" }).includes("Re-read"));
+    const r = applyOps(src, [{ find: "two = 3;", replace: "two = 4;" }]);
+    check("literal MISS reason carries the hint", (r.results[0].reason ?? "").includes("needle not found."));
+}
+
+// ── parseSpec: the CLI's marker format ──────────────────────────────────────
+console.log("parseSpec");
+{
+    const edits = parseSpec({
+        text: [
+            "# comment",
+            "@@ a.ts",
+            "expect: after",
+            "absent: before",
+            "<<<",
+            "before",
+            "===",
+            "after",
+            ">>>",
+            "<<< count=all optional label=every one",
+            "x",
+            "===",
+            "y",
+            ">>>",
+            "<<< regex flags=i count=2",
+            "foo(\\d)",
+            "===",
+            "bar($1)",
+            ">>>",
+            "<<< after",
+            "anchor",
+            "===",
+            "line1",
+            "line2",
+            ">>>",
+            "<<< append",
+            "tail",
+            ">>>",
+            "<<< delete",
+            "gone",
+            ">>>",
+            "<<< block",
+            "/**",
+            "===",
+            " */",
+            "===",
+            ">>>",
+            "@@ b.ts",
+            "<<< create",
+            "fresh",
+            ">>>",
+        ].join("\n"),
+    });
+    check("two file sections", edits.length === 2 && edits[0].file === "a.ts" && edits[1].file === "b.ts");
+    check("post-conditions parsed", edits[0].expectAfter?.[0] === "after" && edits[0].absentAfter?.[0] === "before");
+    const ops = edits[0].ops ?? [];
+    check(
+        "literal op",
+        ops[0] !== undefined &&
+            "find" in ops[0] &&
+            ops[0].find === "before" &&
+            (ops[0] as { replace: string }).replace === "after"
+    );
+    check(
+        "count=all optional label",
+        "count" in ops[1] && ops[1].count === "all" && ops[1].optional === true && ops[1].label === "every one"
+    );
+    check(
+        "regex op with flags and pinned count",
+        ops[2].kind === "regex" &&
+            ops[2].find.flags.includes("i") &&
+            ops[2].find.flags.includes("g") &&
+            ops[2].expect === 2
+    );
+    check(
+        "after → insertLinesAfter with multi-line text",
+        ops[3].kind === "insertLinesAfter" && ops[3].text === "line1\nline2"
+    );
+    check("append", ops[4].kind === "append" && ops[4].text === "tail");
+    check(
+        "delete → literal with newline, empty replace",
+        "find" in ops[5] && ops[5].find === "gone\n" && (ops[5] as { replace: string }).replace === ""
+    );
+    check("block with empty replacement → deleteBlock", ops[6].kind === "deleteBlock");
+    check("create → createWith with trailing newline", edits[1].createWith === "fresh\n" && edits[1].ops === undefined);
+    let err = "";
+    try {
+        parseSpec({ text: "@@ a.ts\n<<< nope\nx\n===\ny\n>>>" });
+    } catch (e) {
+        err = String(e);
+    }
+    check("unknown modifier names the line", err.includes("line 2") && err.includes("nope"));
+    err = "";
+    try {
+        parseSpec({ text: "@@ a.ts\n<<<\nx\n" });
+    } catch (e) {
+        err = String(e);
+    }
+    check("unclosed block is an error", err.includes("never closed"));
+    err = "";
+    try {
+        parseSpec({ text: "<<<\nx\n===\ny\n>>>" });
+    } catch (e) {
+        err = String(e);
+    }
+    check("op before @@ is an error", err.includes("before any @@"));
+    const json = parseSpec({
+        text: '[{"file":"j.ts","ops":[{"kind":"regex","find":"a(\\\\d)","flags":"g","replace":"b$1"}]}]',
+    });
+    check(
+        "JSON spec with a regex op",
+        json[0].ops?.[0].kind === "regex" && (json[0].ops[0] as { find: RegExp }).find.source === "a(\\d)"
+    );
+}
+
+// ── cli.ts end to end ───────────────────────────────────────────────────────
+console.log("cli.ts");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("cli");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "t.ts"), "const a = 1;\nconst b = 2;\n");
+    const runCli = (spec: string, ...args: string[]): { status: number | null; out: string } => {
+        const p = spawnSync("bun", [cli, ...args], { cwd: dir, input: spec, encoding: "utf8", env: hermeticEnv });
+        return { status: p.status, out: `${p.stdout}\n${p.stderr}` };
+    };
+    const ok = runCli(
+        "@@ t.ts\n<<<\nconst a = 1;\n===\nconst a = 10;\n>>>\n<<< append\nexport {};\n>>>\n@@ n.ts\n<<< create\nexport const n = 1;\n>>>\n"
+    );
+    check(
+        "cli: ok run exits 0 and writes",
+        ok.status === 0 &&
+            read("cli/t.ts") === "const a = 10;\nconst b = 2;\nexport {};\n" &&
+            read("cli/n.ts") === "export const n = 1;\n",
+        ok.out
+    );
+    check(
+        "cli: ok run reports OK lines and a backup dir",
+        ok.out.includes("OK") && ok.out.includes("Backed up") && ok.out.includes("SWEEP COMPLETE")
+    );
+    const miss = runCli(
+        "@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n<<<\nconst zz = 9;\n===\nconst zz = 8;\n>>>\n"
+    );
+    check(
+        "cli: one MISS aborts the batch, exit 1, nothing written",
+        miss.status === 1 &&
+            read("cli/t.ts").includes("const b = 2;") &&
+            miss.out.includes("MISS") &&
+            miss.out.includes("wrote NOTHING")
+    );
+    const dry = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--dry");
+    check(
+        "cli: --dry prints a diff and writes nothing",
+        dry.status === 0 && dry.out.includes("+ const b = 3;") && read("cli/t.ts").includes("const b = 2;")
+    );
+    const clash = runCli("@@ t.ts\n<<< create\nx\n>>>\n");
+    check("cli: create refuses an existing file", clash.status === 1 && clash.out.includes("refuses to overwrite"));
+    const bad = runCli("@@ t.ts\n<<< wat\nx\n===\ny\n>>>\n");
+    check(
+        "cli: spec error exits 2 with the line",
+        bad.status === 2 && bad.out.includes("SPEC ERROR") && bad.out.includes("line 2")
+    );
+    const verify = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--verify", "exit 1");
+    const undoLine = verify.out.match(/--rollback "([^"]+)"/)?.[1];
+    check(
+        "cli: a red --verify keeps the write, exits 3 and prints the undo command",
+        verify.status === 3 &&
+            read("cli/t.ts").includes("const b = 3;") &&
+            verify.out.includes("SWEEP WRITTEN, VERIFY FAILED (exit 1)") &&
+            undoLine !== undefined,
+        `${String(verify.status)} ${verify.out.slice(-400)}`
+    );
+    const undone = runCli("", "--rollback", undoLine ?? "/nonexistent");
+    check(
+        "cli: the printed --rollback line restores the file",
+        undone.status === 0 && read("cli/t.ts").includes("const b = 2;"),
+        undone.out
+    );
+    const dryVerify = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--dry", "--verify", "exit 0");
+    check(
+        "cli: --dry with --verify is refused, exit 2, nothing written",
+        dryVerify.status === 2 &&
+            dryVerify.out.includes("nothing to verify") &&
+            read("cli/t.ts").includes("const b = 2;"),
+        dryVerify.out
+    );
+    const piped = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--verify", "bun run test | tail -3");
+    check(
+        "cli: --verify with a pipe is refused, exit 2, nothing written",
+        piped.status === 2 &&
+            piped.out.includes("contains a pipe") &&
+            piped.out.includes("pipefail") &&
+            read("cli/t.ts").includes("const b = 2;"),
+        piped.out
+    );
+    const devnull = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--verify", "exit 0 2>/dev/null");
+    check(
+        "cli: --verify with /dev/null warns and still runs",
+        devnull.status === 0 &&
+            devnull.out.includes("WARNING") &&
+            devnull.out.includes("/dev/null") &&
+            read("cli/t.ts").includes("const b = 3;"),
+        devnull.out
+    );
+    const api = spawnSync("bun", [cli, "--api"], { encoding: "utf8" });
+    check(
+        "cli: --api lists params interfaces with docs",
+        api.status === 0 &&
+            api.stdout.includes("interface RunParams") &&
+            api.stdout.includes("interface LiteralOp") &&
+            api.stdout.includes("parseSpec = (")
+    );
+}
+// ── round 2: what ten stress-test agents tripped over ───────────────────────
+console.log("round 2: run() contract");
+{
+    let err: unknown = null;
+    try {
+        await run({
+            edits: [{ file: f("a.ts"), ops: [{ find: "ALPHA", replace: "A" }] }],
+            verbose: false,
+            ...({ dry: true } as object),
+        });
+    } catch (e) {
+        err = e;
+    }
+    check(
+        "an unknown option key is a pre-flight error (code 2) with a hint",
+        err instanceof FableReplaceError &&
+            err.code === 2 &&
+            err.message.includes('unknown option "dry"') &&
+            err.message.includes("dryRun"),
+        String(err)
+    );
+    err = null;
+    try {
+        await run({
+            edits: [{ file: f("a.ts"), ops: [{ find: "NOPE-NOPE", replace: "A" }] }],
+            verbose: false,
+            dryRun: true,
+        });
+    } catch (e) {
+        err = e;
+    }
+    check(
+        "a dry run with a MISS throws code 1 (default throwOnFailure)",
+        err instanceof FableReplaceError && err.code === 1 && err.message.includes("dry run"),
+        String(err)
+    );
+}
+
+console.log("round 2: ops");
+{
+    const r = applyOps("/** a */\nx\n/** a */\ny\n", [{ kind: "deleteBlock", from: "/** a", to: " */\n" }]);
+    check(
+        "deleteBlock with a non-unique from anchor is a MISS naming the lines",
+        r.results[0].status === "MISS" &&
+            (r.results[0].reason ?? "").includes("occurs 2×") &&
+            (r.results[0].reason ?? "").includes("lines 1, 3"),
+        r.results[0].reason
+    );
+    const r2 = applyOps("/** a */\nx\n/** a */\ny\n", [
+        { kind: "deleteBlock", from: "/** a", to: " */\n", occurrence: 2 },
+    ]);
+    check(
+        "…unless occurrence is given",
+        r2.results[0].status === "OK" && r2.content === "/** a */\nx\ny\n",
+        stringifyJson(r2.content)
+    );
+    const r3 = applyOps("a\n        foo();\n", [{ kind: "insertLinesAfter", anchor: "    foo();", text: "bar();" }]);
+    check(
+        "an indented anchor must match at the start of a line",
+        r3.results[0].status === "MISS" && (r3.results[0].reason ?? "").includes("never at the start of a line"),
+        r3.results[0].reason
+    );
+    const r4 = applyOps("a\n    foo();\n", [
+        { kind: "insertLinesAfter", anchor: "    foo();", text: "    foo();\n    bar();" },
+    ]);
+    check(
+        "repeating the anchor inside the inserted text is flagged in the report",
+        r4.results[0].status === "OK" &&
+            r4.results[0].desc.includes("⚠") &&
+            r4.results[0].desc.includes("KEEP the anchor"),
+        r4.results[0].desc
+    );
+    const r5 = applyOps("x\nx\nx\n", [{ find: "x", replace: "y", count: 2 }]);
+    check(
+        "count mismatch lists the lines found",
+        (r5.results[0].reason ?? "").includes("at line(s) 1, 2, 3"),
+        r5.results[0].reason
+    );
+    const r6 = applyOps("a1 a2 a3", [{ kind: "regex", find: /a\d/g, replace: "b", expect: 2 }]);
+    check(
+        "regex expect mismatch lists the lines found",
+        (r6.results[0].reason ?? "").includes("at line(s) 1, 1, 1"),
+        r6.results[0].reason
+    );
+    const accented = "Doručená";
+    check(
+        "NFD vs NFC needle gets a normalization hint",
+        nearestHint({ content: `${accented.normalize("NFC")}\n`, needle: accented.normalize("NFD") }).includes(
+            "Unicode normalization"
+        )
+    );
+}
+
+console.log("round 2: recon and rename guards");
+{
+    fs.mkdirSync(f("r2/src"), { recursive: true });
+    write("r2/src/lib.ts", "export const oldName = 1;\n");
+    write("r2/src/use.ts", 'import { oldName } from "./lib";\nconsole.log(oldName);\n');
+    write(
+        "r2/src/wrap.ts",
+        'import { oldName as base } from "./lib";\nconst oldName = () => base;\nexport { oldName };\n'
+    );
+    write("r2/README.md", "See oldName.\n");
+    const viaFileRoot = findFiles({ roots: [f("r2/README.md"), f("r2/src")], containing: "oldName", exts: [] });
+    check(
+        "findFiles accepts a plain file as a root",
+        viaFileRoot.includes(f("r2/README.md")) && viaFileRoot.length === 4,
+        stringifyJson(viaFileRoot)
+    );
+    const split = shadowedFiles({
+        files: [f("r2/src/lib.ts"), f("r2/src/use.ts"), f("r2/src/wrap.ts")],
+        name: "oldName",
+    });
+    check(
+        "shadowedFiles splits wrapper vs definer",
+        split.shadows.length === 1 &&
+            split.shadows[0].endsWith("wrap.ts") &&
+            split.declarers.length === 1 &&
+            split.declarers[0].endsWith("lib.ts")
+    );
+    let err: unknown = null;
+    try {
+        renameSymbolAcross({
+            files: [f("r2/src/use.ts"), f("r2/src/wrap.ts")],
+            oldName: "oldName",
+            newName: "newName",
+        });
+    } catch (e) {
+        err = e;
+    }
+    check(
+        "renameSymbolAcross refuses a shadowing wrapper (code 2)",
+        err instanceof FableReplaceError &&
+            err.code === 2 &&
+            err.message.includes("wrap.ts") &&
+            err.message.includes("includeShadowed"),
+        String(err)
+    );
+    const forced = renameSymbolAcross({
+        files: [f("r2/src/wrap.ts")],
+        oldName: "oldName",
+        newName: "newName",
+        includeShadowed: true,
+    });
+    check("…unless includeShadowed is passed", forced.length === 1);
+}
+
+console.log("round 2: rollback");
+{
+    write("r2-rb.ts", "ORIGINAL\n");
+    const bd = path.join(tmp, "r2-bk");
+    await run({
+        edits: [{ file: f("r2-rb.ts"), ops: [{ find: "ORIGINAL", replace: "SWEPT" }] }],
+        verbose: false,
+        backupDir: bd,
+    });
+    const first = rollback({ backupDir: bd });
+    const second = rollback({ backupDir: bd });
+    check(
+        "rolling back twice is a no-op, not drift",
+        first.restored.length === 1 &&
+            second.drifted.length === 0 &&
+            second.restored.length === 1 &&
+            read("r2-rb.ts") === "ORIGINAL\n",
+        stringifyJson(second)
+    );
+}
+
+console.log("round 2: spec parser");
+{
+    const edits = parseSpec({ text: "@@ a.md\n<<<\nx\n===\nline\n\\===\n\\>>>\nend\n>>>\n" });
+    const op = edits[0].ops?.[0] as { replace: string };
+    check("\\=== and \\>>> in a body are unescaped", op.replace === "line\n===\n>>>\nend", stringifyJson(op.replace));
+    const tryParse = (text: string): string => {
+        try {
+            parseSpec({ text });
+            return "";
+        } catch (e) {
+            return String(e);
+        }
+    };
+    const extra = tryParse("@@ a.md\n<<<\nx\n===\ny\n===\nz\n>>>\n");
+    check(
+        "an extra === names ITS line, not the op line",
+        extra.includes("spec line 6") && extra.includes("\\==="),
+        extra
+    );
+    check(
+        "a diff hunk header after a bare >>> is diagnosed",
+        tryParse("@@ a.md\n<<<\nx\n===\ny\n>>>\n@@ -1,2 +1,2 @@\n").includes("diff hunk header")
+    );
+    check("count=0 is a spec error", tryParse("@@ a.md\n<<< count=0\nx\n===\ny\n>>>\n").includes("positive"));
+    const badRx = tryParse("@@ a.md\n<<< regex\n(x\n===\ny\n>>>\n");
+    check(
+        "an invalid regex names the spec line",
+        badRx.includes("spec line 2") && badRx.includes("invalid regex"),
+        badRx
+    );
+    check(
+        "invalid flags name the spec line",
+        tryParse("@@ a.md\n<<< regex flags=q\nx\n===\ny\n>>>\n").includes("spec line 2")
+    );
+    const backspace = String.fromCharCode(8);
+    check(
+        "a control character in a body is a spec error with the printf hint",
+        tryParse(`@@ a.md\n<<< regex\n${backspace}old\n===\ny\n>>>\n`).includes("printf")
+    );
+    const warnings: string[] = [];
+    parseSpec({ text: "@@ a.md\n<<< after\nanchor\n===\n```ts\ncode\n>>>\n", onWarning: (m) => warnings.push(m) });
+    check(
+        "an unbalanced code fence warns about a bare >>>",
+        warnings.length === 1 && warnings[0].includes("\\>>>"),
+        stringifyJson(warnings)
+    );
+    const fragmentWarnings: string[] = [];
+    parseSpec({
+        text: "@@ doc.md\n<<< block\n# Old\n===\nold\n```\n===\n# New\n```sh\nnew\n```\n>>>\n",
+        onWarning: (m) => fragmentWarnings.push(m),
+    });
+    parseSpec({ text: "@@ a.md\n<<<\n```sh\n===\n```bash\n>>>\n", onWarning: (m) => fragmentWarnings.push(m) });
+    parseSpec({
+        text: "@@ a.md\n<<< after\nanchor\n===\ncode\n```\n>>>\n",
+        onWarning: (m) => fragmentWarnings.push(m),
+    });
+    check(
+        "a closing fence in a block end-anchor, a fence-only body and a body ending on a fence do not warn",
+        fragmentWarnings.length === 0,
+        stringifyJson(fragmentWarnings)
+    );
+    const truncated: string[] = [];
+    parseSpec({
+        text: "@@ doc.md\n<<< block\n# Old\n===\nold\n```\n===\n# New\n```sh\nnew\n>>>\n",
+        onWarning: (m) => truncated.push(m),
+    });
+    check(
+        "a block whose last body ends inside an open fence still warns, naming the fence line",
+        truncated.length === 1 && truncated[0].includes("opened at its line 2") && truncated[0].includes("\\>>>"),
+        stringifyJson(truncated)
+    );
+}
+
+console.log("round 2: cli");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("cli2");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "t.ts"), "const a = 1;\n");
+    const runCli = (spec: string, ...args: string[]): { status: number | null; out: string } => {
+        const p = spawnSync("bun", [cli, ...args], { cwd: dir, input: spec, encoding: "utf8", env: hermeticEnv });
+        return { status: p.status, out: `${p.stdout}\n${p.stderr}` };
+    };
+    const typo = runCli("@@ t.ts\n<<<\nconst a = 1;\n===\nconst a = 2;\n>>>\n", "--dyr");
+    check(
+        "cli: an unknown flag exits 2 and writes nothing",
+        typo.status === 2 && typo.out.includes('unknown argument "--dyr"') && read("cli2/t.ts") === "const a = 1;\n",
+        typo.out
+    );
+    const dryMiss = runCli("@@ t.ts\n<<<\nconst zz = 1;\n===\nconst zz = 2;\n>>>\n", "--dry");
+    check("cli: --dry with a MISS exits 1", dryMiss.status === 1 && dryMiss.out.includes("MISS"), dryMiss.out);
+    const missing = runCli("", "--spec", path.join(dir, "nope.txt"));
+    check(
+        "cli: a missing --spec file is a clean SPEC ERROR, exit 2",
+        missing.status === 2 && missing.out.includes("SPEC ERROR") && !missing.out.includes("    at "),
+        missing.out
+    );
+    const real = runCli("@@ t.ts\n<<<\nconst a = 1;\n===\nconst a = 2;\n>>>\n");
+    const bk = real.out.match(/Backed up 1 path\(s\) to (\S+)/)?.[1];
+    check("cli: a real run prints its backup dir", real.status === 0 && bk !== undefined, real.out);
+    const rb = runCli("", "--rollback", bk ?? "/nonexistent");
+    check(
+        "cli: --rollback restores from that dir",
+        rb.status === 0 && read("cli2/t.ts") === "const a = 1;\n" && rb.out.includes("restored"),
+        rb.out
+    );
+    const rbBad = runCli("", "--rollback", path.join(dir, "not-a-backup"));
+    check(
+        "cli: --rollback on a non-backup dir is a clean error, exit 2",
+        rbBad.status === 2 && rbBad.out.includes("ROLLBACK ERROR"),
+        rbBad.out
+    );
+    const api = spawnSync("bun", [cli, "--api"], { encoding: "utf8" });
+    const apiLines = api.stdout.split("\n");
+    check(
+        "cli: --api has no duplicate entries and no function bodies",
+        apiLines.filter((l) => l.startsWith("scratchDir = ")).length === 1 &&
+            !api.stdout.includes("mkdtempSync") &&
+            apiLines.length < 900,
+        String(apiLines.length)
+    );
+    const apiQ = spawnSync("bun", [cli, "--api", "rollback"], { encoding: "utf8" });
+    check(
+        "cli: --api <query> narrows to matching names",
+        apiQ.stdout.includes("rollback = (") && !apiQ.stdout.includes("interface LiteralOp"),
+        apiQ.stdout.slice(0, 200)
+    );
+}
+
+console.log("round 3: error payload and recon guards");
+{
+    write("rp-good.ts", "const a = 1;\n");
+    write("rp-bad.ts", "const b = 2;\n");
+    let caught: FableReplaceError | undefined;
+    try {
+        await run({
+            edits: [
+                { file: f("rp-good.ts"), ops: [{ find: "const a = 1;", replace: "const a = 9;" }] },
+                { file: f("rp-bad.ts"), ops: [{ find: "NOT THERE", replace: "x" }] },
+            ],
+            partial: true,
+        });
+    } catch (e) {
+        caught = e as FableReplaceError;
+    }
+
+    check("a partial failure throws with a report attached", caught?.report !== undefined, String(caught?.message));
+    check(
+        "the attached report carries missCount and written",
+        caught?.report?.missCount === 1 && caught?.report?.written.length === 1 && caught?.report?.ok === false,
+        stringifyJson({ miss: caught?.report?.missCount, written: caught?.report?.written.length })
+    );
+
+    let guarded = "";
+    try {
+        // The type says `containing` is required; a throwaway JS script can still omit it.
+        (findFiles as unknown as (p: { roots: string[] }) => string[])({ roots: [tmp] });
+    } catch (e) {
+        guarded = String(e);
+    }
+
+    check("findFiles without `containing` throws instead of returning []", guarded.includes("is required"), guarded);
+    check(
+        "findFiles with `containing` still works",
+        findFiles({ roots: [tmp], containing: "const a = 9;" }).length === 1
+    );
+
+    // A literal needle is a SUBSTRING match: less indentation than the file still matches
+    // (and the file's own indentation survives), more indentation MISSes. SKILL.md says so;
+    // this pins the asymmetry so the doc cannot drift away from the behaviour.
+    write("ind.ts", "function g() {\n    const v = 1;\n}\n");
+    const under = await run({
+        edits: [{ file: f("ind.ts"), ops: [{ find: "  const v = 1;", replace: "  const v = 2;" }] }],
+    });
+    check(
+        "an under-indented literal needle matches and keeps the file's indentation",
+        under.ok && read("ind.ts") === "function g() {\n    const v = 2;\n}\n",
+        stringifyJson(read("ind.ts"))
+    );
+    const over = await run({
+        edits: [{ file: f("ind.ts"), ops: [{ find: "      const v = 2;", replace: "x" }] }],
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "an over-indented literal needle MISSes with the whitespace hint",
+        read("ind.ts").includes("    const v = 2;"),
+        String(over)
+    );
+
+    const apiCli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const apiOut = spawnSync("bun", [apiCli, "--api", "rollback"], { encoding: "utf8" });
+    check(
+        "cli: --api names the import path, not just the defining file",
+        apiOut.stdout.includes('from "') &&
+            apiOut.stdout.includes("replace-utils") &&
+            apiOut.stdout.includes("## backup-and-rollback.ts"),
+        apiOut.stdout.split("\n").slice(0, 3).join(" | ")
+    );
+
+    // count=N used to re-search the MUTATED text, so a replacement containing the needle
+    // wrapped the first hit twice, skipped the second, and still reported OK ×2 of 2.
+    write("selfwrap.ts", "const a = oldName(1);\nconst b = oldName(2);\n");
+    const wrapped = await run({
+        edits: [{ file: f("selfwrap.ts"), ops: [{ find: "oldName", replace: "wrapper(oldName)", count: 2 }] }],
+    });
+    check(
+        "count=N with a self-containing replacement hits each occurrence once",
+        wrapped.ok && read("selfwrap.ts") === "const a = wrapper(oldName)(1);\nconst b = wrapper(oldName)(2);\n",
+        stringifyJson(read("selfwrap.ts"))
+    );
+
+    // An empty `containing` matched every line/comment and wiped the file, reporting OK.
+    const wipeLines = applyOps("a\nb\nc\n", [{ kind: "deleteLines", containing: "" } as unknown as Op]);
+    check(
+        "deleteLines with an empty `containing` refuses instead of wiping the file",
+        wipeLines.content === "a\nb\nc\n" && wipeLines.results[0].status === "MISS",
+        stringifyJson(wipeLines.results[0])
+    );
+    const wipeComments = applyOps("// keep\nx = 1; // also\n", [
+        { kind: "dropComments", containing: "" } as unknown as Op,
+    ]);
+    check(
+        "dropComments with an empty `containing` refuses instead of dropping all",
+        wipeComments.content === "// keep\nx = 1; // also\n" && wipeComments.results[0].status === "MISS",
+        stringifyJson(wipeComments.results[0])
+    );
+
+    // Inserted lines take the file's own line ending, so a CRLF file stays all-CRLF.
+    const crlf = applyOps("line1\r\nline2\r\nline3\r\n", [
+        { kind: "insertLinesAfter", anchor: "line2", text: "NEWLINE" } as unknown as Op,
+    ]);
+    check(
+        "an insert into a CRLF file uses CRLF",
+        crlf.content === "line1\r\nline2\r\nNEWLINE\r\nline3\r\n",
+        stringifyJson(crlf.content)
+    );
+    const appended = applyOps("line1\r\n", [{ kind: "append", text: "tail" } as unknown as Op]);
+    check(
+        "an append to a CRLF file uses CRLF",
+        appended.content === "line1\r\ntail\r\n",
+        stringifyJson(appended.content)
+    );
+
+    // A restore blocked on ONE file used to abandon every later entry, leaving swept
+    // content live. Each entry is now restored inside its own guard.
+    write("st-a.ts", "const a = 1;\n");
+    write("st-b.ts", "const b = 2;\n");
+    write("st-c.ts", "const c = 3;\n");
+    const strandDir = scratchDir("selftest-strand");
+    await run({
+        edits: [
+            { file: f("st-a.ts"), ops: [{ find: "const a = 1;", replace: "const a = 100;" }] },
+            { file: f("st-b.ts"), ops: [{ find: "const b = 2;", replace: "const b = 200;" }] },
+            { file: f("st-c.ts"), ops: [{ find: "const c = 3;", replace: "const c = 300;" }] },
+        ],
+        backupDir: strandDir,
+        verbose: false,
+    });
+    fs.chmodSync(f("st-b.ts"), 0o444);
+    const strandReport = rollback({ backupDir: strandDir, force: true });
+    check(
+        "a rollback blocked on one file still restores the others",
+        read("st-a.ts") === "const a = 1;\n" && read("st-c.ts") === "const c = 3;\n",
+        `${read("st-a.ts")} | ${read("st-c.ts")}`
+    );
+    check(
+        "the blocked file is named in the rollback report, not silently stranded",
+        strandReport.failed.length === 1 &&
+            strandReport.failed[0].file.endsWith("st-b.ts") &&
+            read("st-b.ts") === "const b = 200;\n",
+        stringifyJson(strandReport.failed)
+    );
+    fs.chmodSync(f("st-b.ts"), 0o644);
+
+    // A rename used to write a fresh 644 file, dropping the executable bit.
+    const modeSrc = write("mode-src.ts", "export const x = 1;\n");
+    fs.chmodSync(modeSrc, 0o750);
+    await run({
+        edits: [
+            {
+                file: modeSrc,
+                renameTo: f("mode-dst.ts"),
+                ops: [{ find: "export const x = 1;", replace: "export const x = 2;" }],
+            },
+        ],
+    });
+    check(
+        "renameTo carries the source file's permission bits",
+        (fs.statSync(f("mode-dst.ts")).mode & 0o777) === 0o750,
+        (fs.statSync(f("mode-dst.ts")).mode & 0o777).toString(8)
+    );
+
+    // Restoring a file that already matches the backup must be a no-op, not an mtime bump.
+    const quietDir = scratchDir("selftest-quiet-rollback");
+    write("quiet.ts", "const q = 1;\n");
+    await run({
+        edits: [{ file: f("quiet.ts"), ops: [{ find: "const q = 1;", replace: "const q = 2;" }] }],
+        backupDir: quietDir,
+    });
+    rollback({ backupDir: quietDir });
+    const mtimeAfterFirst = fs.statSync(f("quiet.ts")).mtimeMs;
+    rollback({ backupDir: quietDir, force: true });
+    check(
+        "a second rollback does not touch a file already at its original content",
+        fs.statSync(f("quiet.ts")).mtimeMs === mtimeAfterFirst,
+        `${mtimeAfterFirst} vs ${fs.statSync(f("quiet.ts")).mtimeMs}`
+    );
+
+    const parseErr = (text: string): string => {
+        try {
+            parseSpec({ text });
+            return "";
+        } catch (e) {
+            return String(e);
+        }
+    };
+
+    // `label=` eats the rest of the line: a modifier written after it silently vanished and
+    // the op ran as a plain literal, matching something unrelated and reporting OK.
+    const swallowed = parseErr("@@ a.md\n<<< label=see ticket 123, regex flags=g\nfo+\n===\nMATCHED\n>>>\n");
+    check(
+        "a modifier absorbed by label= is a spec error",
+        swallowed.includes("absorbed into the label") && swallowed.includes("spec line 2"),
+        swallowed
+    );
+    check(
+        "a quoted label keeps a modifier word as text",
+        (
+            parseSpec({ text: '@@ a.md\n<<< label="cleanup, regex noise"\nx\n===\ny\n>>>\n' })[0].ops?.[0] as {
+                label?: string;
+            }
+        ).label === "cleanup, regex noise"
+    );
+    check(
+        "label= last still works with a real modifier",
+        (
+            parseSpec({ text: "@@ a.md\n<<< regex flags=g label=free text\nx\n===\ny\n>>>\n" })[0].ops?.[0] as {
+                kind?: string;
+            }
+        ).kind === "regex"
+    );
+
+    // A spec pasted from two sources carries CRLF on some lines only; splitting on "\n"
+    // alone left "\r" on the markers and swallowed the next op into the previous body.
+    const mixed = parseSpec({
+        text: "@@ a.md\r\n<<<\r\nline one\r\n===\r\nline ONE\r\n>>>\r\n<<<\nline two\n===\nline TWO\n>>>\n",
+    });
+    check("a spec with mixed CRLF/LF keeps both ops", mixed[0].ops?.length === 2, stringifyJson(mixed[0].ops));
+
+    check(
+        "a marker spec starting with [ says so, naming line 1",
+        parseErr("[legacy] old feature\n<<<\nfoo\n===\nbar\n>>>\n").includes('spec line 1: the spec starts with "["'),
+        parseErr("[legacy] x\n")
+    );
+
+    fs.mkdirSync(f("a-dir"), { recursive: true });
+    const dirErr = await run({ edits: [{ file: f("a-dir"), ops: [{ find: "x", replace: "y" }] }] }).catch(
+        (e: FableReplaceError) => e
+    );
+    check(
+        "a directory as a target is a pre-flight error, not a raw EISDIR",
+        String(dirErr).includes("is a directory, not a file"),
+        String(dirErr)
+    );
+
+    // readFileSync(…,"utf8") decodes lossily, so one stray cp1252 byte used to come back as
+    // U+FFFD and get written into the file, far from the edit, reported as OK.
+    fs.writeFileSync(f("latin1.txt"), Buffer.from([0x6e, 0x65, 0x65, 0x64, 0x6c, 0x65, 0x0a, 0x34, 0x92, 0x0a]));
+    const beforeBytes = fs.readFileSync(f("latin1.txt"));
+    const encErr = (await run({
+        edits: [{ file: f("latin1.txt"), ops: [{ find: "needle", replace: "FOUND" }] }],
+    }).catch((e: FableReplaceError) => e)) as FableReplaceError;
+    const encReason = (encErr.report?.files ?? []).flatMap((file) => file.postConditionFailures).join(" ");
+    check(
+        "a file that is not valid UTF-8 is refused, not silently mangled",
+        fs.readFileSync(f("latin1.txt")).equals(beforeBytes) && encReason.includes("not valid UTF-8"),
+        encReason || String(encErr)
+    );
+
+    // The file is read once at plan time; a concurrent write between read and write used to
+    // be overwritten silently, with the sweep still reporting OK.
+    write("race.ts", "const r = 1;\n");
+    check(
+        "changedOnDisk is false while the file still holds what was read",
+        !changedOnDisk({ abs: f("race.ts"), expected: "const r = 1;\n" })
+    );
+    fs.writeFileSync(f("race.ts"), "SOMEONE ELSE WROTE THIS\n");
+    check("changedOnDisk catches a concurrent write", changedOnDisk({ abs: f("race.ts"), expected: "const r = 1;\n" }));
+    check(
+        "changedOnDisk treats a vanished file as changed",
+        changedOnDisk({ abs: f("gone-forever.ts"), expected: "" })
+    );
+    const raceOk = await run({
+        edits: [{ file: f("race.ts"), ops: [{ find: "SOMEONE ELSE WROTE THIS", replace: "SETTLED" }] }],
+    });
+    check("the guard does not break an ordinary sweep", raceOk.ok && read("race.ts") === "SETTLED\n", read("race.ts"));
+
+    // Two sweeps racing into one backupDir: the loser used to overwrite the winner's
+    // manifest, so its own files could never be rolled back while both reported success.
+    const sharedDir = scratchDir("selftest-shared-backup");
+    write("shareA.ts", "const a = 1;\n");
+    write("shareB.ts", "const b = 1;\n");
+    await run({
+        edits: [{ file: f("shareA.ts"), ops: [{ find: "const a = 1;", replace: "const a = 2;" }] }],
+        backupDir: sharedDir,
+    });
+    const sharedErr = await run({
+        edits: [{ file: f("shareB.ts"), ops: [{ find: "const b = 1;", replace: "const b = 2;" }] }],
+        backupDir: sharedDir,
+        backupOverwrite: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a second sweep may not share a backup dir",
+        sharedErr instanceof FableReplaceError && read("shareB.ts") === "const b = 1;\n",
+        String(sharedErr)
+    );
+    const overwrote = await run({
+        edits: [{ file: f("shareB.ts"), ops: [{ find: "const b = 1;", replace: "const b = 2;" }] }],
+        backupDir: sharedDir,
+        backupOverwrite: true,
+    });
+    check("backupOverwrite: true still works", overwrote.ok && read("shareB.ts") === "const b = 2;\n");
+}
+
+// ── scratch root and prune ──────────────────────────────────────────────────
+console.log("scratchDir() root + pruneScratch()");
+{
+    const root = scratchRoot();
+    const fresh = scratchDir("probe");
+    check(
+        "scratchDir lands under <tmp>/fable-replace/",
+        fresh.startsWith(`${root}${path.sep}`) && path.basename(fresh).startsWith(`probe-${process.pid}-`),
+        fresh
+    );
+    const age = (dir: string): string => {
+        const then = new Date(Date.now() - 25 * 3600 * 1000);
+        fs.utimesSync(dir, then, then);
+        return dir;
+    };
+    const finished = (dir: string): string => {
+        fs.writeFileSync(path.join(dir, "0000-x.ts"), "x".repeat(100));
+        fs.writeFileSync(path.join(dir, "fable-replace-manifest.json"), "{}");
+        return dir;
+    };
+    const oldWithManifest = age(finished(scratchDir("old")));
+    const youngWithManifest = finished(scratchDir("young"));
+    const oldNoManifest = scratchDir("scratch");
+    fs.writeFileSync(path.join(oldNoManifest, "notes.txt"), "keep");
+    age(oldNoManifest);
+    const oldEmpty = age(scratchDir("empty"));
+    const legacy = age(finished(fs.mkdtempSync(path.join(os.tmpdir(), "fable-replace-legacy-1-"))));
+    const current = age(finished(scratchDir("current")));
+    const foreignRoot = path.join(f("other-tmp"), "fable-replace");
+    fs.mkdirSync(foreignRoot, { recursive: true });
+    const foreign = age(finished(fs.mkdtempSync(path.join(foreignRoot, "old-"))));
+    const report = pruneScratch({ keep: [current] });
+    check("an old dir with a manifest is removed", !fs.existsSync(oldWithManifest));
+    check("a young dir survives", fs.existsSync(youngWithManifest));
+    check("an old dir without a manifest survives: not proven ours", fs.existsSync(oldNoManifest));
+    check("an old empty dir is removed", !fs.existsSync(oldEmpty));
+    check("a legacy fable-replace-* dir directly under the temp dir falls under the same gate", !fs.existsSync(legacy));
+    check("the current run's dir survives even when old", fs.existsSync(current));
+    check("the report counts what it removed", report.removed === 3 && report.bytes >= 200, stringifyJson(report));
+    check(
+        "the prune sweeps only the root this process writes to (TMPDIR), never another temp root",
+        report.roots.length === 1 && report.roots[0] === scratchRoot() && fs.existsSync(foreign),
+        stringifyJson(report.roots)
+    );
+    const many = Array.from({ length: 60 }, (_, i) => age(finished(scratchDir(`many${i}`))));
+    const capped = pruneScratch({ keep: [current] });
+    check(
+        "at most 50 removals per run, the rest wait for the next one",
+        capped.removed === 50 && many.filter((dir) => fs.existsSync(dir)).length === 10,
+        String(capped.removed)
+    );
+    pruneScratch({ keep: [current] });
+    fs.rmSync(current, { recursive: true, force: true });
+}
+
+// ── journal ─────────────────────────────────────────────────────────────────
+console.log("cli.ts journal");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("journal");
+    const home = f("journal-home");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+    const journalFile = path.join(home, ".genesis-tools", "fable-replace", "journal.jsonl");
+    const runJ = (
+        spec: string,
+        env: Record<string, string>,
+        ...args: string[]
+    ): { status: number | null; out: string } => {
+        const p = spawnSync("bun", [cli, ...args], {
+            cwd: dir,
+            input: spec,
+            encoding: "utf8",
+            env: { ...hermeticEnv, FABLE_REPLACE_HOME: home, ...env },
+        });
+        return { status: p.status, out: `${p.stdout}\n${p.stderr}` };
+    };
+    const lines = (): JournalEntry[] =>
+        fs.existsSync(journalFile)
+            ? fs
+                  .readFileSync(journalFile, "utf8")
+                  .split("\n")
+                  .filter((line) => line.trim() !== "")
+                  .map((line) => parseJson(line) as JournalEntry)
+            : [];
+    fs.writeFileSync(path.join(dir, "j.ts"), "const j = 1;\n");
+    runJ("@@ j.ts\n<<<\nconst j = 1;\n===\nconst j = 2;\n>>>\n", {});
+    runJ("@@ j.ts\n<<<\nconst nope = 1;\n===\nconst j = 3;\n>>>\n", {});
+    runJ("@@ j.ts\n<<< wat\nx\n===\ny\n>>>\n", {});
+    runJ("@@ j.ts\n<<<\nconst j = 2;\n===\nconst j = 3;\n>>>\n", {}, "--verify", "exit 0 | cat");
+    runJ("@@ j.ts\n<<<\nconst j = 2;\n===\nconst j = 3;\n>>>\n", {}, "--verify", "exit 1");
+    runJ("@@ j.ts\n<<<\nconst j = 3;\n===\nconst j = 4;\n>>>\n", {}, "--dry");
+    const all = lines();
+    const outcomes = all.map((e) => e.outcome);
+    check(
+        "one journal line per real run outcome, a written line before a verify, and nothing for --dry",
+        stringifyJson(outcomes) ===
+            stringifyJson(["ok", "miss", "spec-error", "pre-flight", "written", "verify-failed"]),
+        stringifyJson(outcomes)
+    );
+    const miss = all[1];
+    check(
+        "a MISS line carries its reason, the spec size and a token estimate",
+        miss?.missCount === 1 &&
+            (miss.reasons?.[0] ?? "").includes("const nope") &&
+            (miss.spec?.chars ?? 0) > 0 &&
+            miss.tokensEst?.spec === Math.round((miss.spec?.chars ?? 0) / 3.7),
+        stringifyJson(miss)
+    );
+    check(
+        "a spec error line carries the parser message",
+        all[2]?.specError?.includes("line 2") === true,
+        stringifyJson(all[2])
+    );
+    const vf = all[5];
+    check(
+        "a verify-failed line carries the verdict, the write count and the backup dir",
+        vf?.verify?.status === "fail" && vf.verify.exit === 1 && vf.backupDir !== undefined && vf.written === 1,
+        stringifyJson(vf)
+    );
+    check(
+        "the written line precedes the verify and names the same backup dir",
+        all[4]?.outcome === "written" && all[4].backupDir === vf?.backupDir,
+        stringifyJson(all[4])
+    );
+    check(
+        "the spec text is saved beside the backup, never in the journal",
+        vf?.backupDir !== undefined &&
+            fs.readFileSync(path.join(vf.backupDir, "spec.frspec"), "utf8").includes("const j = 2;") &&
+            !fs.readFileSync(journalFile, "utf8").includes("\\n===\\n")
+    );
+    check(
+        "every line carries what was printed and how long it took",
+        all.every((e) => (e.resultChars ?? 0) > 0 && (e.durationMs ?? -1) >= 0 && e.runId.length > 0),
+        stringifyJson(all.map((e) => [e.outcome, e.resultChars, e.durationMs]))
+    );
+    runJ("", {}, "--rollback", vf?.backupDir ?? "/nonexistent");
+    const rb = lines().at(-1);
+    check(
+        "a rollback is journaled with its counts",
+        rb?.kind === "rollback" && rb.rollback?.restored === 1,
+        stringifyJson(rb)
+    );
+
+    const history = runJ("", {}, "--history", "3");
+    check(
+        "--history prints the last N entries, one line each",
+        history.status === 0 && history.out.split("\n").filter((line) => /^\d{4}-\d{2}-\d{2} /.test(line)).length === 3,
+        history.out
+    );
+    const stats = runJ("", {}, "--stats", "1");
+    check(
+        "--stats prints counts, tokens and waste, and no dollar figure",
+        stats.status === 0 &&
+            stats.out.includes("runs, last 1 day(s): 5") &&
+            !/^\s+written\s+\d+$/m.test(stats.out) &&
+            stats.out.includes("chars ÷ 3.7") &&
+            !stats.out.includes("$") &&
+            stats.out.includes("wasted"),
+        stats.out
+    );
+
+    const home2 = f("journal-home2");
+    fs.mkdirSync(home2, { recursive: true });
+    const noOverride = Object.fromEntries(
+        Object.entries(process.env).filter(([name]) => name !== "FABLE_REPLACE_HOME")
+    );
+    spawnSync("bun", [cli], {
+        cwd: dir,
+        input: "@@ j.ts\n<<<\nconst nope = 1;\n===\nconst j = 9;\n>>>\n",
+        encoding: "utf8",
+        env: { ...noOverride, GENESIS_TOOLS_HOME: home2 },
+    });
+    check(
+        "GENESIS_TOOLS_HOME is honoured when FABLE_REPLACE_HOME is unset",
+        fs.existsSync(path.join(home2, ".genesis-tools", "fable-replace", "journal.jsonl"))
+    );
+
+    fs.writeFileSync(journalFile, "x".repeat(5 * 1024 * 1024 + 1));
+    runJ("@@ j.ts\n<<<\nconst nope = 1;\n===\nconst j = 9;\n>>>\n", {});
+    check(
+        "the journal rotates once past 5 MB",
+        fs.existsSync(path.join(home, ".genesis-tools", "fable-replace", "journal.1.jsonl")) &&
+            fs.statSync(journalFile).size < 4096
+    );
+
+    const blocked = f("journal-blocked");
+    fs.writeFileSync(blocked, "not a dir\n");
+    const warned = runJ("@@ j.ts\n<<<\nconst nope = 1;\n===\nconst j = 9;\n>>>\n", { FABLE_REPLACE_HOME: blocked });
+    check(
+        "a journal that cannot be written warns and leaves the exit code alone",
+        warned.status === 1 && warned.out.includes("journal: could not append"),
+        warned.out.slice(-300)
+    );
+
+    const planted = scratchDir("planted");
+    fs.writeFileSync(path.join(planted, "fable-replace-manifest.json"), "{}");
+    const stale = new Date(Date.now() - 25 * 3600 * 1000);
+    fs.utimesSync(planted, stale, stale);
+    const linesBeforeDry = lines().length;
+    runJ("@@ j.ts\n<<<\nconst j = 2;\n===\nconst j = 3;\n>>>\n", {}, "--dry");
+    check(
+        "a --dry run journals nothing and prunes nothing",
+        lines().length === linesBeforeDry && fs.existsSync(planted),
+        `${lines().length} vs ${linesBeforeDry}, planted exists=${fs.existsSync(planted)}`
+    );
+
+    const pruned = runJ("", {}, "--prune");
+    check(
+        "--prune reports what it swept and is journaled on its own line",
+        pruned.status === 0 &&
+            pruned.out.includes("pruned 1 ") &&
+            !fs.existsSync(planted) &&
+            lines().at(-1)?.kind === "prune",
+        `${pruned.out} ${stringifyJson(lines().at(-1))}`
+    );
+}
+
+// ── diagnostics: same-batch interference vs. a previous run (h_yvyxmctd) ─────
+console.log("diagnostics: consumed needle vs. applied before");
+{
+    const twice = applyOps("const value = 1;\n", [
+        { find: "const value = 1;", replace: "const value = 2;" },
+        { find: "const value = 1;", replace: "const value = 2;" },
+    ]);
+    check(
+        "a needle consumed by an earlier op of the batch is blamed on that op, not on a previous run",
+        twice.results[0].status === "OK" &&
+            twice.results[1].status === "MISS" &&
+            (twice.results[1].reason ?? "").includes("op 1 of this batch") &&
+            (twice.results[1].reason ?? "").includes("consumed") &&
+            !(twice.results[1].reason ?? "").includes("optional"),
+        twice.results[1].reason ?? ""
+    );
+    const before = applyOps("const value = 2;\n", [{ find: "const value = 1;", replace: "const value = 2;" }]);
+    check(
+        "a replacement that was on disk before the run keeps the re-run guidance",
+        before.results[0].status === "MISS" && (before.results[0].reason ?? "").includes("applied before"),
+        before.results[0].reason ?? ""
+    );
+
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("handoff");
+    fs.mkdirSync(dir, { recursive: true });
+    const runH = (spec: string): { status: number | null; out: string } => {
+        const p = spawnSync("bun", [cli], { cwd: dir, input: spec, encoding: "utf8", env: hermeticEnv });
+        return { status: p.status, out: `${p.stdout}\n${p.stderr}` };
+    };
+    fs.writeFileSync(path.join(dir, "doc.md"), "# Old\n```sh\nold\n```\n");
+    const fence = runH("@@ doc.md\n<<< block\n# Old\n===\nold\n```\n===\n# New\n```sh\nnew\n```\n>>>\n");
+    check(
+        "cli: a block replacement whose end anchor is a closing fence lands without a truncation warning",
+        fence.status === 0 && !fence.out.includes("WARNING") && read("handoff/doc.md") === "# New\n```sh\nnew\n```\n",
+        `${String(fence.status)} ${fence.out.slice(0, 300)}`
+    );
+    fs.writeFileSync(path.join(dir, "example.ts"), "const value = 1;\n");
+    const dup = runH(
+        "@@ example.ts\n<<<\nconst value = 1;\n===\nconst value = 2;\n>>>\n<<<\nconst value = 1;\n===\nconst value = 2;\n>>>\n"
+    );
+    check(
+        "cli: a duplicate op aborts the batch, leaves the disk untouched and names the earlier op",
+        dup.status === 1 &&
+            dup.out.includes("op 1 of this batch") &&
+            read("handoff/example.ts") === "const value = 1;\n",
+        `${String(dup.status)} ${dup.out.slice(0, 400)}`
+    );
+}
+
+// ── review round 1 (PR #371): backup reservation, created-file syntax, quoted undo ──
+console.log("review round 1 regressions");
+{
+    write("race-a.ts", "const a = 1;\n");
+    const raceDir = path.join(tmp, "race-backup");
+    writeBackup({ dir: raceDir, files: [f("race-a.ts")] });
+    const storedBefore = fs.readFileSync(path.join(raceDir, "0000-race-a.ts"), "utf8");
+    const manifestBefore = fs.readFileSync(path.join(raceDir, "fable-replace-manifest.json"), "utf8");
+    write("race-a.ts", "const a = 2;\n");
+    let refused = "";
+    try {
+        writeBackup({ dir: raceDir, files: [f("race-a.ts")] });
+    } catch (err) {
+        refused = String(err);
+    }
+    check(
+        "a second writer into one backup dir is refused before it copies, so the first snapshot is intact",
+        refused.includes("another sweep is using it") &&
+            fs.readFileSync(path.join(raceDir, "0000-race-a.ts"), "utf8") === storedBefore &&
+            fs.readFileSync(path.join(raceDir, "fable-replace-manifest.json"), "utf8") === manifestBefore,
+        refused
+    );
+
+    const badCreate = await run({
+        edits: [{ file: f("bad-new.ts"), createWith: "const x = ;\n" }],
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a created .ts file that does not parse is refused and not written",
+        badCreate instanceof FableReplaceError &&
+            badCreate.code === 1 &&
+            (badCreate.report?.files[0]?.postConditionFailures ?? []).some((p) => p.includes("does not parse")) &&
+            !fs.existsSync(f("bad-new.ts")),
+        String(badCreate)
+    );
+
+    const spaceTmp = f("tmp with space");
+    fs.mkdirSync(spaceTmp, { recursive: true });
+    const spaceDir = f("space-cli");
+    fs.mkdirSync(spaceDir, { recursive: true });
+    fs.writeFileSync(path.join(spaceDir, "s.ts"), "const s = 1;\n");
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const red = spawnSync("bun", [cli, "--verify", "exit 1"], {
+        cwd: spaceDir,
+        input: "@@ s.ts\n<<<\nconst s = 1;\n===\nconst s = 2;\n>>>\n",
+        encoding: "utf8",
+        env: { ...hermeticEnv, TMPDIR: spaceTmp },
+    });
+    const quoted = `${red.stdout}\n${red.stderr}`.match(/--rollback "([^"]+)"/)?.[1];
+    const undone =
+        quoted === undefined
+            ? null
+            : spawnSync("bun", [cli, "--rollback", quoted], { cwd: spaceDir, encoding: "utf8", env: hermeticEnv });
+    check(
+        "the undo line quotes a backup path that contains a space, and that path restores",
+        red.status === 3 &&
+            quoted !== undefined &&
+            quoted.includes(" ") &&
+            undone?.status === 0 &&
+            fs.readFileSync(path.join(spaceDir, "s.ts"), "utf8") === "const s = 1;\n",
+        `${String(red.status)} ${quoted ?? "no quoted path"} ${undone?.stdout.slice(-200) ?? ""}`
+    );
+}
+
+// ── review round 2 (PR #371, CodeRabbit + eve): --api dir decoding, CRLF block anchors, nthIndexOf, /g regexes,
+// createWith on an existing file, the rollback guard and exit code ──
+console.log("review round 2 (PR #371)");
+check(
+    "nthIndexOf walks non-overlapping, like countOccurrences",
+    nthIndexOf({ haystack: "aaaa", needle: "aa", n: 2 }) === 2
+);
+check(
+    "nthIndexOf: no 3rd non-overlapping occurrence",
+    nthIndexOf({ haystack: "aaaa", needle: "aa", n: 3 }) === -1 && countOccurrences("aaaa", "aa") === 2
+);
+{
+    const crlf = "keep\r\n/**\r\n * junk\r\n * junk2\r\n */\r\nrest\r\n";
+    const r = applyOps(crlf, [dropJsdocStarting({ fromPrefix: "/**\n * junk" })]);
+    check(
+        "dropJsdocStarting lands on a CRLF file",
+        r.results[0].status === "OK" && r.content === "keep\r\nrest\r\n",
+        r.results[0].reason ?? stringifyJson(r.content)
+    );
+    const lf = applyOps("keep\n/**\n * junk\n */\nrest\n", [dropJsdocStarting({ fromPrefix: "/**\n * junk" })]);
+    check("dropJsdocStarting on an LF file is unchanged", lf.content === "keep\nrest\n");
+    const mixed = applyOps("a\nSTART\nx\nEND\nb\r\n", [{ kind: "deleteBlock", from: "START\n", to: "END\n" }]);
+    check(
+        "an LF anchor that exists literally in a mixed-ending file is still preferred",
+        mixed.content === "a\nb\r\n",
+        mixed.results[0].reason ?? stringifyJson(mixed.content)
+    );
+}
+fs.mkdirSync(f("g-rx"), { recursive: true });
+write("g-rx/one.ts", "needle();\nneedle();\n");
+write("g-rx/two.ts", "needle();\n");
+check(
+    "findFiles with a /g regex keeps every matching file",
+    findFiles({ roots: [f("g-rx")], containing: /needle/g }).length === 2
+);
+check(
+    "grepPreview with a /g regex counts every matching line",
+    grepPreview({ files: [f("g-rx/one.ts")], pattern: /needle/g, context: 0 }) === 2
+);
+{
+    const existing = write("exists.ts", "const keep = 1;\n");
+    let refused: FableReplaceError | undefined;
+    try {
+        await run({ edits: [{ file: existing, createWith: "const other = 2;\n" }], verbose: false });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "run(): createWith on an existing file is refused by the runner (code 1, nothing written)",
+        refused?.code === 1 &&
+            refused.report?.files[0]?.postConditionFailures[0]?.includes("refuses to overwrite") === true &&
+            read("exists.ts") === "const keep = 1;\n",
+        String(refused?.message)
+    );
+}
+{
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const spaced = f("dir with space/scripts");
+    fs.mkdirSync(spaced, { recursive: true });
+    for (const name of fs.readdirSync(here)) {
+        if (name.endsWith(".ts")) {
+            fs.copyFileSync(path.join(here, name), path.join(spaced, name));
+        }
+    }
+    const api = spawnSync("bun", [path.join(spaced, "cli.ts"), "--api", "run"], { encoding: "utf8", env: hermeticEnv });
+    const count = Number(api.stdout.match(/fable-replace API — (\d+) entr/)?.[1] ?? -1);
+    check(
+        "--api from a directory whose path contains a space still lists the modules",
+        api.status === 0 && count > 0,
+        `${String(api.status)} ${api.stdout.slice(0, 200)} ${api.stderr.slice(0, 200)}`
+    );
+}
+
+{
+    const a = write("rb-dir-a.ts", "const a = 1;\n");
+    const b = write("rb-dir-b.ts", "const b = 1;\n");
+    const backupDir = scratchDir("rb-dir");
+    await run({
+        edits: [
+            { file: a, ops: [{ find: "= 1", replace: "= 2" }] },
+            { file: b, ops: [{ find: "= 1", replace: "= 2" }] },
+        ],
+        backupDir,
+        verbose: false,
+    });
+    fs.rmSync(a);
+    fs.mkdirSync(a);
+    const partial = rollback({ backupDir });
+    check(
+        "rollback: a path that became a directory lands in report.failed and the later entry is still restored",
+        partial.failed.length === 1 &&
+            partial.failed[0].file === a &&
+            partial.restored.includes(b) &&
+            read("rb-dir-b.ts") === "const b = 1;\n",
+        stringifyJson(partial)
+    );
+}
+{
+    const cliDir = f("rb-cli");
+    fs.mkdirSync(cliDir, { recursive: true });
+    fs.writeFileSync(path.join(cliDir, "r.ts"), "const r = 1;\n");
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const swept = spawnSync("bun", [cli], {
+        cwd: cliDir,
+        input: "@@ r.ts\n<<<\nconst r = 1;\n===\nconst r = 2;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    const backupDir = `${swept.stdout}\n${swept.stderr}`.match(/Backed up 1 path\(s\) to (.+)/)?.[1]?.trim();
+    fs.chmodSync(path.join(cliDir, "r.ts"), 0o444);
+    const blocked =
+        backupDir === undefined
+            ? null
+            : spawnSync("bun", [cli, "--rollback", backupDir], { cwd: cliDir, encoding: "utf8", env: hermeticEnv });
+    fs.chmodSync(path.join(cliDir, "r.ts"), 0o644);
+    const retried =
+        backupDir === undefined
+            ? null
+            : spawnSync("bun", [cli, "--rollback", backupDir], { cwd: cliDir, encoding: "utf8", env: hermeticEnv });
+    check(
+        "cli --rollback exits 1 while a file could not be restored, then 0 once the cause is fixed",
+        swept.status === 0 &&
+            backupDir !== undefined &&
+            blocked?.status === 1 &&
+            blocked.stderr.includes("COULD NOT RESTORE") &&
+            retried?.status === 0 &&
+            fs.readFileSync(path.join(cliDir, "r.ts"), "utf8") === "const r = 1;\n",
+        `${String(swept.status)} ${backupDir ?? "no backup dir"} ${String(blocked?.status)} ${String(retried?.status)}`
+    );
+}
+
+// ── review round 3 (PR #371, eve): empty anchors, a recovery that restores only what it wrote, hash failures on the
+// written path, inline comment removal that keeps tokens apart, tokens instead of dollars ──
+console.log("review round 3 (PR #371)");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const hangDir = f("empty-anchor");
+    fs.mkdirSync(hangDir, { recursive: true });
+    fs.writeFileSync(path.join(hangDir, "e.ts"), "const e = 1;\n");
+    const markers = spawnSync("bun", [cli], {
+        cwd: hangDir,
+        input: "@@ e.ts\n<<< after\n===\nconst added = 2;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+        timeout: 20_000,
+    });
+    check(
+        "cli: an empty after/before anchor is a spec error, not a hang",
+        markers.status === 2 && markers.stderr.includes("anchor") && !markers.stdout.includes("Wrote"),
+        `${String(markers.status)} ${markers.signal ?? ""} ${markers.stderr.slice(0, 200)}`
+    );
+    const json = spawnSync("bun", [cli], {
+        cwd: hangDir,
+        input: stringifyJson([
+            { file: "e.ts", ops: [{ kind: "insertLinesAfter", anchor: "", text: "const added = 2;" }] },
+        ]),
+        encoding: "utf8",
+        env: hermeticEnv,
+        timeout: 20_000,
+    });
+    check(
+        "cli (JSON form): an empty anchor reaches the runner and is a MISS, not a hang",
+        json.status === 1 &&
+            json.stdout.includes("anchor is empty") &&
+            fs.readFileSync(path.join(hangDir, "e.ts"), "utf8") === "const e = 1;\n",
+        `${String(json.status)} ${json.signal ?? ""} ${json.stdout.slice(-300)}`
+    );
+    const block = applyOps("a\nb\n", [{ kind: "deleteBlock", from: "", to: "b" }]);
+    const inline = applyOps("a\nb\n", [{ kind: "insertAfter", anchor: "", text: "x" }]);
+    check(
+        "api: empty block and same-line anchors are a MISS instead of landing at offset 0",
+        block.results[0].status === "MISS" &&
+            block.content === "a\nb\n" &&
+            inline.results[0].status === "MISS" &&
+            inline.content === "a\nb\n",
+        `${block.results[0].reason ?? ""} | ${inline.results[0].reason ?? ""}`
+    );
+}
+{
+    const a = write("only-a.ts", "const a = 1;\n");
+    const b = write("only-b.ts", "const b = 1;\n");
+    const onlyDir = scratchDir("only");
+    await run({
+        edits: [
+            { file: a, ops: [{ find: "= 1", replace: "= 2" }] },
+            { file: b, ops: [{ find: "= 1", replace: "= 2" }] },
+        ],
+        backupDir: onlyDir,
+        verbose: false,
+    });
+    const partial = rollback({ backupDir: onlyDir, only: [a] });
+    check(
+        "rollback({ only }) restores the listed path and leaves the others alone and unreported",
+        read("only-a.ts") === "const a = 1;\n" &&
+            read("only-b.ts") === "const b = 2;\n" &&
+            partial.restored.length === 1 &&
+            !partial.restored.includes(b),
+        stringifyJson(partial)
+    );
+}
+{
+    for (let i = 0; i < 4; i += 1) {
+        write(`rec${i}.ts`, `const v${i} = "old";\n`);
+    }
+    fs.chmodSync(f("rec2.ts"), 0o444);
+    let message = "";
+    try {
+        await run({
+            edits: [0, 1, 2, 3].map((i) => ({ file: f(`rec${i}.ts`), ops: [{ find: `"old"`, replace: `"new"` }] })),
+            verbose: false,
+            backupDir: scratchDir("recover"),
+        });
+    } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+    }
+    fs.chmodSync(f("rec2.ts"), 0o644);
+    check(
+        "a failed write restores what this sweep wrote and reports the later files as never touched",
+        message.includes("write failed after 2 file(s)") &&
+            message.includes("1 later file(s) were never touched") &&
+            [0, 1, 2, 3].every((i) => read(`rec${i}.ts`).includes(`"old"`)),
+        message
+    );
+}
+{
+    const hashed = write("hash-a.ts", "const h = 1;\n");
+    const hashDir = scratchDir("hash");
+    const moved = f("hash-a.moved.ts");
+    const report = await run({
+        edits: [{ file: hashed, ops: [{ find: "= 1", replace: "= 2" }] }],
+        backupDir: hashDir,
+        verbose: false,
+        verifyCommand: `mv "${hashed}" "${moved}" && mkdir "${hashed}"`,
+    });
+    const undone = rollback({ backupDir: hashDir });
+    check(
+        "a verify that turned a tracked path into a directory: the run stays green, the hash is skipped, the rollback names the path",
+        report.ok && report.verify?.status === "pass" && undone.failed.length === 1 && undone.failed[0].file === hashed,
+        stringifyJson({ ok: report.ok, verify: report.verify?.status, failed: undone.failed })
+    );
+    fs.rmSync(hashed, { recursive: true, force: true });
+    fs.renameSync(moved, hashed);
+}
+{
+    const manifestFile = write("manifest-a.ts", "const m = 1;\n");
+    const manifestDir = scratchDir("manifest");
+    const manifestPath = path.join(manifestDir, "fable-replace-manifest.json");
+    let failure: FableReplaceError | undefined;
+    try {
+        await run({
+            edits: [{ file: manifestFile, ops: [{ find: "= 1", replace: "= 2" }] }],
+            backupDir: manifestDir,
+            verbose: false,
+            verifyCommand: `chmod 444 "${manifestPath}"`,
+        });
+    } catch (err) {
+        failure = err instanceof FableReplaceError ? err : undefined;
+    }
+    fs.chmodSync(manifestPath, 0o644);
+    check(
+        "a manifest the disk refuses after the write is a code-3 written-sweep failure carrying the report and backup dir",
+        failure?.code === 3 &&
+            failure.message.includes("backup manifest not updated") &&
+            failure.report?.backupDir === manifestDir &&
+            read("manifest-a.ts") === "const m = 2;\n",
+        `${String(failure?.code)} ${failure?.message ?? "no error"}`
+    );
+}
+{
+    const keep = (src: string): string => dropComments(src, { containing: "legacy" }).content;
+    check("inline comment removal keeps tokens apart", keep("return/*legacy*/value;\n") === "return value;\n");
+    check(
+        "inline comment removal never forms ++ or a line comment",
+        keep("a +/*legacy*/+b; x/*legacy*//y;\n") === "a + +b; x /y;\n"
+    );
+    check(
+        "inline comment removal adds nothing beside brackets and commas",
+        keep("f(/*legacy*/a,/*legacy*/b);\n") === "f(a,b);\n"
+    );
+}
+
+// ── review round 4 (PR #371, eve): absolute manifest paths under a relative --cwd, empty fuzzy and regex needles,
+// identifier boundaries and literal dollar names in renames ──
+console.log("review round 4 (PR #371)");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const parent = f("relcwd");
+    fs.mkdirSync(path.join(parent, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(parent, "sub", "r.ts"), "const r = 1;\n");
+    const swept = spawnSync("bun", [cli, "--cwd", "sub"], {
+        cwd: parent,
+        input: "@@ r.ts\n<<<\nconst r = 1;\n===\nconst r = 2;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    const backupDir = `${swept.stdout}\n${swept.stderr}`.match(/Backed up 1 path\(s\) to (.+)/)?.[1]?.trim();
+    const elsewhere = f("relcwd-elsewhere");
+    fs.mkdirSync(elsewhere, { recursive: true });
+    const undone =
+        backupDir === undefined
+            ? null
+            : spawnSync("bun", [cli, "--rollback", backupDir], { cwd: elsewhere, encoding: "utf8", env: hermeticEnv });
+    check(
+        "a relative --cwd records absolute paths, so the printed undo works from any directory",
+        swept.status === 0 &&
+            undone?.status === 0 &&
+            fs.readFileSync(path.join(parent, "sub", "r.ts"), "utf8") === "const r = 1;\n" &&
+            !fs.existsSync(path.join(elsewhere, "sub")),
+        `${String(swept.status)} ${backupDir ?? "no backup dir"} ${String(undone?.status)} ${undone?.stdout.slice(-200) ?? ""}`
+    );
+}
+{
+    const blankFuzzy = applyOps("abc", [{ kind: "fuzzy", find: "  \n ", replace: "x", count: "all" }]);
+    const emptyRegex = applyOps("abc", [{ kind: "regex", find: /(?:)/, replace: "x" }]);
+    check(
+        "api: a blank fuzzy needle and an empty regex are a MISS instead of matching between every character",
+        blankFuzzy.results[0].status === "MISS" &&
+            blankFuzzy.content === "abc" &&
+            emptyRegex.results[0].status === "MISS" &&
+            emptyRegex.content === "abc",
+        `${blankFuzzy.results[0].reason ?? ""} | ${emptyRegex.results[0].reason ?? ""}`
+    );
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("blank-needle");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "n.ts"), "const n = 1;\n");
+    const blank = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: "@@ n.ts\n<<< fuzzy\n   \n===\nconst n = 2;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+        timeout: 20_000,
+    });
+    check(
+        "cli: a whitespace-only fuzzy body is a spec error and nothing is written",
+        blank.status === 2 &&
+            blank.stderr.includes("first body is empty") &&
+            fs.readFileSync(path.join(dir, "n.ts"), "utf8") === "const n = 1;\n",
+        `${String(blank.status)} ${blank.stderr.slice(0, 200)}`
+    );
+}
+{
+    const r = applyOps("foo(); $foo(); foo$(); a$foo; foo;", [
+        renameSymbol({ oldName: "foo", newName: "bar", expect: 2 }),
+    ]);
+    check(
+        "renameSymbol stops at $ on either side",
+        r.content === "bar(); $foo(); foo$(); a$foo; bar;",
+        r.results[0].reason ?? r.content
+    );
+    const dollar = applyOps("const $foo = 1; use($foo);", [
+        renameSymbol({ oldName: "$foo", newName: "$$foo", expect: 2 }),
+    ]);
+    check(
+        "renameSymbol matches a $-name and writes a $$-name literally",
+        dollar.content === "const $$foo = 1; use($$foo);",
+        dollar.results[0].reason ?? dollar.content
+    );
+    fs.mkdirSync(f("dollar"), { recursive: true });
+    write("dollar/d.ts", "foo(); $foo(); foo$();\n");
+    const counts = countMatches({ files: [f("dollar/d.ts")], pattern: "foo", quiet: true });
+    check(
+        "countMatches uses the same identifier boundary as the rename",
+        counts[f("dollar/d.ts")] === 1,
+        stringifyJson(counts)
+    );
+}
+
+// ── review round 5 (PR #371, eve): an empty substring beside a regex, exclusive creates at the write, the barrel
+// exports everything --api lists ──
+console.log("review round 5 (PR #371)");
+{
+    const lines = applyOps("a\nDEBUG b\nc\n", [{ kind: "deleteLines", containing: "", matching: /DEBUG/ }]);
+    check(
+        "deleteLines: an empty substring beside a regex deletes only the regex hits",
+        lines.results[0].status === "OK" && lines.content === "a\nc\n",
+        `${lines.results[0].reason ?? ""} ${stringifyJson(lines.content)}`
+    );
+    const dropped = dropComments("// keep\nx(); // drop me\n", { containing: "", matching: /drop/ });
+    check(
+        "dropComments: an empty substring beside a regex drops only the regex hits",
+        dropped.dropped === 1 && dropped.content === "// keep\nx();\n",
+        stringifyJson(dropped)
+    );
+    check(
+        "dropComments: an empty substring alone is no predicate",
+        dropComments("// a\n// b\n", { containing: "" }).dropped === 0
+    );
+}
+{
+    const link = f("create-link.ts");
+    fs.symlinkSync(f("create-link-target.ts"), link);
+    let failure = "";
+    try {
+        await run({
+            edits: [{ file: link, createWith: "export const late = 1;\n" }],
+            verbose: false,
+            backupDir: scratchDir("wx"),
+        });
+    } catch (err) {
+        failure = err instanceof Error ? err.message : String(err);
+    }
+    check(
+        "a create target that exists at write time (a dangling symlink the plan cannot see) is refused with EEXIST, never truncated, and survives the recovery",
+        failure.includes("EEXIST") && fs.lstatSync(link).isSymbolicLink() && !fs.existsSync(f("create-link-target.ts")),
+        failure
+    );
+    const src = write("mv-src.ts", "const mv = 1;\n");
+    const dest = f("mv-dest.ts");
+    fs.symlinkSync(f("mv-dest-target.ts"), dest);
+    let renameFailure = "";
+    try {
+        await run({
+            edits: [{ file: src, ops: [{ find: "= 1", replace: "= 2" }], renameTo: dest }],
+            verbose: false,
+            backupDir: scratchDir("wx-mv"),
+        });
+    } catch (err) {
+        renameFailure = err instanceof Error ? err.message : String(err);
+    }
+    check(
+        "a rename target that exists at write time is refused and the source keeps its content",
+        renameFailure.includes("EEXIST") &&
+            read("mv-src.ts") === "const mv = 1;\n" &&
+            fs.lstatSync(dest).isSymbolicLink(),
+        renameFailure
+    );
+}
+{
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const barrelSource = fs.readFileSync(path.join(here, "replace-utils.ts"), "utf8");
+    const notExported = collectApi(here)
+        .filter((entry) => {
+            const mod = `./${entry.module.replace(/\.ts$/, "")}`;
+            if (!/^(interface|type|class) /.test(entry.signature)) {
+                return !(entry.name in barrel);
+            }
+
+            const star = barrelSource.includes(`export * from "${mod}"`);
+            const typed = new RegExp(`export type \\{[^}]*\\b${entry.name}\\b[^}]*\\} from "${mod}"`).test(
+                barrelSource
+            );
+            return !(star || typed);
+        })
+        .map((entry) => `${entry.module}:${entry.name}`);
+    check(
+        "every symbol --api lists is importable from the barrel it names",
+        notExported.length === 0,
+        notExported.join(", ")
+    );
+}
+
+// ── review round 6 (PR #371, eve): a delete checks drift, an exclusive create is tracked from its descriptor,
+// createWith "" is an empty file ──
+console.log("review round 6 (PR #371)");
+{
+    const hlA = write("hl-a.ts", "const hl = 1;\n");
+    const hlB = f("hl-b.ts");
+    fs.linkSync(hlA, hlB);
+    let message = "";
+    try {
+        await run({
+            edits: [
+                { file: hlA, ops: [{ find: "= 1", replace: "= 2" }] },
+                { file: hlB, delete: true },
+            ],
+            verbose: false,
+            backupDir: scratchDir("hl"),
+        });
+    } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+    }
+    check(
+        "a delete refuses a file whose bytes changed after planning (a hard link the earlier write altered) and the recovery keeps it",
+        message.includes("refusing to delete") && fs.existsSync(hlB) && read("hl-a.ts") === "const hl = 1;\n",
+        message
+    );
+}
+{
+    const c = write("wx-c.ts", "const c = 1;\n");
+    fs.chmodSync(c, 0o444);
+    const b = f("wx-b.ts");
+    let late = "";
+    try {
+        await run({
+            edits: [
+                { file: b, createWith: "export const b = 1;\n" },
+                { file: c, ops: [{ find: "= 1", replace: "= 2" }] },
+            ],
+            verbose: false,
+            backupDir: scratchDir("wx-late"),
+        });
+    } catch (err) {
+        late = err instanceof Error ? err.message : String(err);
+    }
+    fs.chmodSync(c, 0o644);
+    check(
+        "a file created exclusively before a later write failed is removed by the recovery",
+        late.includes("write failed after 1 file(s)") && !fs.existsSync(b) && read("wx-c.ts") === "const c = 1;\n",
+        late
+    );
+    const big = f("wx-big.txt");
+    await run({ edits: [{ file: big, createWith: "x".repeat(3_000_000) }], verbose: false });
+    check("an exclusive create writes every byte through the descriptor", fs.statSync(big).size === 3_000_000);
+}
+{
+    const empty = f("empty.txt");
+    await run({ edits: [{ file: empty, createWith: "" }], verbose: false });
+    check('createWith "" creates an empty file', fs.existsSync(empty) && fs.statSync(empty).size === 0);
+    let refused: FableReplaceError | undefined;
+    try {
+        await run({ edits: [{ file: f("both.ts"), delete: true, createWith: "" }], verbose: false });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        'delete:true with createWith "" is refused as a contradiction',
+        refused?.code === 2 && refused.message.includes("cannot be combined"),
+        String(refused?.message)
+    );
+}
+
+// ── review round 7 (PR #371, eve): protected rename destinations, modifiers a kind does not enforce, the dry-run
+// diff of a created file ──
+console.log("review round 7 (PR #371)");
+{
+    const src = write("mv-guard-src.ts", "const g = 1;\n");
+    let intoNodeModules: FableReplaceError | undefined;
+    try {
+        await run({
+            edits: [{ file: src, ops: [{ find: "= 1", replace: "= 2" }], renameTo: f("node_modules/pkg/g.ts") }],
+            verbose: false,
+        });
+    } catch (err) {
+        intoNodeModules = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "a rename into node_modules is refused in pre-flight",
+        intoNodeModules?.code === 2 &&
+            intoNodeModules.message.includes("node_modules") &&
+            read("mv-guard-src.ts") === "const g = 1;\n",
+        String(intoNodeModules?.message)
+    );
+    const generated = write(
+        "mv-guard-gen.ts",
+        "// This file was automatically generated by a tool.\n// You should NOT make any changes in this file.\nexport const routes = 1;\n"
+    );
+    let ontoGenerated: FableReplaceError | undefined;
+    try {
+        await run({
+            edits: [{ file: src, ops: [{ find: "= 1", replace: "= 2" }], renameTo: generated, overwrite: true }],
+            verbose: false,
+        });
+    } catch (err) {
+        ontoGenerated = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "a rename onto a generated file is refused without allowGenerated",
+        ontoGenerated?.code === 2 &&
+            ontoGenerated.message.includes("GENERATED") &&
+            read("mv-guard-gen.ts").includes("routes = 1"),
+        String(ontoGenerated?.message)
+    );
+    await run({
+        edits: [
+            {
+                file: src,
+                ops: [{ find: "= 1", replace: "= 2" }],
+                renameTo: generated,
+                overwrite: true,
+                allowGenerated: true,
+            },
+        ],
+        verbose: false,
+    });
+    check(
+        "allowGenerated lets the rename replace it",
+        read("mv-guard-gen.ts") === "const g = 2;\n" && !fs.existsSync(src)
+    );
+}
+{
+    const parseError = (text: string): string => {
+        try {
+            parseSpec({ text });
+            return "";
+        } catch (err) {
+            return err instanceof Error ? err.message : String(err);
+        }
+    };
+    check(
+        "count= on a block is a spec error",
+        parseError("@@ a.md\n<<< block count=2\nA\n===\nB\n===\n>>>\n").includes("count= is not enforced")
+    );
+    check(
+        "count= on after is a spec error",
+        parseError("@@ a.md\n<<< after count=1\nA\n===\nB\n>>>\n").includes("count= is not enforced")
+    );
+    check(
+        "flags= outside regex is a spec error",
+        parseError("@@ a.md\n<<< fuzzy flags=g\nA\n===\nB\n>>>\n").includes("flags= only applies to regex")
+    );
+    check(
+        "optional on append is a spec error",
+        parseError("@@ a.md\n<<< append optional\nA\n>>>\n").includes("optional has no meaning")
+    );
+    check("count= on delete still parses", parseError("@@ a.md\n<<< delete count=2\nA\n>>>\n") === "");
+}
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("dry-create");
+    fs.mkdirSync(dir, { recursive: true });
+    const dry = spawnSync("bun", [cli, "--dry"], {
+        cwd: dir,
+        input: "@@ fresh.ts\n<<< create\nexport const fresh = 1;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        "--dry shows the whole content of a created file as additions",
+        dry.status === 0 &&
+            dry.stdout.includes("+ export const fresh = 1;") &&
+            !fs.existsSync(path.join(dir, "fresh.ts")),
+        `${String(dry.status)} ${dry.stdout.slice(-300)}`
+    );
+    const withOps = spawnSync("bun", [cli, "--dry"], {
+        cwd: dir,
+        input: "@@ made.ts\n<<< create\nconst seed = 1;\n>>>\n<<<\nseed = 1\n===\nseed = 2\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        "--dry shows a created-with-ops file against the empty baseline",
+        withOps.status === 0 &&
+            withOps.stdout.includes("+ const seed = 2;") &&
+            !withOps.stdout.includes("- const seed = 1;"),
+        `${String(withOps.status)} ${withOps.stdout.slice(-300)}`
+    );
+}
+
+// ── review round 8 (PR #371, eve): delete bodies anchor to a line start, a rename is syntax-checked as its
+// destination ──
+console.log("review round 8 (PR #371)");
+{
+    const mid = applyOps("notfoo\nfoo\n", [{ find: "foo\n", replace: "", wholeLines: true }]);
+    check(
+        "wholeLines: a needle inside a line is not a match, the line-start one is",
+        mid.results[0].status === "OK" && mid.content === "notfoo\n",
+        mid.results[0].reason ?? mid.content
+    );
+    const only = applyOps("notfoo\n", [{ find: "foo\n", replace: "", wholeLines: true }]);
+    check(
+        "wholeLines: a suffix-only occurrence is a MISS that says so",
+        only.results[0].status === "MISS" &&
+            only.content === "notfoo\n" &&
+            (only.results[0].reason ?? "").includes("start of a line"),
+        only.results[0].reason ?? ""
+    );
+    const multi = applyOps("xfoo\nbar\nfoo\nbar\n", [{ find: "foo\nbar\n", replace: "", wholeLines: true }]);
+    check(
+        "wholeLines: a multi-line body cannot start halfway through a line",
+        multi.results[0].status === "OK" && multi.content === "xfoo\nbar\n",
+        multi.results[0].reason ?? multi.content
+    );
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("delete-lines");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "d.ts"), "const notfoo = 1;\nfoo\nconst b = 2;\n");
+    const del = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: "@@ d.ts\n<<< delete\nfoo\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        "cli: <<< delete removes the whole line and never a suffix",
+        del.status === 0 && fs.readFileSync(path.join(dir, "d.ts"), "utf8") === "const notfoo = 1;\nconst b = 2;\n",
+        `${String(del.status)} ${del.stdout.slice(-200)}`
+    );
+}
+{
+    const words = write("note.txt", "just words, not code\n");
+    let refused: FableReplaceError | undefined;
+    try {
+        await run({ edits: [{ file: words, renameTo: f("note.ts") }], verbose: false });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "a rename-only edit to .ts is checked under the destination loader",
+        refused?.code === 1 &&
+            refused.report?.files[0]?.postConditionFailures[0]?.includes("does not parse as .ts") === true &&
+            fs.existsSync(words) &&
+            !fs.existsSync(f("note.ts")),
+        String(refused?.message)
+    );
+    const view = write("view.tsx", "export const view = <div />;\n");
+    let jsx: FableReplaceError | undefined;
+    try {
+        await run({ edits: [{ file: view, renameTo: f("view.ts") }], verbose: false });
+    } catch (err) {
+        jsx = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "a .tsx holding JSX renamed to .ts is refused",
+        jsx?.code === 1 &&
+            jsx.report?.files[0]?.postConditionFailures[0]?.includes("does not parse as .ts") === true &&
+            fs.existsSync(view),
+        String(jsx?.message)
+    );
+    const plain = write("ok.txt", "export const ok = 1;\n");
+    await run({ edits: [{ file: plain, renameTo: f("ok.ts") }], verbose: false });
+    check("a .txt holding valid TypeScript renames to .ts", fs.existsSync(f("ok.ts")) && !fs.existsSync(plain));
+}
+
+// ── review round 9 (PR #371, eve): an unknown op kind is refused at both doors, dropComments enforces expect
+// itself ──
+console.log("review round 9 (PR #371)");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("bad-kind");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "j.ts"), "const old = 1;\n");
+    const bad = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: stringifyJson([{ file: "j.ts", ops: [{ kind: "fuzxy", find: "old", replace: "new" }] }]),
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        "cli (JSON form): a misspelled op kind is a spec error, not a literal edit",
+        bad.status === 2 &&
+            bad.stderr.includes('unknown kind "fuzxy"') &&
+            fs.readFileSync(path.join(dir, "j.ts"), "utf8") === "const old = 1;\n",
+        `${String(bad.status)} ${bad.stderr.slice(0, 200)}`
+    );
+    const scripted = applyOps("const old = 1;\n", [{ kind: "fuzxy", find: "old", replace: "new" } as never]);
+    check(
+        "api: a misspelled op kind is a MISS, not a literal edit",
+        scripted.results[0].status === "MISS" &&
+            scripted.content === "const old = 1;\n" &&
+            (scripted.results[0].reason ?? "").includes("unknown op kind"),
+        scripted.results[0].reason ?? ""
+    );
+}
+{
+    let refused: FableReplaceError | undefined;
+    try {
+        dropComments("// legacy a\n// legacy b\n", { containing: "legacy", expect: 1 });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "dropComments enforces expect on a direct call",
+        refused?.code === 1 && refused.message.includes("expected 1 comment(s), found 2"),
+        String(refused?.message)
+    );
+    const asOp = applyOps("// legacy a\n// legacy b\n", [{ kind: "dropComments", containing: "legacy", expect: 1 }]);
+    check(
+        "the op form reports the same mismatch as a MISS and changes nothing",
+        asOp.results[0].status === "MISS" &&
+            asOp.content === "// legacy a\n// legacy b\n" &&
+            (asOp.results[0].reason ?? "").includes("found 2"),
+        asOp.results[0].reason ?? ""
+    );
+}
+
+// ── review round 10 (PR #371, eve): JSON field types are checked, deleteLines enforces expect itself, a spec that
+// cannot be read is journaled ──
+console.log("review round 10 (PR #371)");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("json-types");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "n.ts"), "const n = 1;\n");
+    const bad = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: '[{"file":"n.ts","delete":"false"}]',
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        'cli (JSON form): delete: "false" is a spec error, and the file survives',
+        bad.status === 2 &&
+            bad.stderr.includes("delete must be true or false") &&
+            fs.existsSync(path.join(dir, "n.ts")),
+        `${String(bad.status)} ${bad.stderr.slice(0, 200)}`
+    );
+    const overwrite = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: '[{"file":"n.ts","renameTo":"m.ts","overwrite":"false"}]',
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        'cli (JSON form): overwrite: "false" is a spec error',
+        overwrite.status === 2 && overwrite.stderr.includes("overwrite must be true or false"),
+        `${String(overwrite.status)} ${overwrite.stderr.slice(0, 200)}`
+    );
+}
+{
+    let refused: FableReplaceError | undefined;
+    try {
+        deleteLines("a\nDEBUG 1\nDEBUG 2\n", { kind: "deleteLines", containing: "DEBUG", expect: 1 });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "deleteLines enforces expect on a direct call",
+        refused?.code === 1 && refused.message.includes("expected 1 line(s), found 2"),
+        String(refused?.message)
+    );
+    const asOp = applyOps("a\nDEBUG 1\nDEBUG 2\n", [{ kind: "deleteLines", containing: "DEBUG", expect: 1 }]);
+    check(
+        "the deleteLines op reports the mismatch as a MISS and changes nothing",
+        asOp.results[0].status === "MISS" &&
+            asOp.content === "a\nDEBUG 1\nDEBUG 2\n" &&
+            (asOp.results[0].reason ?? "").includes("found 2"),
+        asOp.results[0].reason ?? ""
+    );
+}
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const home = f("journal-spec-error");
+    fs.mkdirSync(home, { recursive: true });
+    const unreadable = spawnSync("bun", [cli, "--spec", f("does-not-exist.frspec")], {
+        encoding: "utf8",
+        env: { ...hermeticEnv, FABLE_REPLACE_HOME: home },
+    });
+    const journalFile = path.join(home, ".genesis-tools", "fable-replace", "journal.jsonl");
+    const journalLines = fs.existsSync(journalFile) ? fs.readFileSync(journalFile, "utf8").trim().split("\n") : [];
+    const last =
+        journalLines.length > 0 ? (parseJson(journalLines[journalLines.length - 1]) as JournalEntry) : undefined;
+    check(
+        "an unreadable --spec is journaled as spec-error",
+        unreadable.status === 2 && last?.outcome === "spec-error" && (last.message ?? "").includes("cannot read"),
+        `${String(unreadable.status)} ${stringifyJson(last)}`
+    );
+}
+
+// ── verdict ─────────────────────────────────────────────────────────────────
+fs.rmSync(tmp, { recursive: true, force: true });
+fs.rmSync(hermeticRoot, { recursive: true, force: true });
+if (failures > 0) {
+    console.error(`\n${failures} SELFTEST FAILURE(S)`);
+    process.exit(1);
+}
+console.log("\nALL SELFTESTS PASSED");

--- a/plugins/genesis-tools/skills/fable-replace/scripts/spec.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/spec.ts
@@ -1,0 +1,449 @@
+/**
+ * fable-replace — THE SPEC FORMAT the CLI reads. Zero escaping, heredoc-friendly,
+ * readable by any model. Git-conflict-marker shaped:
+ *
+ *   @@ src/foo.ts                 # start a file section (path relative to cwd, or absolute)
+ *   expect: newName(              # optional post-conditions for this file, repeatable
+ *   absent: oldName(
+ *   <<<                           # a literal replace op (exactly-once by default)
+ *   exact current text, indentation included
+ *   ===
+ *   replacement text
+ *   >>>
+ *   <<< count=all                 # every occurrence
+ *   <<< count=3                   # exactly three
+ *   <<< optional                  # SKIP instead of MISS when absent (re-runnable)
+ *   <<< label=drop legacy gate    # free text for the report (rest of the line)
+ *   <<< regex flags=gi            # find is a JS regex source, replace may use $1; count=N pins matches
+ *   <<< fuzzy                     # whitespace-insensitive literal
+ *   <<< after                     # insert whole lines AFTER the line containing the (unique) anchor
+ *   anchor text
+ *   ===
+ *   lines to insert
+ *   >>>
+ *   <<< before                    # same, before the line
+ *   <<< append                    # one body only: lines appended at end of file
+ *   <<< delete                    # one body only: these lines go, newline included
+ *   <<< block                     # three bodies: from === to === replacement (empty = delete the block)
+ *   <<< create                    # one body only: create the file with this content (must not exist)
+ *
+ * A body is the lines between the markers, joined with "\n", no trailing newline.
+ * Everything between `<<<` and `>>>` is raw: only a line that is exactly `===` or
+ * `>>>` is special there. Outside a block, blank lines and `#` comments are ignored.
+ * JSON is accepted too: a top-level array of FileEdit objects (regex ops carry
+ * `find` as a string plus optional `flags`).
+ */
+
+import { parseJson } from "./json";
+import type { FileEdit, Op } from "./types";
+
+export interface ParseSpecParams {
+    text: string;
+    /** Receives non-fatal warnings (an unbalanced code fence that hints at a bare >>> closing a block early). */
+    onWarning?: (message: string) => void;
+}
+
+interface Section {
+    file: string;
+    ops: Op[];
+    expectAfter: string[];
+    absentAfter: string[];
+    createWith?: string;
+}
+
+function fail(line: number, message: string): never {
+    throw new Error(`spec line ${line}: ${message}`);
+}
+
+const KINDS = new Set(["regex", "fuzzy", "before", "after", "append", "delete", "block", "create"]);
+/** The kinds whose `count=` is a checked contract; the others anchor on a unique line or have nothing to count. */
+const COUNTED_KINDS = new Set(["replace", "regex", "fuzzy", "delete"]);
+/** Every `kind` a JSON op object may carry (a literal op has none, or "replace"). */
+const OP_KINDS = new Set([
+    "replace",
+    "regex",
+    "fuzzy",
+    "deleteBlock",
+    "replaceBlock",
+    "insertBefore",
+    "insertAfter",
+    "insertLinesBefore",
+    "insertLinesAfter",
+    "append",
+    "dropComments",
+    "deleteLines",
+]);
+
+interface Modifiers {
+    kind: string;
+    count?: number | "all";
+    optional: boolean;
+    label?: string;
+    flags?: string;
+}
+
+const parseModifiers = (raw: string, line: number): Modifiers => {
+    const mods: Modifiers = { kind: "replace", optional: false };
+    let rest = raw.trim();
+    const labelAt = rest.indexOf("label=");
+    if (labelAt !== -1) {
+        const labelText = rest.slice(labelAt + "label=".length).trim();
+        // `label=` takes the REST of the line, so a modifier written AFTER it was silently
+        // absorbed: `<<< label=see ticket, regex flags=g` ran as a LITERAL search, matched
+        // something unrelated once, and reported OK. Quote the label to keep such a word.
+        const quoted =
+            labelText.length > 1 &&
+            ((labelText.startsWith('"') && labelText.endsWith('"')) ||
+                (labelText.startsWith("'") && labelText.endsWith("'")));
+        if (!quoted) {
+            const swallowed = labelText
+                .split(/\s+/)
+                .find((t) => KINDS.has(t) || t === "optional" || /^(count|flags)=/.test(t));
+            if (swallowed !== undefined) {
+                fail(
+                    line,
+                    `"${swallowed}" was absorbed into the label: label= takes the whole rest of the line. Put label= LAST (<<< regex flags=g label=your text). If the word really belongs to the label, quote it: label="your text"`
+                );
+            }
+        }
+
+        mods.label = quoted ? labelText.slice(1, -1) : labelText;
+        rest = rest.slice(0, labelAt);
+    }
+    for (const token of rest.split(/\s+/).filter((t) => t.length > 0)) {
+        const [key, value] = token.includes("=") ? token.split("=", 2) : [token, undefined];
+        if (value === undefined && KINDS.has(key)) {
+            if (mods.kind !== "replace") {
+                fail(line, `two op kinds on one marker: ${mods.kind} and ${key}`);
+            }
+            mods.kind = key;
+        } else if (key === "optional" && value === undefined) {
+            mods.optional = true;
+        } else if (key === "count" && value !== undefined) {
+            if (value === "all") {
+                mods.count = "all";
+            } else if (/^\d+$/.test(value) && Number(value) > 0) {
+                mods.count = Number(value);
+            } else {
+                fail(line, `count must be a positive number or "all", got "${value}"`);
+            }
+        } else if (key === "flags" && value !== undefined) {
+            mods.flags = value;
+        } else {
+            fail(
+                line,
+                `unknown modifier "${token}". Known: ${[...KINDS].join(", ")}, count=N|all, optional, flags=…, label=…`
+            );
+        }
+    }
+    // A modifier the kind does not enforce used to be accepted and dropped, so a declared
+    // constraint read as verified while nothing checked it.
+    if (mods.count !== undefined && !COUNTED_KINDS.has(mods.kind)) {
+        fail(
+            line,
+            `count= is not enforced for ${mods.kind}: before/after/block need a unique anchor, append/create have nothing to count. Remove it.`
+        );
+    }
+    if (mods.flags !== undefined && mods.kind !== "regex") {
+        fail(line, `flags= only applies to regex, not ${mods.kind}`);
+    }
+    if (mods.optional && (mods.kind === "append" || mods.kind === "create")) {
+        fail(line, `optional has no meaning for ${mods.kind}: it cannot miss`);
+    }
+    return mods;
+};
+
+const partsNeeded = (kind: string): number => {
+    switch (kind) {
+        case "append":
+        case "delete":
+        case "create":
+            return 1;
+        case "block":
+            return 3;
+        default:
+            return 2;
+    }
+};
+
+const compileRegex = ({ source, flags, line }: { source: string; flags: string; line: number }): RegExp => {
+    try {
+        return new RegExp(source, flags.includes("g") ? flags : `${flags}g`);
+    } catch (err) {
+        return fail(line, `invalid regex or flags: ${err instanceof Error ? err.message : String(err)}`);
+    }
+};
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: the parser refuses control characters in a spec on purpose
+const CONTROL_CHAR = /[\x00-\x08\x0B\x0C\x0E-\x1F]/;
+
+const buildOp = (mods: Modifiers, parts: string[], line: number, section: Section): void => {
+    const need = partsNeeded(mods.kind);
+    if (parts.length !== need) {
+        fail(line, `${mods.kind} needs ${need} bod${need === 1 ? "y" : "ies"} (separated by ===), got ${parts.length}`);
+    }
+    for (const [k, part] of parts.entries()) {
+        const bad = part.match(CONTROL_CHAR);
+        if (bad !== null) {
+            const code = `0x${bad[0].charCodeAt(0).toString(16).padStart(2, "0")}`;
+            fail(
+                line,
+                `body ${k + 1} contains a control character (${code}). That is a shell escaping artifact: zsh's echo turns \\b into a backspace. Build spec text with printf '%s\\n', never echo.`
+            );
+        }
+    }
+    const [a, b, c] = parts;
+    const emptyFirst = mods.kind === "fuzzy" ? a.trim() === "" : a === "";
+    if (emptyFirst && mods.kind !== "create" && mods.kind !== "append") {
+        // An empty needle or anchor matches everywhere or nowhere; the runner refuses it
+        // too, but a spec error names the line before anything is planned.
+        fail(line, `${mods.kind}: the first body is empty, so there is nothing to find, delete or anchor on`);
+    }
+
+    const common = { optional: mods.optional, label: mods.label };
+    switch (mods.kind) {
+        case "replace":
+            section.ops.push({ find: a, replace: b, count: mods.count, ...common });
+            return;
+        case "regex": {
+            section.ops.push({
+                kind: "regex",
+                find: compileRegex({ source: a, flags: mods.flags ?? "g", line }),
+                replace: b,
+                expect: typeof mods.count === "number" ? mods.count : undefined,
+                ...common,
+            });
+            return;
+        }
+        case "fuzzy":
+            section.ops.push({ kind: "fuzzy", find: a, replace: b, count: mods.count, ...common });
+            return;
+        case "before":
+        case "after":
+            section.ops.push({
+                kind: mods.kind === "before" ? "insertLinesBefore" : "insertLinesAfter",
+                anchor: a,
+                text: b,
+                ...common,
+            });
+            return;
+        case "append":
+            section.ops.push({ kind: "append", text: a, label: mods.label });
+            return;
+        case "delete":
+            section.ops.push({
+                find: `${a}\n`,
+                replace: "",
+                count: mods.count,
+                wholeLines: true,
+                ...common,
+                label: mods.label ?? `delete "${a.split("\n")[0].trim().slice(0, 44)}"`,
+            });
+            return;
+        case "block":
+            section.ops.push(
+                c.length === 0
+                    ? { kind: "deleteBlock", from: a, to: b, ...common }
+                    : { kind: "replaceBlock", from: a, to: b, replace: c, ...common }
+            );
+            return;
+        case "create":
+            if (section.createWith !== undefined) {
+                fail(line, "create given twice for one file");
+            }
+            section.createWith = a.endsWith("\n") ? a : `${a}\n`;
+            return;
+        default:
+            fail(line, `unhandled kind ${mods.kind}`);
+    }
+};
+
+const toFileEdit = (section: Section): FileEdit => {
+    const edit: FileEdit = { file: section.file };
+    if (section.ops.length > 0) {
+        edit.ops = section.ops;
+    }
+    if (section.createWith !== undefined) {
+        edit.createWith = section.createWith;
+    }
+    if (section.expectAfter.length > 0) {
+        edit.expectAfter = section.expectAfter;
+    }
+    if (section.absentAfter.length > 0) {
+        edit.absentAfter = section.absentAfter;
+    }
+    return edit;
+};
+
+const fromJson = (text: string): FileEdit[] => {
+    const raw = parseJson(text);
+    if (!Array.isArray(raw)) {
+        throw new Error("JSON spec must be an array of FileEdit objects");
+    }
+    return raw.map((edit) => {
+        if (edit === null || typeof edit !== "object" || Array.isArray(edit)) {
+            throw new Error("every JSON spec entry must be a FileEdit object");
+        }
+
+        // TypeScript casts do not check external input. "delete": "false" is a truthy
+        // string, and the runner used to delete the file on it.
+        const fields = edit as Record<string, unknown>;
+        const typeErrors: string[] = [];
+        if (typeof fields.file !== "string" || fields.file === "") {
+            typeErrors.push("file must be a non-empty string");
+        }
+        for (const name of ["delete", "overwrite", "allowGenerated"]) {
+            if (fields[name] !== undefined && typeof fields[name] !== "boolean") {
+                typeErrors.push(`${name} must be true or false, got ${String(fields[name])} (${typeof fields[name]})`);
+            }
+        }
+        for (const name of ["renameTo", "createWith"]) {
+            if (fields[name] !== undefined && typeof fields[name] !== "string") {
+                typeErrors.push(`${name} must be a string`);
+            }
+        }
+        if (fields.ops !== undefined && !Array.isArray(fields.ops)) {
+            typeErrors.push("ops must be an array");
+        }
+        if (typeErrors.length > 0) {
+            throw new Error(`${String(fields.file ?? "?")}: ${typeErrors.join("; ")}`);
+        }
+
+        const e = edit as FileEdit;
+        const rawOps = ((edit as { ops?: unknown }).ops ?? []) as Array<Record<string, unknown>>;
+        const ops = rawOps.map((op, index) => {
+            // A misspelled kind used to fall through to the literal branch and edit an exact
+            // occurrence, reporting OK for an op nobody wrote.
+            if (op.kind !== undefined && !OP_KINDS.has(String(op.kind))) {
+                throw new Error(
+                    `${String(e.file)}: op ${index + 1} has unknown kind "${String(op.kind)}". Known: ${[...OP_KINDS].join(", ")}`
+                );
+            }
+
+            return op.kind === "regex" && typeof op.find === "string"
+                ? ({ ...op, find: new RegExp(op.find, typeof op.flags === "string" ? op.flags : "g") } as unknown as Op)
+                : (op as unknown as Op);
+        });
+        return { ...e, ops };
+    });
+};
+
+/** Parse the marker format (or a JSON array) into FileEdits for `run()`. Throws with a line number on any malformed input. */
+export const parseSpec = ({ text, onWarning }: ParseSpecParams): FileEdit[] => {
+    const trimmed = text.trimStart();
+    if (trimmed.startsWith("[")) {
+        try {
+            return fromJson(trimmed);
+        } catch (err) {
+            // A marker spec whose first line happens to start with "[" (a changelog entry,
+            // a markdown link) used to surface a bare JSON error naming no spec line.
+            fail(
+                1,
+                `the spec starts with "[", so it was read as the JSON form: ${String(err)}. A marker spec must start with an "@@ <path>" header.`
+            );
+        }
+    }
+    // A spec pasted from two sources can carry CRLF on some lines only. Splitting on "\n"
+    // alone left a "\r" on the markers, so "===" and ">>>" stopped being recognised and the
+    // next op was swallowed into the previous body — one op silently became none.
+    const lines = text.split(/\r\n|\n/);
+    const sections: Section[] = [];
+    let current: Section | null = null;
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i];
+        const lineNo = i + 1;
+        if (line.startsWith("@@")) {
+            const file = line.slice(2).trim();
+            if (file.length === 0) {
+                fail(lineNo, "@@ needs a file path");
+            }
+            if (/^[-+]\d/.test(file)) {
+                fail(
+                    lineNo,
+                    `"${line.slice(0, 40)}" looks like a diff hunk header, not a file path. A body line that was exactly >>> closed the previous block early; write such a line as \\>>>`
+                );
+            }
+            current = { file, ops: [], expectAfter: [], absentAfter: [] };
+            sections.push(current);
+            i += 1;
+            continue;
+        }
+        if (line.startsWith("<<<")) {
+            if (current === null) {
+                fail(lineNo, "op before any @@ file line");
+            }
+            const mods = parseModifiers(line.slice(3), lineNo);
+            const parts: string[] = [];
+            const separatorLines: number[] = [];
+            let body: string[] = [];
+            let closed = false;
+            i += 1;
+            while (i < lines.length) {
+                const inner = lines[i];
+                if (inner === "===") {
+                    parts.push(body.join("\n"));
+                    body = [];
+                    separatorLines.push(i + 1);
+                } else if (inner === ">>>") {
+                    parts.push(body.join("\n"));
+                    closed = true;
+                    i += 1;
+                    break;
+                } else if (inner === "\\===" || inner === "\\>>>") {
+                    // A body line that must be exactly === or >>> carries one leading backslash.
+                    body.push(inner.slice(1));
+                } else {
+                    body.push(inner);
+                }
+                i += 1;
+            }
+            if (!closed) {
+                fail(lineNo, "block never closed with >>>");
+            }
+            const need = partsNeeded(mods.kind);
+            if (parts.length > need) {
+                fail(
+                    separatorLines[need - 1] ?? lineNo,
+                    `${mods.kind} takes ${need} bod${need === 1 ? "y" : "ies"}, but this line is exactly === and starts body ${need + 1}. A body line that must be exactly === is written \\===`
+                );
+            }
+            // A bare >>> inside a NON-final body already fails ("takes N bodies"), so only the
+            // LAST body can be truncated silently. Only that body is inspected, and only a fence
+            // left OPEN with content after it counts: the anchors of a `block` op are fragments
+            // and may legitimately end on a closing fence alone, and a body that IS a fence line
+            // (replacing ```sh with ```bash) is complete.
+            const lastLines = (parts[parts.length - 1] ?? "").split("\n");
+            const fenceLines = lastLines.map((l, idx) => (l.startsWith("```") ? idx : -1)).filter((idx) => idx !== -1);
+            const openedAt = fenceLines.length % 2 === 1 ? fenceLines[fenceLines.length - 1] : -1;
+            if (openedAt !== -1 && openedAt < lastLines.length - 1) {
+                onWarning?.(
+                    `spec line ${lineNo}: the last body of this block ends inside a code fence opened at its line ${openedAt + 1}. If a body line was exactly >>> it closed the block early and the rest was dropped; write such a line as \\>>>`
+                );
+            }
+            buildOp(mods, parts, lineNo, current);
+            continue;
+        }
+        const cond = line.match(/^(expect|absent):\s?(.*)$/);
+        if (cond !== null) {
+            if (current === null) {
+                fail(lineNo, `${cond[1]}: before any @@ file line`);
+            }
+            (cond[1] === "expect" ? current.expectAfter : current.absentAfter).push(cond[2]);
+            i += 1;
+            continue;
+        }
+        if (line.trim().length === 0 || line.trimStart().startsWith("#")) {
+            i += 1;
+            continue;
+        }
+        fail(
+            lineNo,
+            `unexpected text outside a block: "${line.slice(0, 60)}". Lines outside <<< >>> must be @@ file, expect:, absent:, # comment, or blank. If this line belongs to the previous block, a body line was exactly >>> or === and closed it early: write such lines as \\>>> or \\===`
+        );
+    }
+    if (sections.length === 0) {
+        throw new Error("spec has no @@ file sections");
+    }
+    return sections.map(toFileEdit);
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/sweep-many-files.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/sweep-many-files.ts
@@ -1,0 +1,908 @@
+/**
+ * fable-replace — THE RUNNER. Applying a batch of FileEdits across many files,
+ * transactionally.
+ *
+ * Every file is read and every op applied IN MEMORY first. Only if all required ops
+ * matched, all post-conditions held and every edited script still parses does
+ * anything get written. One required MISS aborts the whole batch.
+ *
+ * It also refuses, in pre-flight: node_modules paths, machine-generated files, a
+ * renameTo onto an existing file, and a reused backupDir.
+ *
+ * `verifyCommand` runs your project's own check after a successful write. USE IT. Every
+ * op reporting OK only proves the ops you DECLARED matched; it cannot know about a call
+ * site your recon never found. A red check keeps the sweep written and exits 3: rolling
+ * back would restore the very needles a re-sent spec matches, and the loop that follows
+ * costs a full-context round trip per turn. The files stay; the undo command is printed.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { backupDirInUse, recordPostWriteHashes, rollback, writeBackup } from "./backup-and-rollback";
+import { scanComments } from "./comments";
+import { applyOps } from "./edit-one-file";
+import { COLORS, changedOnDisk, FableReplaceError, paint, preview } from "./internal";
+import { leftovers } from "./recon";
+import type { FileEdit, FileResult, RunParams, RunReport, SimpleDiffParams, VerifyResult } from "./types";
+import { checkVerifyCommand, runVerifyCommand, verifyUnknownReason } from "./verify-command";
+
+/**
+ * Roll a failed sweep back and return the files the rollback itself could NOT restore.
+ * Those still hold the rejected content, so the caller must name them: an exit code
+ * alone reads as a routine failure, and the user trusts "or not at all".
+ */
+const strandedByRollback = ({ backupDir, touched }: { backupDir: string; touched: string[] }): string[] => {
+    // Only the paths this sweep wrote. A file the changed-on-disk guard refused holds someone
+    // else's write, and a file after the failure was never touched: restoring either from
+    // the snapshot would destroy exactly what the guard protected.
+    console.error(paint(COLORS.miss, `rolling back the ${touched.length} path(s) this sweep wrote.`));
+    const report = rollback({ backupDir, force: true, only: touched });
+    return report.failed.map((f) => f.file);
+};
+
+const CLI_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+
+/**
+ * The failure block a reader must not misread. Its first sentence answers the only
+ * question that matters after a red check: the files ARE written. A rollback here would
+ * restore the originals, and the model's instinct to re-send the whole spec would then
+ * succeed, go red again, and loop. Keeping the files makes a blind re-send MISS instead,
+ * which is a hard stop with a hint.
+ */
+const printVerifyFailure = ({
+    verify,
+    written,
+    backupDir,
+}: {
+    verify: VerifyResult;
+    written: string[];
+    backupDir?: string;
+}): void => {
+    const verdict =
+        verify.status === "fail"
+            ? `VERIFY FAILED (exit ${String(verify.exitCode)})`
+            : `VERIFY UNKNOWN (${verifyUnknownReason(verify)})`;
+    console.error(
+        paint(
+            COLORS.miss,
+            `\nSWEEP WRITTEN, ${verdict}. The ${written.length} file(s) above hold the sweep. Do NOT re-send this spec.`
+        )
+    );
+    console.error("Fix forward with a small follow-up spec, or undo everything with:");
+    console.error(
+        backupDir === undefined
+            ? "  (no backup dir: this run used --no-backup, so undo it with git: `git diff`, then `git stash push -- <files>`)"
+            : `  bun "${CLI_PATH}" --rollback "${backupDir}"`
+    );
+    for (const line of verify.shown) {
+        console.error(`  ${line}`);
+    }
+    if (verify.outputFile !== undefined) {
+        console.error(paint(COLORS.dim, `full verify output: ${verify.outputFile}`));
+    }
+};
+
+/**
+ * Line diff for dry runs. Patience-style: it trims the common prefix/suffix, then
+ * splits the remaining window on lines that occur exactly once on BOTH sides and
+ * recurses. That keeps two edits 40 lines apart as two small hunks instead of one
+ * 40-line block, which used to overstate the blast radius of a multi-hit sweep.
+ */
+const diffRegion = (a: string[], b: string[], aStart: number, out: string[], depth = 0): void => {
+    let prefix = 0;
+    while (prefix < a.length && prefix < b.length && a[prefix] === b[prefix]) {
+        prefix += 1;
+    }
+    let suffix = 0;
+    while (
+        suffix < a.length - prefix &&
+        suffix < b.length - prefix &&
+        a[a.length - 1 - suffix] === b[b.length - 1 - suffix]
+    ) {
+        suffix += 1;
+    }
+    const aMid = a.slice(prefix, a.length - suffix);
+    const bMid = b.slice(prefix, b.length - suffix);
+    if (aMid.length === 0 && bMid.length === 0) {
+        return;
+    }
+    const midStart = aStart + prefix;
+
+    // find a unique common anchor line to split on (patience diff)
+    if (depth < 40 && aMid.length > 0 && bMid.length > 0) {
+        const countIn = (arr: string[]): Map<string, number> => {
+            const m = new Map<string, number>();
+            for (const l of arr) {
+                m.set(l, (m.get(l) ?? 0) + 1);
+            }
+            return m;
+        };
+        const ca = countIn(aMid);
+        const cb = countIn(bMid);
+        let anchorA = -1;
+        let anchorB = -1;
+        for (let i = 0; i < aMid.length; i += 1) {
+            const line = aMid[i];
+            if (line.trim() === "" || ca.get(line) !== 1 || cb.get(line) !== 1) {
+                continue;
+            }
+            anchorA = i;
+            anchorB = bMid.indexOf(line);
+            break;
+        }
+        if (anchorA !== -1 && anchorB !== -1) {
+            diffRegion(aMid.slice(0, anchorA), bMid.slice(0, anchorB), midStart, out, depth + 1);
+            diffRegion(aMid.slice(anchorA + 1), bMid.slice(anchorB + 1), midStart + anchorA + 1, out, depth + 1);
+            return;
+        }
+    }
+
+    out.push(`@@ line ${midStart + 1} (−${aMid.length} +${bMid.length}) @@`);
+    for (const l of aMid) {
+        out.push(`- ${l}`);
+    }
+    for (const l of bMid) {
+        out.push(`+ ${l}`);
+    }
+};
+
+export const simpleDiff = ({ before, after, maxLines = 200 }: SimpleDiffParams): string => {
+    const out: string[] = [];
+    diffRegion(before.split("\n"), after.split("\n"), 0, out);
+    if (out.length === 0) {
+        return "(no line-level change)";
+    }
+    if (out.length > maxLines) {
+        const hidden = out.length - maxLines;
+        return [...out.slice(0, maxLines), `… (${hidden} more diff lines)`].join("\n");
+    }
+    return out.join("\n");
+};
+
+// A sweep that edits generated output looks perfect and typechecks, then vanishes on
+// the next codegen run. SKILL.md always said "never point ops at generated files";
+// this makes the rule mechanical instead of advisory.
+const GENERATED_PATH_RE =
+    /(^|[/\\])(dist|build|out|coverage)[/\\]|\.(gen|generated)\.[cm]?[jt]sx?$|\.pb\.[cm]?[jt]s$|_pb2?\.[cm]?[jt]s$/;
+
+const GENERATED_HEADER_RE =
+    /@generated|code generated by|automatically generated|auto-generated|do not (make any changes|edit|modify)/i;
+
+/** Why `file` looks machine-generated, or null when it does not. */
+export const looksGenerated = (file: string): string | null => {
+    if (GENERATED_PATH_RE.test(file)) {
+        return "path looks generated";
+    }
+    if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) {
+        return null;
+    }
+    const head = fs.readFileSync(file, "utf8").split("\n").slice(0, 60).join("\n");
+    // In source files only a REAL COMMENT counts. A hand-written module whose job is
+    // to EMIT "auto-generated, do not edit" into some other file must not be mistaken
+    // for generated output — src/zsh/lib/hook-generator.ts is exactly that, and a raw
+    // substring sniff flagged it.
+    const haystack = SCRIPT_EXT_RE.test(file)
+        ? scanComments(head)
+              .map((span) => span.text)
+              .join("\n")
+        : head;
+    const hit = haystack.match(GENERATED_HEADER_RE);
+    return hit === null ? null : `header comment says "${hit[0]}"`;
+};
+
+const SCRIPT_EXT_RE = /\.(m|c)?(ts|js)x?$/;
+
+/**
+ * Did the ops turn parseable source into unparseable source? A post-condition is a
+ * substring test and cannot see structure, so a dropped brace passes `expectAfter`
+ * and still breaks the file. This catches that before anything is written.
+ * Returns the parser message, or null when the file is fine (or was already broken,
+ * or is not a script, or Bun's transpiler is unavailable).
+ */
+const brokeSyntax = (file: string, before: string, after: string): string | null => {
+    if (!SCRIPT_EXT_RE.test(file) || before === after) {
+        return null;
+    }
+    const Transpiler = (
+        globalThis as { Bun?: { Transpiler?: new (o: { loader: string }) => { scan: (s: string) => unknown } } }
+    ).Bun?.Transpiler;
+    if (Transpiler === undefined) {
+        return null;
+    }
+    const tp = new Transpiler({ loader: file.endsWith("x") ? "tsx" : "ts" });
+    try {
+        tp.scan(before);
+    } catch {
+        return null; // already unparseable before the sweep — not our doing
+    }
+    try {
+        tp.scan(after);
+        return null;
+    } catch (err) {
+        // Bun's BuildMessage carries the position; without the line number the reader
+        // has to bisect a 700-line file by hand to find which op broke it.
+        const pos = (err as { position?: { line?: number; column?: number; lineText?: string } }).position;
+        const where =
+            pos?.line === undefined
+                ? ""
+                : ` at line ${pos.line + 1}${pos.column === undefined ? "" : `:${pos.column + 1}`}${pos.lineText === undefined ? "" : ` → "${pos.lineText.trim().slice(0, 100)}"`}`;
+        return `${String(err).split("\n")[0].slice(0, 120)}${where}`;
+    }
+};
+
+const validateEdit = (edit: FileEdit): string | null => {
+    // Presence, not truthiness: createWith "" is a legitimate empty file.
+    const creates = edit.createWith !== undefined;
+    if (edit.delete && (edit.ops?.length || edit.renameTo || creates)) {
+        return "delete:true cannot be combined with ops/renameTo/createWith";
+    }
+    if (!edit.delete && !edit.ops?.length && !edit.renameTo && !creates) {
+        return "edit has no ops, no delete, no renameTo, no createWith — nothing to do";
+    }
+    return null;
+};
+
+/**
+ * Execute a batch of file edits.
+ *
+ * Transactional by default: every file is processed IN MEMORY first; if any
+ * required op misses or a post-condition fails, NOTHING is written and the
+ * process exits non-zero (or throws with `throwOnFailure`). Pass `partial: true`
+ * to write the files that fully passed anyway.
+ *
+ * `--dry` on argv (or `dryRun: true`) prints diffs and writes nothing.
+ */
+const KNOWN_RUN_KEYS = [
+    "dryRun",
+    "backupDir",
+    "backupOverwrite",
+    "cwd",
+    "partial",
+    "verbose",
+    "showDiff",
+    "maxDiffLines",
+    "maxTotalDiffLines",
+    "allowNodeModules",
+    "allowGenerated",
+    "syntaxCheck",
+    "throwOnFailure",
+    "verifyCommand",
+    "verifyTimeoutMs",
+    "onWritten",
+    "leftoversCheck",
+];
+
+/** A known key sharing a prefix or a substring with the typo, for the "did you mean" hint. */
+const closestRunKey = (typo: string): string | undefined => {
+    const lower = typo.toLowerCase();
+    return KNOWN_RUN_KEYS.find(
+        (k) => k.toLowerCase().startsWith(lower.slice(0, 3)) || lower.includes(k.toLowerCase().slice(0, 4))
+    );
+};
+
+export const run = async ({ edits, ...opts }: RunParams): Promise<RunReport> => {
+    const dryRun = opts.dryRun || process.argv.includes("--dry");
+    const verbose = opts.verbose ?? true;
+    const throwOnFailure = opts.throwOnFailure ?? true;
+    const bail = (message: string, code: 1 | 2 | 3, report?: RunReport): never => {
+        if (throwOnFailure) {
+            throw new FableReplaceError(message, code, report);
+        }
+        process.exit(code);
+    };
+    const cwd = opts.cwd ?? process.cwd();
+    const maxDiffLines = opts.maxDiffLines ?? 200;
+    // Per-file caps are not enough on a 50-file sweep: the total output overruns any
+    // terminal or log you would `tail`, and a truncated tail reads as a finished report.
+    let diffBudget = opts.maxTotalDiffLines ?? 2000;
+    let diffsSuppressed = 0;
+
+    // Absolute whatever `cwd` is: a relative --cwd used to persist "sub/file.ts" in the
+    // manifest, so the printed undo command restored against the caller's directory.
+    const resolve = (p: string): string => path.resolve(cwd, p);
+
+    // ── pre-flight validation ──────────────────────────────────────────────
+    const preflightErrors: string[] = [];
+    // An unknown option is a typo that would otherwise do nothing: `dry: true` instead of
+    // `dryRun: true` once nearly turned a preview into a real write.
+    for (const key of Object.keys(opts)) {
+        if (!KNOWN_RUN_KEYS.includes(key)) {
+            const hint = closestRunKey(key);
+            preflightErrors.push(
+                `unknown option "${key}"${hint ? ` — did you mean "${hint}"?` : ""}. Known: ${KNOWN_RUN_KEYS.join(", ")}`
+            );
+        }
+    }
+    const seen = new Set<string>();
+    const renameTargets = new Map<string, string>();
+    for (const edit of edits) {
+        const abs = resolve(edit.file);
+        if (seen.has(abs)) {
+            preflightErrors.push(
+                `${edit.file}: listed twice in one batch — merge the ops into one FileEdit, or wrap the batch in mergeFileEdits()`
+            );
+        }
+        seen.add(abs);
+        if (!opts.allowNodeModules && abs.includes(`${path.sep}node_modules${path.sep}`)) {
+            preflightErrors.push(
+                `${edit.file}: refusing to edit inside node_modules (set allowNodeModules to override)`
+            );
+        }
+        if (opts.allowGenerated !== true && edit.allowGenerated !== true && !edit.delete) {
+            const why = looksGenerated(abs);
+            if (why !== null) {
+                preflightErrors.push(
+                    `${edit.file}: refusing to edit a GENERATED file (${why}) — the next codegen run discards the change. Fix the generator, or pass allowGenerated: true.`
+                );
+            }
+        }
+        const structural = validateEdit(edit);
+        if (structural) {
+            preflightErrors.push(`${edit.file}: ${structural}`);
+        }
+        if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) {
+            // Reading it threw a bare EISDIR from deep inside the runner.
+            preflightErrors.push(`${edit.file}: is a directory, not a file`);
+        }
+        if (edit.renameTo) {
+            const target = resolve(edit.renameTo);
+            const claimedBy = renameTargets.get(target);
+            if (claimedBy !== undefined) {
+                preflightErrors.push(`${edit.file}: renames to ${edit.renameTo}, which ${claimedBy} also claims`);
+            }
+            renameTargets.set(target, edit.file);
+            // The destination is a write to a protected path as much as the source is.
+            if (!opts.allowNodeModules && target.includes(`${path.sep}node_modules${path.sep}`)) {
+                preflightErrors.push(
+                    `${edit.file}: refusing to rename into node_modules (${edit.renameTo}; set allowNodeModules to override)`
+                );
+            }
+            if (opts.allowGenerated !== true && edit.allowGenerated !== true && target !== abs) {
+                const why = looksGenerated(target);
+                if (why !== null) {
+                    preflightErrors.push(
+                        `${edit.file}: refusing to rename onto a GENERATED path ${edit.renameTo} (${why}) — pass allowGenerated: true.`
+                    );
+                }
+            }
+            if (target !== abs && fs.existsSync(target) && !edit.overwrite) {
+                preflightErrors.push(
+                    `${edit.file}: renameTo target already exists: ${edit.renameTo} — set overwrite: true to replace it`
+                );
+            }
+        }
+    }
+    for (const [target, claimedBy] of renameTargets) {
+        if (seen.has(target)) {
+            preflightErrors.push(`${claimedBy}: renameTo target is also edited in this batch: ${target}`);
+        }
+    }
+    if (opts.backupDir !== undefined && opts.backupOverwrite !== true && !dryRun) {
+        const inUse = backupDirInUse(opts.backupDir);
+        if (inUse !== null) {
+            preflightErrors.push(
+                `backupDir ${opts.backupDir} already holds a manifest from ${inUse} — reusing it OVERWRITES that snapshot: the original file content stored there becomes UNRECOVERABLE and a later rollback lands on the intermediate version. If you are RE-RUNNING this sweep, point backupDir at a fresh directory (scratchDir()); a dry run never writes one, so this always means an earlier real run. backupOverwrite: true is a one-way door; pass it only when the old snapshot is worthless.`
+            );
+        }
+    }
+    if (opts.verifyCommand !== undefined) {
+        const { refusal, warning } = checkVerifyCommand(opts.verifyCommand);
+        if (refusal !== undefined) {
+            preflightErrors.push(refusal);
+        } else if (warning !== undefined) {
+            console.error(paint(COLORS.skip, `WARNING: ${warning}`));
+        }
+    }
+
+    if (dryRun && opts.verifyCommand !== undefined) {
+        preflightErrors.push(
+            "--dry together with a verify command: a dry run writes nothing, so there is nothing to verify and a green result would be a lie. Drop one of the two."
+        );
+    }
+    if (preflightErrors.length > 0) {
+        for (const e of preflightErrors) {
+            console.error(paint(COLORS.miss, `PRE-FLIGHT: ${e}`));
+        }
+        bail(`fable-replace pre-flight failed:\n${preflightErrors.join("\n")}`, 2);
+    }
+
+    // ── phase 1: apply everything in memory ────────────────────────────────
+    interface Planned {
+        edit: FileEdit;
+        abs: string;
+        result: FileResult;
+        before: string | null;
+        after: string | null;
+        /** The bytes read from disk, so the write phase can prove they are still there. */
+        diskBefore: string | null;
+    }
+    const planned: Planned[] = [];
+
+    for (const edit of edits) {
+        const abs = resolve(edit.file);
+        const fileResult: FileResult = {
+            file: edit.file,
+            action: "unchanged",
+            ops: [],
+            postConditionFailures: [],
+            changed: false,
+        };
+
+        if (edit.delete) {
+            // The bytes at plan time, so the write phase can refuse to delete a file someone
+            // changed in between: the same guard an ordinary edit gets.
+            let bytesAtPlan: string | null = null;
+            if (!fs.existsSync(abs)) {
+                fileResult.action = "failed-read";
+                fileResult.postConditionFailures.push("delete requested but file does not exist");
+            } else {
+                fileResult.action = "deleted";
+                fileResult.changed = true;
+                bytesAtPlan = fs.readFileSync(abs, "utf8");
+            }
+            planned.push({ edit, abs, result: fileResult, before: null, after: null, diskBefore: bytesAtPlan });
+            continue;
+        }
+
+        let before: string;
+        let diskBefore: string | null = null;
+        if (fs.existsSync(abs)) {
+            if (edit.createWith !== undefined) {
+                // Only the CLI used to refuse this, so a library caller got a silent no-op that
+                // reported ok. Both doors share the refusal here.
+                fileResult.action = "failed-read";
+                fileResult.postConditionFailures.push(
+                    'createWith ("<<< create") refuses to overwrite an existing file. Use replace ops on it instead.'
+                );
+                planned.push({ edit, abs, result: fileResult, before: null, after: null, diskBefore: null });
+                continue;
+            }
+
+            // Read the BYTES and prove they survive a UTF-8 round trip. readFileSync(…,"utf8")
+            // decodes lossily, so one stray cp1252 byte (0x92 in a legacy doc) came back as
+            // U+FFFD and was written into the file, changing bytes nowhere near the edit and
+            // still reporting OK. A file we cannot represent exactly is a file we must not
+            // rewrite at all.
+            const raw = fs.readFileSync(abs);
+            before = raw.toString("utf8");
+            if (!Buffer.from(before, "utf8").equals(raw)) {
+                fileResult.action = "failed-read";
+                fileResult.postConditionFailures.push(
+                    "not valid UTF-8 — refusing to rewrite it, because every invalid byte would silently become U+FFFD. Fix the encoding first (iconv), or edit it with a byte-aware tool."
+                );
+                planned.push({ edit, abs, result: fileResult, before: null, after: null, diskBefore: null });
+                continue;
+            }
+
+            diskBefore = before;
+        } else if (edit.createWith !== undefined) {
+            before = edit.createWith;
+            fileResult.action = "created";
+        } else {
+            fileResult.action = "failed-read";
+            fileResult.postConditionFailures.push("file does not exist (use createWith to create)");
+            planned.push({ edit, abs, result: fileResult, before: null, after: null, diskBefore: null });
+            continue;
+        }
+
+        const { content: after, results } = applyOps(before, edit.ops ?? []);
+        fileResult.ops = results;
+        fileResult.changed = after !== before || fileResult.action === "created" || Boolean(edit.renameTo);
+        if (fileResult.action !== "created") {
+            fileResult.action = edit.renameTo ? "renamed" : fileResult.changed ? "edited" : "unchanged";
+        }
+
+        for (const expected of edit.expectAfter ?? []) {
+            if (!after.includes(expected)) {
+                fileResult.postConditionFailures.push(`expectAfter not satisfied: "${preview(expected)}"`);
+            }
+        }
+        for (const absent of edit.absentAfter ?? []) {
+            if (after.includes(absent)) {
+                fileResult.postConditionFailures.push(`absentAfter violated, still present: "${preview(absent)}"`);
+            }
+        }
+        if (opts.syntaxCheck !== false) {
+            // A created file has no "before" on disk: its baseline is the empty file, or the
+            // check would compare the new content against itself and never run. A rename is
+            // checked as its DESTINATION: a .txt renamed to .ts, or a .tsx holding JSX renamed
+            // to .ts, must parse under the new loader even when no op touched the bytes.
+            const created = fileResult.action === "created";
+            const checkPath = edit.renameTo ? resolve(edit.renameTo) : abs;
+            const relanguaged = checkPath !== abs && path.extname(checkPath) !== path.extname(abs);
+            const broke = brokeSyntax(checkPath, created || relanguaged ? "" : before, after);
+            if (broke !== null) {
+                fileResult.postConditionFailures.push(
+                    created
+                        ? `the created content does not parse: ${broke}`
+                        : relanguaged
+                          ? `does not parse as ${path.extname(checkPath)} at ${edit.renameTo}: ${broke}`
+                          : `ops produced unparseable source: ${broke}`
+                );
+            }
+        }
+
+        // A created file's "before" for the diff is the empty file, not its own seed: the
+        // dry run must show what lands on disk.
+        planned.push({
+            edit,
+            abs,
+            result: fileResult,
+            before: fileResult.action === "created" ? "" : before,
+            after,
+            diskBefore,
+        });
+    }
+
+    // ── phase 2: report ────────────────────────────────────────────────────
+    let missCount = 0;
+    for (const plan of planned) {
+        const header = `${paint(COLORS.bold, plan.edit.file)} ${paint(COLORS.dim, `(${plan.result.action})`)}`;
+        console.log(header);
+        for (const op of plan.result.ops) {
+            if (op.status === "OK") {
+                if (verbose) {
+                    const declared = op.expected === undefined ? "" : ` of ${String(op.expected)} declared`;
+                    const where =
+                        op.lines === undefined || op.lines.length === 0
+                            ? ""
+                            : ` @ ${op.lines.slice(0, 8).join(",")}${op.lines.length > 8 ? ",…" : ""}`;
+                    console.log(
+                        `  ${paint(COLORS.ok, "OK  ")} ${op.desc}${op.found !== undefined ? paint(COLORS.dim, ` ×${op.found}${declared}${where}`) : ""}`
+                    );
+                }
+            } else if (op.status === "SKIP") {
+                console.log(`  ${paint(COLORS.skip, "SKIP")} ${op.desc} ${paint(COLORS.dim, `— ${op.reason ?? ""}`)}`);
+            } else {
+                missCount += 1;
+                console.log(`  ${paint(COLORS.miss, "MISS")} ${op.desc} ${paint(COLORS.dim, `— ${op.reason ?? ""}`)}`);
+            }
+        }
+        for (const failure of plan.result.postConditionFailures) {
+            missCount += 1;
+            console.log(`  ${paint(COLORS.miss, "POST")} ${failure}`);
+        }
+        if (
+            (dryRun || opts.showDiff === true) &&
+            plan.before !== null &&
+            plan.after !== null &&
+            plan.before !== plan.after
+        ) {
+            if (diffBudget > 0) {
+                const text = simpleDiff({
+                    before: plan.before,
+                    after: plan.after,
+                    maxLines: Math.min(maxDiffLines, diffBudget),
+                });
+                diffBudget -= text.split("\n").length;
+                console.log(paint(COLORS.dim, text));
+            } else {
+                diffsSuppressed += 1;
+            }
+        }
+    }
+
+    const failed = missCount > 0;
+
+    // ── phase 3: write (or not) ────────────────────────────────────────────
+    const written: string[] = [];
+    const touched: string[] = [];
+    // A new file is created exclusively and joins `touched` the moment its descriptor
+    // exists: a write that fails after creation (ENOSPC) leaves a partial file the recovery
+    // must remove, while an EEXIST never adds the foreign path.
+    const writeNew = (file: string, text: string): void => {
+        const fd = fs.openSync(file, "wx");
+        touched.push(file);
+        try {
+            const data = Buffer.from(text, "utf8");
+            let offset = 0;
+            while (offset < data.length) {
+                offset += fs.writeSync(fd, data, offset, data.length - offset);
+            }
+        } finally {
+            fs.closeSync(fd);
+        }
+    };
+    let leftoverProse = 0;
+    let verify: VerifyResult | undefined;
+    // The hashes are metadata about a sweep that IS on disk. A failure here (a verify
+    // command that turned a tracked path into a directory, a manifest the disk refuses)
+    // used to surface as a generic exit 1 with no undo command, as if nothing was written.
+    const recordHashesOrBail = (): void => {
+        if (opts.backupDir === undefined) {
+            return;
+        }
+
+        try {
+            recordPostWriteHashes(opts.backupDir);
+        } catch (err) {
+            console.error(
+                paint(COLORS.miss, `\nSWEEP WRITTEN, but the backup manifest could not be updated: ${String(err)}`)
+            );
+            if (verify !== undefined && verify.status !== "pass") {
+                printVerifyFailure({ verify, written, backupDir: opts.backupDir });
+            } else {
+                console.error(`  The ${written.length} file(s) hold the sweep. Undo everything with:`);
+                console.error(`  bun "${CLI_PATH}" --rollback "${opts.backupDir}"`);
+            }
+
+            bail(
+                `fable-replace: sweep WRITTEN, backup manifest not updated (${String(err)}) — ${written.length} file(s) hold the swept content`,
+                3,
+                {
+                    ok: false,
+                    files: planned.map((p) => p.result),
+                    written,
+                    missCount,
+                    backupDir: opts.backupDir,
+                    verify,
+                }
+            );
+        }
+    };
+    if (dryRun) {
+        if (diffsSuppressed > 0) {
+            console.log(
+                paint(
+                    COLORS.skip,
+                    `\n… diffs for ${diffsSuppressed} more file(s) suppressed after the ${opts.maxTotalDiffLines ?? 2000}-line total budget. Raise maxTotalDiffLines, or narrow the batch.`
+                )
+            );
+        }
+        console.log(
+            paint(
+                COLORS.bold,
+                `\nDRY RUN — nothing written. ${failed ? `${missCount} MISS(es) to fix.` : "All ops OK."}`
+            )
+        );
+    } else if (failed && !opts.partial) {
+        console.log(
+            paint(
+                COLORS.miss,
+                `\nABORTED — ${missCount} MISS(es); transactional mode wrote NOTHING. Fix the ops and re-run.`
+            )
+        );
+    } else {
+        const writable = planned.filter(
+            (p) =>
+                p.result.changed &&
+                p.result.ops.every((o) => o.status !== "MISS") &&
+                p.result.postConditionFailures.length === 0
+        );
+        if (opts.backupDir && writable.length > 0) {
+            const paths = writable.flatMap((p) => {
+                const targets = [p.abs];
+                if (p.edit.renameTo) {
+                    targets.push(resolve(p.edit.renameTo));
+                }
+                return targets;
+            });
+            writeBackup({ dir: opts.backupDir, files: paths, overwrite: opts.backupOverwrite === true });
+            console.log(paint(COLORS.dim, `\nBacked up ${paths.length} path(s) to ${opts.backupDir}`));
+        }
+        try {
+            for (const plan of writable) {
+                // Everything was read into memory at plan time. If someone else wrote the
+                // file in between, overwriting or deleting it now silently destroys their work
+                // and still reports OK, so prove the bytes are the ones the plan saw. The
+                // refused path never joins `touched`, so the recovery leaves it alone too.
+                if (plan.diskBefore !== null && changedOnDisk({ abs: plan.abs, expected: plan.diskBefore })) {
+                    throw new Error(
+                        `${plan.edit.file} changed on disk after it was read — refusing to ${plan.edit.delete ? "delete" : "overwrite"} someone else's write. Re-run the sweep.`
+                    );
+                }
+
+                if (plan.edit.delete) {
+                    touched.push(plan.abs);
+                    fs.rmSync(plan.abs);
+                    written.push(`${plan.edit.file} (deleted)`);
+                    continue;
+                }
+
+                const target = plan.edit.renameTo ? resolve(plan.edit.renameTo) : plan.abs;
+                // A rename used to write a fresh 644 file, so a 750 script came back
+                // world-readable and no longer executable. Carry the source's mode over.
+                const sourceMode = fs.existsSync(plan.abs) ? fs.statSync(plan.abs).mode : undefined;
+                fs.mkdirSync(path.dirname(target), { recursive: true });
+                // The plan proved a created file and a non-overwriting rename target absent.
+                // "wx" proves it again at the write itself: a path that appeared in between,
+                // or a dangling symlink existsSync cannot see, fails with EEXIST instead of
+                // being truncated, and stays out of `touched`, so the recovery never deletes it.
+                const mustBeNew =
+                    plan.result.action === "created" || (target !== plan.abs && plan.edit.overwrite !== true);
+                if (mustBeNew) {
+                    writeNew(target, plan.after ?? "");
+                } else {
+                    touched.push(target);
+                    fs.writeFileSync(target, plan.after ?? "");
+                }
+
+                if (target !== plan.abs) {
+                    touched.push(plan.abs);
+                }
+                if (plan.edit.renameTo && target !== plan.abs && fs.existsSync(plan.abs)) {
+                    if (sourceMode !== undefined) {
+                        fs.chmodSync(target, sourceMode & 0o7777);
+                    }
+
+                    fs.rmSync(plan.abs);
+                }
+                written.push(plan.edit.renameTo ? `${plan.edit.file} → ${plan.edit.renameTo}` : plan.edit.file);
+            }
+        } catch (err) {
+            // An I/O failure (EACCES, ENOSPC, a read-only file) leaves the batch half
+            // applied. Transactional means transactional: undo what already landed.
+            const notReached = Math.max(0, writable.length - written.length - 1);
+            const later = notReached > 0 ? `; ${notReached} later file(s) were never touched` : "";
+            console.error(paint(COLORS.miss, `\nWRITE FAILED after ${written.length} file(s): ${String(err)}${later}`));
+            const stranded = opts.backupDir ? strandedByRollback({ backupDir: opts.backupDir, touched }) : written;
+            if (!opts.backupDir) {
+                console.error(
+                    paint(COLORS.miss, "no backupDir — the batch is HALF APPLIED. Fix the cause, then re-run.")
+                );
+            }
+
+            const tail =
+                stranded.length > 0
+                    ? ` — ${stranded.length} file(s) still hold the swept content: ${stranded.join(", ")}`
+                    : "";
+            bail(`fable-replace: write failed after ${written.length} file(s): ${String(err)}${later}${tail}`, 1);
+        }
+        const suffix = failed
+            ? paint(COLORS.skip, ` (partial mode: ${missCount} MISS(es) elsewhere — this run still FAILS, exit 1)`)
+            : "";
+        console.log(paint(COLORS.bold, `\nWrote ${written.length} file(s).`) + suffix);
+        if (written.length > 0) {
+            recordHashesOrBail();
+            opts.onWritten?.({ written, backupDir: opts.backupDir });
+        }
+
+        if (opts.verifyCommand !== undefined && written.length > 0) {
+            if (failed) {
+                // A check against a knowingly half-applied tree only produces noise, and
+                // exit 3 must mean everything declared landed.
+                console.log(
+                    paint(
+                        COLORS.skip,
+                        `verify skipped: ${missCount} MISS(es) — a check against a partly applied tree proves nothing.`
+                    )
+                );
+            } else {
+                console.log(paint(COLORS.dim, `verify: ${opts.verifyCommand}`));
+                const result = runVerifyCommand({
+                    command: opts.verifyCommand,
+                    cwd,
+                    backupDir: opts.backupDir,
+                    timeoutMs: opts.verifyTimeoutMs,
+                });
+                verify = result;
+                // The check may have rewritten files (a formatter, codegen). The hashes the
+                // rollback compares against must describe what is on disk NOW, or the undo
+                // command printed on failure refuses with "changed since the sweep".
+                recordHashesOrBail();
+
+                if (result.status !== "pass") {
+                    printVerifyFailure({ verify: result, written, backupDir: opts.backupDir });
+                    const verdict =
+                        result.status === "fail"
+                            ? `verify failed (exit ${String(result.exitCode)})`
+                            : `verify could not be measured (${verifyUnknownReason(result)})`;
+                    bail(
+                        `fable-replace: sweep WRITTEN, ${verdict} — ${written.length} file(s) hold the swept content`,
+                        3,
+                        {
+                            ok: false,
+                            files: planned.map((p) => p.result),
+                            written,
+                            missCount,
+                            backupDir: opts.backupDir,
+                            verify: result,
+                        }
+                    );
+                }
+
+                for (const line of result.shown) {
+                    console.log(paint(COLORS.dim, `  ${line}`));
+                }
+            }
+        }
+
+        // The MISS path is loud; the OK path used to be inferred from the absence of
+        // a MISS line. Say plainly that the sweep landed.
+        // A rename is not finished when the code is green. Relying on the caller to
+        // remember a post-sweep leftover scan failed in a real trial: the agent ran one,
+        // scoped it to src/ only, and shipped three docs naming a symbol it had removed.
+        if (opts.leftoversCheck !== undefined && written.length > 0) {
+            const { names, dirs } = opts.leftoversCheck;
+            const found = leftovers({ names, dirs: dirs ?? [cwd] });
+            if (found.docs.length > 0) {
+                leftoverProse = found.docs.length;
+            }
+        }
+
+        if (!failed && leftoverProse === 0) {
+            const opsOk = planned.reduce((sum, p) => sum + p.result.ops.filter((o) => o.status === "OK").length, 0);
+            const verified = verify !== undefined ? ", verify passed (exit 0)" : "";
+            console.log(
+                paint(COLORS.ok, `SWEEP COMPLETE: ${written.length} file(s) written, ${opsOk} op(s) OK${verified}.`)
+            );
+        } else if (!failed) {
+            console.error(
+                paint(
+                    COLORS.miss,
+                    `SWEEP INCOMPLETE: the code landed and verified, but ${leftoverProse} prose mention(s) survive. The docs now name something that does not exist. Fix them — do NOT re-run this sweep.`
+                )
+            );
+        }
+    }
+
+    const report: RunReport = {
+        ok: !failed && leftoverProse === 0,
+        files: planned.map((p) => p.result),
+        written,
+        missCount,
+        backupDir: opts.backupDir,
+        verify,
+    };
+
+    if (failed || leftoverProse > 0) {
+        // A dry run with misses is a failed rehearsal: `--dry && real` must not proceed.
+        // A partial run with misses wrote the good files but is still not a success.
+        const what = dryRun
+            ? `fable-replace: dry run has ${missCount} MISS(es)`
+            : missCount > 0
+              ? `fable-replace: ${missCount} MISS(es) — ${opts.partial ? `partial mode wrote ${written.length} file(s)` : "nothing written"}`
+              : `fable-replace: ${leftoverProse} stale prose mention(s) after a green sweep`;
+        // Stale prose after a green sweep leaves the code WRITTEN, so it is a 3, like a
+        // red verify; exit 1 means nothing (or not everything) landed.
+        bail(what, dryRun || missCount > 0 ? 1 : 3, report);
+    }
+
+    return report;
+};
+
+/**
+ * Merge FileEdits that target the same file into one, so two independent sweeps can
+ * be concatenated even when their file lists overlap:
+ *
+ *   run(mergeFileEdits([
+ *     ...renameSymbolAcross(filesA, "oldA", "newA"),
+ *     ...renameSymbolAcross(filesB, "oldB", "newB"),
+ *   ]))
+ *
+ * Without this, a file appearing in both lists is two FileEdits and pre-flight
+ * refuses the batch. Ops are concatenated in order and post-conditions are unioned.
+ * Anything that cannot be merged unambiguously (two different `renameTo`, a delete
+ * beside ops) throws rather than guessing. Merging is by the exact `file` string.
+ */
+export const mergeFileEdits = (edits: FileEdit[]): FileEdit[] => {
+    const byFile = new Map<string, FileEdit>();
+    for (const edit of edits) {
+        const existing = byFile.get(edit.file);
+        if (existing === undefined) {
+            byFile.set(edit.file, { ...edit, ops: [...(edit.ops ?? [])] });
+            continue;
+        }
+        for (const field of ["delete", "renameTo", "createWith"] as const) {
+            const a = existing[field];
+            const b = edit[field];
+            if (a !== undefined && b !== undefined && a !== b) {
+                throw new Error(
+                    `mergeFileEdits: ${edit.file} has conflicting "${field}" values (${String(a)} vs ${String(b)})`
+                );
+            }
+        }
+        if ((existing.delete === true && edit.ops?.length) || (edit.delete === true && existing.ops?.length)) {
+            throw new Error(`mergeFileEdits: ${edit.file} is both deleted and edited in the same batch`);
+        }
+        byFile.set(edit.file, {
+            ...existing,
+            ...Object.fromEntries(Object.entries(edit).filter(([, v]) => v !== undefined)),
+            ops: [...(existing.ops ?? []), ...(edit.ops ?? [])],
+            expectAfter: [...(existing.expectAfter ?? []), ...(edit.expectAfter ?? [])],
+            absentAfter: [...(existing.absentAfter ?? []), ...(edit.absentAfter ?? [])],
+        });
+    }
+    return [...byFile.values()];
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/tsconfig.json
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"noEmit": true,
+		"target": "es2022",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"types": ["bun"],
+		"skipLibCheck": true
+	},
+	"include": ["*.ts"]
+}

--- a/plugins/genesis-tools/skills/fable-replace/scripts/types.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/types.ts
@@ -1,0 +1,493 @@
+/**
+ * fable-replace — the vocabulary. Every op shape, edit shape and result shape.
+ * Pure types, zero imports, zero behaviour. Read this first to learn what can be
+ * declared; read the module that owns each behaviour to learn what it does.
+ */
+
+/**
+ * Literal find/replace. The workhorse — behaves like the Edit tool:
+ * with `count: 1` (default) the needle must occur exactly once in the file;
+ * `count: n` requires exactly n occurrences (all are replaced);
+ * `count: "all"` replaces every occurrence and requires at least one.
+ */
+export interface LiteralOp {
+    kind?: "replace";
+    /** Exact text to find — copy it verbatim from the file, indentation included. */
+    find: string;
+    replace: string;
+    /** Occurrence contract. Default 1 = "exactly once". */
+    count?: number | "all";
+    /** Match only where the needle STARTS a line, what `<<< delete` compiles to: "foo" never matches inside "notfoo". */
+    wholeLines?: boolean;
+    /** If true, a non-match is reported as SKIP instead of MISS and doesn't fail the run. */
+    optional?: boolean;
+    /** Free-text tag shown in the report instead of a needle preview. */
+    label?: string;
+}
+
+/** Regex find/replace. `find` MUST carry the `g` flag when you expect multiple matches. */
+export interface RegexOp {
+    kind: "regex";
+    find: RegExp;
+    /** Replacement string ($1 etc. supported) or replacer function. */
+    replace: string | ((substring: string, ...args: unknown[]) => string);
+    /** Require exactly this many matches. Omit = require at least one. */
+    expect?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/**
+ * Delete everything between two anchors. The engine finds the `occurrence`-th
+ * (default first) `from`, then the FIRST `to` after it.
+ * `keepFrom`/`keepTo` (default false) keep the anchor text itself.
+ */
+export interface DeleteBlockOp {
+    kind: "deleteBlock";
+    from: string;
+    to: string;
+    keepFrom?: boolean;
+    keepTo?: boolean;
+    /** 1-based occurrence of `from` to anchor on. Default 1. */
+    occurrence?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/** Like deleteBlock but substitutes `replace` for the removed region. */
+export interface ReplaceBlockOp {
+    kind: "replaceBlock";
+    from: string;
+    to: string;
+    replace: string;
+    keepFrom?: boolean;
+    keepTo?: boolean;
+    occurrence?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/**
+ * Insert `text` immediately before/after the unique `anchor`, at that CHARACTER
+ * position on the same line. Nothing is added around it: a trailing comment needs
+ * its own leading space, a new line needs its own "\n". For whole lines under or
+ * above the anchor's line use InsertLinesOp instead.
+ */
+export interface InsertOp {
+    kind: "insertBefore" | "insertAfter";
+    anchor: string;
+    /** Inserted verbatim. */
+    text: string;
+    /** 1-based occurrence of the anchor. Default 1; anchor must occur at least that many times. */
+    occurrence?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/**
+ * Insert whole LINES before/after the line that contains the unique `anchor`.
+ * The line-oriented cousin of InsertOp: "put this block under that line" without
+ * caring where on the line the anchor sits. The anchor line itself stays exactly as
+ * it was: never repeat it inside `text`. An anchor that starts with whitespace must
+ * match at the start of a line, so a wrong indentation is a MISS, not a match.
+ */
+export interface InsertLinesOp {
+    kind: "insertLinesBefore" | "insertLinesAfter";
+    anchor: string;
+    /** One or more lines, inserted literally: a trailing "\n" adds a blank line after the block. */
+    text: string;
+    optional?: boolean;
+    label?: string;
+}
+
+/** Append lines at the end of the file. Literal like insertLines; the file always ends with one newline. */
+export interface AppendOp {
+    kind: "append";
+    text: string;
+    label?: string;
+}
+
+export type Op =
+    | LiteralOp
+    | RegexOp
+    | DeleteBlockOp
+    | ReplaceBlockOp
+    | InsertOp
+    | InsertLinesOp
+    | AppendOp
+    | DropCommentsOp
+    | DeleteLinesOp
+    | FuzzyOp;
+
+export interface FileEdit {
+    /** Path to the file (absolute, or relative to `opts.cwd` / process.cwd()). */
+    file: string;
+    /** Applied in order. Later ops see the output of earlier ones. */
+    ops?: Op[];
+    /** Delete the file as part of the batch (ops must be absent). */
+    delete?: boolean;
+    /** Rename/move the file after ops are applied. */
+    renameTo?: string;
+    /** Allow `renameTo` to replace an existing file. Off by default — it is data loss. */
+    overwrite?: boolean;
+    /** Edit this file even though it looks generated. Per-file, so one false positive does not disarm the guard for the whole batch. */
+    allowGenerated?: boolean;
+    /** Create the file with this content if it does not exist (ops then apply on top). */
+    createWith?: string;
+    /** Substrings that MUST be present after all ops ran. */
+    expectAfter?: string[];
+    /** Substrings that MUST NOT be present after all ops ran. */
+    absentAfter?: string[];
+}
+
+export interface RunOptions {
+    /** Preview only: print diffs, write nothing. Also enabled by `--dry` on argv. */
+    dryRun?: boolean;
+    /** Snapshot originals + manifest here before writing; enables `rollback()`. */
+    backupDir?: string;
+    /** Allow reusing a backupDir that already holds a manifest. Off: reuse loses the first snapshot. */
+    backupOverwrite?: boolean;
+    /** Resolve relative FileEdit.file paths against this directory. */
+    cwd?: string;
+    /**
+     * Write the files that fully passed even when other files have misses. Default false
+     * (transactional). A partial run with misses is still a FAILURE: `run()` throws (or
+     * exits 1) AFTER writing, and `report.ok` is false.
+     */
+    partial?: boolean;
+    /** Print per-op OK lines too (MISS/SKIP always print). Default true. */
+    verbose?: boolean;
+    /** Print the per-file diff on a REAL run too (dry runs always print it). Default false. */
+    showDiff?: boolean;
+    /** Max diff lines printed per file in dry runs. Default 200. */
+    maxDiffLines?: number;
+    /** Total diff lines across the WHOLE dry run before diffs are suppressed. Default 2000. */
+    maxTotalDiffLines?: number;
+    /** Allow editing paths containing node_modules (off by default on purpose). */
+    allowNodeModules?: boolean;
+    /** Allow editing files that look machine-generated (off by default on purpose). */
+    allowGenerated?: boolean;
+    /** Parse every edited .ts/.tsx/.js/.jsx after the ops and fail the file if the sweep broke it. Default on. */
+    syntaxCheck?: boolean;
+    /**
+     * Default true: every failure throws a `FableReplaceError` whose `code` is the exit
+     * code (1 misses/verify/partial, 2 pre-flight), so a script can catch it and read
+     * the report. `false` calls `process.exit(code)` instead; the CLI does that.
+     */
+    throwOnFailure?: boolean;
+    /**
+     * Shell command executed AFTER a successful write (e.g. "tsgo --noEmit" or
+     * "bun run test path/to/suite"), captured, with stdin closed. A non-zero exit fails
+     * the run with code 3 and the sweep STAYS WRITTEN: rolling back would restore the
+     * very needles a re-sent spec matches, and that loop costs a full-context round trip
+     * per turn. The undo command is printed instead; `report.verify` carries the verdict.
+     * A script that wants atomic behaviour writes `catch { rollback({ backupDir }) }`.
+     * Skipped when the run has misses (`partial`), refused together with `dryRun`.
+     */
+    verifyCommand?: string;
+    /** Backstop for a hung check, in milliseconds. Default 15 minutes; there is no CLI flag. */
+    verifyTimeoutMs?: number;
+    /**
+     * Called once, right after the files are on disk and before any verify runs. The CLI
+     * journals a "written" line here, so a check killed by a timeout still leaves a trace.
+     */
+    onWritten?: (info: { written: string[]; backupDir?: string }) => void;
+    /**
+     * After a successful write, scan `dirs` (default: cwd) for `names` and FAIL the run
+     * when any survive in prose. The code is left written — a stale doc is a follow-up
+     * edit, not a reason to roll back a green sweep.
+     */
+    leftoversCheck?: { names: string[]; dirs?: string[] };
+}
+
+export interface OpResult {
+    status: "OK" | "MISS" | "SKIP";
+    /** Human description of the op. */
+    desc: string;
+    /** Why it missed (only for MISS/SKIP). */
+    reason?: string;
+    /** How many occurrences were found (literal/regex ops). */
+    found?: number;
+    /** The count the op DECLARED (count / expect), echoed back so a green run still proves the contract. */
+    expected?: number | "all";
+    /** 1-based line numbers the op acted on, when it works line-wise (dropComments, deleteLines). */
+    lines?: number[];
+}
+
+export interface FileResult {
+    file: string;
+    action: "edited" | "unchanged" | "deleted" | "renamed" | "created" | "failed-read";
+    ops: OpResult[];
+    postConditionFailures: string[];
+    /** Content before/after (in memory) — present for edited files. */
+    changed: boolean;
+}
+
+export interface RunReport {
+    ok: boolean;
+    files: FileResult[];
+    written: string[];
+    missCount: number;
+    backupDir?: string;
+    /** The captured verify verdict, when a verifyCommand ran. */
+    verify?: VerifyResult;
+}
+
+export interface RunVerifyParams {
+    /** The shell command, run through `sh -c` with cwd set. */
+    command: string;
+    cwd: string;
+    /** Where `verify-output.txt` (the whole output) is written; none without a backup dir. */
+    backupDir?: string;
+    /** Default 15 minutes. */
+    timeoutMs?: number;
+}
+
+export interface VerifyResult {
+    command: string;
+    /**
+     * "pass" = exit 0. "fail" = a real non-zero exit. "unknown" = no exit status at all
+     * (a signal, the timeout, output over the capture buffer): the sweep is on disk and
+     * the verdict could not be measured, which is never reported as a test failure.
+     */
+    status: "pass" | "fail" | "unknown";
+    exitCode: number | null;
+    signal: string | null;
+    timedOut: boolean;
+    /** The output exceeded the capture buffer (ENOBUFS). */
+    buffered: boolean;
+    ms: number;
+    /** Size of the whole captured output (stdout then stderr). */
+    outputChars: number;
+    /** The lines a reader is shown: the last 5 on a pass, head and tail on anything else. */
+    shown: string[];
+    /** The saved whole output, when a backup dir existed. */
+    outputFile?: string;
+    /** The spawn error message, when there was one. */
+    error?: string;
+}
+
+export interface CommentSpan {
+    /** Absolute start offset of the comment (including the // or slash-star). */
+    start: number;
+    /** Absolute end offset (exclusive). Line comments end BEFORE the newline. */
+    end: number;
+    /** The raw comment text, delimiters included. */
+    text: string;
+    type: "line" | "block";
+    /** 1-based line the comment starts on. */
+    line: number;
+}
+
+export interface DropCommentsOptions {
+    /** Only drop comments whose text contains this substring. */
+    containing?: string;
+    /** Only drop comments whose text matches this regex. */
+    matching?: RegExp;
+    /** Restrict to line or block comments. Default both. */
+    scope?: "line" | "block" | "both";
+    /** Require exactly this many comments to be dropped. */
+    expect?: number;
+}
+
+/** Op form of dropComments, usable inside a FileEdit. */
+export interface DropCommentsOp extends DropCommentsOptions {
+    kind: "dropComments";
+    optional?: boolean;
+    label?: string;
+}
+
+/** Delete every full line containing a substring / matching a regex. */
+export interface DeleteLinesOp {
+    kind: "deleteLines";
+    containing?: string;
+    matching?: RegExp;
+    /** Require exactly this many lines removed. Omit = at least one. */
+    expect?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/**
+ * Fuzzy variant of a literal op (exactly-once contract, whitespace-insensitive on the
+ * FIND side only). `replace` is written verbatim, indentation and line endings included.
+ */
+export interface FuzzyOp {
+    kind: "fuzzy";
+    find: string;
+    replace: string;
+    /** Occurrence contract, like LiteralOp. Default 1 = exactly once. */
+    count?: number | "all";
+    optional?: boolean;
+    label?: string;
+}
+
+export interface RollbackReport {
+    restored: string[];
+    /** Paths skipped because they changed after the sweep wrote them. */
+    drifted: string[];
+    /** Paths the restore itself could not write, with the reason. These still hold the swept content. */
+    failed: { file: string; error: string }[];
+}
+
+// ── parameter objects ────────────────────────────────────────────────────────
+// Every exported function with more than two inputs takes ONE object, so a call
+// reads as prose and the --api dump shows every field with its doc.
+
+/** `run({ edits, ...options })`: the batch plus every RunOptions field. */
+export interface RunParams extends RunOptions {
+    edits: FileEdit[];
+}
+
+export interface PruneParams {
+    /** Only dirs older than this are candidates. Default 12 hours. */
+    ttlMs?: number;
+    /** Cap per run, so a huge backlog is worked off over several runs. Default 50. */
+    maxRemovals?: number;
+    /** Dirs never touched, whatever their age: the current run's backup dir. */
+    keep?: string[];
+    /** The clock, for tests. */
+    now?: number;
+}
+
+export interface PruneReport {
+    scanned: number;
+    removed: number;
+    /** Sum of the file sizes in the removed dirs. */
+    bytes: number;
+    /** The `<tmp>/fable-replace` root that was swept: one, the temp dir this process writes to. */
+    roots: string[];
+}
+
+export interface RollbackParams {
+    backupDir: string;
+    /** Restore files that changed after the sweep wrote them too. Default false. */
+    force?: boolean;
+    /**
+     * Restore only these paths (as recorded in the manifest); every other entry is left
+     * alone and not reported. The write-failure recovery passes the paths it actually wrote.
+     */
+    only?: string[];
+}
+
+export interface GrepPreviewParams {
+    files: string[];
+    /** A JS RegExp (lookahead works) or a literal string. */
+    pattern: string | RegExp;
+    /** Lines of context around each match. Default 2. */
+    context?: number;
+}
+
+export interface LeftoversParams {
+    /** Old names to hunt for. Identifiers are matched on word boundaries, anything else literally. */
+    names: string[];
+    /** Directories or files to scan. node_modules, build output and backup dirs are skipped. */
+    dirs: string[];
+    /** Suppress the printed summary. Default false. */
+    quiet?: boolean;
+}
+
+export interface CountMatchesParams {
+    files: string[];
+    /** An identifier-looking string is matched on word boundaries; other strings literally; a RegExp as given (g forced). */
+    pattern: string | RegExp;
+    quiet?: boolean;
+}
+
+export interface FindFilesParams {
+    roots: string[];
+    /** Content filter: literal string or RegExp. REQUIRED — omitting it throws, rather than returning an empty list that reads as "no matches". */
+    containing: string | RegExp;
+    /** File extensions to keep. Default [".ts", ".tsx"]; [] keeps every file. */
+    exts?: string[];
+}
+
+export interface SameOpsAcrossParams {
+    files: string[];
+    ops: Op[];
+    /** Extra FileEdit fields (expectAfter, absentAfter, …) applied to every file. */
+    extra?: Partial<FileEdit>;
+}
+
+export interface RenameSymbolParams {
+    oldName: string;
+    newName: string;
+    /** Pin the match count for this one file. */
+    expect?: number;
+}
+
+export interface RenameSymbolAcrossParams {
+    /** A file list, or the map countMatches() returned (zero-match files are dropped, counts are pinned). */
+    files: string[] | Record<string, number>;
+    oldName: string;
+    newName: string;
+    extra?: Partial<FileEdit>;
+    /**
+     * A file that both IMPORTS and DECLARES `oldName` is a local wrapper; renaming its
+     * declaration changes an unrelated helper, so such files are refused (thrown, code 2)
+     * unless this is true. Drop them from `files` instead when in doubt.
+     */
+    includeShadowed?: boolean;
+}
+
+export interface ShadowedFilesParams {
+    files: string[];
+    /** The identifier being renamed. */
+    name: string;
+}
+
+/** Sugar for a literal op: `all` (every occurrence) and `maybe` (optional). */
+export interface LiteralSugarParams {
+    find: string;
+    replace: string;
+    label?: string;
+}
+
+export interface DropParams {
+    /** Exact chunk to delete; must occur exactly once. */
+    find: string;
+    label?: string;
+}
+
+export interface DropJsdocParams {
+    /** The opening lines of the JSDoc block to delete, e.g. "/**\n * Legacy parity". */
+    fromPrefix: string;
+    label?: string;
+}
+
+export interface NearestHintParams {
+    content: string;
+    needle: string;
+    /** When given, a needle whose replacement is already present is reported as "already applied". */
+    replacement?: string;
+    /**
+     * The content BEFORE any op of this batch ran (what is on disk). With it, a replacement
+     * that is present in `content` but absent here is blamed on an earlier op of the batch,
+     * not on a previous run.
+     */
+    original?: string;
+    /** The most recent earlier op of the batch that changed the content, for the blame line. */
+    producedBy?: { index: number; desc: string };
+}
+
+export interface NthIndexOfParams {
+    haystack: string;
+    needle: string;
+    /** 1-based occurrence. */
+    n: number;
+}
+
+export interface SimpleDiffParams {
+    before: string;
+    after: string;
+    /** Cap on printed lines. Default 200. */
+    maxLines?: number;
+}
+/** `writeBackup({ dir, files, overwrite })`: snapshot the originals before a sweep writes. */
+export interface WriteBackupParams {
+    dir: string;
+    /** Absolute paths to snapshot; a path that does not exist is recorded as "created by this sweep". */
+    files: string[];
+    /** Replace a manifest left by an earlier sweep in the same dir. Default false, which is a loud refusal. */
+    overwrite?: boolean;
+}

--- a/plugins/genesis-tools/skills/fable-replace/scripts/verify-command.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/verify-command.ts
@@ -1,0 +1,227 @@
+/**
+ * fable-replace — RUNNING THE VERIFY COMMAND, the check a sweep runs after it wrote.
+ *
+ * The command is captured, never inherited. That lets the CLI trim what the reader sees
+ * (a green test run is a five-line summary, not 300 lines), save the whole output beside
+ * the backup, and tell three outcomes apart: exit 0 is a pass; a real non-zero exit is a
+ * fail; no exit status at all (a signal, the timeout, more output than the buffer holds)
+ * is "unknown", which means the sweep is on disk and the verdict could not be measured.
+ * That is neither a pass nor a test failure, and it is never reported as one.
+ *
+ * A red verify never rolls the sweep back. The reasons live in sweep-many-files.ts.
+ */
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { stringifyJson } from "./json";
+import type { RunVerifyParams, VerifyResult } from "./types";
+
+/** A fixed backstop, not a flag: one more flag is one more thing to get wrong. */
+export const VERIFY_TIMEOUT_MS = 15 * 60 * 1000;
+/** Well above any test runner's output. The 1 MB default turned a green suite into ENOBUFS. */
+const VERIFY_MAX_BUFFER = 64 * 1024 * 1024;
+const PASS_TAIL_LINES = 5;
+const FAIL_HEAD_LINES = 40;
+const FAIL_TAIL_LINES = 60;
+/** One line can be a 50 KB JSON blob; the reader gets its start. */
+const MAX_LINE_CHARS = 500;
+export const VERIFY_OUTPUT_FILE = "verify-output.txt";
+
+const clip = (line: string): string =>
+    line.length <= MAX_LINE_CHARS ? line : `${line.slice(0, MAX_LINE_CHARS)}… (+${line.length - MAX_LINE_CHARS} chars)`;
+
+/** Head and tail around an omitted-lines marker; the whole output when it is short enough. */
+export const trimOutput = ({ lines, head, tail }: { lines: string[]; head: number; tail: number }): string[] => {
+    if (lines.length <= head + tail) {
+        return lines.map(clip);
+    }
+
+    const omitted = lines.length - head - tail;
+    return [...lines.slice(0, head).map(clip), `… ${omitted} line(s) omitted …`, ...lines.slice(-tail).map(clip)];
+};
+
+const REFUSALS = {
+    pipe: "contains a pipe.\nA pipeline reports the LAST command's exit code, so a failing test reads as PASS\n(/bin/sh), and `set -o pipefail` reports FAIL when `head` closes the pipe early.\nBoth lie. Drop the pipe: this CLI already trims the output for you.\nIf you truly need one, own the exit code yourself:\n  --verify \"bash -c 'set -o pipefail; <your pipeline>'\"",
+    chain: "contains a `;` chain. Only the LAST command's exit code is reported, so `a; b` turns a red `a` into a green verify. Chain with `&&`, or run one command.",
+    newline:
+        "spans more than one line. Only the LAST line's exit code is reported, so an earlier red line reads as PASS. Chain with `&&`, or run one command.",
+    background:
+        "contains a background `&`. A backgrounded command returns 0 immediately, so the check never reaches a verdict. Run it in the foreground.",
+};
+
+/**
+ * Refuse only the shell operators that can hide a non-zero exit status: a pipe, a `;`
+ * chain, a newline, a background `&`. Redirects, `$( )`, backticks and `VAR=1` prefixes
+ * cannot change the status of the command whose status is read, so they pass. `&&`
+ * and `||` pass too. Anything inside single or double quotes is opaque, which is the
+ * escape hatch: `bash -c 'set -o pipefail; …'` names the risk in the command itself.
+ *
+ * A quote-state scanner, not a shell parser: a pipe inside `$( )` is refused as well.
+ * That false positive is cheaper than a parser. Measured on this machine: `exit 7 | cat`
+ * is status 0 under /bin/sh, and `bash -o pipefail` turns `rg | head` into a false FAIL.
+ */
+export const checkVerifyCommand = (command: string): { refusal?: string; warning?: string } => {
+    let single = false;
+    let double = false;
+    let unquoted = "";
+    let found: keyof typeof REFUSALS | undefined;
+    for (let i = 0; i < command.length && found === undefined; i += 1) {
+        const ch = command[i];
+        const next = command[i + 1];
+        if (single) {
+            if (ch === "'") {
+                single = false;
+            }
+
+            continue;
+        }
+
+        if (ch === "\\") {
+            i += 1;
+            continue;
+        }
+
+        if (double) {
+            if (ch === '"') {
+                double = false;
+            }
+
+            continue;
+        }
+
+        if (ch === "'") {
+            single = true;
+            continue;
+        }
+
+        if (ch === '"') {
+            double = true;
+            continue;
+        }
+
+        unquoted += ch;
+        if (ch === "|") {
+            if (next === "|") {
+                unquoted += next;
+                i += 1;
+                continue;
+            }
+
+            found = "pipe";
+        } else if (ch === ";") {
+            found = "chain";
+        } else if (ch === "\n") {
+            found = "newline";
+        } else if (ch === "&") {
+            if (next === "&" || next === ">") {
+                unquoted += next;
+                i += 1;
+                continue;
+            }
+
+            const prev = command[i - 1];
+            if (prev === ">" || prev === "<") {
+                continue;
+            }
+
+            found = "background";
+        }
+    }
+
+    if (found !== undefined) {
+        return { refusal: `--verify ${stringifyJson(command)} ${REFUSALS[found]}\nNothing was written.` };
+    }
+
+    if (unquoted.includes("/dev/null")) {
+        return {
+            warning: `--verify ${stringifyJson(command)} sends output to /dev/null: the check still runs, but the lines needed to fix forward are discarded. Drop the redirect; the CLI trims the output itself.`,
+        };
+    }
+
+    return {};
+};
+
+/** Why a verify has no exit status, in the reader's words. */
+export const verifyUnknownReason = (verify: VerifyResult): string => {
+    if (verify.timedOut) {
+        return `timed out after ${Math.round(verify.ms / 1000)} s`;
+    }
+
+    if (verify.buffered) {
+        return "its output exceeded the 64 MB capture buffer";
+    }
+
+    if (verify.signal !== null) {
+        return `killed by ${verify.signal}`;
+    }
+
+    return verify.error ?? "no exit status";
+};
+
+/**
+ * Run the verify command through the shell with both streams captured and stdin closed
+ * (the CLI already consumed its own stdin for the spec, and an interactive prompt inside
+ * a check would hang the sweep). Returns the verdict plus the lines to show. It prints
+ * nothing itself, so the caller owns the order of the narration.
+ */
+export const runVerifyCommand = ({
+    command,
+    cwd,
+    backupDir,
+    timeoutMs = VERIFY_TIMEOUT_MS,
+}: RunVerifyParams): VerifyResult => {
+    const started = Date.now();
+    const child = spawnSync(command, {
+        shell: true,
+        cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf8",
+        maxBuffer: VERIFY_MAX_BUFFER,
+        timeout: timeoutMs,
+    });
+    const ms = Date.now() - started;
+    // Separate pipes cannot interleave the two streams. stdout first, then stderr, which
+    // keeps a test runner's summary (stderr for `bun test`) at the tail where a reader looks.
+    const output = `${child.stdout ?? ""}${child.stderr ?? ""}`;
+    const errorCode = (child.error as { code?: string } | undefined)?.code;
+    const status: VerifyResult["status"] = child.status === 0 ? "pass" : child.status === null ? "unknown" : "fail";
+
+    let outputFile: string | undefined;
+    if (backupDir !== undefined) {
+        try {
+            fs.mkdirSync(backupDir, { recursive: true });
+            outputFile = path.join(backupDir, VERIFY_OUTPUT_FILE);
+            fs.writeFileSync(outputFile, output);
+        } catch (err) {
+            console.error(`could not save the verify output: ${String(err)}`);
+            outputFile = undefined;
+        }
+    }
+
+    const lines = output.length === 0 ? [] : output.replace(/\n$/, "").split("\n");
+    let shown: string[];
+    if (status === "pass") {
+        shown = lines.slice(-PASS_TAIL_LINES).map(clip);
+        if (lines.length > PASS_TAIL_LINES) {
+            const where = outputFile === undefined ? "" : ` (full output: ${outputFile})`;
+            shown.unshift(`… ${lines.length - PASS_TAIL_LINES} earlier line(s) suppressed${where}`);
+        }
+    } else {
+        shown = trimOutput({ lines, head: FAIL_HEAD_LINES, tail: FAIL_TAIL_LINES });
+    }
+
+    return {
+        command,
+        status,
+        exitCode: child.status,
+        signal: child.signal ?? null,
+        timedOut: errorCode === "ETIMEDOUT",
+        buffered: errorCode === "ENOBUFS",
+        ms,
+        outputChars: output.length,
+        shown,
+        outputFile,
+        error: child.error === undefined ? undefined : String(child.error.message ?? child.error),
+    };
+};

--- a/src/chrome-devtools/README.md
+++ b/src/chrome-devtools/README.md
@@ -20,7 +20,9 @@ listens. **Ask before quitting anyone's browser** — their open tabs are at sta
 
 ⚠️ Chrome ≥ 136 refuses to open the CDP port when launched with the DEFAULT profile
 directory (anti-automation). Chromium builds are unaffected; Brave's stance can differ per
-version. `restart` detects the failure and suggests the `open --fresh` fallback.
+version. `restart` detects the failure and suggests two fallbacks: `open --fresh` (throwaway
+profile) and `open --user-data-dir <dir>` (a persistent separate profile whose logins survive
+between runs, e.g. `~/.genesis-tools/chrome-devtools/profile`).
 
 ## Quick start
 

--- a/src/chrome-devtools/commands/browse.ts
+++ b/src/chrome-devtools/commands/browse.ts
@@ -34,7 +34,11 @@ interface OpenOpts {
     browser?: string;
     fresh?: boolean;
     extension?: string;
+    userDataDir?: string;
 }
+
+/** A persistent separate profile: logins survive between runs, unlike --fresh, and Chrome ≥136 accepts the flag there. */
+const PERSISTENT_PROFILE_HINT = "~/.genesis-tools/chrome-devtools/profile";
 
 export function registerBrowse(program: Command): void {
     withPort(program.command("open"))
@@ -44,6 +48,10 @@ export function registerBrowse(program: Command): void {
         .argument("[url]", "url to open", "about:blank")
         .option("--browser <name>", BROWSER_IDS, "chrome")
         .option("--fresh", "throwaway profile — your own profile stays untouched (but you must log in again)")
+        .option(
+            "--user-data-dir <dir>",
+            `persistent separate profile (logins survive between runs; Chrome ≥136 refuses the debug flag on its default profile, so this is the way to keep sessions), e.g. ${PERSISTENT_PROFILE_HINT}`
+        )
         .option("--extension <dist-dir>", "load an unpacked extension (implies its own profile)")
         .action(async (url: string, opts: OpenOpts) => {
             const { id, name } = browserDefOf(opts.browser);
@@ -55,7 +63,7 @@ export function registerBrowse(program: Command): void {
                 process.exit(1);
             }
 
-            if (!opts.fresh && !opts.extension && listRunningBrowsers().includes(id)) {
+            if (!opts.fresh && !opts.extension && !opts.userDataDir && listRunningBrowsers().includes(id)) {
                 out.log.error(`${name} is already running. The debug flag cannot be added to a live process.`);
                 out.log.info(`  ${suggest(["restart", "--browser", id, "--port", String(port)])}`);
                 process.exit(1);
@@ -69,6 +77,7 @@ export function registerBrowse(program: Command): void {
                     url,
                     fresh: opts.fresh === true,
                     extension: opts.extension,
+                    userDataDir: opts.userDataDir,
                 });
                 up = true;
                 out.log.info(`up: ${result.browser} on ${port} (${result.pages} pages)`);
@@ -130,7 +139,10 @@ export function registerBrowse(program: Command): void {
                         : `relaunched but no CDP on ${port}. Chrome ≥136 refuses the flag on the DEFAULT profile dir (anti-automation).`
                 );
                 out.log.info(
-                    `  fallback with a separate profile: ${suggest(["open", "--browser", id, "--port", String(port), "--fresh", url])}`
+                    `  fallback, throwaway profile (log in again each time): ${suggest(["open", "--browser", id, "--port", String(port), "--fresh", url])}`
+                );
+                out.log.info(
+                    `  fallback, persistent profile (logins kept between runs): ${suggest(["open", "--browser", id, "--port", String(port), "--user-data-dir", PERSISTENT_PROFILE_HINT, url])}`
                 );
                 process.exit(1);
             }

--- a/src/chrome-devtools/commands/shared.ts
+++ b/src/chrome-devtools/commands/shared.ts
@@ -12,13 +12,14 @@ import { readRecorderMeta } from "../lib/recorder.ts";
 import {
     browsersWithEmptyDebugFlag,
     CDP_PORTS,
+    type ConsentEndpoint,
     discoverListeningCdpPorts,
     type Inventory,
     isPortSpecified,
     listRunningBrowsers,
     mergeProbePorts,
     ownerOfPort,
-    readDevToolsActivePortsFromDisk,
+    readDevToolsActivePortEntriesFromDisk,
 } from "../lib/resolve-attach.ts";
 
 const { log } = logger.scoped("chrome-devtools:cli");
@@ -91,14 +92,38 @@ async function isEndpointLive(port: number): Promise<boolean> {
     }
 }
 
+/** Chrome 144+ consent mode: the DevToolsActivePort file names a listening port whose /json/version is 404. */
+async function isConsentPort(port: number): Promise<boolean> {
+    try {
+        const res = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(1200) });
+
+        return res.status === 404;
+    } catch {
+        return false;
+    }
+}
+
 export async function scanInventory(): Promise<Inventory> {
     const running = listRunningBrowsers();
-    const ports = mergeProbePorts(CDP_PORTS, discoverListeningCdpPorts(), readDevToolsActivePortsFromDisk());
+    const activeEntries = readDevToolsActivePortEntriesFromDisk();
+    const ports = mergeProbePorts(
+        CDP_PORTS,
+        discoverListeningCdpPorts(),
+        activeEntries.map((e) => e.port)
+    );
     const found = (await Promise.all(ports.map(probe))).filter((x): x is NonNullable<typeof x> => x != null);
+    const consent: ConsentEndpoint[] = [];
+
+    for (const entry of activeEntries) {
+        if (entry.wsPath && !found.some((f) => f.port === entry.port) && (await isConsentPort(entry.port))) {
+            consent.push({ id: entry.id, port: entry.port, wsPath: entry.wsPath });
+        }
+    }
 
     return {
         running,
         emptyDebugFlag: browsersWithEmptyDebugFlag(),
+        consent,
         endpoints: found.map((f) => ({
             port: f.port,
             browser: f.browser,

--- a/src/chrome-devtools/lib/launch.ts
+++ b/src/chrome-devtools/lib/launch.ts
@@ -4,6 +4,7 @@
  * extension browser all come through here, so a launch gotcha is paid for once.
  */
 import { logger } from "@genesiscz/utils/logger";
+import { profiler } from "@genesiscz/utils/profile";
 import { type CdpProbe, probe } from "./cdp.ts";
 import {
     type BrowserId,
@@ -108,6 +109,7 @@ export interface LaunchedCdpBrowser {
 }
 
 const LOG_TAIL_LINES = 40;
+const prof = profiler.scope("chrome-devtools");
 
 async function readLogTail(path: string, readLog: (path: string) => Promise<string>): Promise<string> {
     try {
@@ -173,8 +175,10 @@ export async function launchCdpBrowser(opts: LaunchCdpOpts): Promise<LaunchedCdp
 
     const probeFn = opts.probe ?? probe;
     const timeoutMs = opts.timeoutMs ?? (isolated ? COLD_PROFILE_TIMEOUT_MS : DEFAULT_LAUNCH_TIMEOUT_MS);
-    const up = await (opts.waitFor ?? waitForCdp)({ port: opts.port, probe: probeFn, timeoutMs });
-    const result = up ? await probeFn(opts.port) : null;
+    const up = await prof.measureAsync(`launch.wait-cdp.${isolated ? "isolated" : "profile"}`, () =>
+        (opts.waitFor ?? waitForCdp)({ port: opts.port, probe: probeFn, timeoutMs })
+    );
+    const result = up ? await prof.measureAsync("launch.probe", () => probeFn(opts.port)) : null;
 
     if (!result) {
         const logTail = opts.logPath

--- a/src/chrome-devtools/lib/resolve-attach.test.ts
+++ b/src/chrome-devtools/lib/resolve-attach.test.ts
@@ -14,6 +14,7 @@ import {
     parseTasklistImages,
     planAttach,
     quitBrowser,
+    readDevToolsActivePortEntries,
     readDevToolsActivePorts,
     renderAttachPlan,
     waitForCdp,
@@ -182,6 +183,30 @@ describe("planAttach", () => {
         expect(text).toContain("osascript -e 'quit app \"Brave Browser\"'");
         expect(text).toContain('open -na "Brave Browser" --args --remote-debugging-port=9223');
         expect(text).toContain("tools chrome-devtools attach --port 9222");
+    });
+
+    test("a consent-mode Chrome is named as such, with its WebSocket, not as 'port is not on'", () => {
+        const plan = planAttach({
+            running: ["chrome"],
+            endpoints: [],
+            consent: [{ id: "chrome", port: 9333, wsPath: "/devtools/browser/abc" }],
+        });
+
+        expect(plan.status).toBe("none");
+        expect(plan.consent).toEqual([{ id: "chrome", port: 9333, wsPath: "/devtools/browser/abc" }]);
+
+        const { text, exitCode } = renderAttachPlan(plan, {
+            cmd: "tools chrome-devtools",
+            suggestCommand: suggest,
+            platform: "darwin",
+        });
+
+        expect(exitCode).toBe(1);
+        expect(text).toContain("consent mode (chrome://inspect/#remote-debugging is on)");
+        expect(text).toContain("ws://127.0.0.1:9333/devtools/browser/abc");
+        expect(text).toContain('asks "Allow remote debugging?"');
+        expect(text).not.toContain("debugging port is not on");
+        expect(text).toContain("--user-data-dir");
     });
 
     test("non-darwin render offers the tool's restart, not osascript", () => {
@@ -392,6 +417,31 @@ describe("discoverListeningCdpPorts", () => {
         };
 
         expect(discoverListeningCdpPorts(exec, "win32")).toEqual([9222]);
+    });
+});
+
+describe("readDevToolsActivePortEntries", () => {
+    test("keeps the browser WebSocket path from line 2 and drops anything that is not one", () => {
+        const entries = readDevToolsActivePortEntries({
+            home: "/h",
+            platform: "darwin",
+            readFile: (abs) => {
+                if (abs.endsWith("Google/Chrome/DevToolsActivePort")) {
+                    return "9222\n/devtools/browser/f83f-1\n";
+                }
+
+                if (abs.endsWith("Brave-Browser/DevToolsActivePort")) {
+                    return "9223\n";
+                }
+
+                return null;
+            },
+        });
+
+        expect(entries).toEqual([
+            { id: "chrome", port: 9222, wsPath: "/devtools/browser/f83f-1" },
+            { id: "brave", port: 9223, wsPath: null },
+        ]);
     });
 });
 

--- a/src/chrome-devtools/lib/resolve-attach.ts
+++ b/src/chrome-devtools/lib/resolve-attach.ts
@@ -329,6 +329,34 @@ export function ownerOfPort(
     return command ? classifyProcessName(command) : null;
 }
 
+export type ActivePortEntry = { id: BrowserId; port: number; wsPath: string | null };
+
+/**
+ * Every DevToolsActivePort file with its port and the browser WebSocket path on line 2. The path is what
+ * Chrome 144+'s consent mode (chrome://inspect/#remote-debugging) leaves usable: /json/* answers 404 there.
+ */
+export function readDevToolsActivePortEntries(opts: {
+    home: string;
+    readFile: (abs: string) => string | null;
+    platform?: Platform;
+}): ActivePortEntry[] {
+    const entries: ActivePortEntry[] = [];
+    for (const { id, rel } of devtoolsPortRelpaths(opts.platform ?? currentPlatform())) {
+        const text = opts.readFile(`${opts.home}/${rel}`);
+        if (!text) {
+            continue;
+        }
+
+        const [portLine, pathLine] = text.split("\n").map((l) => l.trim());
+        const port = Number(portLine);
+        if (Number.isFinite(port) && port > 0) {
+            entries.push({ id, port, wsPath: pathLine?.startsWith("/devtools/browser/") ? pathLine : null });
+        }
+    }
+
+    return entries;
+}
+
 export function readDevToolsActivePorts(opts: {
     home: string;
     readFile: (abs: string) => string | null;
@@ -355,9 +383,16 @@ export function mergeProbePorts(...groups: number[][]): number[] {
 }
 
 export function readDevToolsActivePortsFromDisk(home?: string, platform: Platform = currentPlatform()): number[] {
+    return readDevToolsActivePortEntriesFromDisk(home, platform).map((e) => e.port);
+}
+
+export function readDevToolsActivePortEntriesFromDisk(
+    home?: string,
+    platform: Platform = currentPlatform()
+): ActivePortEntry[] {
     const base = home ?? (platform === "win32" ? (env.get("LOCALAPPDATA") ?? "") : env.paths.getHome());
 
-    return readDevToolsActivePorts({
+    return readDevToolsActivePortEntries({
         home: base,
         platform,
         readFile: (abs) => {
@@ -616,10 +651,14 @@ export type Endpoint = {
     pages: { title: string; url: string }[];
 };
 
+/** A browser in Chrome 144+'s consent mode: the port listens, /json/* is 404, only the browser WebSocket works. */
+export type ConsentEndpoint = { id: BrowserId; port: number; wsPath: string };
+
 export type Inventory = {
     running: BrowserId[];
     endpoints: Endpoint[];
     emptyDebugFlag?: BrowserId[];
+    consent?: ConsentEndpoint[];
 };
 
 export type AttachPlan = {
@@ -628,6 +667,7 @@ export type AttachPlan = {
     endpoints: Endpoint[];
     undebugged: BrowserId[];
     emptyDebugFlag: BrowserId[];
+    consent: ConsentEndpoint[];
     restartPort: number;
 };
 
@@ -653,6 +693,7 @@ export function planAttach(inventory: Inventory, opts?: { explicitPort?: number 
         running: inventory.running,
         undebugged,
         emptyDebugFlag,
+        consent: (inventory.consent ?? []).filter((c) => undebugged.includes(c.id)),
         restartPort,
     };
 
@@ -746,7 +787,19 @@ export function renderAttachPlan(
         const owned = plan.endpoints.filter((e) => e.owner === id);
         const off = plan.undebugged.includes(id);
 
-        if (off && !owned.length) {
+        const consent = plan.consent.find((c) => c.id === id);
+
+        if (off && !owned.length && consent) {
+            lines.push(`=== ${app}: own profile, consent mode (chrome://inspect/#remote-debugging is on) ===`);
+            lines.push(
+                `  port ${consent.port} listens, but /json/version and /json/list answer 404: only the browser WebSocket works,`,
+                `  and ${app} asks "Allow remote debugging?" on every connection.`,
+                `    ws://127.0.0.1:${consent.port}${consent.wsPath}`,
+                `  The ${opts.cmd} verbs need /json (targets, cookies, follow, har) and cannot drive this endpoint yet;`,
+                `  a CDP client that speaks the WebSocket directly can (Target.getTargets, Storage.getCookies per browserContextId).`,
+                `  For the tool's own verbs use a separate profile: ${opts.suggestCommand(["open", "--browser", id, "--port", String(plan.restartPort), "--user-data-dir", "<persistent dir>", "<url>"])}`
+            );
+        } else if (off && !owned.length) {
             const empty = plan.emptyDebugFlag.includes(id);
             lines.push(
                 empty

--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -100,13 +100,22 @@ const SERVER_INSTRUCTIONS =
     '("ok", "thanks", "continue"), or trivial lookups not worth preserving.\n\n' +
     "HANDOFFS (cross-agent task handoff): `handoff_post` creates. `handoff_get` reads. `handoff_list` lists. " +
     "`handoff_action` changes. To delegate work, handoff_post {title, tasks} → copy the returned `paste` block " +
-    'into the receiving agent\'s chat. Receiving agent: handoff_get {id} (default include:["tasks"] — full task ' +
-    "array) → claim (claim: true) → work the tasks " +
+    "into the receiving agent's chat. Address it with target {sessionId|sessionName|agent}, where agent is the " +
+    "intended RECIPIENT harness (claude | codex | grok | copilot), and give it a readable name (or let one be " +
+    'derived from the title) so it can be fetched as handoff_get {name: "fix-active-filter"}; a name shared by ' +
+    "several handoffs is refused with the candidate ids instead of guessing. " +
+    'Receiving agent: handoff_get {id or name} (default include:["tasks"] — full task ' +
+    "array) → READ warnings[] FIRST: it fires when the handoff is addressed to another session or another " +
+    "harness, and then the task is not yours — do not work it unless your user explicitly says to. It is a " +
+    "warning, never a block, and a session whose own identity cannot be detected is told the check was " +
+    "unverifiable rather than being called a mismatch. → claim (claim: true) → work the tasks " +
     "→ handoff_action check_task with proof per task (deny_task with reason for tasks you can't do; " +
     "uncheck_task keeps prior proof) → " +
     'finish_handoff when all resolved. Pass include:["events"] on handoff_get for a bare {events, info} ' +
     "activity trace (editId-free; each event carries `outcome` — a refused action is journaled with " +
     "outcome.applied false and the reason, so the trace never reads as though it happened). " +
+    "handoff_list is never recipient-filtered by default; agent: '<harness>' and session: '<id-or-name>' are " +
+    "opt-in filters on the intended recipient, usable alone or together. " +
     "Poster edits anytime from its own session via handoff_action " +
     "(add_tasks/modify_task/modify_handoff/cancel_handoff); from other sessions pass the editId. Progress is " +
     'live on the dev-dashboard /qa "Agent tasks" tab (SSE via /api/qa/stream type=handoff).\n\n' +

--- a/src/claude/mcp/tools/handoff.ts
+++ b/src/claude/mcp/tools/handoff.ts
@@ -4,6 +4,7 @@ import { SafeJSON } from "@genesiscz/utils/json";
 
 export interface HandoffPostArgs {
     title: string;
+    name?: string;
     description?: string;
     tasks: HandoffTaskInput[];
     target?: HandoffTarget;
@@ -11,7 +12,8 @@ export interface HandoffPostArgs {
 }
 
 export interface HandoffGetArgs {
-    id: string;
+    id?: string;
+    name?: string;
     claim?: boolean;
     unclaim?: boolean;
     include?: string[];
@@ -23,11 +25,14 @@ export interface HandoffListArgs {
     mine?: boolean;
     open?: boolean;
     project?: string;
+    agent?: string;
+    session?: string;
     include?: string[];
 }
 
 export interface HandoffActionArgs {
-    id: string;
+    id?: string;
+    name?: string;
     editId?: string;
     actions: HandoffActionInput[];
     include?: string[];
@@ -58,15 +63,26 @@ export async function handleHandoffAction(args: HandoffActionArgs, deps: Handoff
 export const HANDOFF_POST_DESCRIPTION =
     "Create a handoff — a task list for ANOTHER agent session (cross-repo/cross-project ok). Give title and " +
     "tasks (each has text and optional acceptanceCriteria); optional description (context body), target " +
-    "{sessionId|sessionName}, and refs. Returns the handoff with final task ids, an editId (edit credential " +
-    "for other sessions — your own session edits without it), and a `paste` block: paste it into the " +
-    "receiving agent's chat. To change anything later, call handoff_action.";
+    "{sessionId|sessionName|agent}, refs, and name. target.agent names the INTENDED RECIPIENT harness " +
+    "(claude | codex | grok | copilot) — a session on another harness gets a warning telling it not to work " +
+    "the handoff; it never says who wrote it (that is postedBy). name is a readable slug the receiver can " +
+    "fetch by (handoff_get { name }); omit it and it is derived from the title. Returns the handoff with " +
+    "final task ids, an editId (edit credential for other sessions — your own session edits without it), and " +
+    "a `paste` block: paste it into the receiving agent's chat. To change anything later, call handoff_action.";
 
 export const HANDOFF_GET_DESCRIPTION =
-    "Read a handoff by id (from a paste block or handoff_list). Pass claim: true to claim it for this " +
+    "Read a handoff by id (from a paste block or handoff_list) or by its readable name — pass either as id, " +
+    "or the name as name. A unique name resolves; a name carried by several handoffs is refused WITH the " +
+    "candidate ids so you re-call with the id you meant; passing an id and a name that disagree is an error. " +
+    "ALWAYS read warnings[] first: it fires when the handoff is addressed to another session (explicit " +
+    "target sessionId) or another harness (target.agent), and then this task is NOT yours — do not work it " +
+    "unless your user explicitly tells you to. A warning is not a block: user-authorized cross-target work " +
+    "stays possible, and a caller whose own identity cannot be detected is told the check was unverifiable " +
+    "rather than being called a mismatch. Pass claim: true to claim it for this " +
     "session before working, unclaim: true to release it. Several sessions may claim the same handoff " +
     "(co-owning). If your session IS the target sessionId it auto-claims (response says so; undo with " +
-    "unclaim: true). If this session posted the handoff (same sessionId — sessions are ephemeral, identity " +
+    "unclaim: true) — except under a target.agent this session is not, which never auto-claims. If this " +
+    "session posted the handoff (same sessionId — sessions are ephemeral, identity " +
     "is per-session not per-human), the response also returns your editId; if the posting session is gone " +
     "and the editId is lost, your user can read it on the dev-dashboard /qa Agent-tasks tab. info[] always " +
     "states where you stand and the one next step. After claiming, record work via handoff_action check_task. " +
@@ -75,15 +91,22 @@ export const HANDOFF_GET_DESCRIPTION =
     "returns {events, info} without the handoff envelope.";
 
 export const HANDOFF_LIST_DESCRIPTION =
-    "List recent handoffs, newest-updated first — ALL projects by default; project: '<name>' narrows. " +
+    "List recent handoffs, newest-updated first — ALL projects by default and NEVER filtered by recipient " +
+    "unless you ask; project: '<name>' narrows. " +
     "open: true → only unresolved (not done/cancelled); mine: true → posted by, claimed by, or targeted at " +
-    "this session; limit (default 20) + offset page through. Open rows are detailed, claimed rows concise. " +
+    "this session; limit (default 20) + offset page through. Two opt-in recipient filters, usable alone or " +
+    "together: agent: 'codex' keeps handoffs whose target.agent is that harness (spellings are canonical, so " +
+    "'claude-code' finds 'claude'), and session: '<id-or-name>' keeps handoffs whose target.sessionId matches " +
+    "exactly or by leading-segment abbreviation, or whose target.sessionName matches. Both read the INTENDED " +
+    "RECIPIENT, never the poster. Each row carries name, target and warnings[] (present only when this " +
+    "session is not the intended recipient). Open rows are detailed, claimed rows concise. " +
     'Optional include: ["tasks"] adds a task array per row with proof PREVIEWS (answer clipped, context dropped, ' +
     "id lists capped) — call handoff_get for full proofs. Other include values are ignored with an info line. " +
-    "Use the id with handoff_get.";
+    "Use the id or the name with handoff_get.";
 
 export const HANDOFF_ACTION_DESCRIPTION =
-    "Change a handoff — tasks and lifecycle (claim/unclaim also exist as a convenience on handoff_get; " +
+    "Change a handoff, addressed by id or by readable name (same resolution rules as handoff_get) — tasks " +
+    "and lifecycle (claim/unclaim also exist as a convenience on handoff_get; " +
     'identical effect). Ordered actions array; every action is an object { action: "<verb>", …verb fields } ' +
     "(payload-less verbs may be bare strings). Claimer verbs (be claimed, or start with {action:'claim'}): " +
     "claim, unclaim, check_task {taskId, proof:{answer, commitIds?, context?}}, uncheck_task {taskId} " +
@@ -91,7 +114,7 @@ export const HANDOFF_ACTION_DESCRIPTION =
     "deny_task {taskId, reason}, undeny_task {taskId}, comment {text}, finish_handoff (rejected unless every " +
     "task is checked or denied — force: true overrides; undo via reopen_handoff). Poster verbs (from the " +
     "posting session, or with editId): add_tasks {tasks:[…]}, modify_task {taskId, text?, acceptanceCriteria?}, " +
-    "modify_handoff {title?, description?, target?, refs?}, deny_task, undeny_task, check_task, comment, " +
+    "modify_handoff {title?, name?, description?, target?, refs?}, deny_task, undeny_task, check_task, comment, " +
     "cancel_handoff, reopen_handoff (undoes finish OR cancel; also allowed for the claimer whose own finish " +
     "closed it). attach_file {path, taskId?, note?} attaches a local file (screenshot, log) to the handoff or " +
     "a task. Common short forms are accepted as aliases (done/finish→finish_handoff, check→check_task, " +
@@ -126,10 +149,15 @@ const TASK_ITEM_SCHEMA = {
 const TARGET_SCHEMA = {
     type: "object",
     description:
-        "address a specific session: exact sessionId auto-claims on its first get; sessionName only nudges (names aren't unique)",
+        "who this handoff is FOR: exact sessionId auto-claims on its first get; sessionName only nudges (names aren't unique); agent names the recipient harness. Never describes the poster — that is postedBy",
     properties: {
         sessionId: { type: "string", description: "exact receiving sessionId — auto-claims on its first handoff_get" },
         sessionName: { type: "string", description: "receiving session's name — nudge only, never auto-claims" },
+        agent: {
+            type: "string",
+            description:
+                "intended RECIPIENT harness — claude | codex | grok | copilot. A session on another harness is warned off and never auto-claims. Undocumented values are stored as given but can never raise a warning",
+        },
     },
 } as const;
 
@@ -137,6 +165,11 @@ export const HANDOFF_POST_INPUT_SCHEMA = {
     type: "object",
     properties: {
         title: { type: "string", description: "short imperative title of the work being handed off" },
+        name: {
+            type: "string",
+            description:
+                "readable name the receiver can fetch by (handoff_get { name }) — slugified (lowercase, hyphens); omit it and a slug of the title is used. Not the target session's name",
+        },
         description: { type: "string", description: "markdown body — the why/context the worker needs" },
         tasks: { type: "array", minItems: 1, items: TASK_ITEM_SCHEMA, description: "the checkable task list (≥1)" },
         target: TARGET_SCHEMA,
@@ -154,7 +187,13 @@ export const HANDOFF_GET_INPUT_SCHEMA = {
     properties: {
         id: {
             type: "string",
-            description: "the handoff id from a paste block or handoff_list — h_ prefix optional, whitespace ok",
+            description:
+                "the handoff id from a paste block or handoff_list — h_ prefix optional, whitespace ok; a readable name is accepted here too",
+        },
+        name: {
+            type: "string",
+            description:
+                "readable name instead of an id — a unique name resolves, an ambiguous one is refused with the candidate ids, and a name that disagrees with a supplied id is an error",
         },
         claim: {
             type: "boolean",
@@ -163,7 +202,6 @@ export const HANDOFF_GET_INPUT_SCHEMA = {
         unclaim: { type: "boolean", description: "release ONLY this session's claim (no-op if not claimed)" },
         include: INCLUDE_PROP,
     },
-    required: ["id"],
 } as const;
 
 export const HANDOFF_LIST_INPUT_SCHEMA = {
@@ -177,6 +215,16 @@ export const HANDOFF_LIST_INPUT_SCHEMA = {
         },
         open: { type: "boolean", description: "only unresolved handoffs (status open or claimed)" },
         project: { type: "string", description: "narrow to one project (default: all projects)" },
+        agent: {
+            type: "string",
+            description:
+                "opt-in — only handoffs whose target.agent is this harness (claude | codex | grok | copilot; spellings canonicalized). Off by default; combines with session",
+        },
+        session: {
+            type: "string",
+            description:
+                "opt-in — only handoffs whose target.sessionId matches this id (exactly or by leading-segment abbreviation) or whose target.sessionName matches it. Off by default; combines with agent",
+        },
         include: {
             type: "array",
             items: { type: "string" },
@@ -191,7 +239,11 @@ export const HANDOFF_ACTION_INPUT_SCHEMA = {
     properties: {
         id: {
             type: "string",
-            description: "the handoff id — h_ prefix optional, whitespace ok",
+            description: "the handoff id — h_ prefix optional, whitespace ok; a readable name resolves here too",
+        },
+        name: {
+            type: "string",
+            description: "readable name instead of an id — same resolution rules as handoff_get",
         },
         editId: {
             type: "string",
@@ -285,6 +337,11 @@ export const HANDOFF_ACTION_INPUT_SCHEMA = {
                                 description: "modify_task: replacement acceptance criteria",
                             },
                             title: { type: "string", description: "modify_handoff: replacement title" },
+                            name: {
+                                type: ["string", "null"],
+                                description:
+                                    "modify_handoff: replacement readable name (slugified); null or an empty string clears it. A title edit never renames",
+                            },
                             description: { type: "string", description: "modify_handoff: replacement description" },
                             target: TARGET_SCHEMA,
                             refs: {
@@ -299,5 +356,5 @@ export const HANDOFF_ACTION_INPUT_SCHEMA = {
             },
         },
     },
-    required: ["id", "actions"],
+    required: ["actions"],
 } as const;

--- a/src/dev-dashboard/lib/handoff-types.ts
+++ b/src/dev-dashboard/lib/handoff-types.ts
@@ -29,18 +29,21 @@ export interface HandoffGetResponse {
     handoff: PublicHandoff;
     editId?: string;
     info: string[];
+    /** Recipient warnings for the calling identity — absent when there is nothing to say. */
+    warnings?: string[];
 }
 
 export interface HandoffActionResponse {
     handoff: PublicHandoff;
     results: HandoffActionResult[];
     info: string[];
+    warnings?: string[];
 }
 
 export interface HandoffPostResponse {
     handoff: PublicHandoff;
     editId: string;
-    paste: { _agent: string; id: string; title: string; tasks: string };
+    paste: { _agent: string; id: string; title: string; tasks: string; name?: string };
     info: string[];
 }
 

--- a/src/dev-dashboard/server/routes/handoff.ts
+++ b/src/dev-dashboard/server/routes/handoff.ts
@@ -52,6 +52,8 @@ export function handoffRoutes(): RouteDef[] {
                             offset: offsetRaw !== null ? Number.parseInt(offsetRaw, 10) : undefined,
                             open: ctx.query.get("open") === "1",
                             project: ctx.query.get("project") ?? undefined,
+                            agent: ctx.query.get("agent") ?? undefined,
+                            session: ctx.query.get("session") ?? undefined,
                         },
                         deps
                     );
@@ -69,7 +71,8 @@ export function handoffRoutes(): RouteDef[] {
                 try {
                     const deps = await dashboardDeps();
                     const id = ctx.query.get("id") ?? "";
-                    const res = getHandoff({ id }, deps);
+                    const name = ctx.query.get("name") ?? undefined;
+                    const res = getHandoff({ id, name }, deps);
 
                     return { kind: "json", status: 200, body: res };
                 } catch (err) {
@@ -121,9 +124,14 @@ export function handoffRoutes(): RouteDef[] {
             handler: async (ctx) => {
                 try {
                     const deps = await dashboardDeps();
-                    const body = await ctx.readJson<{ id?: string; editId?: string; actions?: HandoffActionInput[] }>();
+                    const body = await ctx.readJson<{
+                        id?: string;
+                        name?: string;
+                        editId?: string;
+                        actions?: HandoffActionInput[];
+                    }>();
                     const res = executeHandoffActions(
-                        { id: body.id ?? "", editId: body.editId, actions: body.actions ?? [] },
+                        { id: body.id ?? "", name: body.name, editId: body.editId, actions: body.actions ?? [] },
                         deps
                     );
 
@@ -141,6 +149,7 @@ export function handoffRoutes(): RouteDef[] {
                     const deps = await dashboardDeps();
                     const body = await ctx.readJson<{
                         title?: string;
+                        name?: string;
                         description?: string;
                         tasks?: HandoffTaskInput[];
                         target?: HandoffTarget;
@@ -149,6 +158,7 @@ export function handoffRoutes(): RouteDef[] {
                     const res = postHandoff(
                         {
                             title: body.title ?? "",
+                            name: body.name,
                             description: body.description,
                             tasks: body.tasks ?? [],
                             target: body.target,

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
@@ -141,7 +141,9 @@ export function HandoffCreateDialog({
     const [title, setTitle] = useState("");
     const [description, setDescription] = useState("");
     const [tasks, setTasks] = useState<TaskDraft[]>([{ text: "", acceptanceCriteria: "" }]);
+    const [name, setName] = useState("");
     const [targetName, setTargetName] = useState("");
+    const [targetAgent, setTargetAgent] = useState("");
     const [refs, setRefs] = useState("");
 
     const setTask = (index: number, patch: Partial<TaskDraft>): void => {
@@ -157,9 +159,10 @@ export function HandoffCreateDialog({
     const submit = (): void => {
         const payload: {
             title: string;
+            name?: string;
             description?: string;
             tasks: HandoffTaskInput[];
-            target?: { sessionName: string };
+            target?: { sessionName?: string; agent?: string };
             refs?: string[];
         } = {
             title: title.trim(),
@@ -178,8 +181,15 @@ export function HandoffCreateDialog({
             payload.description = description.trim();
         }
 
-        if (targetName.trim().length > 0) {
-            payload.target = { sessionName: targetName.trim() };
+        if (name.trim().length > 0) {
+            payload.name = name.trim();
+        }
+
+        if (targetName.trim().length > 0 || targetAgent.trim().length > 0) {
+            payload.target = {
+                ...(targetName.trim().length > 0 ? { sessionName: targetName.trim() } : {}),
+                ...(targetAgent.trim().length > 0 ? { agent: targetAgent.trim() } : {}),
+            };
         }
 
         const refList = refs
@@ -198,7 +208,9 @@ export function HandoffCreateDialog({
                 setTitle("");
                 setDescription("");
                 setTasks([{ text: "", acceptanceCriteria: "" }]);
+                setName("");
                 setTargetName("");
+                setTargetAgent("");
                 setRefs("");
             },
         });
@@ -320,6 +332,30 @@ export function HandoffCreateDialog({
                                 </Button>
                             </div>
                             <div className="grid gap-4 sm:grid-cols-2">
+                                <div>
+                                    <Label className={LABEL_CLASS} htmlFor="handoff-create-name">
+                                        Readable name (optional)
+                                    </Label>
+                                    <Input
+                                        id="handoff-create-name"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        className={INPUT_CLASS}
+                                        placeholder="derived from the title"
+                                    />
+                                </div>
+                                <div>
+                                    <Label className={LABEL_CLASS} htmlFor="handoff-create-agent">
+                                        Target harness (optional)
+                                    </Label>
+                                    <Input
+                                        id="handoff-create-agent"
+                                        value={targetAgent}
+                                        onChange={(e) => setTargetAgent(e.target.value)}
+                                        className={INPUT_CLASS}
+                                        placeholder="claude | codex | grok | copilot"
+                                    />
+                                </div>
                                 <div>
                                     <Label className={LABEL_CLASS} htmlFor="handoff-create-target">
                                         Target session name (optional)

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
@@ -71,10 +71,14 @@ function HandoffRow({
                         → {row.claimedBy.map((c) => c.sessionName ?? c.sessionId ?? "unnamed").join(", ")}
                     </span>
                 ) : null}
-                {row.target !== undefined ? (
+                {row.name !== undefined ? <span>{row.name}</span> : null}
+                {row.target?.sessionName !== undefined || row.target?.sessionId !== undefined ? (
                     <span className="rounded border border-[var(--dd-border)] px-1 py-px">
                         @{row.target.sessionName ?? row.target.sessionId}
                     </span>
+                ) : null}
+                {row.target?.agent !== undefined ? (
+                    <span className="rounded border border-[var(--dd-border)] px-1 py-px">{row.target.agent}</span>
                 ) : null}
                 <span>{row.ageHours < 24 ? `${row.ageHours}h` : `${Math.round(row.ageHours / 24)}d`}</span>
             </div>

--- a/src/dev-dashboard/ui/src/components/handoff/useHandoffApi.ts
+++ b/src/dev-dashboard/ui/src/components/handoff/useHandoffApi.ts
@@ -82,6 +82,7 @@ export function useHandoffCreate() {
     return useMutation({
         mutationFn: (input: {
             title: string;
+            name?: string;
             description?: string;
             tasks: HandoffTaskInput[];
             target?: HandoffTarget;

--- a/src/github/README.md
+++ b/src/github/README.md
@@ -54,7 +54,9 @@ tools github get https://github.com/owner/repo/blob/main/src/index.ts --clipboar
 tools github merge 123 --rebase           # stack-safe: restack+FF (preserves SHAs) + restack children
 tools github merge 123 --rebase --no-restack  # legacy GitHub rewrite rebase (breaks cascades)
 tools github merge 123 --ff-only          # true FF (base ref → head SHA; keeps commit SHAs)
-tools github merge 123 --squash --delete-branch --subject "feat: ship (#123)"
+tools github merge 123 --squash --delete-branch   # subject = PR title (#123), body = one bullet per commit
+tools github merge 123 --squash --dry-run         # print the generated squash message, merge nothing
+tools github merge 123 --squash --subject "feat: ship (#123)" --body "* one\n* two"   # explicit values win
 tools github merge https://github.com/owner/repo/pull/123 --merge --delete-remote
 
 # Cache + rate limit status
@@ -109,6 +111,18 @@ GitHub only auto-retargets dependent PRs when a branch is deleted via the **web 
 
 Exactly one of `--merge`, `--rebase`, `--squash`, or `--ff-only` is required.
 All progress logs go to stdout.
+
+**`--squash` writes a real commit message by default.** Without `--subject` the
+subject is the PR title, a space, and `(#N)` (not doubled when the title already
+ends with it). Without `--body` the body is every PR commit subject, oldest
+first, as `* <subject>` bullets separated by single newlines. The PR-commits
+endpoint stops at 250 commits, so past that the compare endpoint is walked
+page by page; if the collected count still differs from the PR's own commit
+count the merge refuses rather than write a short body. The CLI prints the message and says
+which part was generated and which came from a flag. Commit text is passed to
+the GitHub API as data, never through a shell. `--merge` is unchanged: no
+default message is generated there. `--dry-run` resolves the PR, lists
+dependents, prints the squash message and stops before any write.
 
 Run any subcommand with `--help` for its full option list. The most common flags (`--format ai|json`, `--limit`, `--last`, `--no-bots`, `--min-reactions`, `--stats`, `--clipboard`) work across multiple subcommands.
 

--- a/src/github/commands/merge.ts
+++ b/src/github/commands/merge.ts
@@ -1,6 +1,7 @@
 // Safe PR merge command — retargets stack dependents before optional branch delete.
 
 import { resolveMergeMethod, type SafeMergeResult, safeMergePull } from "@app/github/lib/merge";
+import { describeSquashMessage } from "@app/github/lib/squash-message";
 import { detectRepoFromGit, parseGitHubUrl } from "@genesiscz/utils/github/url-parser";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
@@ -25,6 +26,8 @@ export interface MergeCommandOptions {
     deleteRemote?: boolean;
     subject?: string;
     body?: string;
+    /** Resolve the PR and show the squash message, then stop before any write. */
+    dryRun?: boolean;
     format?: "text" | "json";
     verbose?: boolean;
 }
@@ -32,11 +35,32 @@ export interface MergeCommandOptions {
 function formatTextSummary(result: SafeMergeResult): string {
     const lines: string[] = [];
     lines.push("");
-    lines.push(chalk.green(`✔ MERGED ${result.owner}/${result.repo}#${result.number} (${result.method})`));
+
+    if (result.dryRun) {
+        lines.push(
+            chalk.yellow(
+                `○ DRY RUN ${result.owner}/${result.repo}#${result.number} (${result.method}) — nothing merged`
+            )
+        );
+    } else {
+        lines.push(chalk.green(`✔ MERGED ${result.owner}/${result.repo}#${result.number} (${result.method})`));
+    }
+
     lines.push(`  title:  ${result.title}`);
     lines.push(`  head:   ${result.headRef}`);
     lines.push(`  base:   ${result.baseRef}`);
     lines.push(`  sha:    ${result.mergeSha || "(n/a)"}`);
+
+    if (result.squashMessage) {
+        for (const line of describeSquashMessage(result.squashMessage)) {
+            lines.push(`  ${line}`);
+        }
+    }
+
+    if (result.dryRun) {
+        lines.push(`  dependents found: ${result.dependentsFound.length}`);
+        return lines.join("\n");
+    }
 
     if (result.rebaseMode) {
         lines.push(`  rebase: ${result.rebaseMode}`);
@@ -112,10 +136,24 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
     const { owner, repo, number } = parsed;
     const { log } = logger.scoped("github:merge");
 
-    log.info({ owner, repo, number, method, deleteBranch, noRestack: Boolean(options.noRestack) }, "safe merge start");
-    out.println(
+    const dryRun = Boolean(options.dryRun);
+    const jsonMode = options.format === "json";
+    log.info(
+        { owner, repo, number, method, deleteBranch, dryRun, noRestack: Boolean(options.noRestack) },
+        "safe merge start"
+    );
+    // In JSON mode stdout carries only the result object; progress goes to the logger (stderr + file).
+    const progress = jsonMode
+        ? (message: string) => log.info(message)
+        : (message: string) => {
+              out.println(message);
+              log.debug(message);
+          };
+    progress(
         chalk.bold(
-            `Safe merge ${owner}/${repo}#${number} (${method}${deleteBranch ? ", delete-branch after retarget" : ""})`
+            `Safe merge ${owner}/${repo}#${number} (${method}${deleteBranch ? ", delete-branch after retarget" : ""}${
+                dryRun ? ", dry run" : ""
+            })`
         )
     );
 
@@ -128,17 +166,18 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
         noRestack: Boolean(options.noRestack),
         commitTitle: options.subject,
         commitMessage: options.body,
-        log: (message) => {
-            out.println(message);
-            log.debug(message);
-        },
+        dryRun,
+        log: progress,
     });
 
     log.info(
         {
             number: result.number,
             mergeSha: result.mergeSha,
+            dryRun: Boolean(result.dryRun),
             rebaseMode: result.rebaseMode,
+            squashTitleGenerated: result.squashMessage?.titleGenerated,
+            squashBodyGenerated: result.squashMessage?.bodyGenerated,
             headRestacked: Boolean(result.headRestack?.rebased),
             dependentsRetargeted: result.retargeted.length,
             dependentsRestacked: result.dependentsRestacked.length,
@@ -164,8 +203,11 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
                     headRef: result.headRef,
                     baseRef: result.baseRef,
                     mergeSha: result.mergeSha,
+                    dryRun: Boolean(result.dryRun),
                     rebaseMode: result.rebaseMode ?? null,
+                    squashMessage: result.squashMessage ?? null,
                     headRestack: result.headRestack ?? null,
+                    dependentsFound: result.dependentsFound,
                     dependents: result.retargeted,
                     dependentsRestacked: result.dependentsRestacked,
                     branchDeleted: result.branchDeleted,
@@ -212,8 +254,15 @@ export function createMergeCommand(): Command {
             "After retargeting dependents, delete the remote head branch (never passes delete to the merge API)"
         )
         .option("--delete-remote", "Alias for --delete-branch")
-        .option("--subject <title>", "Commit title (merge/squash commit_title; ignored for --ff-only)")
-        .option("--body <text>", "Commit message body (merge/squash commit_message; ignored for --ff-only)")
+        .option(
+            "--subject <title>",
+            "Commit title (merge/squash commit_title; ignored for --ff-only). --squash defaults to the PR title plus (#N)"
+        )
+        .option(
+            "--body <text>",
+            "Commit message body (merge/squash commit_message; ignored for --ff-only). --squash defaults to one '* <subject>' bullet per PR commit"
+        )
+        .option("--dry-run", "Resolve the PR, print the squash message and dependents, then stop before any write")
         .option("-f, --format <format>", "Output format: text|json", "text")
         .option("-v, --verbose", "Verbose logging (reserved)")
         .action(async (input: string, opts: MergeCommandOptions) => {

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
     type DependentPull,
     type MergeGitHubClient,
+    type MergeMethod,
     type MergePullOptions,
     type MergePullResult,
     type PullRef,
@@ -9,6 +10,7 @@ import {
     safeMergePull,
 } from "./merge";
 import { NATIVE_STACK_BASE_ERROR } from "./native-stack";
+import type { PullCommitSubject } from "./squash-message";
 import type { RestackBranchInput, RestackBranchResult, StackRestackOps } from "./stack-restack";
 
 type CallLog = Array<{ op: string; args: unknown[] }>;
@@ -18,6 +20,8 @@ function makeMock(opts: {
     dependents?: DependentPull[];
     /** Dependents returned after merge (defaults to pre-merge list). */
     postMergeDependents?: DependentPull[];
+    /** Commit subjects returned by listPullCommits (oldest first). */
+    commits?: PullCommitSubject[];
     mergeResult?: MergePullResult;
     /** Fail updatePullBase for these PR numbers. */
     failRetarget?: number[];
@@ -70,10 +74,15 @@ function makeMock(opts: {
                     baseRef: dep.baseRef,
                     headSha: dep.headSha ?? "dddddddddddddddddddddddddddddddddddddddd",
                     baseSha: opts.pr.baseSha,
+                    commitCount: 1,
                     htmlUrl: dep.htmlUrl,
                 };
             }
             return { ...opts.pr, number, merged };
+        },
+        async listPullCommits(_owner, _repo, pr) {
+            calls.push({ op: "listPullCommits", args: [pr.number] });
+            return (opts.commits ?? []).map((c) => ({ ...c }));
         },
         async listOpenPullsByBase(_owner, _repo, base) {
             calls.push({ op: "listOpenPullsByBase", args: [base] });
@@ -197,6 +206,8 @@ function makeRestackMock(opts?: {
     return { restack, calls };
 }
 
+const HEAD_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
 function basePr(over: Partial<PullRef> = {}): PullRef {
     return {
         number: 1,
@@ -207,8 +218,9 @@ function basePr(over: Partial<PullRef> = {}): PullRef {
         mergeable: true,
         headRef: "branch-a",
         baseRef: "main",
-        headSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        headSha: HEAD_SHA,
         baseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        commitCount: 1,
         htmlUrl: "https://github.com/o/r/pull/1",
         ...over,
     };
@@ -514,10 +526,39 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
         expect(retargetCalls[0].args).toEqual([2, "main"]);
     });
 
-    test("passes squash subject/body through to merge API", async () => {
-        const { client, calls } = makeMock({ pr: basePr() });
+    test("an explicit --body skips the commit fetch, so a failing collector can never block it", async () => {
+        const { client, calls } = makeMock({ pr: basePr(), commits: [] });
+        client.listPullCommits = async () => {
+            throw new Error("Could not collect every PR commit");
+        };
 
-        await safeMergePull({
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "squash",
+            commitMessage: "* hand-written",
+            client,
+        });
+
+        expect(calls.map((c) => c.op)).not.toContain("listPullCommits");
+        expect(calls.find((c) => c.op === "mergePull")?.args[1]).toEqual({
+            method: "squash",
+            commitTitle: "PR A (#1)",
+            commitMessage: "* hand-written",
+            expectedHeadSha: HEAD_SHA,
+        });
+        expect(result.squashMessage?.titleGenerated).toBe(true);
+        expect(result.squashMessage?.bodyGenerated).toBe(false);
+    });
+
+    test("passes explicit squash subject/body through to merge API unchanged", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            commits: [{ sha: "1111111", subject: "ignored: explicit values win" }],
+        });
+
+        const result = await safeMergePull({
             owner: "o",
             repo: "r",
             number: 1,
@@ -532,7 +573,216 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
             method: "squash",
             commitTitle: "feat: ship it (#1)",
             commitMessage: "commit one\ncommit two",
+            expectedHeadSha: HEAD_SHA,
         });
+        expect(result.squashMessage?.titleGenerated).toBe(false);
+        expect(result.squashMessage?.bodyGenerated).toBe(false);
+    });
+
+    test("squash without --subject/--body sends PR title (#N) and one bullet per commit", async () => {
+        const logs: string[] = [];
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 42, title: "feat: widgets — bigger and `better`" }),
+            commits: [
+                { sha: "1111111", subject: "feat(widgets): add the frame" },
+                { sha: "2222222", subject: 'fix(widgets): "quoted" subject with $HOME and `ticks`' },
+                { sha: "3333333", subject: "chore: trailing whitespace   " },
+            ],
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 42,
+            method: "squash",
+            client,
+            log: (m) => logs.push(m),
+        });
+
+        const mergeCall = calls.find((c) => c.op === "mergePull");
+        expect(mergeCall?.args[1]).toEqual({
+            method: "squash",
+            commitTitle: "feat: widgets — bigger and `better` (#42)",
+            commitMessage:
+                "* feat(widgets): add the frame\n" +
+                '* fix(widgets): "quoted" subject with $HOME and `ticks`\n' +
+                "* chore: trailing whitespace",
+            // Bound to the head the commits were read from: a push in between fails the merge.
+            expectedHeadSha: HEAD_SHA,
+        });
+        expect(result.squashMessage).toEqual({
+            title: "feat: widgets — bigger and `better` (#42)",
+            body:
+                "* feat(widgets): add the frame\n" +
+                '* fix(widgets): "quoted" subject with $HOME and `ticks`\n' +
+                "* chore: trailing whitespace",
+            titleGenerated: true,
+            bodyGenerated: true,
+            commitCount: 3,
+        });
+        // The commit list is fetched before the merge call, never after.
+        const ops = calls.map((c) => c.op);
+        expect(ops.indexOf("listPullCommits")).toBeLessThan(ops.indexOf("mergePull"));
+        expect(logs.some((l) => l.includes("squash subject (generated from PR title)"))).toBe(true);
+        expect(logs.some((l) => l.includes("squash body (generated from 3 commit subject(s))"))).toBe(true);
+    });
+
+    test("squash keeps a PR title that already ends with (#N) and honours only one of the overrides", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 7, title: "fix: thing (#7)" }),
+            commits: [{ sha: "1111111", subject: "fix: thing" }],
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 7,
+            method: "squash",
+            commitMessage: "",
+            client,
+        });
+
+        const mergeCall = calls.find((c) => c.op === "mergePull");
+        expect(mergeCall?.args[1]).toEqual({
+            method: "squash",
+            commitTitle: "fix: thing (#7)",
+            commitMessage: "",
+            expectedHeadSha: HEAD_SHA,
+        });
+        expect(result.squashMessage?.titleGenerated).toBe(true);
+        expect(result.squashMessage?.bodyGenerated).toBe(false);
+    });
+
+    test("a head pushed after the commit list was read fails the squash instead of inheriting the body", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 9, title: "feat: nine" }),
+            commits: [{ sha: "1111111", subject: "one" }],
+            dependents: [dep({ number: 10 })],
+        });
+        const originalMerge = client.mergePull;
+        client.mergePull = async (owner, repo, number, options) => {
+            // GitHub answers 409 when `sha` no longer matches the head.
+            if (
+                options.expectedHeadSha !== undefined &&
+                options.expectedHeadSha !== "ffffffffffffffffffffffffffffffffffffffff"
+            ) {
+                calls.push({ op: "mergePull", args: [number, options] });
+                throw new Error("Head branch was modified. Review and try the merge again.");
+            }
+
+            return originalMerge(owner, repo, number, options);
+        };
+
+        await expect(safeMergePull({ owner: "o", repo: "r", number: 9, method: "squash", client })).rejects.toThrow(
+            /Head branch was modified/
+        );
+
+        const ops = calls.map((c) => c.op);
+        expect(ops).toContain("mergePull");
+        expect(ops).not.toContain("updatePullBase");
+        expect(ops).not.toContain("deleteBranch");
+    });
+
+    test("--merge does not list commits and sends no generated message", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            commits: [{ sha: "1111111", subject: "would be a bullet under --squash" }],
+        });
+
+        const result = await safeMergePull({ owner: "o", repo: "r", number: 1, method: "merge", client });
+
+        expect(calls.map((c) => c.op)).not.toContain("listPullCommits");
+        expect(calls.find((c) => c.op === "mergePull")?.args[1]).toEqual({
+            method: "merge",
+            commitTitle: undefined,
+            commitMessage: undefined,
+        });
+        expect(result.squashMessage).toBeUndefined();
+    });
+
+    test.each([
+        ["squash", false],
+        ["merge", false],
+        ["rebase", false],
+        ["rebase", true],
+        ["ff-only", false],
+    ] as Array<
+        [MergeMethod, boolean]
+    >)("dry run with method=%s noRestack=%s reaches no irreversible primitive", async (method, noRestack) => {
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            commits: [{ sha: "1111111", subject: "one" }],
+            dependents: [dep({ number: 2 })],
+        });
+        // Every write throws: a dry run that reaches one fails loudly instead of passing quietly.
+        const armed = (op: string) => async () => {
+            throw new Error(`dry run reached ${op}`);
+        };
+        client.mergePull = armed("mergePull");
+        client.fastForwardBase = armed("fastForwardBase");
+        client.updatePullBase = armed("updatePullBase");
+        client.unstack = armed("unstack");
+        client.deleteBranch = armed("deleteBranch");
+        const restack: StackRestackOps = { restackBranch: armed("restackBranch") };
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method,
+            noRestack,
+            deleteBranch: true,
+            dryRun: true,
+            client,
+            restack,
+        });
+
+        expect(result.dryRun).toBe(true);
+        expect(result.mergeSha).toBe("");
+        expect(result.dependentsFound.map((d) => d.number)).toEqual([2]);
+        const reads = new Set(["getPull", "listOpenPullsByBase", "listPullCommits"]);
+        expect(calls.every((c) => reads.has(c.op))).toBe(true);
+    });
+
+    test("the same armed spies fire on a real rebase, so the dry-run control is not vacuous", async () => {
+        const { client } = makeMock({ pr: basePr() });
+        const restack: StackRestackOps = {
+            restackBranch: async () => {
+                throw new Error("dry run reached restackBranch");
+            },
+        };
+
+        await expect(
+            safeMergePull({ owner: "o", repo: "r", number: 1, method: "rebase", client, restack })
+        ).rejects.toThrow(/reached restackBranch/);
+    });
+
+    test("dry run resolves the squash message and dependents but never writes", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 5, title: "feat: five" }),
+            commits: [{ sha: "1111111", subject: "one" }],
+            dependents: [dep({ number: 6 })],
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 5,
+            method: "squash",
+            deleteBranch: true,
+            dryRun: true,
+            client,
+        });
+
+        const ops = calls.map((c) => c.op);
+        expect(ops).toEqual(["getPull", "listOpenPullsByBase", "listPullCommits"]);
+        expect(result.dryRun).toBe(true);
+        expect(result.mergeSha).toBe("");
+        expect(result.squashMessage?.title).toBe("feat: five (#5)");
+        expect(result.squashMessage?.body).toBe("* one");
+        expect(result.dependentsFound.map((d) => d.number)).toEqual([6]);
+        expect(result.retargeted).toEqual([]);
+        expect(result.branchDeleted).toBe(false);
     });
 
     test("detects child closed after retarget (simulates the gh bug path)", async () => {

--- a/src/github/lib/merge.ts
+++ b/src/github/lib/merge.ts
@@ -31,6 +31,13 @@ import {
     parsePullStackNumber,
     posixShellSingleQuote,
 } from "./native-stack";
+import {
+    buildSquashMessage,
+    collectPullCommits,
+    commitSubjectOf,
+    type PullCommitSubject,
+    type SquashMessage,
+} from "./squash-message";
 
 /** GitHub API merge methods plus local-ref fast-forward. */
 export type MergeMethod = "merge" | "rebase" | "squash" | "ff-only";
@@ -48,6 +55,8 @@ export interface PullRef {
     headSha: string;
     /** Tip SHA of the base branch at PR resolution time. */
     baseSha: string;
+    /** Number of commits on the PR as GitHub counts them. */
+    commitCount: number;
     htmlUrl: string;
     /** GitHub native stack number, or null when the PR is not stacked. */
     stackNumber?: number | null;
@@ -73,6 +82,12 @@ export interface MergePullOptions {
     method: GithubApiMergeMethod;
     commitTitle?: string;
     commitMessage?: string;
+    /**
+     * Head SHA the PR must still be at for the merge to go through. A squash
+     * body lists the commits read BEFORE the merge, so a push in between must
+     * fail the merge instead of landing under a message that omits it.
+     */
+    expectedHeadSha?: string;
 }
 
 export interface MergePullResult {
@@ -85,6 +100,13 @@ export interface MergePullResult {
 export interface MergeGitHubClient {
     getPull(owner: string, repo: string, number: number): Promise<PullRef>;
     listOpenPullsByBase(owner: string, repo: string, base: string): Promise<DependentPull[]>;
+    /** Every commit on the PR, oldest first. Throws rather than return a partial list. */
+    listPullCommits(
+        owner: string,
+        repo: string,
+        pr: PullRef,
+        log?: (message: string) => void
+    ): Promise<PullCommitSubject[]>;
     mergePull(owner: string, repo: string, number: number, options: MergePullOptions): Promise<MergePullResult>;
     /**
      * True fast-forward: move `baseRef` to `headSha` only if base is an ancestor
@@ -120,6 +142,11 @@ export interface SafeMergeOptions {
     noRestack?: boolean;
     commitTitle?: string;
     commitMessage?: string;
+    /**
+     * Resolve the PR and derive the squash message, then stop before any write
+     * (no merge, no retarget, no branch delete).
+     */
+    dryRun?: boolean;
     /** Progress / decision logs (caller routes to stdout). */
     log?: (message: string) => void;
     client?: MergeGitHubClient;
@@ -160,6 +187,10 @@ export interface SafeMergeResult {
     mergeSha: string;
     /** How the merge was applied when method=rebase (stack-safe path). */
     rebaseMode?: "stack-safe-ff" | "api-rewrite";
+    /** The squash commit message that was (or, on dry run, would be) sent. */
+    squashMessage?: SquashMessage;
+    /** True when nothing was written: the run stopped before the merge call. */
+    dryRun?: boolean;
     headRestack?: RestackBranchResult;
     dependentsFound: DependentPull[];
     retargeted: RetargetResult[];
@@ -238,6 +269,7 @@ export function createOctokitMergeClient(): MergeGitHubClient {
                 baseRef: data.base.ref,
                 headSha: data.head.sha,
                 baseSha: data.base.sha,
+                commitCount: data.commits,
                 htmlUrl: data.html_url,
                 stackNumber: parsePullStackNumber(data),
             };
@@ -285,6 +317,48 @@ export function createOctokitMergeClient(): MergeGitHubClient {
             return results;
         },
 
+        async listPullCommits(owner, repo, pr, log) {
+            const basehead = `${pr.baseSha}...${pr.headSha}`;
+
+            return collectPullCommits({
+                expectedCount: pr.commitCount,
+                log,
+                async listPullCommitsPage(page, perPage) {
+                    const { data } = await withRetry(
+                        () =>
+                            octokit.rest.pulls.listCommits({
+                                owner,
+                                repo,
+                                pull_number: pr.number,
+                                per_page: perPage,
+                                page,
+                            }),
+                        { label: `GET /repos/${owner}/${repo}/pulls/${pr.number}/commits (page ${page})` }
+                    );
+
+                    return data.map((commit) => ({ sha: commit.sha, subject: commitSubjectOf(commit.commit.message) }));
+                },
+                async compareCommitsPage(page, perPage) {
+                    const { data } = await withRetry(
+                        () =>
+                            octokit.rest.repos.compareCommitsWithBasehead({
+                                owner,
+                                repo,
+                                basehead,
+                                per_page: perPage,
+                                page,
+                            }),
+                        { label: `GET /repos/${owner}/${repo}/compare/${basehead} (page ${page})` }
+                    );
+
+                    return data.commits.map((commit) => ({
+                        sha: commit.sha,
+                        subject: commitSubjectOf(commit.commit.message),
+                    }));
+                },
+            });
+        },
+
         async mergePull(owner, repo, number, options) {
             const { data } = await withRetry(
                 () =>
@@ -295,6 +369,7 @@ export function createOctokitMergeClient(): MergeGitHubClient {
                         merge_method: options.method,
                         commit_title: options.commitTitle,
                         commit_message: options.commitMessage,
+                        sha: options.expectedHeadSha,
                     }),
                 { label: `PUT /repos/${owner}/${repo}/pulls/${number}/merge (${options.method})` }
             );
@@ -432,6 +507,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         noRestack = false,
         commitTitle,
         commitMessage,
+        dryRun = false,
         log,
     } = options;
     const client = options.client ?? createOctokitMergeClient();
@@ -470,6 +546,53 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         for (const dep of dependents) {
             logLine(log, `  dependent #${dep.number} "${dep.title}" (${dep.headRef} → ${dep.baseRef})`);
         }
+    }
+
+    let squashMessage: SquashMessage | undefined;
+
+    if (method === "squash") {
+        // An explicit --body needs no commit list, so a failing collector can never block it.
+        let commits: PullCommitSubject[] = [];
+
+        if (commitMessage === undefined) {
+            logLine(log, `Listing commits of #${number} for the squash message...`);
+            commits = await client.listPullCommits(owner, repo, pr, log);
+        }
+
+        squashMessage = buildSquashMessage({
+            number: pr.number,
+            title: pr.title,
+            commits,
+            commitTitle,
+            commitMessage,
+        });
+        const titleSource = squashMessage.titleGenerated ? "generated from PR title" : "--subject";
+        const bodySource = squashMessage.bodyGenerated
+            ? `generated from ${squashMessage.commitCount} commit subject(s)`
+            : "--body";
+        logLine(log, `  squash subject (${titleSource}): ${squashMessage.title}`);
+        logLine(log, `  squash body (${bodySource}): ${squashMessage.commitCount} line(s)`);
+    }
+
+    if (dryRun) {
+        logLine(log, "Dry run: stopping before the merge call (nothing written)");
+        return {
+            owner,
+            repo,
+            number: pr.number,
+            title: pr.title,
+            method,
+            headRef: pr.headRef,
+            baseRef: pr.baseRef,
+            mergeSha: "",
+            squashMessage,
+            dryRun: true,
+            dependentsFound: dependents,
+            retargeted: [],
+            dependentsRestacked: [],
+            branchDeleted: false,
+            remainingWork: [],
+        };
     }
 
     // Tip of the PR head before any rewrite — used as --onto oldBase for children.
@@ -538,8 +661,10 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         }
         mergeResult = await client.mergePull(owner, repo, number, {
             method: method as GithubApiMergeMethod,
-            commitTitle,
-            commitMessage,
+            commitTitle: squashMessage?.title ?? commitTitle,
+            commitMessage: squashMessage?.body ?? commitMessage,
+            // The generated body describes pr.headSha; a newer head must fail the merge, not inherit the message.
+            ...(squashMessage ? { expectedHeadSha: pr.headSha } : {}),
         });
     }
 
@@ -849,6 +974,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         baseRef: pr.baseRef,
         mergeSha: mergeResult.sha || effectiveHeadSha,
         rebaseMode,
+        squashMessage,
         headRestack,
         dependentsFound: toRetarget,
         retargeted,

--- a/src/github/lib/squash-message.test.ts
+++ b/src/github/lib/squash-message.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+import {
+    buildSquashMessage,
+    collectPages,
+    collectPullCommits,
+    commitSubjectOf,
+    defaultSquashBody,
+    defaultSquashTitle,
+    describeSquashMessage,
+    type PullCommitSubject,
+} from "./squash-message";
+
+/** A page fetcher over a fixed list, with an optional hard cap like GitHub's 250 on pulls/{n}/commits. */
+function pagedSource(
+    total: number,
+    cap = Number.POSITIVE_INFINITY
+): {
+    fetch: (page: number, perPage: number) => Promise<PullCommitSubject[]>;
+    pages: number[];
+} {
+    const pages: number[] = [];
+    const all = Array.from({ length: total }, (_, i) => ({ sha: `sha${i}`, subject: `c${i}` }));
+    const visible = all.slice(0, Math.min(total, cap));
+
+    return {
+        pages,
+        async fetch(page, perPage) {
+            pages.push(page);
+            return visible.slice((page - 1) * perPage, page * perPage);
+        },
+    };
+}
+
+describe("defaultSquashTitle", () => {
+    test("appends (#N) once", () => {
+        expect(defaultSquashTitle("feat: thing", 12)).toBe("feat: thing (#12)");
+        expect(defaultSquashTitle("feat: thing (#12)", 12)).toBe("feat: thing (#12)");
+        expect(defaultSquashTitle("  feat: thing  ", 12)).toBe("feat: thing (#12)");
+    });
+
+    test("a different PR number in the title is not treated as the suffix", () => {
+        expect(defaultSquashTitle("revert: undo (#11)", 12)).toBe("revert: undo (#11) (#12)");
+    });
+});
+
+describe("commitSubjectOf", () => {
+    test("takes the first line only, trimmed, for LF and CRLF bodies", () => {
+        expect(commitSubjectOf("fix: one\n\nlong body\nmore")).toBe("fix: one");
+        expect(commitSubjectOf("fix: crlf\r\nbody")).toBe("fix: crlf");
+        expect(commitSubjectOf("  padded  ")).toBe("padded");
+    });
+
+    test("an empty message still yields a subject", () => {
+        expect(commitSubjectOf("")).toBe("(no subject)");
+        expect(commitSubjectOf("\n\nbody only")).toBe("(no subject)");
+    });
+});
+
+describe("defaultSquashBody", () => {
+    test("one bullet per commit, original order, single newlines, no blank lines", () => {
+        const body = defaultSquashBody([
+            { sha: "1", subject: "first" },
+            { sha: "2", subject: 'second "quoted" `ticked` $VAR' },
+            { sha: "3", subject: "third" },
+        ]);
+        expect(body).toBe('* first\n* second "quoted" `ticked` $VAR\n* third');
+        expect(body).not.toContain("\n\n");
+    });
+
+    test("no commits gives an empty body", () => {
+        expect(defaultSquashBody([])).toBe("");
+    });
+});
+
+describe("buildSquashMessage", () => {
+    const commits = [
+        { sha: "1", subject: "a" },
+        { sha: "2", subject: "b" },
+    ];
+
+    test("generates both parts when nothing is given", () => {
+        expect(buildSquashMessage({ number: 3, title: "t", commits })).toEqual({
+            title: "t (#3)",
+            body: "* a\n* b",
+            titleGenerated: true,
+            bodyGenerated: true,
+            commitCount: 2,
+        });
+    });
+
+    test("an explicit subject or body wins, independently", () => {
+        const onlyTitle = buildSquashMessage({ number: 3, title: "t", commits, commitTitle: "custom" });
+        expect(onlyTitle.title).toBe("custom");
+        expect(onlyTitle.titleGenerated).toBe(false);
+        expect(onlyTitle.body).toBe("* a\n* b");
+        expect(onlyTitle.bodyGenerated).toBe(true);
+
+        const onlyBody = buildSquashMessage({ number: 3, title: "t", commits, commitMessage: "mine" });
+        expect(onlyBody.title).toBe("t (#3)");
+        expect(onlyBody.body).toBe("mine");
+        expect(onlyBody.bodyGenerated).toBe(false);
+    });
+
+    test("an empty --subject falls back to the generated title, an empty --body is kept", () => {
+        const built = buildSquashMessage({ number: 3, title: "t", commits, commitTitle: "", commitMessage: "" });
+        expect(built.title).toBe("t (#3)");
+        expect(built.titleGenerated).toBe(true);
+        expect(built.body).toBe("");
+        expect(built.bodyGenerated).toBe(false);
+    });
+});
+
+describe("describeSquashMessage", () => {
+    test("names the source of each part and prints every body line", () => {
+        const lines = describeSquashMessage(buildSquashMessage({ number: 9, title: "t", commits: [] }));
+        expect(lines[0]).toBe(
+            "Squash commit message (subject generated from the PR title; body generated from 0 commit subject(s)):"
+        );
+        expect(lines[1]).toBe("  t (#9)");
+        expect(lines[2]).toBe("  (empty body)");
+
+        const explicit = describeSquashMessage(
+            buildSquashMessage({ number: 9, title: "t", commits: [], commitTitle: "s", commitMessage: "l1\nl2" })
+        );
+        expect(explicit).toEqual([
+            "Squash commit message (subject from --subject; body from --body):",
+            "  s",
+            "  l1",
+            "  l2",
+        ]);
+    });
+});
+
+describe("collectPages", () => {
+    test("keeps requesting pages until one comes back short", async () => {
+        const requested: number[] = [];
+        const items = await collectPages(async (page, perPage) => {
+            requested.push(page);
+            const count = page < 3 ? perPage : 3;
+            return Array.from({ length: count }, (_, i) => `p${page}-${i}`);
+        }, 100);
+
+        expect(requested).toEqual([1, 2, 3]);
+        expect(items).toHaveLength(203);
+        expect(items[0]).toBe("p1-0");
+        expect(items[202]).toBe("p3-2");
+    });
+
+    test("an exactly full last page costs one extra empty request, never a truncation", async () => {
+        const requested: number[] = [];
+        const items = await collectPages(async (page, perPage) => {
+            requested.push(page);
+            return page === 1 ? Array.from({ length: perPage }, (_, i) => i) : [];
+        }, 2);
+
+        expect(requested).toEqual([1, 2]);
+        expect(items).toEqual([0, 1]);
+    });
+});
+
+describe("collectPullCommits", () => {
+    test("a PR under the cap comes straight from the PR commits endpoint", async () => {
+        const list = pagedSource(120);
+        const compare = pagedSource(120);
+        const logs: string[] = [];
+
+        const commits = await collectPullCommits({
+            expectedCount: 120,
+            listPullCommitsPage: list.fetch,
+            compareCommitsPage: compare.fetch,
+            log: (m) => logs.push(m),
+        });
+
+        expect(commits).toHaveLength(120);
+        expect(list.pages).toEqual([1, 2]);
+        expect(compare.pages).toEqual([]);
+        expect(logs).toEqual([]);
+    });
+
+    test("a 300-commit PR is walked through the compare endpoint once the 250 cap shows", async () => {
+        const list = pagedSource(300, 250);
+        const compare = pagedSource(300);
+        const logs: string[] = [];
+
+        const commits = await collectPullCommits({
+            expectedCount: 300,
+            listPullCommitsPage: list.fetch,
+            compareCommitsPage: compare.fetch,
+            log: (m) => logs.push(m),
+        });
+
+        expect(list.pages).toEqual([1, 2, 3]);
+        // 300 is three exactly full pages, so the walk needs a fourth, empty page to know it is done.
+        expect(compare.pages).toEqual([1, 2, 3, 4]);
+        expect(commits).toHaveLength(300);
+        expect(commits[0].subject).toBe("c0");
+        expect(commits[299].subject).toBe("c299");
+        expect(logs[0]).toContain("returned 250 of 300 commits");
+    });
+
+    test("a count that still does not match throws instead of producing a short body", async () => {
+        const list = pagedSource(300, 250);
+        const compare = pagedSource(280);
+
+        await expect(
+            collectPullCommits({
+                expectedCount: 300,
+                listPullCommitsPage: list.fetch,
+                compareCommitsPage: compare.fetch,
+            })
+        ).rejects.toThrow(/PR reports 300, compare returned 280.*--body/);
+    });
+});

--- a/src/github/lib/squash-message.ts
+++ b/src/github/lib/squash-message.ts
@@ -1,0 +1,150 @@
+// Default squash commit message: PR title plus " (#N)" as the subject, and the
+// PR's commit subjects in original order as "* <subject>" bullets, one newline
+// apart. Pure; the caller fetches the commits and decides whether to use it.
+
+export interface PullCommitSubject {
+    sha: string;
+    /** First line of the commit message. */
+    subject: string;
+}
+
+export interface SquashMessageInput {
+    number: number;
+    title: string;
+    commits: PullCommitSubject[];
+    /** Explicit --subject; wins over the generated one. */
+    commitTitle?: string;
+    /** Explicit --body; wins over the generated one. */
+    commitMessage?: string;
+}
+
+export interface SquashMessage {
+    title: string;
+    body: string;
+    /** True when the title came from the PR title, not from --subject. */
+    titleGenerated: boolean;
+    /** True when the body came from the commit list, not from --body. */
+    bodyGenerated: boolean;
+    /** Number of commit subjects folded into the generated body. */
+    commitCount: number;
+}
+
+/** First line of a commit message, trimmed; never empty. */
+export function commitSubjectOf(message: string): string {
+    const first = message.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    return first.length > 0 ? first : "(no subject)";
+}
+
+/** `title (#N)` unless the title already carries that exact suffix. */
+export function defaultSquashTitle(title: string, number: number): string {
+    const trimmed = title.trim();
+    const suffix = `(#${number})`;
+
+    if (trimmed.endsWith(suffix)) {
+        return trimmed;
+    }
+
+    return `${trimmed} ${suffix}`;
+}
+
+/** One `* <subject>` bullet per commit, single newline between bullets, no blank lines. */
+export function defaultSquashBody(commits: PullCommitSubject[]): string {
+    return commits.map((c) => `* ${commitSubjectOf(c.subject)}`).join("\n");
+}
+
+export interface CollectPullCommitsInput {
+    /** `commits` from the PR object: the authoritative count. */
+    expectedCount: number;
+    /** Page of `GET /pulls/{n}/commits` (GitHub caps the whole listing at 250). */
+    listPullCommitsPage: (page: number, perPage: number) => Promise<PullCommitSubject[]>;
+    /** Page of `GET /compare/{base}...{head}`, which paginates past 250. */
+    compareCommitsPage: (page: number, perPage: number) => Promise<PullCommitSubject[]>;
+    log?: (message: string) => void;
+}
+
+/**
+ * Every commit of a PR, oldest first. The PR-commits endpoint stops at 250
+ * commits no matter how it is paged, so when it comes back short of the PR's
+ * own commit count the compare endpoint is walked instead. A count that still
+ * does not match is an error: a squash body must never silently drop commits.
+ */
+export async function collectPullCommits(input: CollectPullCommitsInput): Promise<PullCommitSubject[]> {
+    const listed = await collectPages(input.listPullCommitsPage);
+
+    if (listed.length >= input.expectedCount) {
+        return listed;
+    }
+
+    input.log?.(
+        `  PR commits endpoint returned ${listed.length} of ${input.expectedCount} commits (250 cap); walking the compare endpoint`
+    );
+    const compared = await collectPages(input.compareCommitsPage);
+
+    if (compared.length !== input.expectedCount) {
+        throw new Error(
+            `Could not collect every PR commit for the squash body: PR reports ${input.expectedCount}, ` +
+                `compare returned ${compared.length}. Pass --body to supply the message yourself.`
+        );
+    }
+
+    return compared;
+}
+
+/**
+ * Walk a page-numbered GitHub list to its end. A page shorter than `perPage`
+ * is the last one.
+ */
+export async function collectPages<T>(
+    fetchPage: (page: number, perPage: number) => Promise<T[]>,
+    perPage = 100
+): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+
+    while (true) {
+        const data = await fetchPage(page, perPage);
+        results.push(...data);
+
+        if (data.length < perPage) {
+            break;
+        }
+
+        page++;
+    }
+
+    return results;
+}
+
+export function buildSquashMessage(input: SquashMessageInput): SquashMessage {
+    const title = input.commitTitle || defaultSquashTitle(input.title, input.number);
+    const body = input.commitMessage ?? defaultSquashBody(input.commits);
+
+    return {
+        title,
+        body,
+        titleGenerated: !input.commitTitle,
+        bodyGenerated: input.commitMessage === undefined,
+        commitCount: input.commits.length,
+    };
+}
+
+/** Lines the CLI prints so the user can inspect a generated message before trusting it. */
+export function describeSquashMessage(message: SquashMessage): string[] {
+    const lines: string[] = [];
+    const titleSource = message.titleGenerated ? "generated from the PR title" : "from --subject";
+    const bodySource = message.bodyGenerated
+        ? `generated from ${message.commitCount} commit subject(s)`
+        : "from --body";
+    lines.push(`Squash commit message (subject ${titleSource}; body ${bodySource}):`);
+    lines.push(`  ${message.title}`);
+
+    if (message.body.length === 0) {
+        lines.push("  (empty body)");
+    } else {
+        for (const line of message.body.split("\n")) {
+            lines.push(`  ${line}`);
+        }
+    }
+
+    return lines;
+}

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -10,12 +10,23 @@ import { appendHandoffEvents } from "./log-store";
 import { isEventsOnlyInclude, type ProjectedHandoff, parseIncludeSections, projectHandoff } from "./project";
 import {
     catchUpHandoffs,
+    findHandoffsByName,
     getEventOutcome,
     getHandoffById,
     listHandoffEvents,
     listHandoffRows,
     openHandoffModel,
 } from "./read-model";
+import {
+    agentFilterMatches,
+    HANDOFF_AGENTS_LIST,
+    handoffNameFor,
+    isKnownAgent,
+    normalizeHandoffName,
+    normalizeTargetInput,
+    recipientCheck,
+    sessionFilterMatches,
+} from "./targeting";
 import type {
     Handoff,
     HandoffActionInput,
@@ -176,6 +187,7 @@ function stateInfo(h: Handoff, by: HandoffEventBy): string[] {
 function pasteAgentText(id: string): string {
     return (
         `You have been handed a task list. Call the genesis-tools MCP tool handoff_get with { id: "${id}" } to read it, ` +
+        "then check its `warnings` — if it says the handoff is addressed to another session or harness, stop and ask your user before working it. " +
         `then claim it by calling handoff_get again with { id: "${id}", claim: true } before working. ` +
         'Check each finished task off with handoff_action { id, actions: [{ action: "check_task", taskId, proof: { answer, commitIds } }] }. ' +
         'To refuse a task you can\'t do, send { action: "deny_task", taskId, reason }. ' +
@@ -185,12 +197,86 @@ function pasteAgentText(id: string): string {
     );
 }
 
+const REF_REQUIRED =
+    'Pass id or name — e.g. handoff_get { id: "h_x1y2z3ab" } or handoff_get { name: "fix-active-filter" }.';
+
+/**
+ * Resolve a handoff from an id, a readable name, or an `id` field that holds
+ * either. Deterministic on purpose: an id always wins, a unique name resolves,
+ * and an ambiguous name is refused WITH its candidates. Picking the newest of
+ * several same-named handoffs would silently work the wrong one.
+ */
+function resolveHandoffRef(db: Database, input: { id?: string; name?: string }): Handoff {
+    const rawId = typeof input.id === "string" ? input.id.trim() : "";
+    const rawName = typeof input.name === "string" ? input.name.trim() : "";
+
+    if (rawId.length === 0 && rawName.length === 0) {
+        throw new Error(REF_REQUIRED);
+    }
+
+    const byId = rawId.length > 0 ? getHandoffById(db, normalizeHandoffId(rawId)) : null;
+
+    if (byId !== null) {
+        const wanted = normalizeHandoffName(rawName);
+
+        if (wanted !== undefined && byId.name !== wanted) {
+            throw new Error(
+                `The id and the name point at different handoffs: ${byId.id} is called "${byId.name ?? "(unnamed)"}", not "${wanted}". Pass one of them, not both.`
+            );
+        }
+
+        return byId;
+    }
+
+    // An `h_`-prefixed value is an id claim (no slug can carry an underscore). Beside a
+    // name it must resolve as an id: a stale id never falls back to whatever the name finds.
+    if (rawId.startsWith("h_") && rawName.length > 0) {
+        throw new Error(
+            `No handoff ${rawId} — the id does not resolve, so the name "${rawName}" is not used. Re-call with just the one you mean.`
+        );
+    }
+
+    // The `id` field also accepts a name, so a paste of either resolves.
+    const lookup = normalizeHandoffName(rawName.length > 0 ? rawName : rawId);
+    const matches = lookup !== undefined ? findHandoffsByName(db, lookup) : [];
+
+    if (matches.length === 1) {
+        // Both fields were names: the one not used for the lookup must name the same handoff.
+        const other = rawName.length > 0 && rawId.length > 0 ? normalizeHandoffName(rawId) : undefined;
+
+        if (other !== undefined && other !== lookup) {
+            throw new Error(
+                `The id and the name point at different handoffs: "${rawId}" is not "${lookup}". Pass one of them, not both.`
+            );
+        }
+
+        return matches[0];
+    }
+
+    if (matches.length > 1) {
+        const candidates = matches.map((h) => `${h.id} (${h.status}, updated ${h.updatedTs}) "${h.title}"`).join("; ");
+        throw new Error(
+            `Name "${lookup}" is ambiguous — ${matches.length} handoffs carry it: ${candidates}. Re-call with the id of the one you mean.`
+        );
+    }
+
+    if (rawId.length > 0) {
+        throw new Error(
+            `No handoff ${normalizeHandoffId(rawId)} — re-check the paste block or call handoff_list to find it.`
+        );
+    }
+
+    throw new Error(`No handoff named "${lookup ?? rawName}" — call handoff_list to see what exists.`);
+}
+
 // ---------------------------------------------------------------------------
 // handoff_post
 // ---------------------------------------------------------------------------
 
 export interface PostHandoffInput {
     title: string;
+    /** Readable slug this handoff can also be fetched by. Defaults to a slug of the title. */
+    name?: string;
     description?: string;
     tasks: HandoffTaskInput[];
     target?: HandoffTarget;
@@ -200,7 +286,7 @@ export interface PostHandoffInput {
 export interface PostHandoffResponse {
     handoff: PublicHandoff;
     editId: string;
-    paste: { _agent: string; id: string; title: string; tasks: string };
+    paste: { _agent: string; id: string; title: string; tasks: string; name?: string };
     info: string[];
 }
 
@@ -229,16 +315,20 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
         tasks,
         by,
     };
+    const name = handoffNameFor({ name: input.name, title });
+
+    if (name !== undefined) {
+        event.name = name;
+    }
 
     if (input.description !== undefined && input.description.trim().length > 0) {
         event.description = input.description;
     }
 
-    if (
-        input.target !== undefined &&
-        (input.target.sessionId !== undefined || input.target.sessionName !== undefined)
-    ) {
-        event.target = input.target;
+    const target = normalizeTargetInput(input.target);
+
+    if (target !== undefined) {
+        event.target = target;
     }
 
     if (input.refs !== undefined && input.refs.length > 0) {
@@ -255,7 +345,37 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
             throw new Error(`handoff_post failed to fold ${event.id} — check ~/.genesis-tools/logs for details.`);
         }
 
-        log.info({ id: handoff.id, tasks: handoff.tasks.length, by: by.sessionId }, "handoff posted");
+        log.info(
+            {
+                id: handoff.id,
+                name: handoff.name,
+                tasks: handoff.tasks.length,
+                by: by.sessionId,
+                targetAgent: target?.agent,
+            },
+            "handoff posted"
+        );
+
+        const info = [
+            "Posted. Copy `paste` into the target agent's chat.",
+            "You can edit from this session anytime via handoff_action (no editId needed).",
+        ];
+
+        if (handoff.name !== undefined) {
+            // A title-derived name can already be taken; promising a lookup that will be refused as ambiguous helps nobody.
+            const clashes = findHandoffsByName(db, handoff.name).filter((h) => h.id !== handoff.id);
+            info.push(
+                clashes.length === 0
+                    ? `Readable name: "${handoff.name}" — receivers can also call handoff_get { name: "${handoff.name}" }.`
+                    : `Readable name "${handoff.name}" is already carried by ${clashes.map((h) => h.id).join(", ")} — handoff_get { name } will be refused as ambiguous. Hand out the id, or rename via handoff_action modify_handoff { name }.`
+            );
+        }
+
+        if (target?.agent !== undefined && !isKnownAgent(target.agent)) {
+            info.push(
+                `target.agent "${target.agent}" is not a documented harness (${HANDOFF_AGENTS_LIST}) — it is stored as given, but no recipient warning can ever fire for it.`
+            );
+        }
 
         return {
             handoff: publicHandoff(handoff, deps.base),
@@ -265,11 +385,9 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
                 id: handoff.id,
                 title: handoff.title,
                 tasks: `0/${handoff.tasks.length}`,
+                ...(handoff.name !== undefined ? { name: handoff.name } : {}),
             },
-            info: [
-                "Posted. Copy `paste` into the target agent's chat.",
-                "You can edit from this session anytime via handoff_action (no editId needed).",
-            ],
+            info,
         };
     });
 }
@@ -279,7 +397,10 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
 // ---------------------------------------------------------------------------
 
 export interface GetHandoffInput {
-    id: string;
+    /** Handoff id, or a readable name — both resolve here. */
+    id?: string;
+    /** Readable name, when you would rather not overload `id`. */
+    name?: string;
     claim?: boolean;
     unclaim?: boolean;
     /** MCP section scoping. Omit → full PublicHandoff (HTTP). MCP handlers default to ["tasks"]. */
@@ -290,6 +411,8 @@ export type GetHandoffFullResponse = {
     handoff: PublicHandoff;
     editId?: string;
     info: string[];
+    /** Recipient warnings for the CALLING session — absent when there is nothing to say. */
+    warnings?: string[];
 };
 
 export type GetHandoffScopedResponse =
@@ -297,10 +420,12 @@ export type GetHandoffScopedResponse =
           handoff: ProjectedHandoff;
           editId?: string;
           info: string[];
+          warnings?: string[];
       }
     | {
           events: HandoffPublicEvent[];
           info: string[];
+          warnings?: string[];
       };
 
 export type GetHandoffResponse = GetHandoffFullResponse | GetHandoffScopedResponse;
@@ -313,21 +438,18 @@ export function getHandoff(input: Omit<GetHandoffInput, "include">, deps?: Hando
 export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetHandoffResponse {
     if (input.claim === true && input.unclaim === true) {
         throw new Error(
-            `Pass either claim: true or unclaim: true, not both — e.g. handoff_get { id: "${input.id}", claim: true }.`
+            `Pass either claim: true or unclaim: true, not both — e.g. handoff_get { id: "${input.id ?? input.name}", claim: true }.`
         );
     }
 
     const sections = input.include !== undefined ? parseIncludeSections(input.include) : null;
-    const id = normalizeHandoffId(String(input.id ?? ""));
     const by = buildBy(deps);
 
     return withDb(deps, (db) => {
         catchUpHandoffs(db, deps.base);
-        const existing = getHandoffById(db, id);
-
-        if (existing === null) {
-            throw new Error(`No handoff ${id} — re-check the paste block or call handoff_list to find it.`);
-        }
+        const existing = resolveHandoffRef(db, input);
+        const id = existing.id;
+        const recipient = recipientCheck({ target: existing.target, by });
 
         const events: HandoffEvent[] = [];
         const extraInfo: string[] = [];
@@ -335,12 +457,21 @@ export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetH
         let claimUid: string | undefined;
         let unclaimUid: string | undefined;
 
-        const autoClaim =
-            input.unclaim !== true &&
+        const addressedToThisSession =
             existing.target?.sessionId !== undefined &&
             targetMatchesSession(existing.target.sessionId, by.sessionId) &&
             !isClaimedBy(existing, by) &&
             (existing.status === "open" || existing.status === "claimed");
+
+        // A session-id hit under a harness the handoff is NOT addressed to must not
+        // claim silently: the poster named two recipients and only one of them is us.
+        const autoClaim = input.unclaim !== true && addressedToThisSession && recipient.agent !== "mismatch";
+
+        if (input.unclaim !== true && addressedToThisSession && recipient.agent === "mismatch") {
+            extraInfo.push(
+                `NOT auto-claimed: the target sessionId names this session, but the handoff is addressed to harness "${existing.target?.agent}". Claim explicitly only if your user asks you to.`
+            );
+        }
 
         if (autoClaim) {
             autoClaimUid = generateEventUid();
@@ -399,10 +530,11 @@ export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetH
         }
 
         const info = [...extraInfo, ...stateInfo(handoff, by)];
+        const warnings = recipient.warnings.length > 0 ? { warnings: recipient.warnings } : {};
 
         if (sections !== null && isEventsOnlyInclude(sections)) {
             const { events: publicEvents } = listHandoffEvents({ db, handoffId: id });
-            return { events: publicEvents, info };
+            return { events: publicEvents, info, ...warnings };
         }
 
         const full = publicHandoff(handoff, deps.base);
@@ -415,6 +547,7 @@ export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetH
         const response = {
             handoff: sections === null ? full : projectHandoff({ handoff: full, sections, events: projectedEvents }),
             info,
+            ...warnings,
         } as GetHandoffFullResponse | Extract<GetHandoffScopedResponse, { handoff: unknown }>;
 
         // editId recovery: ONLY the posting session (or the dashboard owner) ever sees it (§3).
@@ -436,6 +569,10 @@ export interface ListHandoffsInput {
     mine?: boolean;
     open?: boolean;
     project?: string;
+    /** Opt-in: only handoffs whose INTENDED RECIPIENT harness is this one. Never the poster's. */
+    agent?: string;
+    /** Opt-in: only handoffs whose INTENDED RECIPIENT session is this id (or abbreviation) or name. */
+    session?: string;
     /** Only `"tasks"` is honored on list rows; other values no-op with an info line. */
     include?: string[];
 }
@@ -485,6 +622,19 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
             );
         }
 
+        // Opt-in only: with neither flag the listing stays exactly what it was.
+        const agentFilter = input.agent !== undefined && input.agent.trim().length > 0 ? input.agent.trim() : undefined;
+        const sessionFilter =
+            input.session !== undefined && input.session.trim().length > 0 ? input.session.trim() : undefined;
+
+        if (agentFilter !== undefined) {
+            rows = rows.filter((h) => agentFilterMatches(h.target, agentFilter));
+        }
+
+        if (sessionFilter !== undefined) {
+            rows = rows.filter((h) => sessionFilterMatches(h.target, sessionFilter));
+        }
+
         const total = rows.length;
         const page = rows.slice(offset, offset + limit);
         const now = Date.now();
@@ -501,8 +651,17 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
                 ageHours: Math.round(((now - new Date(h.createdTs).getTime()) / 3_600_000) * 10) / 10,
             };
 
+            if (h.name !== undefined) {
+                row.name = h.name;
+            }
+
             if (h.target !== undefined) {
                 row.target = h.target;
+                const recipient = recipientCheck({ target: h.target, by });
+
+                if (recipient.warnings.length > 0) {
+                    row.warnings = recipient.warnings;
+                }
             }
 
             if (h.claimedBy.length > 0) {
@@ -541,6 +700,20 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
         });
 
         const info: string[] = [`${total} handoff${total === 1 ? "" : "s"} matched; showing ${page.length}.`];
+
+        if (agentFilter !== undefined) {
+            info.push(
+                isKnownAgent(agentFilter)
+                    ? `Filtered to handoffs addressed to harness "${agentFilter}" — the intended recipient, not the poster.`
+                    : `agent filter "${agentFilter}" is not a documented harness (${HANDOFF_AGENTS_LIST}) — matched as literal text against target.agent.`
+            );
+        }
+
+        if (sessionFilter !== undefined) {
+            info.push(
+                `Filtered to handoffs addressed to session "${sessionFilter}" — matches target.sessionId (exactly or by leading-segment abbreviation) or target.sessionName.`
+            );
+        }
 
         if (proofsClipped) {
             info.push("Task proofs are previews on list — call handoff_get for the full proof.");
@@ -627,7 +800,10 @@ function asStringArray(value: unknown): string[] | undefined {
 }
 
 export interface ExecuteActionsInput {
-    id: string;
+    /** Handoff id, or a readable name — both resolve here. */
+    id?: string;
+    /** Readable name, when you would rather not overload `id`. */
+    name?: string;
     editId?: string;
     actions: HandoffActionInput[];
     /** MCP section scoping. Omit → full PublicHandoff (HTTP). MCP handlers default to ["tasks"]. */
@@ -638,12 +814,15 @@ export type ExecuteActionsFullResponse = {
     handoff: PublicHandoff;
     results: HandoffActionResult[];
     info: string[];
+    /** Recipient warnings for the CALLING session — absent when there is nothing to say. */
+    warnings?: string[];
 };
 
 export type ExecuteActionsScopedResponse = {
     handoff: ProjectedHandoff;
     results: HandoffActionResult[];
     info: string[];
+    warnings?: string[];
 };
 
 export type ExecuteActionsResponse = ExecuteActionsFullResponse | ExecuteActionsScopedResponse;
@@ -665,17 +844,13 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
     }
 
     const sections = input.include !== undefined ? parseIncludeSections(input.include) : null;
-    const id = normalizeHandoffId(String(input.id ?? ""));
     const editId = normalizeEditId(input.editId);
     const by = buildBy(deps);
 
     return withDb(deps, (db) => {
         catchUpHandoffs(db, deps.base);
-        const existing = getHandoffById(db, id);
-
-        if (existing === null) {
-            throw new Error(`No handoff ${id} — re-check the paste block or call handoff_list to find it.`);
-        }
+        const existing = resolveHandoffRef(db, input);
+        const id = existing.id;
 
         const stamp = (): { ts: string; uid: string; id: string; by: HandoffEventBy; editId?: string } => ({
             ts: nowIso(deps),
@@ -746,6 +921,9 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
             "handoff actions executed"
         );
 
+        // Checked against the FOLDED target: a modify_handoff that retargets in this
+        // batch must produce (or clear) the warning in this same response.
+        const recipient = recipientCheck({ target: handoff.target, by });
         const full = publicHandoff(handoff, deps.base);
         let projectedEvents: HandoffPublicEvent[] | undefined;
 
@@ -757,6 +935,7 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
             handoff: sections === null ? full : projectHandoff({ handoff: full, sections, events: projectedEvents }),
             results,
             info: stateInfo(handoff, by),
+            ...(recipient.warnings.length > 0 ? { warnings: recipient.warnings } : {}),
         } as ExecuteActionsResponse;
     });
 }
@@ -1083,19 +1262,51 @@ function parseAction(
             const title =
                 typeof payload.title === "string" && payload.title.trim().length > 0 ? payload.title : undefined;
             const description = typeof payload.description === "string" ? payload.description : undefined;
+            // An object that carries nothing usable clears the target, same as null.
             const target =
                 payload.target === null
                     ? null
-                    : payload.target !== null && typeof payload.target === "object"
-                      ? (payload.target as HandoffTarget)
+                    : payload.target !== undefined && typeof payload.target === "object"
+                      ? (normalizeTargetInput(payload.target) ?? null)
                       : undefined;
             const refs = asStringArray(payload.refs);
+            let name: string | null | undefined;
 
-            if (title === undefined && description === undefined && target === undefined && refs === undefined) {
+            if ("name" in payload) {
+                if (payload.name === null || (typeof payload.name === "string" && payload.name.trim().length === 0)) {
+                    name = null;
+                } else if (typeof payload.name !== "string") {
+                    return shapeFail(
+                        index,
+                        verb,
+                        'modify_handoff: name must be a string, or null to clear it — e.g. { action: "modify_handoff", name: "fix-active-filter" }.'
+                    );
+                } else {
+                    const slug = normalizeHandoffName(payload.name);
+
+                    if (slug === undefined) {
+                        return shapeFail(
+                            index,
+                            verb,
+                            `modify_handoff: name "${payload.name}" has no letters or digits to build a name from — try something like "fix-active-filter".`
+                        );
+                    }
+
+                    name = slug;
+                }
+            }
+
+            if (
+                title === undefined &&
+                name === undefined &&
+                description === undefined &&
+                target === undefined &&
+                refs === undefined
+            ) {
                 return shapeFail(
                     index,
                     verb,
-                    'modify_handoff needs at least one of title/description/target/refs — e.g. { action: "modify_handoff", title: "…" }. Tasks are edited via modify_task/add_tasks.'
+                    'modify_handoff needs at least one of title/name/description/target/refs — e.g. { action: "modify_handoff", title: "…" }. Tasks are edited via modify_task/add_tasks.'
                 );
             }
 
@@ -1106,6 +1317,7 @@ function parseAction(
                     ev: "modify_handoff",
                     ...stamp(),
                     ...(title !== undefined ? { title } : {}),
+                    ...(name !== undefined ? { name } : {}),
                     ...(description !== undefined ? { description } : {}),
                     ...(target !== undefined ? { target } : {}),
                     ...(refs !== undefined ? { refs } : {}),

--- a/src/handoff/fold.ts
+++ b/src/handoff/fold.ts
@@ -252,6 +252,10 @@ export function applyHandoffEvent(
             updatedTs: event.ts,
         };
 
+        if (event.name !== undefined) {
+            next.name = event.name;
+        }
+
         if (event.description !== undefined) {
             next.description = event.description;
         }
@@ -625,6 +629,16 @@ export function applyHandoffEvent(
 
             if (event.title !== undefined && event.title.trim().length > 0) {
                 next.title = event.title;
+            }
+
+            // A title edit never renames: agents were handed the old name and
+            // must keep resolving it until the poster says otherwise.
+            if (event.name !== undefined) {
+                if (event.name === null) {
+                    delete next.name;
+                } else {
+                    next.name = event.name;
+                }
             }
 
             if (event.description !== undefined) {

--- a/src/handoff/handoff-name.test.ts
+++ b/src/handoff/handoff-name.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from "bun:test";
+import { executeHandoffActions, getHandoff, listHandoffs, postHandoff } from "./executor";
+import { generateEditId, generateEventUid, generateHandoffId } from "./ids";
+import { appendHandoffEvents } from "./log-store";
+import { byFor, freshEnv } from "./test-utils";
+import type { HandoffEvent } from "./types";
+
+const POSTER = byFor("sess-poster", "poster");
+const WORKER = byFor("sess-worker", "worker");
+
+describe("naming a handoff", () => {
+    test("a name is derived from the title when none is given", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            { title: "Fix e2e Active-filter semantics", tasks: [{ text: "one" }] },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.name).toBe("fix-e2e-active-filter-semantics");
+        expect(res.paste.name).toBe("fix-e2e-active-filter-semantics");
+        expect(res.info.join(" ")).toContain("Readable name");
+    });
+
+    test("a supplied name wins and is slugified", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            { title: "Fix e2e Active-filter semantics", name: "Active Filter", tasks: [{ text: "one" }] },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.name).toBe("active-filter");
+    });
+
+    test("the name is distinct from the target session name", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            {
+                title: "Ship the fix",
+                name: "ship-the-fix",
+                tasks: [{ text: "one" }],
+                target: { sessionName: "gt-worker" },
+            },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.name).toBe("ship-the-fix");
+        expect(res.handoff.target?.sessionName).toBe("gt-worker");
+    });
+});
+
+describe("resolving by name", () => {
+    test("a unique name resolves, through the name field and through id", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+        // Agents paste whatever they were handed into `id`; a name has to work there too.
+        expect(getHandoff({ id: "ship-the-fix" }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+        // The un-slugged form a human would type resolves as well.
+        expect(getHandoff({ name: "Ship The Fix" }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+    });
+
+    test("the id path is unchanged and still wins", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(getHandoff({ id: posted.id }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+        // The `h_` prefix stays optional.
+        expect(getHandoff({ id: posted.id.slice(2) }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+    });
+
+    test("a duplicate name is refused with its candidates instead of silently picking one", () => {
+        const env = freshEnv();
+        const first = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+        const secondPost = postHandoff({ title: "Ship the fix", tasks: [{ text: "two" }] }, env.depsFor(POSTER));
+        const second = secondPost.handoff;
+
+        // The poster is told at post time, instead of the receiver finding out at lookup time.
+        const nameInfo = secondPost.info.find((line) => line.includes("Readable name")) ?? "";
+        expect(nameInfo).toContain(`already carried by ${first.id}`);
+        expect(nameInfo).toContain("refused as ambiguous");
+
+        expect(() => getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER))).toThrow(/ambiguous/);
+
+        try {
+            getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER));
+            throw new Error("expected an ambiguity error");
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            expect(message).toContain(first.id);
+            expect(message).toContain(second.id);
+            expect(message).toContain("Re-call with the id");
+        }
+
+        // Disambiguation by id keeps working for both.
+        expect(getHandoff({ id: first.id }, env.depsFor(WORKER)).handoff.tasks[0].text).toBe("one");
+        expect(getHandoff({ id: second.id }, env.depsFor(WORKER)).handoff.tasks[0].text).toBe("two");
+    });
+
+    test("an id and a name that disagree is an error, never a silent pick", () => {
+        const env = freshEnv();
+        const a = postHandoff({ title: "Alpha work", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+        postHandoff({ title: "Beta work", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+
+        expect(() => getHandoff({ id: a.id, name: "beta-work" }, env.depsFor(WORKER))).toThrow(
+            /point at different handoffs/
+        );
+        // Agreeing values resolve normally.
+        expect(getHandoff({ id: a.id, name: "alpha-work" }, env.depsFor(WORKER)).handoff.id).toBe(a.id);
+    });
+
+    test("two names that disagree are refused too, even when one arrives in the id field", () => {
+        const env = freshEnv();
+        postHandoff({ title: "Alpha work", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+        const b = postHandoff({ title: "Beta work", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(() => getHandoff({ id: "alpha-work", name: "beta-work" }, env.depsFor(WORKER))).toThrow(
+            /point at different handoffs/
+        );
+        expect(() =>
+            executeHandoffActions({ id: "alpha-work", name: "beta-work", actions: ["claim"] }, env.depsFor(WORKER))
+        ).toThrow(/point at different handoffs/);
+        // The same name twice is one reference, not a conflict.
+        expect(getHandoff({ id: "beta-work", name: "Beta Work" }, env.depsFor(WORKER)).handoff.id).toBe(b.id);
+    });
+
+    test("a stale h_ id beside a name never falls back to the name, even one spelled like the id", () => {
+        const env = freshEnv();
+        // A handoff whose readable name is the slug of a stale id: the one case where
+        // the two-name comparison alone would agree.
+        postHandoff({ title: "h_deadbeef", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+
+        expect(() => getHandoff({ id: "h_deadbeef", name: "h-deadbeef" }, env.depsFor(WORKER))).toThrow(
+            /No handoff h_deadbeef — the id does not resolve/
+        );
+        expect(() => getHandoff({ id: "h_deadbeef", name: "beta-work" }, env.depsFor(WORKER))).toThrow(
+            /No handoff h_deadbeef/
+        );
+        // Alone, the same value still resolves as a name, as documented.
+        expect(getHandoff({ name: "h-deadbeef" }, env.depsFor(WORKER)).handoff.name).toBe("h-deadbeef");
+    });
+
+    test("an unknown name and an unknown id fail differently, and both say where to look", () => {
+        const env = freshEnv();
+
+        expect(() => getHandoff({ name: "nothing-here" }, env.depsFor(WORKER))).toThrow(
+            /No handoff named "nothing-here"/
+        );
+        expect(() => getHandoff({ id: "h_zzzzzzzz" }, env.depsFor(WORKER))).toThrow(/No handoff h_zzzzzzzz/);
+        expect(() => getHandoff({}, env.depsFor(WORKER))).toThrow(/Pass id or name/);
+    });
+
+    test("recipient warnings apply after a name lookup exactly as after an id lookup", () => {
+        const env = freshEnv();
+        postHandoff({ title: "Codex only", tasks: [{ text: "one" }], target: { agent: "codex" } }, env.depsFor(POSTER));
+
+        const byName = getHandoff({ name: "codex-only" }, env.depsFor(WORKER));
+        expect((byName.warnings ?? []).join(" ")).toContain("another harness");
+    });
+
+    test("a legacy handoff has no name, keeps working by id, and is not found by name", () => {
+        const env = freshEnv();
+        const id = generateHandoffId();
+        const legacy: HandoffEvent = {
+            ev: "post",
+            ts: new Date().toISOString(),
+            uid: generateEventUid(),
+            id,
+            editId: generateEditId(),
+            title: "Legacy handoff",
+            tasks: [{ text: "one" }],
+            by: POSTER,
+        };
+        appendHandoffEvents([legacy], env.base);
+
+        expect(getHandoff({ id }, env.depsFor(WORKER)).handoff.name).toBeUndefined();
+        expect(listHandoffs({}, env.depsFor(WORKER)).handoffs[0].name).toBeUndefined();
+        expect(() => getHandoff({ name: "legacy-handoff" }, env.depsFor(WORKER))).toThrow(/No handoff named/);
+    });
+});
+
+describe("names survive edits and reach handoff_action", () => {
+    test("handoff_action resolves by name too", () => {
+        const env = freshEnv();
+        postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+
+        const res = executeHandoffActions({ id: "ship-the-fix", actions: [{ action: "claim" }] }, env.depsFor(WORKER));
+        expect(res.results[0].ok).toBe(true);
+        expect(res.handoff.claimedBy).toHaveLength(1);
+    });
+
+    test("modify_handoff renames, and the new name is what resolves", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        const res = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", name: "Active Filter" }] },
+            env.depsFor(POSTER)
+        );
+        expect(res.results[0].ok).toBe(true);
+        expect(res.handoff.name).toBe("active-filter");
+        expect(getHandoff({ name: "active-filter" }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+        expect(() => getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER))).toThrow(/No handoff named/);
+    });
+
+    test("an empty name clears it; a title edit never renames", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        const retitled = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", title: "Something else entirely" }] },
+            env.depsFor(POSTER)
+        );
+        expect(retitled.handoff.title).toBe("Something else entirely");
+        expect(retitled.handoff.name).toBe("ship-the-fix");
+
+        const cleared = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", name: "" }] },
+            env.depsFor(POSTER)
+        );
+        expect(cleared.results[0].ok).toBe(true);
+        expect(cleared.handoff.name).toBeUndefined();
+    });
+
+    test("a name with nothing to slug is refused rather than clearing the name", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        const res = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", name: "!!!" }] },
+            env.depsFor(POSTER)
+        );
+        expect(res.results[0].ok).toBe(false);
+        expect(res.results[0].error).toContain("no letters or digits");
+        expect(res.handoff.name).toBe("ship-the-fix");
+    });
+
+    test("modify_handoff can retarget the recipient harness", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        const res = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", target: { agent: "Grok" } }] },
+            env.depsFor(POSTER)
+        );
+        expect(res.results[0].ok).toBe(true);
+        expect(res.handoff.target).toEqual({ agent: "grok" });
+    });
+
+    test("the action response warns from the target AFTER the batch, not before it", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+        const codexWorker = { ...byFor("sess-codex", "codex-worker"), agent: "codex" };
+
+        // Untargeted → retargeted away from the caller: the warning appears in this response.
+        const away = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", target: { agent: "grok" } }] },
+            env.depsFor(POSTER)
+        );
+        expect(away.results[0].ok).toBe(true);
+        expect((away.warnings ?? []).join(" ")).toContain('targets harness "grok"');
+
+        // Mismatched → retargeted to the caller: the stale warning is gone from this response.
+        const back = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", target: { agent: "codex" } }] },
+            env.depsFor({ ...codexWorker, sessionId: POSTER.sessionId })
+        );
+        expect(back.results[0].ok).toBe(true);
+        expect(back.warnings).toBeUndefined();
+    });
+});

--- a/src/handoff/project.ts
+++ b/src/handoff/project.ts
@@ -49,6 +49,7 @@ export function parseIncludeSections(raw: unknown): HandoffIncludeSection[] {
 export type HandoffCoreProjection = {
     id: string;
     title: string;
+    name?: string;
     description?: string;
     status: Handoff["status"];
     project: string | null;
@@ -96,6 +97,10 @@ export function projectHandoff({
         createdTs: handoff.createdTs,
         updatedTs: handoff.updatedTs,
     };
+
+    if (handoff.name !== undefined) {
+        core.name = handoff.name;
+    }
 
     if (handoff.description !== undefined) {
         core.description = handoff.description;

--- a/src/handoff/read-model.ts
+++ b/src/handoff/read-model.ts
@@ -43,6 +43,7 @@ function createTables(db: Database): { eventsTableCreated: boolean } {
     db.exec(`CREATE TABLE IF NOT EXISTS handoffs (
         id                     TEXT PRIMARY KEY,
         title                  TEXT NOT NULL,
+        name                   TEXT,
         description            TEXT,
         status                 TEXT NOT NULL DEFAULT 'open',
         tasks                  TEXT NOT NULL,
@@ -92,6 +93,9 @@ function createTables(db: Database): { eventsTableCreated: boolean } {
     );
     // Who finished it — needed for the reopen-by-finisher credential (§2 reopen_handoff).
     ensureColumn(db, "handoffs", "finished_by", "ALTER TABLE handoffs ADD COLUMN finished_by TEXT");
+    // Readable name (nullable: every handoff posted before names existed has none).
+    ensureColumn(db, "handoffs", "name", "ALTER TABLE handoffs ADD COLUMN name TEXT");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_handoffs_name ON handoffs(name);");
 
     return { eventsTableCreated: !hadEventsTable && tableExists(db, "handoff_events") };
 }
@@ -121,6 +125,7 @@ export function openHandoffModel(dbPath?: string): Database {
 interface HandoffRow {
     id: string;
     title: string;
+    name: string | null;
     description: string | null;
     status: string;
     tasks: string;
@@ -185,6 +190,10 @@ function rowToHandoff(row: HandoffRow): Handoff {
         updatedTs: row.updated_ts,
     };
 
+    if (row.name !== null) {
+        handoff.name = row.name;
+    }
+
     if (row.description !== null) {
         handoff.description = row.description;
     }
@@ -209,15 +218,16 @@ function rowToHandoff(row: HandoffRow): Handoff {
 }
 
 const UPSERT_SQL = `INSERT OR REPLACE INTO handoffs
-    (id, title, description, status, tasks, target, refs, posted_by_context, posted_by_session_id,
+    (id, title, name, description, status, tasks, target, refs, posted_by_context, posted_by_session_id,
      posted_by_session_name, project, claimed_by, comments, edit_id, created_ts, updated_ts,
      finished_ts, attachments, finished_by)
-    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
+    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
 
 function upsertHandoff(db: Database, h: Handoff): void {
     db.prepare(UPSERT_SQL).run(
         h.id,
         h.title,
+        h.name ?? null,
         h.description ?? null,
         h.status,
         SafeJSON.stringify(h.tasks, { strict: true }),
@@ -241,6 +251,16 @@ function upsertHandoff(db: Database, h: Handoff): void {
 export function getHandoffById(db: Database, id: string): Handoff | null {
     const row = db.query("SELECT * FROM handoffs WHERE id = ?").get(id) as HandoffRow | null;
     return row ? rowToHandoff(row) : null;
+}
+
+/**
+ * Every handoff carrying this exact name, newest-updated first. Duplicates are
+ * legal (two posters can pick the same slug), so this returns a list and the
+ * caller decides — silently taking the newest would work the wrong handoff.
+ */
+export function findHandoffsByName(db: Database, name: string): Handoff[] {
+    const rows = db.query("SELECT * FROM handoffs WHERE name = ? ORDER BY updated_ts DESC").all(name) as HandoffRow[];
+    return rows.map(rowToHandoff);
 }
 
 export function listHandoffRows(db: Database, opts: { statuses?: string[]; project?: string } = {}): Handoff[] {

--- a/src/handoff/recipient.test.ts
+++ b/src/handoff/recipient.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "bun:test";
+import { executeHandoffActions, getHandoff, listHandoffs, postHandoff } from "./executor";
+import { generateEditId, generateEventUid, generateHandoffId } from "./ids";
+import { appendHandoffEvents } from "./log-store";
+import { byFor, freshEnv } from "./test-utils";
+import type { HandoffEvent, HandoffEventBy } from "./types";
+
+function on(agent: string, sessionId: string | null, sessionName: string | null = null): HandoffEventBy {
+    return { ...byFor(sessionId, sessionName), agent };
+}
+
+const POSTER = on("claude-code", "sess-poster", "poster");
+const CODEX_WORKER = on("codex", "sess-codex", "codex-worker");
+const CLAUDE_WORKER = on("claude-code", "sess-claude", "claude-worker");
+const GROK_WORKER = on("grok", "sess-grok", "grok-worker");
+const FACELESS = on("unknown", null, "headless");
+
+describe("recipient agent on handoff_post", () => {
+    test("the documented harnesses are accepted and stored on the target, not on postedBy", () => {
+        const env = freshEnv();
+
+        for (const agent of ["claude", "codex", "grok"]) {
+            const res = postHandoff(
+                { title: `work for ${agent}`, tasks: [{ text: "do it" }], target: { agent } },
+                env.depsFor(POSTER)
+            );
+
+            expect(res.handoff.target?.agent).toBe(agent);
+            // The author's harness is a separate fact and must survive untouched.
+            expect(res.handoff.postedBy.agent).toBe("claude-code");
+            expect(res.handoff.postedByContext.agent).toBe("claude-code");
+        }
+    });
+
+    test("a session target still works, alone and beside an agent", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            {
+                title: "addressed twice",
+                tasks: [{ text: "do it" }],
+                target: { sessionId: "sess-codex", sessionName: "codex-worker", agent: "Codex" },
+            },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.target).toEqual({
+            sessionId: "sess-codex",
+            sessionName: "codex-worker",
+            agent: "codex",
+        });
+    });
+
+    test("an undocumented harness is stored as given, with an info line saying warnings cannot fire", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            { title: "for a future host", tasks: [{ text: "do it" }], target: { agent: "Borg" } },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.target?.agent).toBe("borg");
+        expect(res.info.join(" ")).toContain("not a documented harness");
+    });
+});
+
+describe("recipient warnings on handoff_get", () => {
+    function postedForCodex(env: ReturnType<typeof freshEnv>) {
+        return postHandoff(
+            { title: "codex work", tasks: [{ text: "one" }], target: { agent: "codex" } },
+            env.depsFor(POSTER)
+        ).handoff;
+    }
+
+    test("the intended harness sees no warning", () => {
+        const env = freshEnv();
+        const handoff = postedForCodex(env);
+        const res = getHandoff({ id: handoff.id }, env.depsFor(CODEX_WORKER));
+
+        expect(res.warnings).toBeUndefined();
+    });
+
+    test("another harness is warned off, and the warning names the override", () => {
+        const env = freshEnv();
+        const handoff = postedForCodex(env);
+        const res = getHandoff({ id: handoff.id }, env.depsFor(CLAUDE_WORKER));
+
+        const text = (res.warnings ?? []).join(" ");
+        expect(text).toContain("This task is for another harness");
+        expect(text).toContain("unless your user explicitly asks");
+    });
+
+    test("a warning never blocks — user-authorized cross-target work still claims and checks", () => {
+        const env = freshEnv();
+        const handoff = postedForCodex(env);
+        const claimed = getHandoff({ id: handoff.id, claim: true }, env.depsFor(GROK_WORKER));
+
+        expect(claimed.handoff.claimedBy).toHaveLength(1);
+        expect(claimed.warnings?.length).toBeGreaterThan(0);
+
+        const acted = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "check_task", taskId: "t1", proof: { answer: "did it anyway" } }] },
+            env.depsFor(GROK_WORKER)
+        );
+        expect(acted.results[0].ok).toBe(true);
+        // The action response keeps warning, so the mismatch is not lost after the claim.
+        expect((acted.warnings ?? []).join(" ")).toContain("another harness");
+    });
+
+    test("a caller with no detectable identity is told the check was unverifiable", () => {
+        const env = freshEnv();
+        const handoff = postHandoff(
+            { title: "codex work", tasks: [{ text: "one" }], target: { sessionId: "sess-codex", agent: "codex" } },
+            env.depsFor(POSTER)
+        ).handoff;
+        const res = getHandoff({ id: handoff.id }, env.depsFor(FACELESS));
+
+        const text = (res.warnings ?? []).join(" ");
+        expect(text).toContain("unverifiable");
+        expect(text).not.toContain("Recipient mismatch");
+    });
+
+    test("a legacy untargeted handoff warns nobody", () => {
+        const env = freshEnv();
+        const handoff = postHandoff({ title: "open to anyone", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(getHandoff({ id: handoff.id }, env.depsFor(CODEX_WORKER)).warnings).toBeUndefined();
+        expect(getHandoff({ id: handoff.id }, env.depsFor(FACELESS)).warnings).toBeUndefined();
+    });
+
+    test("a legacy record stored before targeting existed still reads and warns about nothing", () => {
+        const env = freshEnv();
+        const id = generateHandoffId();
+        // Written the way the log looked before target.agent and name existed.
+        const legacy: HandoffEvent = {
+            ev: "post",
+            ts: new Date().toISOString(),
+            uid: generateEventUid(),
+            id,
+            editId: generateEditId(),
+            title: "legacy handoff",
+            tasks: [{ text: "one" }],
+            by: POSTER,
+        };
+        appendHandoffEvents([legacy], env.base);
+
+        const res = getHandoff({ id }, env.depsFor(CODEX_WORKER));
+        expect(res.handoff.title).toBe("legacy handoff");
+        expect(res.handoff.name).toBeUndefined();
+        expect(res.handoff.target).toBeUndefined();
+        expect(res.warnings).toBeUndefined();
+    });
+});
+
+describe("auto-claim under a mismatched recipient", () => {
+    test("a session target still auto-claims when the harness agrees", () => {
+        const env = freshEnv();
+        const handoff = postHandoff(
+            { title: "for codex", tasks: [{ text: "one" }], target: { sessionId: "sess-codex", agent: "codex" } },
+            env.depsFor(POSTER)
+        ).handoff;
+
+        const res = getHandoff({ id: handoff.id }, env.depsFor(CODEX_WORKER));
+        expect(res.info.join(" ")).toContain("Auto-claimed");
+        expect(res.handoff.claimedBy).toHaveLength(1);
+    });
+
+    test("a session-id hit under the wrong harness never claims silently", () => {
+        const env = freshEnv();
+        const handoff = postHandoff(
+            {
+                title: "contradictory address",
+                tasks: [{ text: "one" }],
+                // The poster named a claude session but addressed the codex harness.
+                target: { sessionId: "sess-claude", agent: "codex" },
+            },
+            env.depsFor(POSTER)
+        ).handoff;
+
+        const res = getHandoff({ id: handoff.id }, env.depsFor(CLAUDE_WORKER));
+        expect(res.handoff.claimedBy).toEqual([]);
+        expect(res.handoff.status).toBe("open");
+        expect(res.info.join(" ")).toContain("NOT auto-claimed");
+        expect((res.warnings ?? []).join(" ")).toContain("another harness");
+    });
+});
+
+describe("handoff_list recipient filters", () => {
+    function seeded() {
+        const env = freshEnv();
+        postHandoff(
+            { title: "for codex", tasks: [{ text: "one" }], target: { agent: "codex", sessionId: "sess-codex" } },
+            env.depsFor(POSTER)
+        );
+        postHandoff(
+            { title: "for claude", tasks: [{ text: "one" }], target: { agent: "claude", sessionId: "sess-claude" } },
+            env.depsFor(POSTER)
+        );
+        postHandoff(
+            { title: "for a named session", tasks: [{ text: "one" }], target: { sessionName: "gt-worker" } },
+            env.depsFor(POSTER)
+        );
+        postHandoff({ title: "for anybody", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+        return env;
+    }
+
+    test("the default listing is unfiltered", () => {
+        const env = seeded();
+        const res = listHandoffs({}, env.depsFor(CODEX_WORKER));
+
+        expect(res.handoffs).toHaveLength(4);
+        expect(res.info.join(" ")).not.toContain("Filtered to handoffs");
+    });
+
+    test("the agent filter keeps only the intended harness", () => {
+        const env = seeded();
+        const res = listHandoffs({ agent: "codex" }, env.depsFor(POSTER));
+
+        expect(res.handoffs.map((h) => h.title)).toEqual(["for codex"]);
+        expect(res.info.join(" ")).toContain("intended recipient, not the poster");
+    });
+
+    test("the session filter matches an id or a session name", () => {
+        const env = seeded();
+
+        expect(listHandoffs({ session: "sess-claude" }, env.depsFor(POSTER)).handoffs.map((h) => h.title)).toEqual([
+            "for claude",
+        ]);
+        expect(listHandoffs({ session: "gt-worker" }, env.depsFor(POSTER)).handoffs.map((h) => h.title)).toEqual([
+            "for a named session",
+        ]);
+    });
+
+    test("both filters together narrow to their intersection", () => {
+        const env = seeded();
+
+        expect(
+            listHandoffs({ agent: "codex", session: "sess-codex" }, env.depsFor(POSTER)).handoffs.map((h) => h.title)
+        ).toEqual(["for codex"]);
+        expect(listHandoffs({ agent: "codex", session: "sess-claude" }, env.depsFor(POSTER)).handoffs).toHaveLength(0);
+    });
+
+    test("an undocumented filter value says so instead of pretending to match a harness", () => {
+        const env = seeded();
+        const res = listHandoffs({ agent: "borg" }, env.depsFor(POSTER));
+
+        expect(res.handoffs).toHaveLength(0);
+        expect(res.info.join(" ")).toContain("not a documented harness");
+    });
+
+    test("rows carry the name, the recipient target and per-row warnings", () => {
+        const env = seeded();
+        const rows = listHandoffs({}, env.depsFor(GROK_WORKER)).handoffs;
+        const codexRow = rows.find((h) => h.title === "for codex");
+
+        expect(codexRow?.name).toBe("for-codex");
+        expect(codexRow?.target?.agent).toBe("codex");
+        expect((codexRow?.warnings ?? []).join(" ")).toContain("another harness");
+        expect(rows.find((h) => h.title === "for anybody")?.warnings).toBeUndefined();
+    });
+});

--- a/src/handoff/targeting.test.ts
+++ b/src/handoff/targeting.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+import {
+    agentFilterMatches,
+    canonicalAgent,
+    handoffNameFor,
+    isKnownAgent,
+    MAX_HANDOFF_NAME_LENGTH,
+    normalizeAgentInput,
+    normalizeHandoffName,
+    normalizeTargetInput,
+    recipientCheck,
+    sessionFilterMatches,
+} from "./targeting";
+import { byFor } from "./test-utils";
+import type { HandoffEventBy } from "./types";
+
+const FULL = "cd4e9457-105b-45f5-829d-9c4f554df36a";
+const LEADING_SEGMENT = "cd4e9457";
+
+function on(agent: string, sessionId: string | null, sessionName: string | null = null): HandoffEventBy {
+    return { ...byFor(sessionId, sessionName), agent };
+}
+
+describe("harness names", () => {
+    test("the runtime's claude-code and a poster's claude are the same harness", () => {
+        // AgentRuntimeContext.agent says "claude-code"; humans and tool schemas say
+        // "claude". Without this they would read as a mismatch against each other.
+        expect(canonicalAgent("claude-code")).toBe("claude");
+        expect(canonicalAgent("Claude")).toBe("claude");
+        expect(canonicalAgent("codex")).toBe("codex");
+        expect(canonicalAgent("grok")).toBe("grok");
+        expect(canonicalAgent("copilot")).toBe("copilot");
+    });
+
+    test("inherited object keys are not harnesses either", () => {
+        // A plain-object alias table would answer Object.prototype members.
+        for (const key of ["constructor", "__proto__", "toString", "hasOwnProperty"]) {
+            expect(canonicalAgent(key)).toBeNull();
+            expect(isKnownAgent(key)).toBe(false);
+            expect(normalizeAgentInput(key)).toBe(key.toLowerCase());
+        }
+
+        const by = on("claude-code", "sess-me");
+        const check = recipientCheck({ target: { agent: "constructor" }, by });
+        expect(check.agent).toBe("unverifiable");
+        expect(check.warnings.join(" ")).toContain('"constructor", which is not a documented harness');
+    });
+
+    test("an undocumented name is not a harness", () => {
+        expect(canonicalAgent("borg")).toBeNull();
+        expect(canonicalAgent("")).toBeNull();
+        expect(canonicalAgent(null)).toBeNull();
+        expect(isKnownAgent("borg")).toBe(false);
+    });
+
+    test("input normalization keeps an undocumented name instead of dropping it", () => {
+        expect(normalizeAgentInput("  CODEX ")).toBe("codex");
+        expect(normalizeAgentInput("Claude-Code")).toBe("claude");
+        expect(normalizeAgentInput("Borg")).toBe("borg");
+        expect(normalizeAgentInput("   ")).toBeUndefined();
+        expect(normalizeAgentInput(42)).toBeUndefined();
+    });
+});
+
+describe("target normalization", () => {
+    test("both doors store one shape", () => {
+        expect(
+            normalizeTargetInput({ sessionId: " sess-alpha ", sessionName: " worker ", agent: "Claude-Code" })
+        ).toEqual({ sessionId: "sess-alpha", sessionName: "worker", agent: "claude" });
+    });
+
+    test("an agent alone is a valid target", () => {
+        expect(normalizeTargetInput({ agent: "codex" })).toEqual({ agent: "codex" });
+    });
+
+    test("nothing usable normalizes to undefined", () => {
+        expect(normalizeTargetInput({ sessionId: "   " })).toBeUndefined();
+        expect(normalizeTargetInput({})).toBeUndefined();
+        expect(normalizeTargetInput(null)).toBeUndefined();
+        expect(normalizeTargetInput("codex")).toBeUndefined();
+    });
+});
+
+describe("handoff names", () => {
+    test("a name is a slug and can never look like an id", () => {
+        expect(normalizeHandoffName("Fix e2e Active-filter semantics")).toBe("fix-e2e-active-filter-semantics");
+        // `h_` survives id normalization; slugging turns the underscore into a hyphen,
+        // so no name can collide with the id namespace.
+        expect(normalizeHandoffName("h_abc")).toBe("h-abc");
+        expect(normalizeHandoffName("  --Trim Me--  ")).toBe("trim-me");
+    });
+
+    test("a name with nothing to slug is no name", () => {
+        expect(normalizeHandoffName("!!!")).toBeUndefined();
+        expect(normalizeHandoffName("")).toBeUndefined();
+        expect(normalizeHandoffName(undefined)).toBeUndefined();
+    });
+
+    test("long names are capped without a trailing hyphen", () => {
+        const slug = normalizeHandoffName(`${"a".repeat(40)} ${"b".repeat(40)}`);
+        expect(slug).toBeDefined();
+        expect((slug as string).length).toBeLessThanOrEqual(MAX_HANDOFF_NAME_LENGTH);
+        expect(slug).not.toEndWith("-");
+    });
+
+    test("a supplied name wins over the title, and the title is the default", () => {
+        expect(handoffNameFor({ name: "Pick Me", title: "Some Title" })).toBe("pick-me");
+        expect(handoffNameFor({ name: undefined, title: "Some Title" })).toBe("some-title");
+        expect(handoffNameFor({ name: "!!!", title: "Some Title" })).toBe("some-title");
+    });
+});
+
+describe("recipientCheck", () => {
+    test("an untargeted handoff warns about nothing", () => {
+        const check = recipientCheck({ target: undefined, by: on("codex", "sess-beta") });
+        expect(check).toEqual({ agent: "not-targeted", session: "not-targeted", warnings: [] });
+    });
+
+    test("the intended harness gets no warning", () => {
+        const check = recipientCheck({ target: { agent: "codex" }, by: on("codex", "sess-alpha") });
+        expect(check.agent).toBe("match");
+        expect(check.warnings).toEqual([]);
+    });
+
+    test("another harness is told to stop, and how its user can override", () => {
+        const check = recipientCheck({ target: { agent: "codex" }, by: on("claude-code", "sess-alpha") });
+        expect(check.agent).toBe("mismatch");
+        const text = check.warnings.join(" ");
+        expect(text).toContain('targets harness "codex"');
+        expect(text).toContain('this session runs "claude"');
+        expect(text).toContain("This task is for another harness");
+        expect(text).toContain("unless your user explicitly asks");
+        expect(text).toContain("claim it explicitly");
+    });
+
+    test("an undetectable caller harness is unverifiable, never a mismatch", () => {
+        const check = recipientCheck({ target: { agent: "codex" }, by: on("unknown", "sess-alpha") });
+        expect(check.agent).toBe("unverifiable");
+        const text = check.warnings.join(" ");
+        expect(text).toContain("unverifiable");
+        expect(text).not.toContain("mismatch");
+    });
+
+    test("an undocumented target harness is unverifiable in both directions", () => {
+        const check = recipientCheck({ target: { agent: "borg" }, by: on("codex", "sess-alpha") });
+        expect(check.agent).toBe("unverifiable");
+        expect(check.warnings.join(" ")).toContain("not a documented harness");
+    });
+
+    test("an explicit target sessionId that is not ours is a mismatch", () => {
+        const check = recipientCheck({ target: { sessionId: "sess-alpha" }, by: on("claude-code", "sess-beta") });
+        expect(check.session).toBe("mismatch");
+        const text = check.warnings.join(" ");
+        expect(text).toContain('targets sessionId "sess-alpha"');
+        expect(text).toContain("This task is for another session");
+    });
+
+    test("an abbreviated target sessionId still names this session", () => {
+        const check = recipientCheck({ target: { sessionId: LEADING_SEGMENT }, by: on("claude-code", FULL) });
+        expect(check.session).toBe("match");
+        expect(check.warnings).toEqual([]);
+    });
+
+    test("no sessionId of our own means unverifiable, never a mismatch", () => {
+        const check = recipientCheck({ target: { sessionId: "sess-alpha" }, by: on("claude-code", null) });
+        expect(check.session).toBe("unverifiable");
+        const text = check.warnings.join(" ");
+        expect(text).toContain("unverifiable");
+        expect(text).not.toContain("mismatch");
+    });
+
+    test("a differing sessionName is a hint, not a mismatch — names are not unique", () => {
+        const check = recipientCheck({
+            target: { sessionName: "gt-worker" },
+            by: on("claude-code", "sess-beta", "other-worker"),
+        });
+        expect(check.session).toBe("unverifiable");
+        expect(check.warnings.join(" ")).toContain("not unique");
+    });
+
+    test("a matching sessionName is a match", () => {
+        const check = recipientCheck({
+            target: { sessionName: "gt-worker" },
+            by: on("claude-code", "sess-beta", "gt-worker"),
+        });
+        expect(check.session).toBe("match");
+        expect(check.warnings).toEqual([]);
+    });
+});
+
+describe("list filter semantics", () => {
+    test("the agent filter compares canonical harness names", () => {
+        expect(agentFilterMatches({ agent: "claude" }, "claude-code")).toBe(true);
+        expect(agentFilterMatches({ agent: "claude" }, "codex")).toBe(false);
+        expect(agentFilterMatches(undefined, "codex")).toBe(false);
+        expect(agentFilterMatches({ sessionId: "sess-alpha" }, "codex")).toBe(false);
+    });
+
+    test("an undocumented filter value falls back to literal text", () => {
+        expect(agentFilterMatches({ agent: "borg" }, "Borg")).toBe(true);
+        expect(agentFilterMatches({ agent: "borg" }, "codex")).toBe(false);
+    });
+
+    test("the session filter matches an id in either abbreviation direction, or the name", () => {
+        expect(sessionFilterMatches({ sessionId: FULL }, FULL)).toBe(true);
+        expect(sessionFilterMatches({ sessionId: LEADING_SEGMENT }, FULL)).toBe(true);
+        expect(sessionFilterMatches({ sessionId: FULL }, LEADING_SEGMENT)).toBe(true);
+        expect(sessionFilterMatches({ sessionId: FULL }, "cd4e9458")).toBe(false);
+        expect(sessionFilterMatches({ sessionName: "gt-worker" }, "GT-Worker")).toBe(true);
+        expect(sessionFilterMatches({ sessionName: "gt-worker" }, "other")).toBe(false);
+        expect(sessionFilterMatches(undefined, "gt-worker")).toBe(false);
+    });
+});

--- a/src/handoff/targeting.ts
+++ b/src/handoff/targeting.ts
@@ -1,0 +1,300 @@
+/**
+ * Who a handoff is FOR, and what it is called.
+ *
+ * Recipient identity is deliberately separate from author identity. `postedBy`
+ * and `postedByContext.agent` say which harness WROTE the handoff; `target.agent`
+ * says which harness should WORK it. Reading one for the other would make every
+ * codex task look addressed to the claude session that filed it.
+ *
+ * Nothing here blocks: a mismatch produces a warning line and the caller decides.
+ * User-authorized cross-target work stays possible on purpose — the agent is told
+ * to stop, not prevented from continuing when its user says to.
+ */
+
+import { targetMatchesSession } from "./fold";
+import type { HandoffEventBy, HandoffTarget } from "./types";
+
+/** Documented recipient harness names — the values `target.agent` compares against. */
+export const HANDOFF_AGENTS = ["claude", "codex", "grok", "copilot"] as const;
+
+export type HandoffAgent = (typeof HANDOFF_AGENTS)[number];
+
+export const HANDOFF_AGENTS_LIST = HANDOFF_AGENTS.join(", ");
+
+/**
+ * Spelling → canonical harness. The runtime context calls the Claude host
+ * "claude-code" (AgentRuntimeContext.agent) while posters write "claude", so the
+ * two must land on the same value or every claude session would read as a
+ * mismatch against every claude-targeted handoff.
+ */
+const AGENT_ALIASES: Record<string, HandoffAgent> = {
+    claude: "claude",
+    "claude-code": "claude",
+    claude_code: "claude",
+    claudecode: "claude",
+    "claude-cli": "claude",
+    codex: "codex",
+    "codex-cli": "codex",
+    grok: "grok",
+    "grok-cli": "grok",
+    copilot: "copilot",
+    "github-copilot": "copilot",
+};
+
+/** Canonical harness name, or null when the value names no documented harness. */
+export function canonicalAgent(raw: string | null | undefined): HandoffAgent | null {
+    if (typeof raw !== "string") {
+        return null;
+    }
+
+    const key = raw.trim().toLowerCase();
+
+    // Own-property check: "constructor" or "__proto__" must not read as a harness.
+    return Object.hasOwn(AGENT_ALIASES, key) ? AGENT_ALIASES[key] : null;
+}
+
+export function isKnownAgent(raw: string | null | undefined): boolean {
+    return canonicalAgent(raw) !== null;
+}
+
+/**
+ * Stored form of a supplied recipient harness: the canonical name when the value
+ * is documented, the trimmed lowercase form otherwise. An undocumented name is
+ * kept rather than rejected so a harness added later survives a round trip; it
+ * simply can never prove a mismatch (see recipientCheck).
+ */
+export function normalizeAgentInput(raw: unknown): string | undefined {
+    if (typeof raw !== "string") {
+        return undefined;
+    }
+
+    const trimmed = raw.trim().toLowerCase();
+
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    return canonicalAgent(trimmed) ?? trimmed;
+}
+
+/**
+ * The one place a caller-supplied target is cleaned up: trimmed session fields
+ * plus a normalized recipient harness. Both the post door and the modify_handoff
+ * door go through it, so `{ agent: "Claude-Code" }` cannot be stored one way
+ * here and another way there.
+ */
+export function normalizeTargetInput(raw: unknown): HandoffTarget | undefined {
+    if (raw === null || typeof raw !== "object") {
+        return undefined;
+    }
+
+    const input = raw as { sessionId?: unknown; sessionName?: unknown; agent?: unknown };
+    const target: HandoffTarget = {};
+
+    if (typeof input.sessionId === "string" && input.sessionId.trim().length > 0) {
+        target.sessionId = input.sessionId.trim();
+    }
+
+    if (typeof input.sessionName === "string" && input.sessionName.trim().length > 0) {
+        target.sessionName = input.sessionName.trim();
+    }
+
+    const agent = normalizeAgentInput(input.agent);
+
+    if (agent !== undefined) {
+        target.agent = agent;
+    }
+
+    return Object.keys(target).length > 0 ? target : undefined;
+}
+
+export const MAX_HANDOFF_NAME_LENGTH = 60;
+
+/**
+ * A handoff name is a slug: lowercase, alphanumeric, hyphen-separated. Slugging
+ * is what keeps a name from ever colliding with an id — `_` is not alphanumeric,
+ * so no slug can start with the `h_` prefix `normalizeHandoffId` produces.
+ */
+export function normalizeHandoffName(raw: unknown): string | undefined {
+    if (typeof raw !== "string") {
+        return undefined;
+    }
+
+    const slug = raw
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+
+    if (slug.length === 0) {
+        return undefined;
+    }
+
+    return slug.slice(0, MAX_HANDOFF_NAME_LENGTH).replace(/-+$/g, "");
+}
+
+/**
+ * The name a new handoff gets: the supplied one, else derived from the title.
+ * Derivation happens HERE and not in the fold, so the final name is written into
+ * the post event. The fold stays a pure copy, and a later title edit never
+ * silently renames a handoff other agents were told to look up by name.
+ */
+export function handoffNameFor({ name, title }: { name?: unknown; title: string }): string | undefined {
+    return normalizeHandoffName(name) ?? normalizeHandoffName(title);
+}
+
+/** What the recipient check concluded for one dimension of the target. */
+export type RecipientStatus = "not-targeted" | "match" | "mismatch" | "unverifiable";
+
+export interface RecipientCheck {
+    agent: RecipientStatus;
+    session: RecipientStatus;
+    /** Human-readable lines for the caller. Empty when nothing is worth saying. */
+    warnings: string[];
+}
+
+const ANOTHER_HARNESS = "This task is for another harness — do not work on it unless your user explicitly asks you to.";
+
+const ANOTHER_SESSION = "This task is for another session — do not work on it unless your user explicitly asks you to.";
+
+function checkAgent(target: HandoffTarget | undefined, by: HandoffEventBy, warnings: string[]): RecipientStatus {
+    const wanted = target?.agent;
+
+    if (wanted === undefined || wanted.trim().length === 0) {
+        return "not-targeted";
+    }
+
+    const wantedCanonical = canonicalAgent(wanted);
+
+    if (wantedCanonical === null) {
+        warnings.push(
+            `⚠️ Recipient unverifiable: this handoff targets harness "${wanted}", which is not a documented harness (${HANDOFF_AGENTS_LIST}). No match or mismatch can be proven — ask your user who it is for.`
+        );
+        return "unverifiable";
+    }
+
+    const mine = canonicalAgent(by.agent);
+
+    if (mine === null) {
+        warnings.push(
+            `⚠️ Recipient unverifiable: this handoff targets harness "${wantedCanonical}", but this session's own harness was not detected (agent "${by.agent}"). Treat it as addressed elsewhere until your user confirms.`
+        );
+        return "unverifiable";
+    }
+
+    if (mine === wantedCanonical) {
+        return "match";
+    }
+
+    warnings.push(
+        `⚠️ Recipient mismatch: this handoff targets harness "${wantedCanonical}", this session runs "${mine}". ${ANOTHER_HARNESS}`
+    );
+    return "mismatch";
+}
+
+function checkSession(target: HandoffTarget | undefined, by: HandoffEventBy, warnings: string[]): RecipientStatus {
+    const wantedId = target?.sessionId;
+
+    if (wantedId !== undefined && wantedId.trim().length > 0) {
+        if (by.sessionId == null) {
+            warnings.push(
+                `⚠️ Recipient unverifiable: this handoff targets sessionId "${wantedId}", but this session has no sessionId, so the match cannot be checked. Treat it as addressed elsewhere until your user confirms.`
+            );
+            return "unverifiable";
+        }
+
+        if (targetMatchesSession(wantedId, by.sessionId)) {
+            return "match";
+        }
+
+        warnings.push(
+            `⚠️ Recipient mismatch: this handoff targets sessionId "${wantedId}", this session is "${by.sessionId}". ${ANOTHER_SESSION}`
+        );
+        return "mismatch";
+    }
+
+    const wantedName = target?.sessionName;
+
+    if (wantedName === undefined || wantedName.trim().length === 0) {
+        return "not-targeted";
+    }
+
+    if (by.sessionTitle != null && by.sessionTitle === wantedName) {
+        return "match";
+    }
+
+    // Session names are not unique, so a difference never proves the handoff is
+    // for someone else. Say so rather than raising a mismatch nobody can act on.
+    warnings.push(
+        `⚠️ Recipient unverifiable: this handoff targets sessionName "${wantedName}", which is not this session's name (${by.sessionTitle == null ? "unnamed" : `"${by.sessionTitle}"`}). Session names are not unique, so this is a hint, not proof.`
+    );
+    return "unverifiable";
+}
+
+/**
+ * Compare a handoff's intended recipient against the calling session.
+ *
+ * A missing caller identity is reported as unverifiable, never as a mismatch:
+ * "I could not check" and "this is not for you" are different claims, and only
+ * one of them is true when the harness could not be detected.
+ */
+export function recipientCheck({ target, by }: { target?: HandoffTarget; by: HandoffEventBy }): RecipientCheck {
+    const warnings: string[] = [];
+    const agent = checkAgent(target, by, warnings);
+    const session = checkSession(target, by, warnings);
+
+    if (agent === "mismatch" || session === "mismatch") {
+        warnings.push(
+            "If your user explicitly asks you to take it anyway, claim it explicitly (handoff_get with claim: true) and say in a comment why you are working someone else's handoff."
+        );
+    }
+
+    return { agent, session, warnings };
+}
+
+/**
+ * `handoff_list { agent }` — matches the INTENDED RECIPIENT harness only, never
+ * the posting harness. Documented spellings are compared canonically, so
+ * `agent: "claude-code"` finds handoffs stored as `claude`.
+ */
+export function agentFilterMatches(target: HandoffTarget | undefined, query: string): boolean {
+    const stored = target?.agent;
+
+    if (stored === undefined) {
+        return false;
+    }
+
+    const wanted = canonicalAgent(query);
+    const have = canonicalAgent(stored);
+
+    if (wanted !== null || have !== null) {
+        return wanted !== null && have !== null && wanted === have;
+    }
+
+    return stored.trim().toLowerCase() === query.trim().toLowerCase();
+}
+
+/**
+ * `handoff_list { session }` — matches the intended recipient session: the
+ * target sessionId exactly or by leading-segment abbreviation in EITHER
+ * direction (a stored `cd4e9457` and a queried full id name the same session),
+ * or the target sessionName case-insensitively.
+ */
+export function sessionFilterMatches(target: HandoffTarget | undefined, query: string): boolean {
+    const wanted = query.trim();
+
+    if (wanted.length === 0 || target === undefined) {
+        return false;
+    }
+
+    const storedId = target.sessionId;
+
+    if (storedId !== undefined) {
+        if (storedId === wanted || targetMatchesSession(storedId, wanted) || targetMatchesSession(wanted, storedId)) {
+            return true;
+        }
+    }
+
+    const storedName = target.sessionName;
+    return storedName !== undefined && storedName.trim().toLowerCase() === wanted.toLowerCase();
+}

--- a/src/handoff/types.ts
+++ b/src/handoff/types.ts
@@ -3,6 +3,13 @@ export type HandoffStatus = "open" | "claimed" | "done" | "cancelled";
 export interface HandoffTarget {
     sessionId?: string;
     sessionName?: string;
+    /**
+     * Intended RECIPIENT harness — claude | codex | grok | copilot (see
+     * `src/handoff/targeting.ts`). Never the author's harness: that is
+     * `postedBy.agent` / `postedByContext.agent`, which the fold stamps from the
+     * posting session and which this field must never be confused with.
+     */
+    agent?: string;
 }
 
 export interface HandoffTaskInput {
@@ -113,6 +120,8 @@ export type HandoffEvent =
           ev: "post";
           editId: string;
           title: string;
+          /** Final slug, resolved by the caller (supplied or title-derived) — the fold only copies it. */
+          name?: string;
           description?: string;
           tasks: HandoffTaskInput[];
           target?: HandoffTarget;
@@ -139,6 +148,8 @@ export type HandoffEvent =
     | (HandoffEventBase & {
           ev: "modify_handoff";
           title?: string;
+          /** Replacement slug, already normalized by the caller; null clears it. */
+          name?: string | null;
           description?: string;
           target?: HandoffTarget | null;
           refs?: string[];
@@ -163,6 +174,12 @@ export type HandoffPublicEvent = Omit<HandoffEvent, "editId"> & { outcome?: Fold
 export interface Handoff {
     id: string;
     title: string;
+    /**
+     * Human-readable slug this handoff can also be fetched by. Absent on records
+     * posted before names existed — those stay reachable by id, which is why
+     * nothing here may assume a name is present.
+     */
+    name?: string;
     description?: string;
     status: HandoffStatus;
     tasks: HandoffTask[];
@@ -205,10 +222,13 @@ export interface HandoffActionResult {
 export interface HandoffListRow {
     id: string;
     title: string;
+    name?: string;
     status: HandoffStatus;
     tasks: string;
     progress?: string;
     target?: HandoffTarget;
+    /** Recipient warnings for the LISTING session — absent when there is nothing to say. */
+    warnings?: string[];
     postedBy: { sessionName: string | null };
     claimedBy?: {
         sessionId: string | null;

--- a/src/macos/README.md
+++ b/src/macos/README.md
@@ -81,6 +81,37 @@ While a plan runs, the command prints one line per finished stage (discover, cac
 
 ---
 
+## Mail: search modes, the stage watchdog, mailbox names, benchmarks
+
+`tools macos mail search` runs against the FTS index at `~/.genesis-tools/indexer/macos-mail/index.db` (`--mode fulltext | hybrid | vector | auto`; `auto` is hybrid when the index has embeddings). Two facts that used to cost hours:
+
+- **The hybrid over-fetch used to kill any big page.** Hybrid asks sqlite-vec for `limit × 15` neighbours (3× for the RRF pool, 5× for a filtered cosine query) and sqlite-vec refuses `k > 4096`, so `--limit 500` over a month window died with `k value in knn query too large, provided 7500 and the limit is 4096` (2026-09-07). The store now clamps `k` (`SQLITE_VEC_MAX_K` in `src/utils/search/stores/sqlite-vec-store.ts`) and the search prints one warning naming the covered rank (`results past about 273 are ranked by fulltext matches only`). `--mode fulltext` never had the problem.
+- **Every stage has a hard deadline.** `--timeout <seconds>` (default 60) bounds the index query, the row fetch, the Spotlight and LIKE fallback and the attachments join separately; a stuck stage exits 1 with `mail search timed out after 60s in stage "<name>"` instead of a silent process. `PROFILE=macos-mail` (scope `macos-mail`, `src/utils/profile`) prints one `[profile:macos-mail] <stage> <ms>` line per stage for `search` and `list`; `-v` shows the stage transitions. The hour-long "hang" a keyword sweep reported on 2026-09-07 did not reproduce: the same queries back to back finish in about a second each, and a search with an open stdin pipe exits normally, so the watchdog is insurance, not a fix for a known stall.
+
+**Mailbox names** (`list <mailbox>`, `--mailbox`, `--account`): `INBOX` means every account's inbox (localized names included). Anything else is a case-insensitive substring of the percent-decoded, NFC-normalized mailbox URL, so `Deleted Messages`, `Deleted`, `Koš`, `Ko%C5%A1`, `Odstran` and `Archiv` all work; an accent-free `Kos` does not.
+
+### Benchmarks
+
+`bun src/macos/lib/mail/bench.ts "<label>" [rounds]` runs the arms below interleaved (A,B,C,A,B,C,…) and prints the table. Wall time on this machine swings with load, so treat anything under about 20 % as noise, and note the load average. The stage timers say the work itself is small: a fulltext month search spends ~15 ms in the index query, ~5 ms fetching rows; a month list ~26 ms in SQL and ~42 ms rendering 10 000 JSON rows. The rest of each ~330 ms is bun start-up plus the launcher.
+
+#### 2026-09-07 17:03, before the knn clamp and watchdog (load 41.7 / 29.6, 5 interleaved rounds)
+
+| Arm | min | median | max | exit codes | first error line |
+|---|---|---|---|---|---|
+| list month, limit 10000 | 334ms | 466ms | 1.3s | 0 |  |
+| search faktura, fulltext, limit 500 | 358ms | 383ms | 655ms | 0 |  |
+| search faktura, auto, limit 500 | 498ms | 730ms | 2.0s | 1 | ERROR: k value in knn query too large, provided 7500 and the limit is 4096 |
+
+#### 2026-09-07 17:09, after (load 14.3 / 29.5, 5 interleaved rounds)
+
+| Arm | min | median | max | exit codes | first error line |
+|---|---|---|---|---|---|
+| list month, limit 10000 | 334ms | 336ms | 348ms | 0 |  |
+| search faktura, fulltext, limit 500 | 311ms | 314ms | 380ms | 0 |  |
+| search faktura, auto, limit 500 | 643ms | 645ms | 699ms | 0 |  |
+
+The auto arm went from "fails every run" to a working ~645 ms (the embedding of the query plus the 4096-neighbour scan sit on top of the fulltext cost). The list and fulltext medians moved by less than the load swing between the two runs and are noise; the watchdog is a `Promise.race` per stage and adds nothing measurable.
+
 ## Permissions
 
 macOS keys every privacy grant (Calendars, Reminders, Contacts, Full Disk Access, Accessibility, Automation, Speech, Microphone, protected folders) to the **responsible process**. For a plain CLI that is the terminal that launched it, or `bun` itself under launchd, so every terminal needed its own grants and a launchd job had none. Since 2026-09-03 19:40 GenesisTools owns them itself:

--- a/src/macos/commands/mail/list.ts
+++ b/src/macos/commands/mail/list.ts
@@ -14,7 +14,10 @@ import { isQuietOutput } from "@genesiscz/utils/cli/output-mode";
 import { createQuietSpinner } from "@genesiscz/utils/cli/quiet-spinner";
 import { MailDatabase } from "@genesiscz/utils/macos/MailDatabase";
 import type { MailMessage } from "@genesiscz/utils/macos/mail/types";
+import { profiler } from "@genesiscz/utils/profile";
 import type { Command } from "commander";
+
+const prof = profiler.scope("macos-mail");
 
 interface ListOptions {
     limit?: string;
@@ -77,7 +80,9 @@ export function registerListCommand(program: Command): void {
                 const spinner = isQuietOutput(format) ? createQuietSpinner() : p.spinner();
                 spinner.start(`Fetching latest ${limit} emails from ${targetMailbox}...`);
 
-                const rows = await db.listMessages(targetMailbox, limit, { ...filters, offset });
+                const rows = await prof.measureAsync("list.sql", () =>
+                    db.listMessages(targetMailbox, limit, { ...filters, offset })
+                );
 
                 if (rows.length === 0) {
                     spinner.stop(`No messages found in ${targetMailbox}.`);
@@ -90,18 +95,18 @@ export function registerListCommand(program: Command): void {
                 }
 
                 const rowids = rows.map((r) => r.rowid);
-                const attachmentsMap = await db.getAttachments(rowids);
+                const attachmentsMap = await prof.measureAsync("list.attachments", () => db.getAttachments(rowids));
                 const messages: MailMessage[] = rows.map((row) => {
                     const msg = rowToMessage(row);
                     msg.attachments = attachmentsMap.get(row.rowid) ?? [];
                     return msg;
                 });
 
-                await enrichWithBodies(messages, columns);
+                await prof.measureAsync("list.bodies", () => enrichWithBodies(messages, columns));
 
                 // Enrich with recipients if any recipient column is selected
                 if (needsRecipients(columns)) {
-                    const recipientsMap = await db.getRecipients(rowids);
+                    const recipientsMap = await prof.measureAsync("list.recipients", () => db.getRecipients(rowids));
 
                     for (const msg of messages) {
                         msg.recipients = recipientsMap.get(msg.rowid) ?? [];
@@ -110,11 +115,13 @@ export function registerListCommand(program: Command): void {
 
                 spinner.stop(`${messages.length} emails from ${targetMailbox}`);
 
-                await outputFormattedResults({
-                    messages,
-                    columns,
-                    format,
-                });
+                await prof.measureAsync("list.output", () =>
+                    outputFormattedResults({
+                        messages,
+                        columns,
+                        format,
+                    })
+                );
             } catch (error) {
                 p.log.error(error instanceof Error ? error.message : String(error));
                 process.exit(1);

--- a/src/macos/commands/mail/search.e2e.test.ts
+++ b/src/macos/commands/mail/search.e2e.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
-import { env } from "@genesiscz/utils/env";
 import { SafeJSON } from "@genesiscz/utils/json";
 
-const INDEX_DB = join(env.tools.getHome(), ".genesis-tools/indexer/macos-mail/index.db");
+// These tests spawn `tools` against the REAL mail index (read-only), so the sandbox home the test
+// preload sets must not leak into the child: with it, the index is "missing" and every search silently
+// takes the Spotlight fallback. Gate: RUN_E2E=1 RUN_MAIL_INFRA=1.
+const INDEX_DB = join(homedir(), ".genesis-tools/indexer/macos-mail/index.db");
 const TOOLS_BIN = join(import.meta.dir, "../../../../tools");
 const CAN_RUN = process.platform === "darwin" && existsSync(INDEX_DB) && existsSync(TOOLS_BIN);
+const { GENESIS_TOOLS_HOME: _sandboxHome, ...REAL_HOME_ENV } = process.env;
 
 describe("tools macos mail search --mode auto (e2e)", () => {
     it.skipIf(!CAN_RUN)(
@@ -14,13 +18,48 @@ describe("tools macos mail search --mode auto (e2e)", () => {
         async () => {
             const proc = Bun.spawn(
                 [TOOLS_BIN, "macos", "mail", "search", "invoice", "--mode", "auto", "--limit", "1", "--format", "json"],
-                { stdout: "pipe", stderr: "pipe" }
+                { stdout: "pipe", stderr: "pipe", env: REAL_HOME_ENV }
             );
             const stdout = await new Response(proc.stdout).text();
             const stderr = await new Response(proc.stderr).text();
             const exitCode = await proc.exited;
 
             expect(stderr).not.toContain("sqlite-vec extension failed to load");
+            expect(exitCode).toBe(0);
+            expect(() => SafeJSON.parse(stdout.trim() || "[]", { strict: true })).not.toThrow();
+        },
+        60_000
+    );
+
+    it.skipIf(!CAN_RUN)(
+        "auto mode survives --limit 500 over a month window (sqlite-vec k cap)",
+        async () => {
+            const proc = Bun.spawn(
+                [
+                    TOOLS_BIN,
+                    "macos",
+                    "mail",
+                    "search",
+                    "faktura",
+                    "--mode",
+                    "auto",
+                    "--from",
+                    "2026-03-01",
+                    "--to",
+                    "2026-04-01",
+                    "--limit",
+                    "500",
+                    "--format",
+                    "json",
+                ],
+                { stdout: "pipe", stderr: "pipe", env: REAL_HOME_ENV }
+            );
+            const stdout = await new Response(proc.stdout).text();
+            const stderr = await new Response(proc.stderr).text();
+            const exitCode = await proc.exited;
+
+            expect(stderr).not.toContain("k value in knn query too large");
+            expect(stderr).toContain("vector candidates capped at 4096");
             expect(exitCode).toBe(0);
             expect(() => SafeJSON.parse(stdout.trim() || "[]", { strict: true })).not.toThrow();
         },
@@ -46,7 +85,7 @@ describe("tools macos mail search --mode auto (e2e)", () => {
                     "--format",
                     "json",
                 ],
-                { stdout: "pipe", stderr: "pipe" }
+                { stdout: "pipe", stderr: "pipe", env: REAL_HOME_ENV }
             );
             const stdout = await new Response(proc.stdout).text();
             const exitCode = await proc.exited;
@@ -84,7 +123,7 @@ describe("tools macos mail search --mode auto (e2e)", () => {
                     "3",
                     "--yes",
                 ],
-                { stdout: "pipe", stderr: "pipe" }
+                { stdout: "pipe", stderr: "pipe", env: REAL_HOME_ENV }
             );
             const stderr = await new Response(proc.stderr).text();
             const exitCode = await proc.exited;
@@ -115,7 +154,7 @@ describe("tools macos mail search --mode auto (e2e)", () => {
                     "--format",
                     "json",
                 ],
-                { stdout: "pipe", stderr: "pipe" }
+                { stdout: "pipe", stderr: "pipe", env: REAL_HOME_ENV }
             );
             const idsRaw = await new Response(idsProc.stdout).text();
             await idsProc.exited;
@@ -130,6 +169,7 @@ describe("tools macos mail search --mode auto (e2e)", () => {
                 const p = Bun.spawn([TOOLS_BIN, "macos", "mail", "show", String(id), "--json"], {
                     stdout: "pipe",
                     stderr: "pipe",
+                    env: REAL_HOME_ENV,
                 });
                 const text = await new Response(p.stdout).text();
                 await p.exited;
@@ -148,6 +188,7 @@ describe("tools macos mail search --mode auto (e2e)", () => {
             const piped = Bun.spawn(["sh", "-c", `'${TOOLS_BIN}' macos mail show ${bigId} --json | cat`], {
                 stdout: "pipe",
                 stderr: "pipe",
+                env: REAL_HOME_ENV,
             });
             const pipedText = await new Response(piped.stdout).text();
             await piped.exited;

--- a/src/macos/commands/mail/search.ts
+++ b/src/macos/commands/mail/search.ts
@@ -7,14 +7,17 @@ import {
     resolveColumnsFromFlag,
     resolveListFilters,
 } from "@app/macos/lib/mail/command-helpers";
-import { resolveMailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
+import { DEFAULT_SEARCH_TIMEOUT_MS, resolveMailSearchMode, runMailSearch } from "@app/macos/lib/mail/search-runner";
 import * as p from "@clack/prompts";
 import { isQuietOutput } from "@genesiscz/utils/cli/output-mode";
 import { createQuietSpinner } from "@genesiscz/utils/cli/quiet-spinner";
 import { logger } from "@genesiscz/utils/logger";
 import { MailDatabase } from "@genesiscz/utils/macos/MailDatabase";
 import type { SearchOptions } from "@genesiscz/utils/macos/mail/types";
+import { profiler } from "@genesiscz/utils/profile";
 import type { Command } from "commander";
+
+const prof = profiler.scope("macos-mail");
 
 interface SearchCommandOptions {
     withoutBody?: boolean;
@@ -32,6 +35,7 @@ interface SearchCommandOptions {
     maxDistance?: string;
     columns?: string | true;
     format?: string;
+    timeout?: string;
 }
 
 function buildSearchColumns({
@@ -85,6 +89,7 @@ export function registerSearchCommand(program: Command): void {
         .option("--mode <mode>", "Search mode: auto | fulltext | hybrid | vector (default: auto)", "auto")
         .option("--semantic", "Enable Apple NL re-ranking after RRF (not recommended — overwrites embedding scores)")
         .option("--max-distance <n>", "Max semantic distance to include (0–2, default: 1.2)", "1.2")
+        .option("--timeout <seconds>", "Abort a stage (index query, row fetch, Spotlight) after this long", "60")
         .option("--columns [cols]", `Columns to show (${ALL_COLUMN_KEYS.join(",")})`)
         .option("-f, --format <type>", "Output format: table, json, toon", "table")
         .action(async (query: string, options: SearchCommandOptions) => {
@@ -130,20 +135,27 @@ export function registerSearchCommand(program: Command): void {
                 // 100, which is higher than the list default.
                 const { filters, limit, offset } = resolveListFilters({ ...options, limit: options.limit ?? "100" });
 
-                const searchOpts: SearchOptions = await db.resolveMailboxFilter({
-                    query,
-                    withoutBody: options.withoutBody,
-                    ...filters,
-                    limit,
-                    offset,
-                });
+                const searchOpts: SearchOptions = await prof.measureAsync("search.mailbox", () =>
+                    db.resolveMailboxFilter({
+                        query,
+                        withoutBody: options.withoutBody,
+                        ...filters,
+                        limit,
+                        offset,
+                    })
+                );
 
+                const timeoutSeconds = Number.parseFloat(options.timeout ?? "");
                 const outcome = await runMailSearch(query, {
                     searchOpts,
                     mode: resolveMailSearchMode(options.mode),
                     jxa: options.jxa,
                     semantic: options.semantic,
                     maxDistance: options.maxDistance ? Number.parseFloat(options.maxDistance) : undefined,
+                    timeoutMs:
+                        Number.isFinite(timeoutSeconds) && timeoutSeconds > 0
+                            ? timeoutSeconds * 1000
+                            : DEFAULT_SEARCH_TIMEOUT_MS,
                     db,
                     onProgress: spinner,
                     onWarning: (message): void => {
@@ -171,7 +183,7 @@ export function registerSearchCommand(program: Command): void {
                     return;
                 }
 
-                await enrichWithBodies(messages, baseColumns);
+                await prof.measureAsync("search.bodies", () => enrichWithBodies(messages, baseColumns));
 
                 const finalColumns = buildSearchColumns({
                     columns: baseColumns,
@@ -182,7 +194,9 @@ export function registerSearchCommand(program: Command): void {
                 });
 
                 if (needsRecipients(finalColumns)) {
-                    const recipientsMap = await db.getRecipients(messages.map((m) => m.rowid));
+                    const recipientsMap = await prof.measureAsync("search.recipients", () =>
+                        db.getRecipients(messages.map((m) => m.rowid))
+                    );
 
                     for (const msg of messages) {
                         msg.recipients = recipientsMap.get(msg.rowid) ?? [];
@@ -194,11 +208,13 @@ export function registerSearchCommand(program: Command): void {
                 const totalCount = outcome.totalCount;
                 const paginatedMessages = messages.slice(paginationOffset, paginationOffset + pageLimit);
 
-                await outputFormattedResults({
-                    messages: paginatedMessages,
-                    columns: finalColumns,
-                    format: options.format ?? "table",
-                });
+                await prof.measureAsync("search.output", () =>
+                    outputFormattedResults({
+                        messages: paginatedMessages,
+                        columns: finalColumns,
+                        format: options.format ?? "table",
+                    })
+                );
 
                 if (!isStructuredOutput && !quiet && (options.format ?? "table") === "table") {
                     const rangeEnd = Math.min(paginationOffset + pageLimit, totalCount);

--- a/src/macos/lib/mail/bench.ts
+++ b/src/macos/lib/mail/bench.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+/**
+ * Interleaved wall-clock benchmark of the `tools macos mail` paths the collector skill leans on.
+ * Arms run A,B,C,A,B,C,... so a load change cannot become "the fix". Prints a markdown row per arm
+ * (min / median / max, exit codes) for `src/macos/README.md`. Usage:
+ *
+ *   bun src/macos/lib/mail/bench.ts <label> [rounds=5] [--tools /path/to/tools]
+ */
+import { loadavg } from "node:os";
+import { join } from "node:path";
+import { formatDuration } from "@genesiscz/utils/format";
+
+const args = process.argv.slice(2);
+const label = args[0] ?? "unlabelled";
+const rounds = Number.parseInt(args[1] ?? "5", 10) || 5;
+const toolsIdx = args.indexOf("--tools");
+const tools = toolsIdx >= 0 ? (args[toolsIdx + 1] ?? "tools") : join(import.meta.dir, "../../../../tools");
+
+const WINDOW = ["--from", "2026-03-01", "--to", "2026-04-01"];
+const ARMS: Array<{ name: string; argv: string[] }> = [
+    {
+        name: "list month, limit 10000",
+        argv: ["macos", "mail", "list", ...WINDOW, "--limit", "10000", "--format", "json"],
+    },
+    {
+        name: "search faktura, fulltext, limit 500",
+        argv: [
+            "macos",
+            "mail",
+            "search",
+            "faktura",
+            "--mode",
+            "fulltext",
+            ...WINDOW,
+            "--limit",
+            "500",
+            "--format",
+            "json",
+        ],
+    },
+    {
+        name: "search faktura, auto, limit 500",
+        argv: ["macos", "mail", "search", "faktura", "--mode", "auto", ...WINDOW, "--limit", "500", "--format", "json"],
+    },
+];
+
+const samples = new Map<string, Array<{ ms: number; exit: number; err: string }>>(ARMS.map((a) => [a.name, []]));
+
+for (let round = 0; round < rounds; round++) {
+    for (const arm of ARMS) {
+        const t0 = performance.now();
+        const proc = Bun.spawnSync([tools, ...arm.argv], { stdout: "ignore", stderr: "pipe" });
+        const ms = performance.now() - t0;
+        const err =
+            proc.stderr
+                .toString()
+                .split("\n")
+                .find((l) => /error|too large|Error/.test(l)) ?? "";
+        samples.get(arm.name)?.push({ ms, exit: proc.exitCode, err });
+        process.stderr.write(`round ${round + 1}/${rounds} ${arm.name}: ${formatDuration(ms)} exit ${proc.exitCode}\n`);
+    }
+}
+
+const [l1, l5] = loadavg();
+process.stdout.write(
+    `\n### ${label} (${new Date().toISOString().slice(0, 16).replace("T", " ")} UTC, load ${l1.toFixed(1)} / ${l5.toFixed(1)}, ${rounds} interleaved rounds)\n\n`
+);
+process.stdout.write("| Arm | min | median | max | exit codes | first error line |\n|---|---|---|---|---|---|\n");
+
+for (const arm of ARMS) {
+    const list = samples.get(arm.name) ?? [];
+    const sorted = list.map((s) => s.ms).sort((a, b) => a - b);
+    const median = sorted[Math.floor(sorted.length / 2)] ?? 0;
+    const exits = [...new Set(list.map((s) => s.exit))].join(",");
+    const err = list.find((s) => s.err)?.err ?? "";
+    process.stdout.write(
+        `| ${arm.name} | ${formatDuration(sorted[0] ?? 0)} | ${formatDuration(median)} | ${formatDuration(sorted.at(-1) ?? 0)} | ${exits} | ${err.replace(/\|/g, "\\|").slice(0, 90)} |\n`
+    );
+}

--- a/src/macos/lib/mail/search-runner.test.ts
+++ b/src/macos/lib/mail/search-runner.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { SQLITE_VEC_MAX_K } from "@genesiscz/utils/search/stores/sqlite-vec-store";
+import { stageGuard, vectorCapWarning } from "./search-runner";
+
+describe("stageGuard", () => {
+    it("rejects a stage that never settles, naming the stage", async () => {
+        const stage = stageGuard(30);
+        const never = new Promise<number>(() => {});
+        const t0 = performance.now();
+
+        await expect(stage("search.index.hybrid", () => never)).rejects.toThrow(
+            /timed out after 0s in stage "search.index.hybrid".*--timeout/
+        );
+        expect(performance.now() - t0).toBeLessThan(1000);
+    });
+
+    it("passes a settling stage through untouched and clears its timer", async () => {
+        const stage = stageGuard(30);
+        const value = await stage("search.attachments", async () => 42);
+        expect(value).toBe(42);
+        await Bun.sleep(40);
+    });
+
+    it("propagates the stage's own error", async () => {
+        const stage = stageGuard(1000);
+        await expect(stage("search.index.rows", () => Promise.reject(new Error("locked")))).rejects.toThrow("locked");
+    });
+});
+
+describe("vectorCapWarning", () => {
+    it("is silent while the hybrid over-fetch stays under the sqlite-vec cap", () => {
+        expect(vectorCapWarning(250, true)).toBeUndefined();
+        expect(vectorCapWarning(1000, false)).toBeUndefined();
+    });
+
+    it("names the cap, the ask and the covered rank once the over-fetch exceeds it", () => {
+        const warning = vectorCapWarning(500, true);
+        expect(warning).toContain(`capped at ${SQLITE_VEC_MAX_K}`);
+        expect(warning).toContain("asked for 7500 for --limit 500");
+        expect(warning).toContain("past about 273");
+        expect(vectorCapWarning(2000, false)).toContain("asked for 6000");
+    });
+});

--- a/src/macos/lib/mail/search-runner.ts
+++ b/src/macos/lib/mail/search-runner.ts
@@ -18,6 +18,8 @@ import { closeDarwinKit, rankBySimilarity } from "@genesiscz/utils/macos";
 import type { MailDatabase } from "@genesiscz/utils/macos/MailDatabase";
 import { ENVELOPE_INDEX_PATH } from "@genesiscz/utils/macos/mail/constants";
 import type { MailMessage, MailMessageRow, SearchOptions } from "@genesiscz/utils/macos/mail/types";
+import { profiler } from "@genesiscz/utils/profile";
+import { SQLITE_VEC_MAX_K } from "@genesiscz/utils/search/stores/sqlite-vec-store";
 
 export type MailSearchMode = "auto" | "fulltext" | "hybrid" | "vector";
 
@@ -48,6 +50,42 @@ export interface RunMailSearchOptions {
     db: MailDatabase;
     onProgress?: { start: (msg: string) => void; stop: (msg: string) => void };
     onWarning?: (message: string) => void;
+    /** Hard deadline per stage (index query, row fetch, fallback, attachments). Default 60 s. */
+    timeoutMs?: number;
+}
+
+export const DEFAULT_SEARCH_TIMEOUT_MS = 60_000;
+
+/**
+ * Wraps every stage of a search in a hard deadline. A stage that never settles rejects with an error that
+ * names the stage, so a stuck SQLite lock or Spotlight call ends as "timed out in stage X" instead of a
+ * silent process that lives for an hour (hunter A, 2026-09-07). The stuck promise is left behind; the
+ * command exits right after, which is the only way to abort a synchronous SQLite call.
+ */
+export function stageGuard(timeoutMs: number): <T>(label: string, fn: () => Promise<T>) => Promise<T> {
+    return async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
+        logger.debug(`[mail/search] stage ${label} start`);
+        const t0 = performance.now();
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const deadline = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+                reject(
+                    new Error(
+                        `mail search timed out after ${Math.round(timeoutMs / 1000)}s in stage "${label}". ` +
+                            "Narrow --from/--to or --limit, or raise --timeout <seconds>."
+                    )
+                );
+            }, timeoutMs);
+        });
+
+        try {
+            const result = await Promise.race([fn(), deadline]);
+            logger.debug(`[mail/search] stage ${label} done in ${Math.round(performance.now() - t0)}ms`);
+            return result;
+        } finally {
+            clearTimeout(timer);
+        }
+    };
 }
 
 export interface MailSearchOutcome {
@@ -61,6 +99,27 @@ export interface MailSearchOutcome {
 
 const MAIL_INDEX_NAME = "macos-mail";
 const STABLE_INDEX_FETCH_LIMIT = 250;
+/** Hybrid over-fetch: 3x for the RRF pool, then 5x for a filtered cosine query (sqlite-fts5 driver). */
+const HYBRID_VECTOR_OVERFETCH = 15;
+const prof = profiler.scope("macos-mail");
+
+/**
+ * The vector side of a hybrid search asks sqlite-vec for `fetchLimit * 15` neighbours and sqlite-vec caps
+ * `k` at 4096, so past `4096 / 15` results the ranking is fulltext-only. Says so once per run.
+ */
+export function vectorCapWarning(fetchLimit: number, hasFilters: boolean): string | undefined {
+    const asked = fetchLimit * (hasFilters ? HYBRID_VECTOR_OVERFETCH : 3);
+
+    if (asked <= SQLITE_VEC_MAX_K) {
+        return undefined;
+    }
+
+    const covered = Math.floor(SQLITE_VEC_MAX_K / (hasFilters ? HYBRID_VECTOR_OVERFETCH : 3));
+    return (
+        `vector candidates capped at ${SQLITE_VEC_MAX_K} by sqlite-vec (the hybrid search asked for ${asked} for ` +
+        `--limit ${fetchLimit}); results past about ${covered} are ranked by fulltext matches only`
+    );
+}
 
 export async function runMailSearch(query: string, options: RunMailSearchOptions): Promise<MailSearchOutcome> {
     const searchOpts = options.searchOpts;
@@ -75,6 +134,9 @@ export async function runMailSearch(query: string, options: RunMailSearchOptions
     let rows: MailMessageRow[] = [];
     let searchMethod: "fts" | "spotlight+like" = "spotlight+like";
     let resolvedMethod: ResolvedMethod | undefined;
+    const guard = stageGuard(options.timeoutMs ?? DEFAULT_SEARCH_TIMEOUT_MS);
+    const stage = <T>(label: string, fn: () => Promise<T>): Promise<T> =>
+        guard(label, () => prof.measureAsync(label, fn));
 
     logger.debug(
         `[mail/search] mode=${resolvedMode} willUseIndex=${willUseIndex} ` +
@@ -87,24 +149,26 @@ export async function runMailSearch(query: string, options: RunMailSearchOptions
         const t0 = performance.now();
         const fetchLimit = Math.max((searchOpts.offset ?? 0) + (searchOpts.limit ?? 100), STABLE_INDEX_FETCH_LIMIT);
 
-        const ftsResults = await searchIndexReadonly(MAIL_INDEX_NAME, query, {
-            mode: resolvedMode,
-            limit: fetchLimit,
-            onWarning: options.onWarning,
-            ...((searchOpts.from || searchOpts.to) && {
-                coverageCheck: {
-                    from: searchOpts.from,
-                    to: searchOpts.to,
-                    onOutside: (advisory: string): void => {
-                        process.stderr.write(advisory);
+        const ftsResults = await stage(`search.index.${resolvedMode}`, () =>
+            searchIndexReadonly(MAIL_INDEX_NAME, query, {
+                mode: resolvedMode,
+                limit: fetchLimit,
+                onWarning: options.onWarning,
+                ...((searchOpts.from || searchOpts.to) && {
+                    coverageCheck: {
+                        from: searchOpts.from,
+                        to: searchOpts.to,
+                        onOutside: (advisory: string): void => {
+                            process.stderr.write(advisory);
+                        },
                     },
-                },
-            }),
-            ...(filterPredicate && {
-                filters: filterPredicate,
-                attach: { alias: "mailapp", dbPath: ENVELOPE_INDEX_PATH, mode: "ro" as const },
-            }),
-        });
+                }),
+                ...(filterPredicate && {
+                    filters: filterPredicate,
+                    attach: { alias: "mailapp", dbPath: ENVELOPE_INDEX_PATH, mode: "ro" as const },
+                }),
+            })
+        );
 
         const ms = performance.now() - t0;
         const ftsRowids: number[] = [];
@@ -137,7 +201,17 @@ export async function runMailSearch(query: string, options: RunMailSearchOptions
         }
 
         resolvedMethod = ftsResults[0]?.method;
-        rows = ftsRowids.length > 0 ? await options.db.getMessagesByRowids(ftsRowids, searchOpts) : [];
+        const capWarning =
+            resolvedMethod && resolvedMethod !== "bm25" ? vectorCapWarning(fetchLimit, !!filterPredicate) : undefined;
+
+        if (capWarning) {
+            logger.debug(`[mail/search] ${capWarning}`);
+            options.onWarning?.(capWarning);
+        }
+        rows =
+            ftsRowids.length > 0
+                ? await stage("search.index.rows", () => options.db.getMessagesByRowids(ftsRowids, searchOpts))
+                : [];
         searchMethod = "fts";
 
         const orderByRowid = new Map(ftsRowids.map((rowid, index) => [rowid, index]));
@@ -155,13 +229,15 @@ export async function runMailSearch(query: string, options: RunMailSearchOptions
         const t0 = performance.now();
 
         const [spotlightRowids, likeRows] = await Promise.all([
-            mdfindMailRowids(query),
-            options.db.searchMessages(searchOpts),
+            stage("search.fallback.spotlight", () => mdfindMailRowids(query)),
+            stage("search.fallback.like", () => options.db.searchMessages(searchOpts)),
         ]);
         const rowidSet = new Set<number>(likeRows.map((r) => r.rowid));
         const newSpotlightIds = spotlightRowids.filter((r) => !rowidSet.has(r));
         const spotlightRows =
-            newSpotlightIds.length > 0 ? await options.db.getMessagesByRowids(newSpotlightIds, searchOpts) : [];
+            newSpotlightIds.length > 0
+                ? await stage("search.fallback.rows", () => options.db.getMessagesByRowids(newSpotlightIds, searchOpts))
+                : [];
 
         rows = [...likeRows, ...spotlightRows];
         const fallbackOrder = new Map(rows.map((row, index) => [row.rowid, index]));
@@ -174,7 +250,7 @@ export async function runMailSearch(query: string, options: RunMailSearchOptions
 
     const isFts = searchMethod === "fts";
     const rowids = rows.map((r) => r.rowid);
-    const attachmentsMap = await options.db.getAttachments(rowids);
+    const attachmentsMap = await stage("search.attachments", () => options.db.getAttachments(rowids));
     const messages: MailMessage[] = rows.map((row) => {
         const msg = rowToMessage(row);
         msg.attachments = attachmentsMap.get(row.rowid) ?? [];
@@ -196,7 +272,9 @@ export async function runMailSearch(query: string, options: RunMailSearchOptions
                     .join(" ")
                     .slice(0, 2000),
             }));
-            const ranked = await rankBySimilarity(query, items, { maxDistance: maxDist, language: "en" });
+            const ranked = await stage("search.semantic", () =>
+                rankBySimilarity(query, items, { maxDistance: maxDist, language: "en" })
+            );
             const reordered: MailMessage[] = ranked.map((r) => {
                 const msg = r.item as MailMessage;
                 msg.semanticScore = r.score;

--- a/src/utils/bun/preload-test-tmpdir.test.ts
+++ b/src/utils/bun/preload-test-tmpdir.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+
+const PRELOAD = resolve(import.meta.dir, "preload-test-tmpdir.ts");
+
+/**
+ * The preload cannot be imported here (it runs before any test module loads, and a second
+ * import would install a second root), so the first test asserts the invariants it
+ * maintains from inside a process it already configured, and the second drives a child
+ * `bun test` with the preload on a scratch suite to watch what happens at exit.
+ */
+describe("test tmpdir preload", () => {
+    test("this process's temp dir is a private gt-test-tmp root, and the sandbox home lives inside it", () => {
+        expect(basename(tmpdir())).toStartWith("gt-test-tmp-");
+        expect(process.env.GENESIS_TOOLS_HOME?.startsWith(tmpdir())).toBe(true);
+    });
+
+    test("a run removes its root, green or red, and stale siblings are swept", () => {
+        const parent = mkdtempSync(join(tmpdir(), "tmpdir-preload-parent-"));
+        const suite = mkdtempSync(join(tmpdir(), "tmpdir-preload-suite-"));
+        writeFileSync(
+            join(suite, "green.test.ts"),
+            [
+                'import { expect, test } from "bun:test";',
+                'import { mkdtempSync } from "node:fs";',
+                'import { tmpdir } from "node:os";',
+                'import { join } from "node:path";',
+                'test("fixtures land in the root", () => {',
+                '    expect(mkdtempSync(join(tmpdir(), "fixture-"))).toContain("gt-test-tmp-");',
+                "});",
+                "",
+            ].join("\n")
+        );
+        writeFileSync(
+            join(suite, "red.test.ts"),
+            [
+                'import { expect, test } from "bun:test";',
+                'test("fails on purpose", () => {',
+                "    expect(1).toBe(2);",
+                "});",
+                "",
+            ].join("\n")
+        );
+        const stale = join(parent, "gt-test-tmp-stale");
+        const young = join(parent, "gt-test-tmp-young");
+        mkdirSync(stale);
+        mkdirSync(young);
+        const sevenHoursAgo = new Date(Date.now() - 7 * 60 * 60 * 1000);
+        utimesSync(stale, sevenHoursAgo, sevenHoursAgo);
+
+        const run = (file: string) =>
+            spawnSync("bun", ["test", "--preload", PRELOAD, file], {
+                cwd: suite,
+                encoding: "utf8",
+                env: { ...process.env, TMPDIR: parent, TMP: parent, TEMP: parent },
+            });
+
+        const green = run("green.test.ts");
+        if (green.status !== 0) {
+            console.error(green.stdout, green.stderr);
+        }
+        expect(green.status).toBe(0);
+        expect(readdirSync(parent).filter((name) => name.startsWith("gt-test-tmp-"))).toEqual(["gt-test-tmp-young"]);
+
+        const red = run("red.test.ts");
+        expect(red.status).not.toBe(0);
+        expect(readdirSync(parent).filter((name) => name.startsWith("gt-test-tmp-"))).toEqual(["gt-test-tmp-young"]);
+    });
+});

--- a/src/utils/bun/preload-test-tmpdir.ts
+++ b/src/utils/bun/preload-test-tmpdir.ts
@@ -1,0 +1,89 @@
+import { afterAll } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+
+/**
+ * Give every test process its own temp root, and remove it when the run is green.
+ *
+ * 799 call sites in the suite do `mkdtempSync(join(tmpdir(), "<prefix>-"))` and most never
+ * remove the dir. Measured 2026-09-07 15:05: 17,949 entries and 1.45 GB in the per-user
+ * temp folder, 4,880 of them `gt-test-home-*` from the sandbox preload alone, 6,568
+ * distinct prefixes in all, growing by about 1,100 entries per ten minutes while agents
+ * ran tests. Fixing that at every call site is the wrong altitude.
+ *
+ * `os.tmpdir()` reads TMPDIR (TEMP and TMP on Windows) on every call, so pointing the
+ * variable at one fresh root here, before any test module loads, moves every fixture, the
+ * `gt-test-home` sandbox and every child that inherits the environment into one
+ * directory. One `rmSync` at exit then covers all of them.
+ *
+ * Rules:
+ *  - Removed in a global `afterAll`, once per test process, green or red. `bun test` fires
+ *    neither the `exit` nor the `beforeExit` event (measured on 1.3.13), and no hook sees
+ *    the run's verdict, so "keep the evidence on red" is not available. A failed
+ *    assertion is in the transcript; the fixture dir was never what anyone read.
+ *  - Stale sibling roots (older than 6 h; no test process lives that long) are swept at
+ *    the same point, at most 200 per process, so a KILLED run (no afterAll) cannot
+ *    accumulate forever. Only the `gt-test-tmp-` prefix is ever touched: nothing else in
+ *    the temp folder is ours.
+ *  - Listed right after the sqlite-vec preload in bunfig.toml, BEFORE the sandbox preload,
+ *    so the sandbox home lands inside this root.
+ *
+ * Known gap: Bun does not forward process.env mutations to children spawned without an
+ * explicit `env`, so such a child still writes to the real temp folder. A test that spawns
+ * passes `env: { ...process.env }` when that matters.
+ */
+const PREFIX = "gt-test-tmp-";
+const STALE_AFTER_MS = 6 * 60 * 60 * 1000;
+const MAX_SWEEP = 200;
+
+const realTmpdir = tmpdir();
+const root = mkdtempSync(join(realTmpdir, PREFIX));
+for (const name of ["TMPDIR", "TMP", "TEMP"]) {
+    // Writes straight through to process.env, which is what os.tmpdir() reads.
+    env.testing.set(name, root);
+}
+
+const sweepStale = (): void => {
+    let names: string[];
+    try {
+        names = readdirSync(realTmpdir);
+    } catch {
+        // The temp folder itself is unreadable: nothing to sweep, nothing to report.
+        return;
+    }
+
+    let removed = 0;
+    for (const name of names) {
+        if (removed >= MAX_SWEEP) {
+            break;
+        }
+
+        if (!name.startsWith(PREFIX)) {
+            continue;
+        }
+
+        const dir = join(realTmpdir, name);
+        if (dir === root) {
+            continue;
+        }
+
+        try {
+            // A live run's root keeps a fresh mtime: every fixture created inside it touches it.
+            if (Date.now() - statSync(dir).mtimeMs < STALE_AFTER_MS) {
+                continue;
+            }
+
+            rmSync(dir, { recursive: true, force: true });
+            removed += 1;
+        } catch {
+            // Vanished under us, or refused by the filesystem: the next run tries again.
+        }
+    }
+};
+
+afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+    sweepStale();
+});

--- a/src/utils/profile/scopes.ts
+++ b/src/utils/profile/scopes.ts
@@ -16,6 +16,8 @@ export const PROFILER_SCOPE_NAMES = [
     "pipeline",
     "ai-proxy",
     "ttyd",
+    "macos-mail",
+    "chrome-devtools",
 ] as const;
 
 export const PROFILING_DETAIL_VALUES = ["phases", "all"] as const;

--- a/src/utils/search/stores/sqlite-vec-store.test.ts
+++ b/src/utils/search/stores/sqlite-vec-store.test.ts
@@ -2,7 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { loadSqliteVec } from "./sqlite-vec-loader";
-import { SqliteVecVectorStore } from "./sqlite-vec-store";
+import { SQLITE_VEC_MAX_K, SqliteVecVectorStore } from "./sqlite-vec-store";
 
 describe("sqlite-vec loading", () => {
     it("loads the sqlite-vec extension into bun:sqlite", () => {
@@ -87,6 +87,20 @@ describe("SqliteVecVectorStore", () => {
         store.store("a", new Float32Array([1, 0, 0]));
         store.store("b", new Float32Array([0, 1, 0]));
         expect(store.count()).toBe(2);
+    });
+
+    it("clamps k to the sqlite-vec limit instead of throwing on a large limit", () => {
+        const store = new SqliteVecVectorStore(db, { tableName: "test", dimensions: 3 });
+        store.store("a", new Float32Array([1, 0, 0]));
+        store.store("b", new Float32Array([0, 1, 0]));
+
+        // Unclamped, sqlite-vec answers "k value in knn query too large, provided 7500 and the limit is 4096".
+        expect(() =>
+            db.query("SELECT doc_id FROM test_vec WHERE embedding MATCH ? AND k = ?").all(new Uint8Array(12), 7500)
+        ).toThrow(/too large/);
+
+        const results = store.search(new Float32Array([1, 0, 0]), SQLITE_VEC_MAX_K + 3404);
+        expect(results.map((r) => r.docId)).toEqual(["a", "b"]);
     });
 
     it("replaces vector for existing ID", () => {

--- a/src/utils/search/stores/sqlite-vec-store.ts
+++ b/src/utils/search/stores/sqlite-vec-store.ts
@@ -19,6 +19,13 @@ export interface SqliteVecVectorStoreConfig {
 /** Max bind parameters per SQL IN(...) clause */
 const SQL_BATCH_SIZE = 500;
 
+/**
+ * sqlite-vec refuses `k` above this ("k value in knn query too large, provided N and the limit is 4096").
+ * The hybrid path over-fetches 15x (3x RRF pool, 5x for filtered cosine), so `--limit 500` asked for 7500
+ * and every month-window search in auto mode died. Clamped here, above the query that spends it.
+ */
+export const SQLITE_VEC_MAX_K = 4096;
+
 export class SqliteVecVectorStore implements VectorStore {
     private db: Database;
     private vecTable: string;
@@ -66,6 +73,7 @@ export class SqliteVecVectorStore implements VectorStore {
     search(queryVector: Float32Array, limit: number): VectorSearchHit[] {
         // sqlite-vec KNN query: MATCH + k constraint + ORDER BY distance
         const blob = new Uint8Array(queryVector.buffer, queryVector.byteOffset, queryVector.byteLength);
+        const k = Math.min(limit, SQLITE_VEC_MAX_K);
 
         const rows = this.db
             .query(
@@ -75,7 +83,7 @@ export class SqliteVecVectorStore implements VectorStore {
                   AND k = ?
                 ORDER BY distance`
             )
-            .all(blob, limit) as Array<{ doc_id: string; distance: number }>;
+            .all(blob, k) as Array<{ doc_id: string; distance: number }>;
 
         // With distance_metric=cosine, distance = 1 - cosine_similarity (range 0..2).
         // Convert to similarity: score = 1 - distance (range -1..1, typically 0..1 for normalized vectors).


### PR DESCRIPTION
## What this PR carried when it merged

Enhancements branch cut 2026-09-07 on top of `feat/2026-09-04-enhancements` (4ebc4822c). It merged into that base on 2026-09-07 at 16:46Z by fast-forward to **c0cd7b9fd**, with seven commits:

| Commit | Change |
|---|---|
| 05a728889 | chore: open the branch (empty) |
| d67ae14cc | fix(macos/mail): clamp the sqlite-vec `k` so hybrid search survives big pages; per-stage watchdog; `macos-mail` profiling scope |
| 474187606 | feat(chrome-devtools): `open --user-data-dir` for a persistent profile; `restart` names it as the Chrome 136 fallback |
| 5e894ae70 | feat(chrome-devtools): `attach` names the Chrome 144+ consent mode (DevToolsActivePort path, `/json` 404) instead of "port is not on" |
| bf54accce | feat(github): `merge --squash` defaults the subject to the PR title `(#N)` and the body to one bullet per commit, with `--dry-run` (PR #372) |
| 4fb21607c | feat(fable-replace): port the skill into the plugin; keep-on-red verify; pipe refusal; journal; temp hygiene; test temp-root leak fix (PR #371) |
| c0cd7b9fd | feat(handoff): recipient harness targeting, readable names, mismatch warnings and opt-in list filters (PR #373) |

## Follow-up

Work continues on the same branch. Everything that landed after c0cd7b9fd is in the follow-up PR titled "feat: 2026-09-07 enhancements, round 2".

<sub>Body updated 2026-09-07 19:30 to record the merged state; the original text said "empty at creation; work lands here from now on".</sub>
