### PR TITLE
feat(fable-replace): port the skill into the plugin, keep-on-red verify, pipe refusal, journal, temp hygiene, and the test temp-root leak fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
     "name": "genesis-tools",
-    "version": "1.0.54",
+    "version": "1.0.55",
     "description": "Plugins for GenesisTools CLI development and management",
     "owner": {
         "name": "genesiscz",
@@ -11,7 +11,7 @@
         {
             "name": "genesis-tools",
             "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
-            "version": "1.0.54",
+            "version": "1.0.55",
             "author": {
                 "name": "GenesisTools"
             },

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -29,6 +29,9 @@ preload = [
     # every sqlite-vec suite fail with "no such module: vec0" whenever another
     # test file in the same worker had opened a Database first.
     "./src/utils/search/stores/sqlite-vec-preload.ts",
+    # One temp root per test process, removed on a green exit, so fixtures that never clean
+    # up cannot fill the temp folder. Before the sandbox preload, whose home lands inside it.
+    "./src/utils/bun/preload-test-tmpdir.ts",
     "./src/utils/bun/preload-test-sandbox.ts",
     "./src/utils/bun/preload-test-keyring.ts",
     "./src/utils/bun/preload-test-process-exit.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ],
     "scripts": {
         "prepare": "git config core.hooksPath .githooks",
-        "typecheck:all": "tsgo --noEmit && tsgo -p src/claude-history-dashboard/tsconfig.json --noEmit && tsgo -p src/spotify/ui/tsconfig.json --noEmit && tsgo -p src/monitor/ui/tsconfig.json --noEmit && tsgo -p src/clarity/ui/tsconfig.json --noEmit",
+        "typecheck:all": "tsgo --noEmit && tsgo -p src/claude-history-dashboard/tsconfig.json --noEmit && tsgo -p src/spotify/ui/tsconfig.json --noEmit && tsgo -p src/monitor/ui/tsconfig.json --noEmit && tsgo -p src/clarity/ui/tsconfig.json --noEmit && tsgo -p plugins/genesis-tools/skills/fable-replace/scripts/tsconfig.json --noEmit",
         "tsgo": "tsgo --noEmit",
         "tsc": "tsgo --noEmit",
         "lint": "bun run lint:biome && bun run lint:rules",

--- a/plugins/genesis-tools/.claude-plugin/plugin.json
+++ b/plugins/genesis-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "genesis-tools",
-    "version": "1.0.54",
+    "version": "1.0.55",
     "description": "Skills and utilities for working with GenesisTools CLI toolkit. Provides guidance for discovering, executing, and troubleshooting genesis tools with integrated workflow support.",
     "author": {
         "name": "GenesisTools"

--- a/plugins/genesis-tools/skills/fable-replace/SKILL.md
+++ b/plugins/genesis-tools/skills/fable-replace/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: fable-replace
+description: Verified, transactional find/replace for code and docs. Use INSTEAD of sed, perl, python s.replace() or repeated Edit calls whenever you change text in a file: one literal edit, a rename across 50 files, an insert under a line, a new file, a comment sweep. Every op is checked (a needle must match exactly as declared), the batch is all-or-nothing with a backup, and a MISS tells you which line to re-read. Triggers on "replace", "rename everywhere", "sweep", "batch edit", "mass replace", "insert after", "fable replace", and on any edit you were about to do with a shell one-liner.
+---
+
+# fable-replace — verified editing, from a heredoc or a script
+
+## The one rule
+
+**Never edit text with `sed`, `perl -pi`, `python -c "s.replace(...)"` or a Bash heredoc that
+rewrites a whole file.** They do not verify: a needle that does not match is a silent no-op,
+a needle that matches twice edits both, and nothing tells you. Use the CLI below. It is one
+call, needs no code, and refuses to write anything unless every op matched exactly as declared.
+
+The Edit tool is fine for ONE edit in ONE file you have just read. From two edits up, the CLI
+is fewer calls and the only option that verifies.
+
+## Quick path: the CLI (use this 90% of the time)
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" <<'FRSPEC'
+@@ src/foo/widget.ts
+<<<
+const gate = getLinkGate(link);
+===
+const gate = getActionDisabledState(link);
+>>>
+<<< after
+import React from "react";
+===
+import { thing } from "pkg";
+>>>
+@@ src/foo/new-file.ts
+<<< create
+export const fresh = 1;
+>>>
+FRSPEC
+```
+
+The harness substitutes `${CLAUDE_PLUGIN_ROOT}` at load time; if you see the placeholder
+unsubstituted, build the path from the "Base directory for this skill" line printed when this
+skill loaded. Keep the quotes: an install path can contain spaces.
+
+- `@@ path` starts a file section (relative to cwd, or absolute).
+- `<<<` … `===` … `>>>` is one op: the exact current text, then the replacement. Bodies are
+  raw lines; there is NO escaping, which is why a quoted heredoc is the right carrier. Only a
+  line that is exactly `===` or `>>>` is special inside a block.
+- ⚠️ Pick a heredoc delimiter that cannot appear in the bodies (`FRSPEC`, not `EOF`): a body
+  line equal to the delimiter ends the heredoc early and zsh rejects the whole command.
+- Bodies are literal, line for line. An empty last line in an `after`/`before`/`append` body
+  is a real blank line in the file (the usual "insert this block, then a gap"). A multi-line
+  anchor for `after` inserts below the anchor's LAST line; `before` inserts above its FIRST.
+- Compose big specs programmatically when the replacement text already exists somewhere:
+  `{ echo '@@ f.ts'; echo '<<< after'; echo 'anchor'; echo '==='; git show ref:f.ts | sed -n '10,40p'; echo '>>>'; } | bun cli.ts`
+  keeps placement and verification in the tool while the text comes from the source of truth.
+- Default contract: the needle occurs **exactly once**. Twice is a MISS (ambiguous), zero is a
+  MISS (stale). Modifiers on the `<<<` line change it:
+
+| marker | meaning |
+|---|---|
+| `<<<` | literal replace, exactly once |
+| `<<< count=all` / `count=3` | every occurrence / exactly three |
+| `<<< optional` | SKIP instead of MISS when absent; use for re-runnable specs |
+| `<<< label=free text` | name shown in the report (rest of the line, so put it LAST; a modifier written after it is a spec error, and `label="…"` keeps a word like `regex` as text) |
+| `<<< regex flags=gi count=2` | body 1 is a JS regex source, body 2 may use `$1`; `count` pins the match count |
+| `<<< fuzzy` | whitespace-insensitive literal |
+| `<<< after` (anchor `===` lines) | insert whole lines after the line holding the unique anchor |
+| `<<< before` (anchor `===` lines) | same, before it |
+| `<<< append` (lines) | append at end of file |
+| `<<< delete` (lines) | remove these lines, newline included |
+| `<<< block` (from `===` to `===` replacement) | replace the region between two anchors; empty replacement deletes it |
+| `<<< create` (content) | create a new file; refuses to overwrite an existing one |
+
+Per-file post-conditions go between `@@` and the first op: `expect: text` (must be present
+afterwards), `absent: text` (must be gone). Both repeatable. `# comments` and blank lines are
+allowed outside blocks.
+
+`block` is the only op with THREE bodies: the from-anchor, the to-anchor, then what replaces
+the whole region. Leave the third body empty to delete it.
+
+```
+@@ src/foo/widget.ts
+<<< block label=drop the legacy branch
+// ── Legacy parity ──
+===
+// ── end legacy ──
+===
+>>>
+```
+
+The region includes both anchors. ⚠️ An EMPTY third body is one empty line, not nothing, so
+the five lines above collapse to a single blank line rather than vanishing. That is usually
+what you want between two declarations; when it is not, put the following line in the third
+body instead, or use `delete`. `block` is no more markdown-aware than `append` is, so read
+the `--dry --diff` output before the real run.
+
+Flags: `--dry` (preview diffs, write nothing), `--diff` (show diffs on a real run too),
+`--verify "bun run test src/x.test.ts"` (runs after writing, captured and trimmed: a pass shows
+its last 5 lines, a fail shows the first 40 and last 60 and saves the whole output as
+`verify-output.txt` in the backup dir; a red check NEVER rolls the sweep back, see exit 3 below;
+a `|`, a `;` chain or a background `&` outside quotes is refused before anything is written;
+⚠️ in a scratch tree `bunx tsgo --noEmit` reports `Cannot find module 'bun:test'` on perfectly
+correct code, because the copy has no bun-types or tsconfig: scope tsgo to the non-test files,
+or verify with a `bun -e 'import("./x.ts")'` smoke import instead),
+`--cwd <dir>`, `--partial`, `--quiet`, `--spec <file>` (the spec from a file instead of stdin:
+use it whenever a heredoc is refused by a sandbox hook or gets long), `--rollback <backupDir>
+[--force]` (undo the sweep whose backup dir a run printed), `--api [query]`, `--help`.
+
+Exit 0: everything landed, or the dry run is clean. Exit 1: at least one MISS (**nothing was
+written**, also on `--dry`; a `--partial` run with misses is 1 too). Exit 2: malformed spec,
+unknown flag, missing file, `--dry` together with `--verify`. **Exit 3: the sweep IS written**,
+and something after the write is unhappy: the verify failed (or could not be measured: a
+timeout, a signal), or `leftoversCheck` found stale prose. An unknown or misspelled flag is an
+error, so `--dyr` can never turn a preview into a real write.
+
+After `SWEEP WRITTEN, VERIFY FAILED`: the files hold the sweep, so do NOT re-send the spec (it
+would MISS: the needles are gone). Read the head and tail it printed, send a SMALL follow-up
+spec for the fix, and run the check again. To undo everything instead, run the exact
+`--rollback <dir>` line it printed.
+
+Rules that the spec format does not say out loud:
+
+- **`before` and `after` keep the anchor line.** Never repeat it inside the body; the report
+  flags a body that starts or ends with the anchor line, because it would appear twice.
+- **A body line that must be exactly `===` or `>>>` is written `\===` or `\>>>`.** A bare
+  `>>>` closes the block early; a bare `===` starts an extra body (the error names its line).
+  For content full of such lines, use the JSON form: a top-level array of FileEdit objects.
+- **Ops apply in order, each sees the previous op's output.** Converting call sites AND the
+  declaration in one spec: put the declaration edit last, or write a regex that cannot match
+  the already converted line, or the syntax check will stop you with a parse error.
+- **Regex replacements follow JavaScript rules:** `$1` is a group, `$&` the whole match, `$$`
+  a literal dollar. A literal `$` in the replacement body must be `$$`.
+- **`fuzzy` forgives whitespace on the FIND side only.** The replacement lands exactly as
+  typed, indentation and line endings included.
+- **Build spec text with `printf '%s\n'`, never `echo`,** when a shell loop writes it: zsh's
+  `echo` turns `\b` into a backspace byte, and the parser now refuses control characters
+  with that hint instead of reporting "regex matched nothing" 62 times.
+- **`append` is not markdown-aware:** it adds no separating blank line. End the previous
+  content with a blank line in the body when the file needs one.
+
+### Reading a MISS
+
+Every MISS says why, and where to look. The hints, in order of what the runner tries:
+
+- *the REPLACEMENT is already in the file* — the edit was applied before. Re-running is not an
+  error in itself; add `optional` if the spec must be re-runnable.
+- *matches when ALL whitespace is ignored (first at line N)* — indentation, tabs or a line
+  break differ. Re-read line N and paste the exact text, or use `fuzzy`.
+  ⚠️ A literal needle is a SUBSTRING match, so this fires only when your needle carries MORE
+  whitespace than the file. A needle with LESS leading indentation than the file line still
+  matches silently, and the file's own indentation survives, because only the matched span is
+  replaced. So "it matched" does not prove you copied the line exactly.
+- *matches when case AND whitespace are ignored (line N)* — a letter-case typo in the needle.
+- *matches after Unicode normalization (line N)* — the file and the needle spell an accented
+  word with different code points (NFC vs NFD). Copy the text from the file, or use `fuzzy`.
+- *anchor occurs N× but never at the start of a line* — an indented `after`/`before` anchor
+  carries its indentation on purpose; copy the leading whitespace exactly.
+  An anchor that does NOT start with whitespace is matched anywhere in the line, mid-line
+  included; it must still be unique, and the insert lands on its own line above or below.
+- *"from" anchor occurs N× (lines …)* — a `block` needs a unique start; add context.
+- *first line found at line N, text diverges at line M: file has "…", needle has "…"* — your
+  copy of the file is stale from line M on.
+- *expected exactly 1 occurrence(s), found 3 at line(s) 12, 40, 77* — add surrounding
+  context, or say `count=3` when all three are meant.
+- *no line of the file contains the needle's first line* — wrong file, or the text is gone.
+
+A MISS is not a failure of the tool. It is the tool telling you your model of the file is
+wrong, before anything was written. Re-read, fix the op, re-run.
+
+## When you need a script instead
+
+Use the TypeScript API when the CLI cannot express it: recon (find the files first, count the
+occurrences), a rename across many files with a pinned count per file, comment sweeps, a
+replacer FUNCTION, file delete/rename in the same transaction.
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" --api     # every function + params + docs
+```
+
+Every function with more than two inputs takes ONE object, so `--api` shows every field and
+its doc next to the signature (`--api rename` narrows it). Contract of the script API:
+
+- **`run()` throws a `FableReplaceError`** (its `code` is the exit code: 1 misses or a
+  partial write; 2 pre-flight; 3 written but the verify failed or stale prose survived, with
+  the captured verdict in `err.report.verify`) instead of exiting your process. Catch it if
+  you want to continue; an uncaught one still ends the script non-zero. `throwOnFailure: false`
+  restores the exit behaviour.
+- **A red `verifyCommand` keeps the files written**, exactly like the CLI. A script with no
+  model in the loop that wants the old atomic behaviour writes it in three lines:
+  `catch (err) { rollback({ backupDir }); throw err; }`. `rollback` is exported.
+- **Unknown option keys are a pre-flight error** with a "did you mean" hint: `dry: true` is
+  not `dryRun: true`, and used to be a silent real write.
+- **`partial: true` still fails when anything missed:** the clean files are written, then the
+  error is thrown. `report.ok` is false.
+- **The thrown error carries the report:** `err.report` is the same `RunReport` a green run
+  returns, so a catch reads `err.report.written` / `.missCount` / `.files` instead of parsing
+  the message. A pre-flight refusal (code 2) happens before any file is planned, so there
+  `err.report` is undefined.
+- **`findFiles` needs `containing`:** it is the content filter, not an option. Omitting it
+  throws rather than returning `[]`, which used to read as "no file holds the symbol".
+- **`renameSymbolAcross` refuses a file that both imports and declares the symbol** (a local
+  wrapper) unless `includeShadowed: true`; `countMatches` prints the same split, and
+  `shadowedFiles({ files, name })` returns it.
+- **`findFiles` roots may be plain files** (`README.md`, `CLAUDE.md`) as well as directories.
+- **`insertAfter` is same-line and verbatim** (add your own space or newline);
+  `insertLinesAfter` inserts whole lines under the anchor's line.
+
+The shapes you will use most:
+
+```ts
+import { countMatches, findFiles, leftovers, renameSymbolAcross, run, scratchDir } from "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/replace-utils";
+
+const files = findFiles({ roots: ["src"], containing: /\boldName\b/ });
+const counts = countMatches({ files, pattern: "oldName" }); // per-file numbers, zero-match and shadowing warnings
+
+await run({
+  edits: [
+    { file: "src/a.ts", ops: [{ find: "old", replace: "new" }], absentAfter: ["old"] },
+    ...renameSymbolAcross({ files: counts, oldName: "oldName", newName: "newName" }), // counts pinned per file
+  ],
+  backupDir: scratchDir("rename-oldName"),
+  verifyCommand: "bunx tsgo --noEmit",
+  leftoversCheck: { names: ["oldName"], dirs: ["."] },
+});
+```
+
+`scripts/example.ts` is a fuller template. `--dry` on argv previews. The modules, if you need
+to read one: `types.ts` (every shape), `edit-one-file.ts` (ops), `comments.ts` (comment and
+line sweeps), `rename-symbols.ts`, `recon.ts`, `sweep-many-files.ts` (the runner),
+`backup-and-rollback.ts`, `spec.ts` (the CLI format). `replace-utils.ts` re-exports all.
+
+## Recon before a sweep
+
+Ops are literal. Copy the text verbatim from the file, indentation included; a MISS means your
+mental model of the file is stale, which is the point. Traps that each cost a wasted round:
+
+- **Match the thing, not the statement shape.** Hunting import specifiers with a pattern
+  anchored on `import … from` misses multi-line imports, `export … from` barrels, dynamic
+  `import("…")` and type-only positions. Match the quoted specifier itself.
+- **One grep shape is never the whole picture.** The same module is imported as
+  `"@pkg/format"`, `"@pkg/format.ts"` and `"./format"` in one repo.
+- 🛑 **Never pipe recon through `head`/`tail` on its way to a file.** `head` exits early,
+  SIGPIPE kills `tee` and `rg`, and the file is truncated. A trial captured 109 of 411 matches
+  this way. Redirect to the file first, then read it.
+- 🛑 **`--type tsx` is not a ripgrep type.** `rg -l foo --type ts --type tsx` matches nothing
+  and exits 0. Use `-g '*.ts' -g '*.tsx'`. Treat any surprisingly empty recon as broken
+  instrumentation, not an answer.
+- 🛑 **Never count with `rg --heading … | wc -l`.** Heading mode adds a filename line and a
+  blank per file. Use `countMatches`, or `rg -o … | wc -l`.
+- **`countMatches` prints the `expect:` numbers** and warns about zero-match files (a
+  guaranteed MISS) and files that DECLARE a symbol of the same name (renaming those changes an
+  unrelated helper). Do not transcribe counts by hand.
+
+## 🛑 Every op OK does not mean the sweep is complete
+
+The report only proves the ops you DECLARED matched. It cannot know about a call site your
+recon never found. A 50-file rename once reported zero MISS and was still broken. So:
+
+- **Put the project's own check in `--verify` / `verifyCommand`** on every real sweep. A red
+  check keeps the sweep written, exits 3 and prints the undo command; fix forward with a small
+  follow-up spec. Write the BARE command: a `|`, a `;` chain or a background `&` outside quotes
+  is refused in pre-flight (exit 2, nothing written), because both `/bin/sh` and `pipefail` lie
+  about a pipeline's exit code, and the CLI trims the output itself. `&&`, `||` and redirects
+  are fine; `2>/dev/null` only warns. The escape hatch names the risk in the command:
+  `--verify "bash -c 'set -o pipefail; bun run test | tail -3'"`. A pipe inside `$( )` is
+  refused too: the check is a quote scanner, not a shell parser. The same rule applies to a
+  check you run AFTER the CLI: never `cli.ts … ; bun run test | tail -3` in one Bash call,
+  because the `;` and the pipe hide the test's exit code from you as well.
+- **A green check does not mean the sweep was RIGHT.** A blanket rename across 71 files
+  typechecked while renaming three unrelated local helpers that shared the name. Read the diff
+  (`--dry` first, `--diff` on the real run).
+- **`expectAfter` / `expect:` and `absentAfter` / `absent:` are plain substring checks**, not
+  word-boundary matches. They cannot see structure; a dropped brace passes them. That is what
+  the built-in syntax check is for: every edited `.ts/.tsx/.js/.jsx` is parsed after the ops,
+  and a file that stopped parsing fails the batch with the line number.
+- **A rename is not finished when the code is green.** Sweep README, CLAUDE.md, docs and plans
+  that name the symbol. `leftoversCheck` (script) fails the run when the old name survives in
+  prose while leaving the verified code written; `leftovers({ names, dirs })` is the manual form.
+
+## Renames: the two forks
+
+- **Renaming a PUBLIC API:** the `export { old }` barrel line is in scope, rename it and its
+  consumers, the old name should disappear.
+- **Renaming an INTERNAL helper that a barrel still publishes as `old`:** alias on the way in
+  (`import { newName as old }`), keep `export { old }` exactly, leave the barrel's consumers
+  untouched. A blanket regex rename silently breaks this contract.
+
+The two look identical in a grep and want opposite edits. Grep for `export {` before any
+blanket rename, and say in the sweep which fork you chose. If the brief does not say, ask.
+
+Several symbols in overlapping file sets: build one file list per symbol from `countMatches`
+(a listed file that lacks the symbol is a MISS), and wrap the batch in `mergeFileEdits` so a
+shared file is not "listed twice". `sameOpsAcross` carries ONE op list and therefore ONE
+`expect`; the moment per-file counts differ, build the edits from the counts map instead.
+
+## Guards that fire before anything is written
+
+- `node_modules` paths are refused (`allowNodeModules` overrides).
+- Generated files are refused: `*.gen.ts`, `dist/`, `build/`, or a header comment saying
+  `@generated` / `DO NOT EDIT` (only a real comment counts; a module that EMITS such text is
+  not itself generated). Fix the generator. `allowGenerated: true` per file overrides.
+- Syntax check on every edited script, with the line that broke.
+- `renameTo` refuses an existing target, a target claimed twice, or a target also edited.
+- A reused `backupDir` is refused (the CLI always makes a fresh one).
+- Two sweeps racing into ONE `backupDir` are refused: the manifest is created exclusively, so
+  the loser aborts before writing instead of overwriting the winner's manifest and silently
+  losing its own undo.
+- A file that is not valid UTF-8 is refused. The whole file is read as text and written back,
+  so one stray cp1252 byte would silently become U+FFFD far from your edit.
+- A file that changed on disk between the read and the write is refused and the batch rolls
+  back: the ops were computed against a snapshot, and writing anyway erases whoever wrote in
+  between while still reporting OK.
+- A file listed twice in one batch is refused; merge the ops.
+
+## Rollback
+
+`backupDir` (the CLI prints it) holds the originals plus a manifest with a hash of what was
+written. Undo from the shell:
+
+```bash
+bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" --rollback /var/folders/…/fable-replace-cli-1234-AbCdEf
+```
+
+or `rollback({ backupDir })` in a script. Both restore byte-for-byte and SKIP any file that
+changed after the sweep wrote it, reporting it as drifted; `--force` / `force: true` restores
+those too. A file that is already back at its original content is reported as such, not as
+drift. Stacked sweeps unwind newest-first or refuse. `backupOverwrite: true` is a one-way
+door: the original content in the old snapshot becomes unrecoverable. 🛑 Never
+`git checkout --` as the undo; it destroys uncommitted work.
+
+A restore that the filesystem itself blocks (a file some later command chmod'd read-only, a
+full disk) never stops the others: each entry is restored inside its own guard, the survivors
+come back, and the blocked ones land in `report.failed` plus the thrown error's message. Those
+files still hold the SWEPT content, so fix the cause and re-run the rollback; the backup is
+intact.
+
+## Recipe: positional arguments to one object
+
+```
+<<< regex count=6 label=call sites first, declaration last
+(?<!function )describeMail\(\s*([^,]+?)\s*,\s*([^,]+?)\s*,\s*([^)]+?)\s*\)
+===
+describeMail({ subject: $1, sender: $2, mailbox: $3 })
+>>>
+<<<
+function describeMail(subject: string, sender: string, mailbox: string): string {
+===
+function describeMail({ subject, sender, mailbox }: { subject: string; sender: string; mailbox: string }): string {
+>>>
+```
+
+`\s*,\s*` survives a call that wraps its arguments over several lines; a literal `, ` does
+not. `count=6` was measured first (`countMatches`, or a deliberately wrong count whose MISS
+reports the real number and the lines).
+
+🛑 **The lookbehind is not optional.** A three-parameter DECLARATION has the same comma and
+paren shape as a three-argument CALL, so the call-site regex matches the declaration too and
+the count comes out one too high. Reordering the ops does not help: the already-destructured
+declaration still matches the same naive pattern. If your count is exactly one above what
+`countMatches` reported, this is why. Keep `(?<!function )`, and add the declaration's own
+prefix (`(?<!const )`, a method name) when it is not a plain `function`. Never "fix" the
+mismatch by raising `count`: that rewrites the declaration with the call-site template and
+produces garbage.
+
+## Comment sweeps (script only)
+
+`dropComments` (`containing` or `matching`): the COMMENT goes, code on the same line stays;
+string, template and regex aware, and it knows the JSX tag shapes `</Foo>` and `<Foo />`. It
+does not model JSX TEXT: a comment-shaped run inside rendered text (`<p>/* note */</p>`, a
+URL in a paragraph) counts as a comment, so on .tsx files keep the predicate narrow and read
+`--dry --diff`. `deleteLines`: the WHOLE line goes. For
+`}, [onConfirm]); // eslint-disable-line` the first keeps the statement, the second deletes it.
+Both refuse to run without a predicate.
+
+## Housekeeping
+
+- 🛑 `/tmp` is shared machine-wide. Two agents sweeping in parallel overwrote each other's
+  log at `/tmp/sweep-dry.log`. The CLI uses `scratchDir()`; scripts must too. Every scratch
+  and backup dir lives under `<tmp>/fable-replace/`, and every CLI run prunes that root:
+  age-only (older than 12 h), manifest-gated (only a dir this tool created and finished, or
+  an empty one), at most 50 per run, never the current run's dir. `--prune` runs it now. A
+  reboot empties the temp folder anyway; the prune matters on machines that stay up for weeks.
+- One spec or script per logical sweep, so the report maps to one reviewable change.
+- Every real CLI run, rollback and prune is journaled to `~/.genesis-tools/fable-replace/journal.jsonl`
+  (a `--dry` run writes nothing at all, not even the journal, and never prunes)
+  (`GENESIS_TOOLS_HOME` or `FABLE_REPLACE_HOME` move it). The spec text is never stored there,
+  only its size and hash; the text goes to `<backupDir>/spec.frspec`. `--history [N]` lists the
+  last runs with outcome, tokens and backup dir; `--stats [days]` sums outcomes, tokens written
+  and read back, the tokens wasted on failed runs (no dollar figure: multiply by your model's
+  output rate), and the top MISS reasons.
+- Literal ops match RAW BYTES: a find that spans a string-concatenation boundary in the source
+  can never match. Split it per line.
+- `bun scripts/selftest.ts` after touching anything under `scripts/`; it must end with
+  `ALL SELFTESTS PASSED`. It pins every op kind, the spec parser, the CLI end to end, the
+  transaction, every guard and the rollback contract.

--- a/plugins/genesis-tools/skills/fable-replace/scripts/api.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/api.ts
@@ -1,0 +1,176 @@
+/**
+ * fable-replace — PRINT THE TYPED API. `bun cli.ts --api` dumps every exported
+ * function signature, interface and type alias together with its JSDoc, straight
+ * from the source, so an agent gets the full parameter types without reading the
+ * modules. Nothing here is hand-maintained; if it is exported, it is listed.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const MODULES = [
+    "types.ts",
+    "spec.ts",
+    "sweep-many-files.ts",
+    "edit-one-file.ts",
+    "comments.ts",
+    "rename-symbols.ts",
+    "recon.ts",
+    "backup-and-rollback.ts",
+    "verify-command.ts",
+];
+
+interface ApiEntry {
+    module: string;
+    name: string;
+    doc: string;
+    signature: string;
+}
+
+/** Text of the JSDoc block that ends right above `lineIdx`, or "". */
+const docAbove = (lines: string[], lineIdx: number): string => {
+    let j = lineIdx - 1;
+    if (j < 0 || !lines[j].trim().endsWith("*/")) {
+        return "";
+    }
+    const end = j;
+    while (j >= 0 && !lines[j].trim().startsWith("/**")) {
+        j -= 1;
+    }
+    if (j < 0) {
+        return "";
+    }
+    return lines
+        .slice(j, end + 1)
+        .map((l) =>
+            l
+                .trim()
+                .replace(/^\/\*\*\s?/, "")
+                .replace(/^\*\/?\s?/, "")
+                .replace(/\*\/$/, "")
+        )
+        .join("\n")
+        .trim();
+};
+
+/**
+ * Text from `start` up to the line where the depth opened by `open` on that line
+ * returns to zero, plus the character offset of that closing bracket. Nothing past
+ * it: a function BODY is not part of its signature.
+ */
+const balancedSpan = ({
+    lines,
+    start,
+    open,
+    close,
+}: {
+    lines: string[];
+    start: number;
+    open: string;
+    close: string;
+}): { text: string; closeAt: number } => {
+    let depth = 0;
+    let seen = false;
+    let offset = 0;
+    for (let i = start; i < lines.length; i += 1) {
+        const line = lines[i];
+        for (let c = 0; c < line.length; c += 1) {
+            const ch = line[c];
+            if (ch === open) {
+                depth += 1;
+                seen = true;
+            } else if (ch === close) {
+                depth -= 1;
+                if (seen && depth === 0) {
+                    return { text: lines.slice(start, i + 1).join("\n"), closeAt: offset + c };
+                }
+            }
+        }
+        offset += line.length + 1;
+    }
+    return { text: lines[start], closeAt: lines[start].length };
+};
+
+/** `export const name = (params): Return => …` reduced to `name = (params): Return`. */
+const arrowSignature = ({ lines, start }: { lines: string[]; start: number }): string => {
+    const span = balancedSpan({ lines, start, open: "(", close: ")" });
+    const arrow = span.text.indexOf("=>", span.closeAt);
+    const head = arrow === -1 ? span.text : span.text.slice(0, arrow).trimEnd();
+    return head.replace(/^export const /, "");
+};
+
+const declarationSignature = ({ lines, start }: { lines: string[]; start: number }): string => {
+    const first = lines[start];
+    if (first.includes("{")) {
+        return balancedSpan({ lines, start, open: "{", close: "}" }).text.replace(/^export /, "");
+    }
+    // `type X = A | B;` possibly continued on following lines until the terminating `;`
+    const out: string[] = [];
+    for (let i = start; i < lines.length; i += 1) {
+        out.push(lines[i]);
+        if (lines[i].trimEnd().endsWith(";")) {
+            break;
+        }
+    }
+    return out.join("\n").replace(/^export /, "");
+};
+
+export const collectApi = (dir: string): ApiEntry[] => {
+    const entries: ApiEntry[] = [];
+    for (const module of MODULES) {
+        const file = path.join(dir, module);
+        if (!fs.existsSync(file)) {
+            continue;
+        }
+        const lines = fs.readFileSync(file, "utf8").split("\n");
+        for (let i = 0; i < lines.length; i += 1) {
+            const l = lines[i];
+            const fn = l.match(/^export const (\w+) = (?:async )?\(/);
+            const decl = l.match(/^export (interface|type|class) (\w+)/);
+            if (fn !== null) {
+                entries.push({
+                    module,
+                    name: fn[1],
+                    doc: docAbove(lines, i),
+                    signature: arrowSignature({ lines, start: i }),
+                });
+            } else if (decl !== null) {
+                entries.push({
+                    module,
+                    name: decl[2],
+                    doc: docAbove(lines, i),
+                    signature: declarationSignature({ lines, start: i }),
+                });
+            }
+        }
+    }
+    return entries;
+};
+
+/** Print the API, optionally only the entries whose name or module contains `query` (case-insensitive). */
+export const printApi = ({ dir, query }: { dir: string; query?: string }): void => {
+    const q = query?.toLowerCase();
+    const entries = collectApi(dir).filter(
+        (e) => q === undefined || e.name.toLowerCase().includes(q) || e.module.toLowerCase().includes(q)
+    );
+    console.log(
+        `fable-replace API — ${entries.length} entr${entries.length === 1 ? "y" : "ies"}${q === undefined ? " (narrow with --api <query>)" : ` matching "${query}"`}`
+    );
+    // The "## module" headings below name the file that DEFINES a symbol. That is not the
+    // import path: everything is re-exported from the barrel, so a script written from this
+    // dump imports one specifier and never has to track which module moved.
+    console.log(
+        `import { … } from "${path.join(dir, "replace-utils")}";  // every symbol below; ## headings name the defining file, not the import path`
+    );
+    let lastModule = "";
+    for (const entry of entries) {
+        if (entry.module !== lastModule) {
+            console.log(`\n## ${entry.module}\n`);
+            lastModule = entry.module;
+        }
+        if (entry.doc.length > 0) {
+            console.log(`/** ${entry.doc.replace(/\n/g, "\n    ")} */`);
+        }
+        console.log(`${entry.signature}\n`);
+    }
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/backup-and-rollback.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/backup-and-rollback.ts
@@ -1,0 +1,370 @@
+/**
+ * fable-replace — BACKUP AND ROLLBACK. The undo story.
+ *
+ * `backupDir` snapshots every file the sweep is about to touch, plus a manifest,
+ * BEFORE anything is written. After the write phase the manifest also records a
+ * hash of what the sweep produced.
+ *
+ * `rollback(dir)` restores byte-for-byte — but SKIPS any file whose content changed
+ * after the sweep wrote it (a hand edit, a formatter, a later sweep) and reports it
+ * as drifted, because restoring it would destroy work the snapshot never saw. Pass
+ * `force: true` to restore those too. A side effect worth knowing: stacked
+ * sweeps therefore refuse to unwind out of order.
+ *
+ * Never point two sweeps at one backupDir — the second overwrites the first
+ * snapshot. The runner refuses this in pre-flight.
+ */
+
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { FableReplaceError } from "./internal";
+import { parseJson, stringifyJson } from "./json";
+import type { PruneParams, PruneReport, RollbackParams, RollbackReport, WriteBackupParams } from "./types";
+
+interface BackupManifestEntry {
+    /** Absolute original path. */
+    original: string;
+    /** File name inside the backup dir, or null when the file did not exist (created/renamed targets). */
+    stored: string | null;
+    /**
+     * sha256 of what the sweep WROTE to `original`, filled in after the write phase
+     * (null when the sweep deleted the file). `rollback()` compares against it, so an
+     * edit made by hand after the sweep is never silently overwritten.
+     */
+    hashAfter?: string | null;
+}
+
+const MANIFEST_NAME = "fable-replace-manifest.json";
+
+const hashOf = (file: string): string | null => {
+    if (!fs.existsSync(file)) {
+        return null;
+    }
+    return createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+};
+
+/** Is `dir` already holding a manifest from an earlier sweep? */
+export const backupDirInUse = (dir: string): string | null => {
+    const manifestPath = path.join(dir, MANIFEST_NAME);
+    if (!fs.existsSync(manifestPath)) {
+        return null;
+    }
+    try {
+        return (
+            (parseJson(fs.readFileSync(manifestPath, "utf8")) as { createdAt?: string }).createdAt ?? "an earlier run"
+        );
+    } catch {
+        return "an unreadable earlier manifest";
+    }
+};
+
+export const writeBackup = ({ dir, files, overwrite = false }: WriteBackupParams): void => {
+    fs.mkdirSync(dir, { recursive: true });
+    const manifestPath = path.join(dir, MANIFEST_NAME);
+    const createdAt = new Date().toISOString();
+    // Reserve the dir BEFORE any byte is copied. The stored names are deterministic
+    // (0000-<name>), so a second writer that copied first would overwrite the first
+    // snapshot's originals and only then fail on the manifest. "wx" fails when the manifest
+    // already exists, and the pre-flight `backupDirInUse` check cannot cover two sweeps
+    // racing past it. The loser fails loudly here, with the winner's snapshot intact.
+    try {
+        fs.writeFileSync(manifestPath, stringifyJson({ createdAt, entries: [] }, 2), { flag: overwrite ? "w" : "wx" });
+    } catch (err) {
+        throw new FableReplaceError(
+            `backup dir ${dir} gained a manifest while this sweep was starting: another sweep is using it. Give this run its own backupDir (scratchDir("my-sweep")). Nothing was written. (${String(err)})`,
+            2
+        );
+    }
+
+    const entries: BackupManifestEntry[] = [];
+    let i = 0;
+    for (const file of files) {
+        if (fs.existsSync(file)) {
+            const stored = `${String(i).padStart(4, "0")}-${path.basename(file)}`;
+            fs.copyFileSync(file, path.join(dir, stored));
+            entries.push({ original: file, stored });
+        } else {
+            entries.push({ original: file, stored: null });
+        }
+        i += 1;
+    }
+    fs.writeFileSync(manifestPath, stringifyJson({ createdAt, entries }, 2));
+};
+
+/**
+ * Record what the sweep actually wrote, so `rollback()` can detect a file that
+ * changed again afterwards. Called once, after the write phase succeeds.
+ */
+export const recordPostWriteHashes = (dir: string): void => {
+    const manifestPath = path.join(dir, MANIFEST_NAME);
+    if (!fs.existsSync(manifestPath)) {
+        return;
+    }
+    const manifest = parseJson(fs.readFileSync(manifestPath, "utf8")) as {
+        createdAt: string;
+        entries: BackupManifestEntry[];
+    };
+    for (const entry of manifest.entries) {
+        try {
+            entry.hashAfter = hashOf(entry.original);
+        } catch (err) {
+            // A verify command may have turned the path into a directory or made it
+            // unreadable. Without a hash the rollback restores it with no drift check, the
+            // right default for a path this run can no longer describe.
+            entry.hashAfter = undefined;
+            console.error(
+                `⚠ could not hash ${entry.original} after the write (${String(err)}); its rollback skips the drift check`
+            );
+        }
+    }
+    fs.writeFileSync(manifestPath, stringifyJson(manifest, 2));
+};
+
+/**
+ * Restore every file recorded in a backup dir's manifest byte-for-byte.
+ * Files that did not exist at backup time are deleted if they exist now.
+ *
+ * A file that changed AFTER the sweep wrote it (someone edited it by hand, a
+ * formatter ran, a later sweep touched it) is reported as drifted and SKIPPED —
+ * restoring it would destroy work the backup never saw. Pass `force: true`
+ * to restore those too.
+ */
+export const rollback = ({ backupDir, force = false, only }: RollbackParams): RollbackReport => {
+    const manifestPath = path.join(backupDir, MANIFEST_NAME);
+    if (!fs.existsSync(manifestPath)) {
+        throw new Error(`No ${MANIFEST_NAME} in ${backupDir} — not a fable-replace backup dir`);
+    }
+    const manifest = parseJson(fs.readFileSync(manifestPath, "utf8")) as { entries: BackupManifestEntry[] };
+    const report: RollbackReport = { restored: [], drifted: [], failed: [] };
+    const wanted = only === undefined ? null : new Set(only.map((file) => path.resolve(file)));
+    for (const entry of manifest.entries) {
+        if (wanted !== null && !wanted.has(path.resolve(entry.original))) {
+            continue;
+        }
+
+        // Every entry is inspected AND restored inside its OWN guard. The obstruction that
+        // broke the sweep (a read-only file, a full disk) usually blocks the restore of the
+        // SAME file, and an uncaught throw here used to abandon every LATER entry with the
+        // rejected sweep content still live, under an exit code that read as a routine
+        // failure. The drift check reads the file too: a path that became unreadable, or a
+        // directory, threw before the guard and stranded the rest the same way.
+        try {
+            if (
+                entry.hashAfter !== undefined &&
+                force &&
+                fs.existsSync(entry.original) &&
+                hashOf(entry.original) !== entry.hashAfter
+            ) {
+                // `force` still overwrites, but never silently. The content here is neither what
+                // the sweep wrote nor the snapshot, so this file is not simply "drifted": a
+                // hand-edited manifest pointing somewhere else looks exactly the same, and the
+                // tool's own drift message invites the user to run `--force` next.
+                console.error(`⚠ FORCING over content this sweep never wrote: ${entry.original}`);
+            }
+
+            if (entry.hashAfter !== undefined && !force) {
+                const now = hashOf(entry.original);
+                if (now !== entry.hashAfter) {
+                    // Already back at the snapshot (a previous rollback, or a hand revert) is
+                    // not drift: nothing would be lost by restoring, and nothing needs doing.
+                    const original = entry.stored === null ? null : hashOf(path.join(backupDir, entry.stored));
+                    if (now === original) {
+                        console.log(`· already at its original content: ${entry.original}`);
+                        report.restored.push(entry.original);
+                        continue;
+                    }
+                    report.drifted.push(entry.original);
+                    console.log(`⚠ SKIPPED, changed since the sweep: ${entry.original}`);
+                    continue;
+                }
+            }
+
+            if (entry.stored === null) {
+                if (fs.existsSync(entry.original)) {
+                    fs.rmSync(entry.original);
+                    console.log(`↩ deleted (did not exist at backup time): ${entry.original}`);
+                }
+            } else {
+                const stored = path.join(backupDir, entry.stored);
+                if (fs.existsSync(entry.original) && hashOf(entry.original) === hashOf(stored)) {
+                    // Byte-identical already: copying would only bump the mtime and wake
+                    // every file watcher and incremental build cache for nothing.
+                    console.log(`· already at its original content: ${entry.original}`);
+                    report.restored.push(entry.original);
+                    continue;
+                }
+
+                fs.mkdirSync(path.dirname(entry.original), { recursive: true });
+                fs.copyFileSync(stored, entry.original);
+                console.log(`↩ restored: ${entry.original}`);
+            }
+        } catch (err) {
+            report.failed.push({ file: entry.original, error: String(err) });
+            console.error(`✗ COULD NOT RESTORE, still holds the swept content: ${entry.original} — ${String(err)}`);
+            continue;
+        }
+
+        report.restored.push(entry.original);
+    }
+    console.log(
+        `Rollback complete: ${report.restored.length} restored, ${report.drifted.length} skipped as changed, ${report.failed.length} FAILED, from ${backupDir}`
+    );
+    if (report.drifted.length > 0) {
+        console.log(
+            `  re-run with rollback({ backupDir, force: true }) to overwrite the ${report.drifted.length} changed file(s) too.`
+        );
+    }
+    if (report.failed.length > 0) {
+        console.error(`🛑 ${report.failed.length} file(s) still hold the swept content and could NOT be restored:`);
+        for (const f of report.failed) {
+            console.error(`   ${f.file}`);
+        }
+        console.error(
+            `   Fix the cause (permissions, disk space), then re-run the rollback: the backup at ${backupDir} is intact.`
+        );
+    }
+    return report;
+};
+
+/** One root for every scratch and backup dir, so a listing and a prune stay cheap and scoped. */
+export const scratchRoot = (): string => path.join(os.tmpdir(), "fable-replace");
+
+/**
+ * A collision-proof scratch directory under `<tmp>/fable-replace/`.
+ *
+ * /tmp is shared machine-wide. Two agents running similar sweeps in parallel both
+ * reached for `/tmp/sweep-dry.log` and one silently overwrote the other's evidence,
+ * so a log read back from disk described a different sweep entirely. Never hard-code
+ * a generic /tmp path for a backupDir or a log.
+ */
+export const scratchDir = (label: string): string => {
+    const root = scratchRoot();
+    fs.mkdirSync(root, { recursive: true });
+    // mkdtemp, not a timestamp: two calls in the same millisecond must not collide.
+    return fs.mkdtempSync(path.join(root, `${label}-${process.pid}-`));
+};
+
+/** Longer than any session's need for its undo trail, shorter than a typical uptime, so it fires. */
+export const PRUNE_TTL_MS = 12 * 60 * 60 * 1000;
+const PRUNE_MAX_REMOVALS = 50;
+/** The layout before the single root: dirs directly under the temp dir, swept by the same gate. */
+const LEGACY_PREFIX = "fable-replace-";
+
+/**
+ * Only a dir this tool created AND finished writing (it holds the manifest), or an empty
+ * one. A name pattern could match someone else's dir; a manifest cannot. That is also
+ * what protects scratch dirs without one, such as a selftest's own.
+ */
+const isPrunable = (dir: string): boolean => {
+    try {
+        const entries = fs.readdirSync(dir);
+        return entries.length === 0 || entries.includes(MANIFEST_NAME);
+    } catch {
+        // Vanished between the listing and this read: another prune got it first.
+        return false;
+    }
+};
+
+const dirBytes = (dir: string): number => {
+    let bytes = 0;
+    try {
+        for (const name of fs.readdirSync(dir)) {
+            try {
+                const stat = fs.statSync(path.join(dir, name));
+                if (stat.isFile()) {
+                    bytes += stat.size;
+                }
+            } catch {
+                // A file removed under us costs nothing to skip.
+            }
+        }
+    } catch {
+        // The dir itself vanished: nothing to count.
+    }
+    return bytes;
+};
+
+const listDirs = (dir: string, filter: (name: string) => boolean): string[] => {
+    try {
+        return fs
+            .readdirSync(dir)
+            .filter(filter)
+            .map((name) => path.join(dir, name));
+    } catch (err) {
+        if ((err as { code?: string }).code === "ENOENT") {
+            return [];
+        }
+
+        throw err;
+    }
+};
+
+/**
+ * Remove stale scratch dirs. Age-only (never count- or size-based, so a live run's young
+ * dir is safe and two prunes at once are benign), manifest-gated, capped per run, and the
+ * dirs in `keep` are never touched. Only the temp dir this process writes to is swept
+ * (`os.tmpdir()`, so TMPDIR decides), never another root. Legacy `fable-replace-*`
+ * entries directly under it fall under the same gate.
+ *
+ * On a machine that reboots often this rarely fires: a reboot empties the temp folder
+ * first. It pays off on machines that stay up for weeks.
+ */
+export const pruneScratch = ({
+    ttlMs = PRUNE_TTL_MS,
+    maxRemovals = PRUNE_MAX_REMOVALS,
+    keep = [],
+    now = Date.now(),
+}: PruneParams = {}): PruneReport => {
+    // One root only: the temp dir THIS process writes to. A launchd job with no TMPDIR has
+    // os.tmpdir() === /tmp and prunes /tmp itself. Sweeping /tmp from every process as well
+    // made a TMPDIR-redirected run (the selftest, a sandbox) delete backups it never wrote.
+    const temp = os.tmpdir();
+    const candidates = [
+        ...listDirs(path.join(temp, "fable-replace"), () => true),
+        ...listDirs(temp, (name) => name.startsWith(LEGACY_PREFIX)),
+    ];
+
+    const keepSet = new Set(keep.map((dir) => path.resolve(dir)));
+    const report: PruneReport = {
+        scanned: candidates.length,
+        removed: 0,
+        bytes: 0,
+        roots: [path.join(temp, "fable-replace")],
+    };
+    for (const dir of candidates) {
+        if (report.removed >= maxRemovals) {
+            break;
+        }
+
+        if (keepSet.has(path.resolve(dir))) {
+            continue;
+        }
+
+        let stat: fs.Stats;
+        try {
+            stat = fs.statSync(dir);
+        } catch {
+            // Gone already: a concurrent prune or the OS sweep.
+            continue;
+        }
+
+        if (!stat.isDirectory() || now - stat.mtimeMs < ttlMs || !isPrunable(dir)) {
+            continue;
+        }
+
+        const bytes = dirBytes(dir);
+        try {
+            fs.rmSync(dir, { recursive: true, force: true });
+        } catch {
+            // Refused by the filesystem: leave it, the next run tries again.
+            continue;
+        }
+
+        report.removed += 1;
+        report.bytes += bytes;
+    }
+
+    return report;
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/cli.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/cli.ts
@@ -1,0 +1,365 @@
+#!/usr/bin/env bun
+/**
+ * fable-replace — THE CLI. One call, zero ceremony, verified and transactional:
+ *
+ *   bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" <<'EOF'
+ *   @@ src/foo.ts
+ *   <<<
+ *   const gate = getLinkGate(link);
+ *   ===
+ *   const gate = getActionDisabledState(link);
+ *   >>>
+ *   EOF
+ *
+ * Reads the spec from stdin (or --spec <file>), applies every op in memory, writes
+ * only when ALL of them matched, backs up first, prints one OK/MISS line per op and
+ * a hint on every MISS. Exit 0 = everything landed. Exit 1 = nothing written.
+ * Exit 3 = written, but the verify failed (the sweep stays; the undo command is printed).
+ *
+ * Flags: --dry (preview, write nothing) · --diff (print diffs on a real run too)
+ *        --verify "<cmd>" (run after writing, captured and trimmed; red keeps the files) · --cwd <dir>
+ *        --partial (write the files that fully passed) · --quiet (MISS/SKIP only)
+ *        --no-backup · --spec <file> · --api (print the typed library API) · --help
+ */
+
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { format } from "node:util";
+import { printApi } from "./api";
+import { pruneScratch, rollback, scratchDir, scratchRoot } from "./backup-and-rollback";
+import { FableReplaceError } from "./internal";
+import { appendJournal, estimateTokens, type JournalEntry, printHistory, printStats } from "./journal";
+import { parseSpec } from "./spec";
+import { run } from "./sweep-many-files";
+import type { RunReport, VerifyResult } from "./types";
+
+const HELP = `fable-replace CLI — verified, transactional find/replace from a heredoc or a spec file.
+
+usage: bun cli.ts [--dry] [--diff] [--verify "<cmd>"] [--cwd <dir>] [--partial] [--quiet] [--no-backup] < spec
+       bun cli.ts --spec <file> …        # same, spec from a file (use this when a heredoc is refused or long)
+       bun cli.ts --rollback <backupDir> [--force]   # undo a sweep from the backup dir a run printed
+       bun cli.ts --api [query]          # every exported function/type with its docs; query narrows
+       bun cli.ts --help
+
+housekeeping (below the fold on purpose):
+       bun cli.ts --history [N]          # the last N journaled runs (default 20): outcome, tokens, verify, backup dir
+       bun cli.ts --stats [days]         # counts per outcome, tokens written and read back, tokens wasted on failed runs
+       bun cli.ts --prune                # remove backup dirs older than 12 h under <tmp>/fable-replace/ (every sweep does this too)
+       Every real run (never --dry), rollback and prune is journaled to ~/.genesis-tools/fable-replace/journal.jsonl
+       (GENESIS_TOOLS_HOME or FABLE_REPLACE_HOME move it). The spec text is saved beside the backup, never there.
+
+exit 0  everything landed (or the dry run is clean)     exit 1  a MISS: nothing written (a partial write with misses is 1 too)
+exit 2  bad spec, unknown flag, a --verify with | ; or &   exit 3  the sweep IS written, but the verify failed or stale prose survived
+An unknown flag is an ERROR: "--dyr" never becomes a real write. After exit 3, fix forward with a small
+follow-up spec, or run the --rollback line the failure printed; never re-send the same spec.
+
+spec (git-marker shaped, no escaping, heredoc-friendly; pick a delimiter that cannot appear in bodies, e.g. FRSPEC):
+
+  @@ path/to/file.ts            start a file section
+  expect: text                  optional: must be present after the ops (repeatable)
+  absent: text                  optional: must be absent after the ops (repeatable)
+  <<<                           literal replace, exactly once (the workhorse)
+  old text (verbatim, indentation included)
+  ===
+  new text
+  >>>
+  <<< count=all | count=3 | optional | label=free text
+  <<< regex flags=gi            find is a JS regex; replace may use $1 ($$ for a literal $, $& is the match); count=N pins matches
+  <<< fuzzy                     whitespace-insensitive FIND; the replacement is written verbatim
+  <<< after   (anchor === lines)   insert whole lines after the line holding the unique anchor; the anchor line stays, never repeat it
+  <<< before  (anchor === lines)   same, above it
+  <<< append  (lines)              append at end of file
+  <<< delete  (lines)              remove these lines, newline included
+  <<< block   (from === to === replacement)   replace a region; empty replacement deletes it
+  <<< create  (whole file content) create a new file; refuses an existing one
+
+Bodies are raw, line for line. Only a line that is exactly === or >>> is special inside a block:
+write such a line as \\=== or \\>>>. Ops apply in order, each sees the previous op's output.
+Build spec text with printf '%s\\n', never echo (zsh echo turns \\b into a backspace byte).
+Nothing is written unless every required op matches. Backups go to a fresh temp dir (printed).
+A MISS names the line to re-read; a spec error names the spec line.
+`;
+
+const VALUE_FLAGS = ["--verify", "--cwd", "--spec", "--rollback"];
+const OPTIONAL_VALUE_FLAGS = ["--api", "--history", "--stats"];
+const BOOL_FLAGS = ["--dry", "--diff", "--partial", "--quiet", "--no-backup", "--force", "--prune", "--help", "-h"];
+const argv = process.argv.slice(2);
+const values = new Map<string, string>();
+const flags = new Set<string>();
+
+for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (VALUE_FLAGS.includes(arg)) {
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith("--")) {
+            console.error(`${arg} needs a value. Run with --help.`);
+            process.exit(2);
+        }
+        values.set(arg, next);
+        i += 1;
+    } else if (OPTIONAL_VALUE_FLAGS.includes(arg)) {
+        flags.add(arg);
+        if (argv[i + 1] !== undefined && !argv[i + 1].startsWith("--")) {
+            values.set(arg, argv[i + 1]);
+            i += 1;
+        }
+    } else if (BOOL_FLAGS.includes(arg)) {
+        flags.add(arg);
+    } else {
+        // Silently ignoring "--dyr" once turned a preview into a real write.
+        console.error(
+            `unknown argument "${arg}". Known flags: ${[...BOOL_FLAGS, ...VALUE_FLAGS, "--api [query]", "--history [N]", "--stats [days]"].join(" ")}. Nothing was done.`
+        );
+        process.exit(2);
+    }
+}
+
+const flag = (name: string): boolean => flags.has(name);
+const value = (name: string): string | undefined => values.get(name);
+
+// Everything the CLI prints is what a model reads back, so count it for the journal. Bun's
+// console writes natively and never passes through process.stdout.write, so the console
+// methods themselves are wrapped; each still calls the original, nothing else changes.
+let printedChars = 0;
+for (const name of ["log", "error", "warn", "info"] as const) {
+    const original = console[name].bind(console);
+    console[name] = (...args: unknown[]): void => {
+        printedChars += format(...args).length + 1;
+        original(...args);
+    };
+}
+
+// One journal line per run or rollback, written on exit whatever path got there. The
+// exit hook is the single place, so a spec error, a pre-flight refusal and a MISS are
+// recorded by the same code as a green sweep. Help, --api, --history and --stats skip it.
+const startedAt = Date.now();
+const entry: JournalEntry = {
+    ts: new Date(startedAt).toISOString(),
+    runId: `${startedAt.toString(36)}-${process.pid}`,
+    pid: process.pid,
+    cwd: process.cwd(),
+    kind: "run",
+    outcome: "error",
+};
+let journalThisRun = false;
+process.on("exit", () => {
+    // A dry run is a preview: it writes nothing, not even the journal, and it never prunes.
+    if (!journalThisRun || flag("--dry")) {
+        return;
+    }
+
+    entry.durationMs = Date.now() - startedAt;
+    entry.resultChars = printedChars;
+    entry.tokensEst = { spec: estimateTokens(entry.spec?.chars ?? 0), result: estimateTokens(printedChars) };
+    appendJournal(entry);
+
+    // Housekeeping rides on every run: age-only, manifest-gated, capped, this run's own
+    // backup dir excluded. Silent unless it removed something.
+    const pruned = pruneScratch({ keep: entry.backupDir === undefined ? [] : [entry.backupDir] });
+    if (pruned.removed > 0) {
+        console.log(`pruned ${pruned.removed} stale scratch dir(s) older than 12 h under ${scratchRoot()}`);
+        appendJournal({
+            ...entry,
+            kind: "prune",
+            outcome: "prune",
+            prune: { removed: pruned.removed, bytes: pruned.bytes },
+        });
+    }
+});
+
+const journalVerify = (verify: VerifyResult | undefined): JournalEntry["verify"] =>
+    verify === undefined
+        ? undefined
+        : {
+              cmd: verify.command,
+              status: verify.status,
+              exit: verify.exitCode,
+              ms: verify.ms,
+              outputChars: verify.outputChars,
+              shownLines: verify.shown.length,
+              timedOut: verify.timedOut,
+              buffered: verify.buffered,
+          };
+
+const missReasons = (report: RunReport | undefined): string[] =>
+    (report?.files ?? []).flatMap((file) => [
+        ...file.ops.filter((op) => op.status === "MISS").map((op) => `${file.file}: ${op.desc}: ${op.reason ?? ""}`),
+        ...file.postConditionFailures.map((failure) => `${file.file}: ${failure}`),
+    ]);
+
+if (flag("--help") || flag("-h")) {
+    console.log(HELP);
+    process.exit(0);
+}
+if (flag("--api")) {
+    printApi({ dir: path.dirname(fileURLToPath(import.meta.url)), query: value("--api") });
+    process.exit(0);
+}
+if (flag("--history")) {
+    printHistory(Number(value("--history") ?? 20) || 20);
+    process.exit(0);
+}
+if (flag("--stats")) {
+    printStats(Number(value("--stats") ?? 7) || 7);
+    process.exit(0);
+}
+if (flag("--prune")) {
+    const report = pruneScratch();
+    console.log(
+        `pruned ${report.removed} stale scratch dir(s), ${Math.round(report.bytes / 1024)} KB, older than 12 h, under ${report.roots.join(" and ")} (${report.scanned} scanned)`
+    );
+    appendJournal({
+        ...entry,
+        kind: "prune",
+        outcome: "prune",
+        prune: { removed: report.removed, bytes: report.bytes },
+    });
+    process.exit(0);
+}
+
+const rollbackDir = value("--rollback");
+if (rollbackDir !== undefined) {
+    entry.kind = "rollback";
+    entry.backupDir = rollbackDir;
+    entry.flags = [...flags];
+    journalThisRun = true;
+    try {
+        const report = rollback({ backupDir: rollbackDir, force: flag("--force") });
+        entry.outcome = "rollback";
+        entry.rollback = {
+            restored: report.restored.length,
+            drifted: report.drifted.length,
+            failed: report.failed.length,
+        };
+        process.exit(report.drifted.length > 0 || report.failed.length > 0 ? 1 : 0);
+    } catch (err) {
+        entry.message = err instanceof Error ? err.message : String(err);
+        console.error(`ROLLBACK ERROR: ${entry.message}`);
+        process.exit(2);
+    }
+}
+
+const specPath = value("--spec");
+// Journal from here on: a spec that cannot be read, or an empty one, is a failed run too,
+// and used to leave no trace in --history.
+entry.flags = [...flags, ...values.keys()];
+journalThisRun = true;
+let text: string;
+try {
+    text = fs.readFileSync(specPath ?? 0, "utf8");
+} catch (err) {
+    entry.outcome = "spec-error";
+    entry.message = `cannot read ${specPath ?? "stdin"}: ${err instanceof Error ? err.message : String(err)}`;
+    console.error(`SPEC ERROR: ${entry.message}`);
+    process.exit(2);
+}
+if (text.trim().length === 0) {
+    entry.outcome = "spec-error";
+    entry.message = "no spec on stdin and no --spec file";
+    console.error("no spec on stdin and no --spec file. Run with --help for the format.");
+    process.exit(2);
+}
+entry.spec = {
+    files: 0,
+    ops: 0,
+    chars: text.length,
+    hash: createHash("sha256").update(text).digest("hex").slice(0, 12),
+};
+
+let edits: ReturnType<typeof parseSpec>;
+try {
+    edits = parseSpec({ text, onWarning: (message) => console.error(`WARNING: ${message}`) });
+} catch (err) {
+    entry.outcome = "spec-error";
+    entry.specError = err instanceof Error ? err.message : String(err);
+    console.error(`SPEC ERROR: ${entry.specError}`);
+    process.exit(2);
+}
+
+const cwd = value("--cwd") ?? process.cwd();
+
+const opCount = edits.reduce((sum, e) => sum + (e.ops?.length ?? 0), 0);
+entry.spec.files = edits.length;
+entry.spec.ops = opCount;
+const creates = edits.filter((e) => e.createWith !== undefined).length;
+console.log(
+    `spec: ${edits.length} file(s), ${opCount} op(s)${creates > 0 ? `, ${creates} create` : ""}${flag("--dry") ? " — DRY RUN" : ""}`
+);
+
+try {
+    const report = await run({
+        edits,
+        cwd,
+        dryRun: flag("--dry"),
+        showDiff: flag("--diff"),
+        verbose: !flag("--quiet"),
+        partial: flag("--partial"),
+        backupDir: flag("--no-backup") || flag("--dry") ? undefined : scratchDir("cli"),
+        verifyCommand: value("--verify"),
+        throwOnFailure: true,
+        onWritten: ({ written, backupDir }) => {
+            if (backupDir !== undefined) {
+                // The ephemeral place for the spec text: collected with the originals it edited.
+                try {
+                    fs.writeFileSync(path.join(backupDir, "spec.frspec"), text);
+                } catch (err) {
+                    console.error(`could not save the spec beside the backup: ${String(err)}`);
+                }
+            }
+
+            if (value("--verify") !== undefined) {
+                // A check the Bash tool kills mid-run never reaches the exit hook; this line proves
+                // the sweep landed before it started.
+                appendJournal({
+                    ...entry,
+                    outcome: "written",
+                    written: written.length,
+                    backupDir,
+                    durationMs: Date.now() - startedAt,
+                    resultChars: printedChars,
+                });
+            }
+        },
+    });
+    entry.outcome = flag("--dry") ? "dry-ok" : "ok";
+    entry.written = report.written.length;
+    entry.backupDir = report.backupDir;
+    entry.verify = journalVerify(report.verify);
+} catch (err) {
+    if (err instanceof FableReplaceError) {
+        const report = err.report;
+        entry.written = report?.written.length;
+        entry.backupDir = report?.backupDir;
+        entry.missCount = report?.missCount;
+        entry.reasons = missReasons(report);
+        entry.verify = journalVerify(report?.verify);
+        entry.message = err.message;
+        if (err.code === 2) {
+            entry.outcome = "pre-flight";
+        } else if (err.code === 3) {
+            const verifyStatus = report?.verify?.status;
+            entry.outcome =
+                verifyStatus === "unknown"
+                    ? "verify-unknown"
+                    : verifyStatus === "fail"
+                      ? "verify-failed"
+                      : err.message.includes("backup manifest not updated")
+                        ? "written"
+                        : "stale-prose";
+        } else if (flag("--dry")) {
+            entry.outcome = "dry-miss";
+        } else if (err.message.startsWith("fable-replace: write failed")) {
+            entry.outcome = "write-failed";
+        } else if (flag("--partial") && (report?.written.length ?? 0) > 0) {
+            entry.outcome = "partial";
+        } else {
+            entry.outcome = "miss";
+        }
+        process.exit(err.code);
+    }
+    entry.message = err instanceof Error ? err.message : String(err);
+    console.error(`ERROR: ${entry.message}`);
+    process.exit(1);
+}

--- a/plugins/genesis-tools/skills/fable-replace/scripts/comments.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/comments.ts
@@ -1,0 +1,396 @@
+/**
+ * fable-replace — COMMENT AND LINE SWEEPS on a single file's text.
+ *
+ * `scanComments` is a real tokenizer: it tracks '…', "…", `…` (with ${} nesting),
+ * escapes, regex literals, and the two JSX tag shapes that look like operators
+ * (`</Foo>`, `<Foo />`), so "//" inside a string or a regex is never mistaken for a
+ * comment. That matters — a naive scanner corrupted 0.95% of a real 5252-file repo
+ * before the regex/JSX handling was added.
+ *
+ * It does NOT model JSX text. A comment-shaped run inside rendered text
+ * (`<p>/* note *\/</p>`, `<a>https://…</a>`) is scanned as a comment, because telling
+ * `<` as a tag from `<` as a comparison needs a parser this dependency-free script does
+ * not have. On .tsx/.jsx files keep the predicate narrow and read `--dry --diff`.
+ *
+ * Use `dropComments` when the COMMENT must go but code on the same line must stay.
+ * Use `deleteLines` when the WHOLE line must go. Getting that pair the wrong way
+ * round is the commonest mistake in a comment sweep.
+ */
+
+import { FableReplaceError, stateless } from "./internal";
+import type { CommentSpan, DeleteLinesOp, DropCommentsOp, DropCommentsOptions, OpResult } from "./types";
+
+export const scanComments = (src: string): CommentSpan[] => {
+    const spans: CommentSpan[] = [];
+    let i = 0;
+    let line = 1;
+    // stack of template-literal contexts: each entry is the ${}-depth inside that template
+    const templateStack: number[] = [];
+    const n = src.length;
+
+    // Previous significant code character, and the identifier ending on it. This is
+    // the only way to tell a regex literal `/re/` from a division `a / b`. Without
+    // it a literal such as /[&<>"']/g reads as a string opener and desyncs the rest
+    // of the file, which corrupted 0.95% of a real 5252-file repo before this fix.
+    const REGEX_OK_AFTER = new Set([
+        "return",
+        "typeof",
+        "instanceof",
+        "in",
+        "of",
+        "new",
+        "delete",
+        "void",
+        "throw",
+        "case",
+        "do",
+        "else",
+        "yield",
+        "await",
+    ]);
+    let prevChar = "";
+    let prevWord = "";
+    let wordBroke = true;
+    const noteChar = (ch: string): void => {
+        if (/\s/.test(ch)) {
+            wordBroke = true;
+            return;
+        }
+        if (/[\w$]/.test(ch)) {
+            prevWord = wordBroke || !/[\w$]/.test(prevChar) ? ch : prevWord + ch;
+        } else {
+            prevWord = "";
+        }
+        prevChar = ch;
+        wordBroke = false;
+    };
+    /** A string, template or regex literal just closed, so a value ended here. */
+    const noteValueEnd = (): void => {
+        prevChar = ")";
+        prevWord = "";
+        wordBroke = false;
+    };
+    const regexAllowedHere = (): boolean => {
+        if (prevChar === "") {
+            return true;
+        }
+        // "<" means a JSX closing tag (</Foo>), not a regex.
+        if (prevChar === ")" || prevChar === "]" || prevChar === "<") {
+            return false;
+        }
+        if (/[\w$]/.test(prevChar)) {
+            return REGEX_OK_AFTER.has(prevWord);
+        }
+        return true;
+    };
+    /** Consume a regex literal so its slashes and quotes never reach the comment checks. */
+    const skipRegexLiteral = (): void => {
+        i += 1;
+        let inClass = false;
+        while (i < n) {
+            const ch = src[i];
+            if (ch === "\\") {
+                i += 2;
+                continue;
+            }
+            if (ch === "\n") {
+                return;
+            }
+            if (ch === "[") {
+                inClass = true;
+            } else if (ch === "]") {
+                inClass = false;
+            } else if (ch === "/" && !inClass) {
+                i += 1;
+                while (i < n && /[a-z]/.test(src[i] ?? "")) {
+                    i += 1;
+                }
+                noteValueEnd();
+                return;
+            }
+            i += 1;
+        }
+    };
+
+    const skipString = (quote: string): void => {
+        i += 1; // past the opening quote
+        while (i < n) {
+            const c = src[i];
+            if (c === "\\") {
+                i += 2;
+                continue;
+            }
+            if (c === "\n") {
+                line += 1;
+            }
+            if (c === quote) {
+                i += 1;
+                return;
+            }
+            i += 1;
+        }
+    };
+
+    while (i < n) {
+        const c = src[i];
+        const next = src[i + 1];
+
+        if (c === "\n") {
+            line += 1;
+            i += 1;
+            continue;
+        }
+
+        // inside a template literal body?
+        if (templateStack.length > 0 && templateStack[templateStack.length - 1] === 0) {
+            if (c === "\\") {
+                i += 2;
+                continue;
+            }
+            if (c === "`") {
+                templateStack.pop();
+                noteValueEnd();
+                i += 1;
+                continue;
+            }
+            if (c === "$" && next === "{") {
+                templateStack[templateStack.length - 1] = 1; // entering an interpolation
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+
+        // in code (top level, or inside a ${…} interpolation)
+        if (templateStack.length > 0) {
+            if (c === "{") {
+                templateStack[templateStack.length - 1] += 1;
+            } else if (c === "}") {
+                templateStack[templateStack.length - 1] -= 1;
+            }
+        }
+
+        if (c === '"' || c === "'") {
+            skipString(c);
+            noteValueEnd();
+            continue;
+        }
+        if (c === "`") {
+            templateStack.push(0);
+            i += 1;
+            continue;
+        }
+        // next === ">" is a JSX self-close (<Foo />), never a regex.
+        if (c === "/" && next !== "/" && next !== "*" && next !== ">" && regexAllowedHere()) {
+            skipRegexLiteral();
+            continue;
+        }
+        if (c === "/" && next === "/") {
+            const start = i;
+            const startLine = line;
+            let end = src.indexOf("\n", i);
+            if (end === -1) {
+                end = n;
+            }
+            spans.push({ start, end, text: src.slice(start, end), type: "line", line: startLine });
+            i = end;
+            continue;
+        }
+        if (c === "/" && next === "*") {
+            const start = i;
+            const startLine = line;
+            let end = src.indexOf("*/", i + 2);
+            end = end === -1 ? n : end + 2;
+            line += (src.slice(start, end).match(/\n/g) ?? []).length;
+            spans.push({ start, end, text: src.slice(start, end), type: "block", line: startLine });
+            i = end;
+            continue;
+        }
+        noteChar(c);
+        i += 1;
+    }
+    return spans;
+};
+
+/**
+ * Remove a set of spans from the source. When removing a span leaves its line(s)
+ * as pure whitespace, the whole line (including the newline) is removed too — so
+ * dropping a full-line comment doesn't leave a blank hole.
+ */
+/** Neighbours that never fuse with a token, so no separator is needed beside them. */
+const NEVER_FUSES = /[()[\]{},;:]/;
+
+export const removeSpans = (src: string, spans: Array<{ start: number; end: number }>): string => {
+    let out = src;
+    const sorted = [...spans].sort((a, b) => b.start - a.start);
+    for (const span of sorted) {
+        let { start, end } = span;
+        const lineStart = out.lastIndexOf("\n", start - 1) + 1;
+        let lineEnd = out.indexOf("\n", end);
+        lineEnd = lineEnd === -1 ? out.length : lineEnd + 1;
+        const remainder = out.slice(lineStart, start) + out.slice(end, lineEnd);
+        if (remainder.trim() === "") {
+            start = lineStart;
+            end = lineEnd;
+        } else if (out.slice(end, lineEnd).trim() === "") {
+            // span ends the line (e.g. trailing comment) — eat the whitespace before it too
+            while (start > lineStart && (out[start - 1] === " " || out[start - 1] === "\t")) {
+                start -= 1;
+            }
+        }
+        // An inline comment is lexical whitespace: `return/*legacy*/value` must not fuse
+        // into `returnvalue`, and `x/*c*//y` must not become a line comment. One space stays
+        // when both neighbours are non-blank, unless one is a bracket, a comma, a semicolon
+        // or a colon. A whole-line or trailing removal has a line break on one side.
+        const before = out[start - 1] ?? "";
+        const after = out[end] ?? "";
+        const glue =
+            /\S/.test(before) && /\S/.test(after) && !NEVER_FUSES.test(before) && !NEVER_FUSES.test(after) ? " " : "";
+        out = out.slice(0, start) + glue + out.slice(end);
+    }
+    return out;
+};
+
+/**
+ * Drop comments matching a predicate — string-aware (never touches "//" inside
+ * strings), and removes the whole line when the comment was alone on it.
+ * Returns the new content and how many comments were dropped.
+ */
+export const dropComments = (
+    src: string,
+    options: DropCommentsOptions
+): { content: string; dropped: number; lines: number[] } => {
+    const scope = options.scope ?? "both";
+    // "" is not a predicate: every text includes it. Treated as absent, so it can neither
+    // select every comment on its own nor widen a regex it is combined with.
+    const containing = options.containing === "" ? undefined : options.containing;
+    const matching = options.matching === undefined ? undefined : stateless(options.matching);
+    const targets = scanComments(src).filter((span) => {
+        if (scope !== "both" && span.type !== scope) {
+            return false;
+        }
+        if (containing !== undefined && !span.text.includes(containing)) {
+            return false;
+        }
+        if (matching !== undefined && !matching.test(span.text)) {
+            return false;
+        }
+        return containing !== undefined || matching !== undefined;
+    });
+    if (options.expect !== undefined && targets.length !== options.expect) {
+        // The direct call used to ignore `expect` and remove whatever matched; only the op
+        // form checked it. The contract lives here now, for both doors.
+        const where = targets.length > 0 ? ` at line(s) ${targets.map((span) => span.line).join(", ")}` : "";
+        throw new FableReplaceError(
+            `dropComments: expected ${options.expect} comment(s), found ${targets.length}${where} — nothing removed`,
+            1
+        );
+    }
+
+    return { content: removeSpans(src, targets), dropped: targets.length, lines: targets.map((span) => span.line) };
+};
+
+export const deleteLines = (src: string, op: DeleteLinesOp): { content: string; removed: number; lines: number[] } => {
+    const lines = src.split("\n");
+    const kept: string[] = [];
+    // "" is not a predicate: every line includes it, so OR-ed with a regex it deleted the
+    // whole file and reported OK. Treated as absent.
+    const containing = op.containing === "" ? undefined : op.containing;
+    const matching = op.matching === undefined ? undefined : stateless(op.matching);
+    const hitLines: number[] = [];
+    for (const [idx, l] of lines.entries()) {
+        const hit = (containing !== undefined && l.includes(containing)) || matching?.test(l);
+        if (hit) {
+            hitLines.push(idx + 1);
+        } else {
+            kept.push(l);
+        }
+    }
+    if (op.expect !== undefined && hitLines.length !== op.expect) {
+        // The direct call used to ignore `expect`; only the op form checked it. Same
+        // contract as dropComments: enforced here, for both doors.
+        const where = hitLines.length > 0 ? ` at line(s) ${hitLines.join(", ")}` : "";
+        throw new FableReplaceError(
+            `deleteLines: expected ${op.expect} line(s), found ${hitLines.length}${where} — nothing removed`,
+            1
+        );
+    }
+
+    return { content: kept.join("\n"), removed: hitLines.length, lines: hitLines };
+};
+
+export const applyDropComments = (content: string, op: DropCommentsOp): { content: string; result: OpResult } => {
+    const desc = op.label ?? `dropComments ${op.containing ? `containing "${op.containing}"` : String(op.matching)}`;
+    // An EMPTY `containing` is not a predicate: "".includes("") is true for every comment,
+    // so it silently dropped all of them and reported OK. Same guard recon.ts uses.
+    if ((op.containing === undefined || op.containing === "") && op.matching === undefined) {
+        return {
+            content,
+            result: {
+                status: "MISS",
+                desc,
+                reason: "dropComments needs a non-empty `containing` or a `matching` regex — refusing to drop ALL comments",
+            },
+        };
+    }
+    let outcome: { content: string; dropped: number; lines: number[] };
+    try {
+        outcome = dropComments(content, op);
+    } catch (err) {
+        // The shared function enforces `expect`; the op form reports it as a MISS.
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: err instanceof Error ? err.message : String(err),
+            },
+        };
+    }
+    const { content: next, dropped, lines } = outcome;
+    if (dropped === 0) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: "no comment matched", found: 0 },
+        };
+    }
+    return { content: next, result: { status: "OK", desc, found: dropped, expected: op.expect, lines } };
+};
+
+export const applyDeleteLines = (content: string, op: DeleteLinesOp): { content: string; result: OpResult } => {
+    const desc = op.label ?? `deleteLines ${op.containing ? `containing "${op.containing}"` : String(op.matching)}`;
+    // An empty `containing` matches every line: it used to wipe the file and report OK.
+    if ((op.containing === undefined || op.containing === "") && op.matching === undefined) {
+        return {
+            content,
+            result: {
+                status: "MISS",
+                desc,
+                reason: "deleteLines needs a non-empty `containing` or a `matching` regex — refusing to delete EVERY line",
+            },
+        };
+    }
+    let outcome: { content: string; removed: number; lines: number[] };
+    try {
+        outcome = deleteLines(content, op);
+    } catch (err) {
+        // The shared function enforces `expect`; the op form reports it as a MISS.
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: err instanceof Error ? err.message : String(err),
+            },
+        };
+    }
+    const { content: next, removed, lines } = outcome;
+    if (removed === 0) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: "no line matched", found: 0 },
+        };
+    }
+    return { content: next, result: { status: "OK", desc, found: removed, expected: op.expect, lines } };
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/edit-one-file.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/edit-one-file.ts
@@ -1,0 +1,578 @@
+/**
+ * fable-replace — EDITING THE TEXT OF ONE FILE. Everything here is pure: string in,
+ * string out, no filesystem.
+ *
+ * These are the ops you put in a FileEdit's `ops` array: literal (the workhorse),
+ * regex, deleteBlock/replaceBlock, insertBefore/insertAfter, fuzzy. Every op is
+ * VERIFIED — a literal op with the default `count: 1` requires the needle exactly
+ * once, so a stale assumption is a loud MISS, never a silent no-op.
+ *
+ * Prefer literal over regex. Paste the exact current text, indentation included.
+ */
+
+import { applyDeleteLines, applyDropComments } from "./comments";
+import {
+    countOccurrences,
+    dominantEol,
+    escapeRegex,
+    lineStartOffsets,
+    matchLines,
+    nthIndexOf,
+    opDesc,
+    preview,
+    replaceAllLiteral,
+    replaceNLiteral,
+} from "./internal";
+import type {
+    AppendOp,
+    DeleteBlockOp,
+    DropJsdocParams,
+    DropParams,
+    FuzzyOp,
+    InsertLinesOp,
+    InsertOp,
+    LiteralOp,
+    LiteralSugarParams,
+    NearestHintParams,
+    Op,
+    OpResult,
+    RegexOp,
+    ReplaceBlockOp,
+} from "./types";
+
+/** What the ops before this one did to the buffer, so a MISS can tell "re-run" from "consumed". */
+interface BatchContext {
+    original: string;
+    producedBy?: { index: number; desc: string };
+}
+
+/** Splice `replacement` over `length` characters at each offset, from the end so offsets stay valid. */
+const replaceAtOffsets = ({
+    content,
+    offsets,
+    length,
+    replacement,
+}: {
+    content: string;
+    offsets: number[];
+    length: number;
+    replacement: string;
+}): string => {
+    let out = content;
+    for (const at of [...offsets].reverse()) {
+        out = out.slice(0, at) + replacement + out.slice(at + length);
+    }
+    return out;
+};
+
+const applyLiteral = (content: string, op: LiteralOp, batch?: BatchContext): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    // `wholeLines` (what `<<< delete` compiles to) counts only occurrences that start a
+    // line: "foo" inside "notfoo" used to match, report OK, and leave "not" behind.
+    const atLineStarts = op.wholeLines === true ? lineStartOffsets(content, op.find) : null;
+    const found = atLineStarts === null ? countOccurrences(content, op.find) : atLineStarts.length;
+    const want = op.count ?? 1;
+
+    if (op.find === op.replace) {
+        return { content, result: { status: "MISS", desc, reason: "find === replace (no-op edit)", found } };
+    }
+
+    if (found === 0) {
+        const midLine = atLineStarts === null ? 0 : countOccurrences(content, op.find);
+        const where =
+            midLine > 0
+                ? `needle occurs ${midLine}× but never at the start of a line (a delete body must be whole lines).`
+                : `needle not found. ${nearestHint({
+                      content,
+                      needle: op.find,
+                      replacement: op.replace,
+                      original: batch?.original,
+                      producedBy: batch?.producedBy,
+                  })}`;
+        return { content, result: { status: op.optional ? "SKIP" : "MISS", desc, reason: where, found } };
+    }
+
+    if (want === "all") {
+        return {
+            content:
+                atLineStarts === null
+                    ? replaceAllLiteral(content, op.find, op.replace)
+                    : replaceAtOffsets({
+                          content,
+                          offsets: atLineStarts,
+                          length: op.find.length,
+                          replacement: op.replace,
+                      }),
+            result: { status: "OK", desc, found, expected: want },
+        };
+    }
+
+    if (found !== want) {
+        const lines =
+            atLineStarts === null
+                ? matchLines({ content, needle: op.find })
+                : atLineStarts.map((at) => content.slice(0, at).split("\n").length).join(", ");
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: `expected exactly ${want} occurrence(s), found ${found} at line(s) ${lines} — add surrounding context to disambiguate, or set count to ${found}`,
+                found,
+            },
+        };
+    }
+
+    return {
+        content:
+            atLineStarts === null
+                ? replaceNLiteral(content, op.find, op.replace, want)
+                : replaceAtOffsets({
+                      content,
+                      offsets: atLineStarts.slice(0, want),
+                      length: op.find.length,
+                      replacement: op.replace,
+                  }),
+        result: { status: "OK", desc, found, expected: want },
+    };
+};
+
+const applyRegex = (content: string, op: RegexOp): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    const global = op.find.global ? op.find : new RegExp(op.find.source, `${op.find.flags}g`);
+    const found = (content.match(global) ?? []).length;
+
+    if (found === 0) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: "regex matched nothing", found },
+        };
+    }
+
+    if (op.expect !== undefined && found !== op.expect) {
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: `expected ${op.expect} match(es), found ${found} at line(s) ${matchLines({ content, needle: op.find })}`,
+                found,
+            },
+        };
+    }
+
+    const next =
+        typeof op.replace === "string"
+            ? content.replace(global, op.replace)
+            : content.replace(global, op.replace as (substring: string, ...args: unknown[]) => string);
+
+    return { content: next, result: { status: "OK", desc, found, expected: op.expect } };
+};
+
+/**
+ * A block anchor written with LF against a CRLF file. The literal form is tried first, so
+ * a mixed-ending file keeps matching exactly what it did; only an absent LF anchor is
+ * retried in its CRLF spelling. `dropJsdocStarting` closes on the JSDoc terminator plus
+ * "\n", which no CRLF file contains.
+ */
+const eolAnchor = (content: string, anchor: string): string => {
+    if (content.includes(anchor) || !anchor.includes("\n") || anchor.includes("\r") || !content.includes("\r\n")) {
+        return anchor;
+    }
+
+    return anchor.replace(/\n/g, "\r\n");
+};
+
+const locateBlock = (
+    content: string,
+    op: DeleteBlockOp | ReplaceBlockOp
+): { start: number; end: number } | { error: string } => {
+    const from = eolAnchor(content, op.from);
+    const to = eolAnchor(content, op.to);
+    if (op.occurrence === undefined) {
+        // Acting on the FIRST of several matching anchors silently leaves the others
+        // alone and still reports OK. Ambiguity is a MISS, like every other op.
+        const fromCount = countOccurrences(content, from);
+        if (fromCount > 1) {
+            return {
+                error: `"from" anchor occurs ${fromCount}× (lines ${matchLines({ content, needle: from })}); add context to make it unique, or set occurrence`,
+            };
+        }
+    }
+    const fromIdx = nthIndexOf({ haystack: content, needle: from, n: op.occurrence ?? 1 });
+    if (fromIdx === -1) {
+        return {
+            error: `"from" anchor not found (occurrence ${op.occurrence ?? 1}). ${nearestHint({ content, needle: from })}`,
+        };
+    }
+    const searchFrom = fromIdx + from.length;
+    const toIdx = content.indexOf(to, searchFrom);
+    if (toIdx === -1) {
+        return { error: `"to" anchor not found after "from"` };
+    }
+    const start = op.keepFrom ? fromIdx + from.length : fromIdx;
+    const end = op.keepTo ? toIdx : toIdx + to.length;
+    return { start, end };
+};
+
+const applyBlock = (content: string, op: DeleteBlockOp | ReplaceBlockOp): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    const loc = locateBlock(content, op);
+    if ("error" in loc) {
+        return { content, result: { status: op.optional ? "SKIP" : "MISS", desc, reason: loc.error } };
+    }
+    const substitute = op.kind === "replaceBlock" ? op.replace : "";
+    return {
+        content: content.slice(0, loc.start) + substitute + content.slice(loc.end),
+        result: { status: "OK", desc },
+    };
+};
+
+const applyInsert = (content: string, op: InsertOp): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    const idx = nthIndexOf({ haystack: content, needle: op.anchor, n: op.occurrence ?? 1 });
+    if (idx === -1) {
+        return {
+            content,
+            result: {
+                status: op.optional ? "SKIP" : "MISS",
+                desc,
+                reason: `anchor not found (occurrence ${op.occurrence ?? 1})`,
+            },
+        };
+    }
+    const at = op.kind === "insertBefore" ? idx : idx + op.anchor.length;
+    return { content: content.slice(0, at) + op.text + content.slice(at), result: { status: "OK", desc } };
+};
+
+/**
+ * Offset in `content` where `needle` starts once EVERY whitespace character is
+ * removed from both sides, or -1. "two=2" finds "two = 2" and vice versa, which a
+ * whitespace-run-tolerant regex cannot do (it needs at least one space on both sides).
+ */
+const squashedIndexOf = ({ content, needle }: { content: string; needle: string }): number => {
+    const map: number[] = [];
+    let squashed = "";
+    for (let i = 0; i < content.length; i += 1) {
+        if (!/\s/.test(content[i])) {
+            squashed += content[i];
+            map.push(i);
+        }
+    }
+    const target = needle.replace(/\s+/g, "");
+    if (target.length === 0) {
+        return -1;
+    }
+    const at = squashed.indexOf(target);
+    return at === -1 ? -1 : map[at];
+};
+/** 1-based line number of the line that contains offset `at`. */
+const lineAt = (content: string, at: number): number => content.slice(0, at).split("\n").length;
+
+/**
+ * Why did a literal needle miss? Say something a reader can act on: the file
+ * already holds the replacement, the needle matches once whitespace is ignored
+ * (so it is an indentation problem, use `fuzzy`), or the needle's first line
+ * exists at line N and the text diverges from line N+k. A bare "not found" made
+ * agents guess; this points at the line to re-read.
+ */
+export const nearestHint = ({ content, needle, replacement, original, producedBy }: NearestHintParams): string => {
+    if (replacement !== undefined && replacement.length > 0 && content.includes(replacement)) {
+        if (original !== undefined && !original.includes(replacement)) {
+            // The text is there because THIS batch put it there: an earlier op consumed the
+            // needle. "Make it optional" would hide an ordering mistake, so it is not offered.
+            const who =
+                producedBy === undefined
+                    ? "an earlier op in this batch"
+                    : `op ${producedBy.index + 1} of this batch (${producedBy.desc})`;
+            return `the REPLACEMENT is present only because ${who} produced it: that op consumed this needle before this one ran. This is not a re-run. Reorder or merge the two ops, or drop this one.`;
+        }
+
+        return "the REPLACEMENT is already in the file: this edit was probably applied before (make the op optional to allow re-runs).";
+    }
+    const noSpace = squashedIndexOf({ content, needle });
+    if (noSpace !== -1) {
+        return `matches when ALL whitespace is ignored (first at line ${lineAt(content, noSpace)}): the difference is spaces, tabs, indentation or line breaks. Copy the exact text, or use kind "fuzzy".`;
+    }
+    const noCase = squashedIndexOf({ content: content.toLowerCase(), needle: needle.toLowerCase() });
+    if (noCase !== -1) {
+        return `matches when case AND whitespace are ignored (first at line ${lineAt(content, noCase)}): the needle has a letter-case typo somewhere. Re-read that line.`;
+    }
+    const nfcAt = content.normalize("NFC").indexOf(needle.normalize("NFC"));
+    if (nfcAt !== -1) {
+        return `matches after Unicode normalization (line ${lineAt(content.normalize("NFC"), nfcAt)}): the file and the needle spell the same accented text with different code points (NFC vs NFD). Copy the text from the file itself, or use kind "fuzzy".`;
+    }
+    const needleLines = needle.split("\n");
+    const firstLine = needleLines.find((l) => l.trim().length > 0)?.trim() ?? "";
+    if (firstLine.length === 0) {
+        return "the needle is blank.";
+    }
+    const contentLines = content.split("\n");
+    const candidates = contentLines.map((l, i) => ({ i, l })).filter(({ l }) => l.includes(firstLine));
+    if (candidates.length === 0) {
+        const probe = firstLine.slice(0, Math.max(12, Math.floor(firstLine.length / 2)));
+        const probeLower = probe.toLowerCase();
+        const partial = contentLines.findIndex((l) => l.toLowerCase().includes(probeLower));
+        return partial === -1
+            ? "no line of the file contains the needle's first line. Re-read the file: the text is different, or it lives in another file."
+            : `the needle's first line is not in the file, but line ${partial + 1} starts the same way: "${preview(contentLines[partial].trim(), 70)}". Re-read from there.`;
+    }
+    for (const { i } of candidates) {
+        for (let k = 1; k < needleLines.length; k += 1) {
+            const actual = contentLines[i + k];
+            if (actual === undefined || actual.trim() !== needleLines[k].trim()) {
+                return `first line found at line ${i + 1}, text diverges at line ${i + k + 1}: file has "${preview((actual ?? "<end of file>").trim(), 70)}", needle has "${preview(needleLines[k].trim(), 70)}".`;
+            }
+        }
+    }
+    return `the needle's first line is at line ${candidates[0].i + 1} but the exact text is not. Check trailing spaces and tabs.`;
+};
+
+const lineBounds = (content: string, at: number): { start: number; end: number } => {
+    const start = content.lastIndexOf("\n", at - 1) + 1;
+    const nl = content.indexOf("\n", at);
+    return { start, end: nl === -1 ? content.length : nl };
+};
+
+/**
+ * Every offset where `anchor` occurs. An anchor that starts with whitespace carries its
+ * indentation on purpose, so it only counts where it begins a line: "    foo" must not
+ * match inside "        foo", or a wrong indentation would land the insert anyway.
+ */
+const anchorOffsets = ({ content, anchor }: { content: string; anchor: string }): number[] => {
+    const offsets: number[] = [];
+    if (anchor === "") {
+        return offsets;
+    }
+
+    let idx = content.indexOf(anchor);
+    while (idx !== -1) {
+        if (!/^\s/.test(anchor) || idx === 0 || content[idx - 1] === "\n") {
+            offsets.push(idx);
+        }
+        idx = content.indexOf(anchor, idx + 1);
+    }
+    return offsets;
+};
+
+const applyInsertLines = (content: string, op: InsertLinesOp): { content: string; result: OpResult } => {
+    const offsets = anchorOffsets({ content, anchor: op.anchor });
+    const found = offsets.length;
+    const raw = countOccurrences(content, op.anchor);
+    const anchorLine = op.anchor.split("\n");
+    const textLines = op.text.replace(/\n$/, "").split("\n");
+    const repeatsAnchor =
+        textLines[0] === anchorLine[anchorLine.length - 1] || textLines[textLines.length - 1] === anchorLine[0];
+    const desc = repeatsAnchor
+        ? `${opDesc(op)} ⚠ the inserted text starts or ends with the anchor line; before/after KEEP the anchor, so it will appear twice`
+        : opDesc(op);
+    if (found !== 1) {
+        const reason =
+            found === 0 && raw > 0
+                ? `anchor occurs ${raw}× but never at the start of a line: its indentation is wrong. Re-read line ${matchLines({ content, needle: op.anchor })} and copy the leading whitespace exactly`
+                : found === 0
+                  ? `anchor not found. ${nearestHint({ content, needle: op.anchor })}`
+                  : `anchor occurs ${found}× (lines ${matchLines({ content, needle: op.anchor })}), must be unique: add surrounding context`;
+        return { content, result: { status: op.optional ? "SKIP" : "MISS", desc, reason, found } };
+    }
+    // `text` is inserted line for line. A trailing "\n" is a real blank line, because
+    // that is what an agent means when it leaves an empty last line in a spec body
+    // ("insert this block, then a gap"). Stripping it once made a helper land glued to
+    // the next declaration.
+    // Inserted lines take the file's own line ending. Hardcoding "\n" spliced a lone LF
+    // line into an otherwise all-CRLF file, which every later diff then shows as noise.
+    const eol = dominantEol(content);
+    const text = op.text.replace(/\r?\n/g, eol);
+    // A multi-line anchor starts on one line and ends on another: "before" goes above
+    // the line where it STARTS, "after" goes below the line where it ENDS. Inserting
+    // after the first line of a two-line anchor once nested a new object key inside
+    // the previous one, and the result still parsed.
+    const anchorAt = offsets[0];
+    const { start } = lineBounds(content, anchorAt);
+    const bounds = lineBounds(content, anchorAt + op.anchor.length - 1);
+    // lineBounds stops before the "\n" but AFTER a "\r", so on a CRLF file inserting at
+    // `end` would leave the anchor line ending in a bare "\r" and split the pair.
+    const end = content[bounds.end - 1] === "\r" ? bounds.end - 1 : bounds.end;
+    const next =
+        op.kind === "insertLinesBefore"
+            ? `${content.slice(0, start)}${text}${eol}${content.slice(start)}`
+            : `${content.slice(0, end)}${eol}${text}${content.slice(end)}`;
+    return { content: next, result: { status: "OK", desc, found, expected: 1 } };
+};
+
+const applyAppend = (content: string, op: AppendOp): { content: string; result: OpResult } => {
+    const desc = opDesc(op);
+    // Same rule as insertLines: the text is literal, it takes the file's line ending, and
+    // the file ends with a newline.
+    const eol = dominantEol(content);
+    const body = op.text.replace(/\r?\n/g, eol);
+    const text = body.endsWith(eol) ? body : `${body}${eol}`;
+    const glue = content.length === 0 || content.endsWith("\n") ? "" : eol;
+    return { content: `${content}${glue}${text}`, result: { status: "OK", desc } };
+};
+
+const applyFuzzy = (content: string, op: FuzzyOp): { content: string; result: OpResult } => {
+    const desc = op.label ?? `fuzzy "${op.find.replace(/\s+/g, " ").slice(0, 48)}"`;
+    const rx = fuzzyWhitespaceRegex(op.find);
+    const found = (content.match(rx) ?? []).length;
+    const want = op.count ?? 1;
+    if (found === 0) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: "no whitespace-tolerant match", found },
+        };
+    }
+    if (want !== "all" && found !== want) {
+        return {
+            content,
+            result: { status: op.optional ? "SKIP" : "MISS", desc, reason: `expected ${want}, found ${found}`, found },
+        };
+    }
+    return { content: content.replace(rx, () => op.replace), result: { status: "OK", desc, found } };
+};
+
+/**
+ * Build a regex that matches `needle` treating every run of whitespace as "any
+ * whitespace". Lets a literal op survive reindentation/reformatting drift:
+ * pass `fuzzy: true` on a LiteralOp when an exact match keeps missing on
+ * whitespace grounds only.
+ */
+export const fuzzyWhitespaceRegex = (needle: string): RegExp => {
+    const parts = needle
+        .split(/\s+/)
+        .filter((p) => p.length > 0)
+        .map(escapeRegex);
+    return new RegExp(parts.join("\\s+"), "g");
+};
+
+/**
+ * An empty needle is never a match: `indexOf("")` succeeds at every offset, so the offset
+ * scan of a line insert never terminated, a same-line insert or a block landed at offset
+ * 0 and reported OK, and an empty fuzzy or regex needle matched between every character
+ * and wrote the replacement everywhere. The marker parser refuses these earlier; this
+ * guards the JSON and script doors.
+ */
+const emptyNeedle = (op: Op): string | null => {
+    switch (op.kind) {
+        case "fuzzy":
+            return op.find.trim() === "" ? "fuzzy needle is empty or whitespace-only" : null;
+        case "regex":
+            return op.find.source === "(?:)" ? "regex is empty: it would match between every character" : null;
+        case "insertBefore":
+        case "insertAfter":
+        case "insertLinesBefore":
+        case "insertLinesAfter":
+            return op.anchor === "" ? "anchor is empty: the anchor must hold the line to anchor on" : null;
+        case "deleteBlock":
+        case "replaceBlock":
+            if (op.from === "") {
+                return '"from" anchor is empty';
+            }
+
+            return op.to === "" ? '"to" anchor is empty' : null;
+        default:
+            return null;
+    }
+};
+
+/** Apply a list of ops to a string. Pure — no filesystem access. */
+export const applyOps = (content: string, ops: Op[]): { content: string; results: OpResult[] } => {
+    let current = content;
+    const results: OpResult[] = [];
+    let producedBy: BatchContext["producedBy"];
+    for (const op of ops) {
+        let outcome: { content: string; result: OpResult };
+        const empty = emptyNeedle(op);
+        if (empty !== null) {
+            const optional = "optional" in op && op.optional === true;
+            results.push({ status: optional ? "SKIP" : "MISS", desc: opDesc(op), reason: empty });
+            continue;
+        }
+
+        switch (op.kind) {
+            case "regex":
+                outcome = applyRegex(current, op);
+                break;
+            case "deleteBlock":
+            case "replaceBlock":
+                outcome = applyBlock(current, op);
+                break;
+            case "insertBefore":
+            case "insertAfter":
+                outcome = applyInsert(current, op);
+                break;
+            case "insertLinesBefore":
+            case "insertLinesAfter":
+                outcome = applyInsertLines(current, op);
+                break;
+            case "append":
+                outcome = applyAppend(current, op);
+                break;
+            case "dropComments":
+                outcome = applyDropComments(current, op);
+                break;
+            case "deleteLines":
+                outcome = applyDeleteLines(current, op);
+                break;
+            case "fuzzy":
+                outcome = applyFuzzy(current, op);
+                break;
+            default: {
+                // The script door: a misspelled kind is not a literal op.
+                const kind = (op as { kind?: string }).kind;
+                if (kind !== undefined && kind !== "replace") {
+                    outcome = {
+                        content: current,
+                        result: { status: "MISS", desc: opDesc(op), reason: `unknown op kind "${kind}"` },
+                    };
+                    break;
+                }
+
+                outcome = applyLiteral(current, op as LiteralOp, { original: content, producedBy });
+                break;
+            }
+        }
+        if (outcome.result.status === "OK" && outcome.content !== current) {
+            producedBy = { index: results.length, desc: outcome.result.desc };
+        }
+
+        current = outcome.content;
+        results.push(outcome.result);
+    }
+    return { content: current, results };
+};
+
+/** Literal op with count:"all" — replace every occurrence in the file. */
+export const all = ({ find, replace, label }: LiteralSugarParams): LiteralOp => ({
+    find,
+    replace,
+    count: "all",
+    label,
+});
+
+/** Literal op that is allowed to not match (idempotent re-runs, optional cleanups). */
+export const maybe = ({ find, replace, label }: LiteralSugarParams): LiteralOp => ({
+    find,
+    replace,
+    optional: true,
+    label,
+});
+
+/** Delete an exact literal chunk (must occur exactly once). */
+export const drop = ({ find, label }: DropParams): LiteralOp => ({
+    find,
+    replace: "",
+    label: label ?? `drop "${preview(find, 44)}"`,
+});
+
+/**
+ * Delete a whole /** … *\/ JSDoc (or any block) that STARTS with the given prefix.
+ * Sugar over deleteBlock with the closing anchor defaulted to the end of a JSDoc
+ * plus its trailing newline.
+ */
+export const dropJsdocStarting = ({ fromPrefix, label }: DropJsdocParams): DeleteBlockOp => ({
+    kind: "deleteBlock",
+    from: fromPrefix,
+    to: " */\n",
+    label: label ?? `dropJsdoc "${preview(fromPrefix, 40)}"`,
+});

--- a/plugins/genesis-tools/skills/fable-replace/scripts/example.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/example.ts
@@ -1,0 +1,105 @@
+/**
+ * Template for a throwaway sweep SCRIPT. You rarely need one: for literal edits,
+ * inserts, appends and new files the CLI is one call with no code at all —
+ *
+ *   bun "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/cli.ts" <<'EOF'
+ *   @@ src/foo.ts
+ *   <<<
+ *   old text
+ *   ===
+ *   new text
+ *   >>>
+ *   EOF
+ *
+ * Reach for a script when you need recon (findFiles / countMatches / grepPreview),
+ * a cross-file rename with pinned counts, comment sweeps, or a replacer FUNCTION.
+ * Every multi-input function takes ONE object; `bun cli.ts --api` prints every
+ * signature with its docs.
+ *
+ *   bun <your-script>.ts --dry   # preview diffs, writes nothing
+ *   bun <your-script>.ts         # transactional apply (all-or-nothing)
+ *
+ * 🛑 Never a hard-coded generic /tmp path for backupDir or logs: /tmp is shared
+ * machine-wide and two parallel agents overwrote each other's evidence. scratchDir().
+ */
+import {
+    all,
+    countMatches,
+    drop,
+    dropJsdocStarting,
+    findFiles,
+    grepPreview,
+    leftovers,
+    maybe,
+    mergeFileEdits,
+    renameSymbolAcross,
+    run,
+    sameOpsAcross,
+    scratchDir,
+} from "./replace-utils";
+
+// A copy of this template that lives elsewhere imports from
+// "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/replace-utils" instead.
+
+const scratch = scratchDir("my-sweep");
+
+// ── recon, entirely inside the API ───────────────────────────────────────────
+const targets = findFiles({ roots: ["src"], containing: /\boldName\b/ });
+const EXPECT = countMatches({ files: targets, pattern: "oldName" }); // paste-ready counts + zero-match and shadowing warnings
+grepPreview({ files: targets.slice(0, 3), pattern: /oldName(?=\()/, context: 2 });
+
+await run({
+    edits: [
+        {
+            file: "src/some/File.ts",
+            ops: [
+                { find: `const x = oldName(y);`, replace: `const x = newName(y);` }, // exactly once (default)
+                all({ find: "oldName(", replace: "newName(" }), // every occurrence
+                dropJsdocStarting({ fromPrefix: "/**\n * Legacy parity" }), // delete a JSDoc by its opening lines
+                maybe({ find: "// TODO remove me\n", replace: "" }), // fine if already gone on a re-run
+                { kind: "regex", find: /useFoo\(([^)]*)\)/g, replace: "useBar($1)", expect: 3 }, // pinned match count
+                {
+                    kind: "insertLinesAfter",
+                    anchor: `import React from "react";`,
+                    text: `import { thing } from "pkg";`,
+                },
+                { kind: "append", text: "export {};" },
+            ],
+            expectAfter: ["newName"],
+            absentAfter: ["oldName"],
+        },
+
+        // Comment sweep: the COMMENT goes, code on the same line stays (deleteLines would
+        // delete the whole statement). One expect per file, from the countMatches map.
+        ...Object.entries(EXPECT).map(([file, n]) => ({
+            file,
+            ops: [{ kind: "dropComments" as const, containing: "eslint-disable", expect: n }],
+        })),
+
+        // Identical counts → one shared op list is safe:
+        ...sameOpsAcross({
+            files: ["src/a.tsx", "src/b.tsx"],
+            ops: [{ kind: "deleteLines", containing: "console.debug(" }],
+        }),
+
+        // Cross-file identifier rename, word-boundary anchored. Pass the countMatches map
+        // to pin every count; mergeFileEdits lets two renames share files.
+        ...mergeFileEdits([
+            ...renameSymbolAcross({ files: EXPECT, oldName: "oldName", newName: "newName" }),
+            ...renameSymbolAcross({
+                files: findFiles({ roots: ["src"], containing: /\botherName\b/ }),
+                oldName: "otherName",
+                newName: "renamedOther",
+            }),
+        ]),
+
+        { file: "src/dead/Orphan.ts", delete: true },
+        { file: "src/old/Path.ts", renameTo: "src/new/Path.ts" },
+        { file: "src/two.ts", ops: [drop({ find: "// old comment\n" })] },
+    ],
+    backupDir: scratch, // one per sweep, never reused; the scratch dir ITSELF, so the age prune can reclaim it
+    verifyCommand: "bunx tsgo --noEmit", // proves completeness; red keeps the writes and throws code 3 (rollback({ backupDir }) undoes)
+    leftoversCheck: { names: ["oldName"], dirs: ["."] }, // a rename is not done while docs still say oldName
+});
+
+leftovers({ names: ["oldName"], dirs: ["src", "docs", "README.md"] });

--- a/plugins/genesis-tools/skills/fable-replace/scripts/internal.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/internal.ts
@@ -1,0 +1,211 @@
+/**
+ * fable-replace — private helpers shared by the other modules. Not part of the
+ * story a sweep script needs; nothing here decides policy.
+ */
+
+import * as fs from "node:fs";
+import type { LiteralOp, NthIndexOfParams, Op, RunReport } from "./types";
+
+/**
+ * Every failure `run()` / `rollback()` / `renameSymbolAcross()` raises. `code` mirrors
+ * the CLI exit code: 1 = misses or a partial write (nothing, or not everything, landed);
+ * 2 = pre-flight / spec; 3 = the sweep IS written, but the verify failed or stale prose
+ * survived. Three is the one a reader must never mistake for one.
+ *
+ * `report` carries the same RunReport a successful `run()` returns, so a catch can read
+ * `err.report.files` / `.written` / `.missCount` instead of parsing the message. It is
+ * set on the MISS and stale-prose failures, where a report exists; a pre-flight refusal
+ * happens before any file is planned, so there it stays undefined.
+ */
+export class FableReplaceError extends Error {
+    readonly code: 1 | 2 | 3;
+
+    readonly report?: RunReport;
+
+    constructor(message: string, code: 1 | 2 | 3, report?: RunReport) {
+        super(message);
+        this.name = "FableReplaceError";
+        this.code = code;
+        this.report = report;
+    }
+}
+
+/** 1-based line numbers where `needle` (string or RegExp) matches, capped, for MISS reasons. */
+export const matchLines = ({
+    content,
+    needle,
+    cap = 12,
+}: {
+    content: string;
+    needle: string | RegExp;
+    cap?: number;
+}): string => {
+    const lines: number[] = [];
+    if (typeof needle === "string") {
+        let idx = content.indexOf(needle);
+        while (idx !== -1 && lines.length <= cap) {
+            lines.push(content.slice(0, idx).split("\n").length);
+            idx = content.indexOf(needle, idx + Math.max(1, needle.length));
+        }
+    } else {
+        const rx = new RegExp(needle.source, needle.flags.includes("g") ? needle.flags : `${needle.flags}g`);
+        for (const m of content.matchAll(rx)) {
+            lines.push(content.slice(0, m.index ?? 0).split("\n").length);
+            if (lines.length > cap) {
+                break;
+            }
+        }
+    }
+    const shown = lines.slice(0, cap).join(", ");
+    return lines.length > cap ? `${shown}, …` : shown;
+};
+
+/**
+ * A regex carrying `g` or `y` keeps `lastIndex` between `.test()` calls, so one
+ * instance tested against many strings silently skips every other match. Every
+ * predicate use goes through this stateless clone instead.
+ */
+export const stateless = (rx: RegExp): RegExp =>
+    rx.global || rx.sticky ? new RegExp(rx.source, rx.flags.replace(/[gy]/g, "")) : rx;
+
+export const preview = (s: string, max = 60): string => {
+    const flat = s.replace(/\n/g, "\\n").replace(/\t/g, "\\t");
+    return flat.length <= max ? flat : `${flat.slice(0, max)}…`;
+};
+
+export const countOccurrences = (haystack: string, needle: string): number => {
+    if (needle.length === 0) {
+        return 0;
+    }
+    let count = 0;
+    let idx = haystack.indexOf(needle);
+    while (idx !== -1) {
+        count += 1;
+        idx = haystack.indexOf(needle, idx + needle.length);
+    }
+    return count;
+};
+
+/** Offsets where `needle` STARTS a line (offset 0 or right after "\n"), non-overlapping. */
+export const lineStartOffsets = (haystack: string, needle: string): number[] => {
+    const offsets: number[] = [];
+    if (needle.length === 0) {
+        return offsets;
+    }
+    let idx = haystack.indexOf(needle);
+    while (idx !== -1) {
+        if (idx === 0 || haystack[idx - 1] === "\n") {
+            offsets.push(idx);
+            idx = haystack.indexOf(needle, idx + needle.length);
+        } else {
+            idx = haystack.indexOf(needle, idx + 1);
+        }
+    }
+    return offsets;
+};
+
+/**
+ * The line ending the file already uses, so inserted lines match their neighbours.
+ * A file holding any CRLF at all is treated as CRLF: splicing one LF line into a CRLF
+ * file is what later shows up as phantom diff noise.
+ */
+export const dominantEol = (content: string): string => (content.includes("\r\n") ? "\r\n" : "\n");
+
+/** Index of the 1-based n-th occurrence of `needle`, or -1. */
+export const nthIndexOf = ({ haystack, needle, n }: NthIndexOfParams): number => {
+    // Non-overlapping, the same walk `countOccurrences` does: "aa" in "aaaa" has two
+    // occurrences, so the 2nd starts at 2, not 1. Advancing one character at a time
+    // disagreed with the count `locateBlock` had just used to prove the anchor unique.
+    let idx = -1;
+    let from = 0;
+    for (let i = 0; i < n; i += 1) {
+        idx = haystack.indexOf(needle, from);
+        if (idx === -1) {
+            return -1;
+        }
+        from = idx + Math.max(1, needle.length);
+    }
+    return idx;
+};
+
+export const replaceAllLiteral = (haystack: string, needle: string, replacement: string): string =>
+    haystack.split(needle).join(replacement);
+
+export const replaceNLiteral = (haystack: string, needle: string, replacement: string, n: number): string => {
+    // The offsets are collected against the ORIGINAL string, non-overlapping (the same
+    // walk `countOccurrences` does), and spliced in from the END. Searching the MUTATED
+    // string on each pass meant a replacement that CONTAINS the needle re-matched itself:
+    // count=2 of "oldName" → "wrapper(oldName)" wrapped the first call site twice, never
+    // touched the second, and still reported "OK ×2 of 2 declared".
+    const offsets: number[] = [];
+    let idx = haystack.indexOf(needle);
+    while (idx !== -1 && offsets.length < n) {
+        offsets.push(idx);
+        idx = haystack.indexOf(needle, idx + needle.length);
+    }
+
+    let out = haystack;
+    for (const at of offsets.reverse()) {
+        out = out.slice(0, at) + replacement + out.slice(at + needle.length);
+    }
+
+    return out;
+};
+
+export const opDesc = (op: Op): string => {
+    if (op.label) {
+        return op.label;
+    }
+    switch (op.kind) {
+        case "regex":
+            return `regex ${String(op.find)}`;
+        case "deleteBlock":
+            return `deleteBlock "${preview(op.from, 40)}" → "${preview(op.to, 24)}"`;
+        case "replaceBlock":
+            return `replaceBlock "${preview(op.from, 40)}" → "${preview(op.to, 24)}"`;
+        case "insertBefore":
+        case "insertAfter":
+        case "insertLinesBefore":
+        case "insertLinesAfter":
+            return `${op.kind} "${preview(op.anchor, 40)}"`;
+        case "append":
+            return `append "${preview(op.text, 40)}"`;
+        default:
+            return `replace "${preview((op as LiteralOp).find, 48)}"`;
+    }
+};
+
+export const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * A JavaScript identifier on its own. `\b` is a WORD boundary and `$` is not a word
+ * character, so `\bfoo\b` also matched inside `$foo`, and `\b$foo\b` never matched a
+ * declaration of `$foo`.
+ */
+export const identifierPattern = (name: string): string => `(?<![\\w$])${escapeRegex(name)}(?![\\w$])`;
+
+export const COLORS = {
+    ok: "\x1b[32m",
+    miss: "\x1b[31m",
+    skip: "\x1b[33m",
+    dim: "\x1b[2m",
+    bold: "\x1b[1m",
+    reset: "\x1b[0m",
+};
+
+const useColor = process.stdout.isTTY === true;
+
+export const paint = (code: string, s: string): string => (useColor ? `${code}${s}${COLORS.reset}` : s);
+
+/**
+ * Did `abs` change since the sweep read it? The whole file is read into memory at plan
+ * time; writing without this check silently destroyed a concurrent write and still
+ * reported OK. A file that vanished counts as changed.
+ */
+export const changedOnDisk = ({ abs, expected }: { abs: string; expected: string }): boolean => {
+    if (!fs.existsSync(abs)) {
+        return true;
+    }
+
+    return fs.readFileSync(abs, "utf8") !== expected;
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/journal.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/journal.ts
@@ -1,0 +1,257 @@
+/**
+ * fable-replace — THE JOURNAL. One JSON line per CLI run, rollback and prune, so "which
+ * sweeps failed this week", "what did that failure cost" and "which spec trap costs the
+ * most" have an answer without re-reading session transcripts.
+ *
+ * Lives beside the other GenesisTools data, `<home>/.genesis-tools/fable-replace/journal.jsonl`,
+ * where home is FABLE_REPLACE_HOME, else GENESIS_TOOLS_HOME (the repo's test sandbox sets it,
+ * so `bun test` never writes the real file), else the user's home. Plain appends, no lock:
+ * eight processes appending 250 lines each produced 2,000 well-formed lines at 400-byte and
+ * 90 KB payloads. That holds for a local filesystem, never a network share. The writer never
+ * throws: a failed append is one stderr line and the run's exit code stands.
+ *
+ * The spec text is never journaled (the file is durable, specs are source). Its size and
+ * hash are. The text itself goes beside the backup, the ephemeral place.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseJson, stringifyJson } from "./json";
+
+export type JournalOutcome =
+    | "ok"
+    | "miss"
+    | "spec-error"
+    | "pre-flight"
+    | "write-failed"
+    | "written"
+    | "verify-failed"
+    | "verify-unknown"
+    | "stale-prose"
+    | "dry-ok"
+    | "dry-miss"
+    | "partial"
+    | "rollback"
+    | "prune"
+    | "error";
+
+export interface JournalEntry {
+    ts: string;
+    runId: string;
+    pid: number;
+    cwd: string;
+    kind: "run" | "rollback" | "prune";
+    outcome: JournalOutcome;
+    spec?: { files: number; ops: number; chars: number; hash: string };
+    flags?: string[];
+    missCount?: number;
+    /** The first three MISS reasons, truncated: what aggregates into "which trap costs the most". */
+    reasons?: string[];
+    specError?: string;
+    written?: number;
+    backupDir?: string;
+    verify?: {
+        cmd: string;
+        status: string;
+        exit: number | null;
+        ms: number;
+        outputChars: number;
+        shownLines: number;
+        timedOut: boolean;
+        buffered: boolean;
+    };
+    durationMs?: number;
+    /** Everything the CLI printed: the tokens a model reads back. */
+    resultChars?: number;
+    tokensEst?: { spec: number; result: number };
+    rollback?: { restored: number; drifted: number; failed: number };
+    prune?: { removed: number; bytes: number };
+    message?: string;
+}
+
+/**
+ * Tokens only, never dollars: this script cannot reach the shared price catalog, and a
+ * second rate table goes stale silently. A reader multiplies the spec tokens by the output
+ * rate of the model that wrote them. The divisor is the measured average for code and specs.
+ */
+export const TOKEN_ESTIMATE = {
+    charsPerToken: 3.7,
+};
+
+/** One archive at the cap; the second rotation discards the first archive. About 30 heavy sessions. */
+export const JOURNAL_MAX_BYTES = 5 * 1024 * 1024;
+const MAX_FIELD_CHARS = 300;
+const MAX_REASON_CHARS = 80;
+
+export const journalHome = (): string => {
+    const home = process.env.FABLE_REPLACE_HOME ?? process.env.GENESIS_TOOLS_HOME ?? os.homedir();
+    return path.join(home, ".genesis-tools", "fable-replace");
+};
+
+export const journalPath = (): string => path.join(journalHome(), "journal.jsonl");
+
+const archivePath = (): string => path.join(journalHome(), "journal.1.jsonl");
+
+export const estimateTokens = (chars: number): number => Math.round(chars / TOKEN_ESTIMATE.charsPerToken);
+
+const clipField = (text: string, max = MAX_FIELD_CHARS): string =>
+    text.length <= max ? text : `${text.slice(0, max)}…`;
+
+/** Append one line. Never throws. Long fields are clipped so a runaway command string cannot bloat every line. */
+export const appendJournal = (entry: JournalEntry): void => {
+    const file = journalPath();
+    try {
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        const clipped: JournalEntry = {
+            ...entry,
+            specError: entry.specError === undefined ? undefined : clipField(entry.specError),
+            reasons: entry.reasons?.slice(0, 3).map((reason) => clipField(reason, MAX_REASON_CHARS)),
+            verify: entry.verify === undefined ? undefined : { ...entry.verify, cmd: clipField(entry.verify.cmd) },
+            message: entry.message === undefined ? undefined : clipField(entry.message),
+        };
+        try {
+            if (fs.statSync(file).size > JOURNAL_MAX_BYTES) {
+                fs.renameSync(file, archivePath());
+            }
+        } catch (err) {
+            if ((err as { code?: string }).code !== "ENOENT") {
+                throw err;
+            }
+        }
+        fs.appendFileSync(file, `${stringifyJson(clipped)}\n`);
+    } catch (err) {
+        console.error(`journal: could not append to ${file}: ${String(err)}`);
+    }
+};
+
+/** Every parseable line, archive first, oldest to newest. Malformed lines are counted, never fatal. */
+export const readJournal = ({ limit, sinceMs }: { limit?: number; sinceMs?: number } = {}): JournalEntry[] => {
+    const entries: JournalEntry[] = [];
+    let malformed = 0;
+    for (const file of [archivePath(), journalPath()]) {
+        if (!fs.existsSync(file)) {
+            continue;
+        }
+
+        for (const line of fs.readFileSync(file, "utf8").split("\n")) {
+            if (line.trim() === "") {
+                continue;
+            }
+
+            try {
+                entries.push(parseJson(line) as JournalEntry);
+            } catch {
+                malformed += 1;
+            }
+        }
+    }
+    if (malformed > 0) {
+        console.error(`journal: skipped ${malformed} malformed line(s)`);
+    }
+
+    const since = sinceMs === undefined ? entries : entries.filter((entry) => Date.parse(entry.ts) >= sinceMs);
+    return limit === undefined ? since : since.slice(-limit);
+};
+
+const compact = (n: number): string => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n));
+
+export const printHistory = (limit: number): void => {
+    const entries = readJournal({ limit });
+    if (entries.length === 0) {
+        console.log(`journal is empty: ${journalPath()}`);
+        return;
+    }
+
+    console.log(`last ${entries.length} entries from ${journalPath()}`);
+    for (const entry of entries) {
+        const when = entry.ts.slice(0, 16).replace("T", " ");
+        const spec = entry.spec === undefined ? "" : `${entry.spec.files}f/${entry.spec.ops}op`;
+        const tokens =
+            entry.tokensEst === undefined
+                ? ""
+                : `spec ${compact(entry.tokensEst.spec)} result ${compact(entry.tokensEst.result)} tok`;
+        const verify =
+            entry.verify === undefined
+                ? ""
+                : `verify ${entry.verify.status}${entry.verify.exit === null ? "" : ` (exit ${entry.verify.exit})`}`;
+        const extra =
+            entry.rollback !== undefined
+                ? `restored ${entry.rollback.restored}, drifted ${entry.rollback.drifted}, failed ${entry.rollback.failed}`
+                : entry.prune !== undefined
+                  ? `removed ${entry.prune.removed} dir(s), ${compact(entry.prune.bytes)} B`
+                  : "";
+        const backup = entry.backupDir === undefined ? "" : `backup ${entry.backupDir}`;
+        console.log(
+            [when, entry.outcome.padEnd(14), spec.padEnd(9), tokens, verify, extra, backup]
+                .filter((s) => s !== "")
+                .join("  ")
+        );
+        if (entry.reasons !== undefined && entry.reasons.length > 0) {
+            console.log(`                 ↳ ${entry.reasons.join(" | ")}`);
+        }
+    }
+};
+
+/** Outcomes whose spec had to be re-sent: the text cost that a better spec would have avoided. */
+const WASTED = new Set<JournalOutcome>(["miss", "spec-error", "pre-flight", "write-failed", "dry-miss", "error"]);
+
+export const printStats = (days: number): void => {
+    const raw = readJournal({ sinceMs: Date.now() - days * 86_400_000 }).filter((entry) => entry.kind === "run");
+    // The CLI writes a "written" breadcrumb before a verify and a terminal line after it,
+    // both under one runId. A run counts once: the terminal line wins, and the breadcrumb
+    // survives only for a run that never reached its terminal line (killed mid-verify).
+    const byRun = new Map<string, JournalEntry>();
+    for (const entry of raw) {
+        const seen = byRun.get(entry.runId);
+        if (seen === undefined || seen.outcome === "written") {
+            byRun.set(entry.runId, entry);
+        }
+    }
+    const entries = [...byRun.values()];
+    if (entries.length === 0) {
+        console.log(`no runs in the last ${days} day(s) in ${journalPath()}`);
+        return;
+    }
+
+    const byOutcome = new Map<string, number>();
+    const reasons = new Map<string, number>();
+    let specTokens = 0;
+    let resultTokens = 0;
+    let wastedTokens = 0;
+    let wastedRuns = 0;
+    for (const entry of entries) {
+        byOutcome.set(entry.outcome, (byOutcome.get(entry.outcome) ?? 0) + 1);
+        specTokens += entry.tokensEst?.spec ?? 0;
+        resultTokens += entry.tokensEst?.result ?? 0;
+        if (WASTED.has(entry.outcome)) {
+            wastedTokens += entry.tokensEst?.spec ?? 0;
+            wastedRuns += 1;
+        }
+        for (const reason of entry.reasons ?? []) {
+            const key = reason.replace(/\d+/g, "N").slice(0, 60);
+            reasons.set(key, (reasons.get(key) ?? 0) + 1);
+        }
+    }
+
+    const { charsPerToken } = TOKEN_ESTIMATE;
+    console.log(`fable-replace runs, last ${days} day(s): ${entries.length} (${journalPath()})`);
+    for (const [outcome, count] of [...byOutcome.entries()].sort((a, b) => b[1] - a[1])) {
+        console.log(`  ${outcome.padEnd(14)} ${count}`);
+    }
+    console.log(
+        `tokens (chars ÷ ${charsPerToken}): spec ${compact(specTokens)} written by the model, result ${compact(resultTokens)} read back`
+    );
+    console.log(
+        `wasted on ${wastedRuns} failed run(s) whose spec had to be re-sent: ${compact(wastedTokens)} spec tokens`
+    );
+    console.log(
+        "no price here: multiply the spec tokens by the output rate of the model that wrote them. Round trips cost more than text: each failed run also bought one."
+    );
+    if (reasons.size > 0) {
+        console.log("top MISS reasons:");
+        for (const [reason, count] of [...reasons.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5)) {
+            console.log(`  ${count}× ${reason}`);
+        }
+    }
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/json.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/json.ts
@@ -1,0 +1,15 @@
+/**
+ * fable-replace — JSON without the bare global. The repo's lint denies `JSON` so that
+ * application code goes through SafeJSON; a standalone plugin script cannot import it,
+ * so the two calls live here, once, instead of one ignore per call site.
+ */
+
+export const parseJson = (text: string): unknown => {
+    // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+    return JSON.parse(text);
+};
+
+export const stringifyJson = (value: unknown, indent?: number): string => {
+    // biome-ignore lint/style/noRestrictedGlobals: standalone script without access to SafeJSON
+    return JSON.stringify(value, null, indent);
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/recon.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/recon.ts
@@ -1,0 +1,301 @@
+/**
+ * fable-replace — RECON. Look before you declare an op.
+ *
+ * `grepPreview` takes a JS RegExp (so lookahead/lookbehind work, unlike plain
+ * ripgrep) or a literal string, and prints every match with context.
+ *
+ * When you are hunting import specifiers, match the QUOTED SPECIFIER itself, not
+ * the statement shape. A pattern anchored on `import … from` silently undercounts:
+ * it misses multi-line import statements, `export … from`, dynamic `import("…")`
+ * and type-only `import("…").Type` positions.
+ */
+
+import * as fs from "node:fs";
+import { escapeRegex, FableReplaceError, identifierPattern, stateless } from "./internal";
+import { stringifyJson } from "./json";
+import type {
+    CountMatchesParams,
+    FindFilesParams,
+    GrepPreviewParams,
+    LeftoversParams,
+    ShadowedFilesParams,
+} from "./types";
+
+/**
+ * Recon helper: print every match of `pattern` across files with `context`
+ * lines around it. Use INSIDE a sweep script before committing to ops, or in a
+ * quick `bun -e` — keeps the recon and the edit in one reviewable place.
+ */
+export const grepPreview = ({ files, pattern, context = 2 }: GrepPreviewParams): number => {
+    const rx = typeof pattern === "string" ? new RegExp(escapeRegex(pattern)) : stateless(pattern);
+    let total = 0;
+    for (const file of files) {
+        if (!fs.existsSync(file)) {
+            console.log(`?? ${file} (missing)`);
+            continue;
+        }
+        const lines = fs.readFileSync(file, "utf8").split("\n");
+        lines.forEach((l, idx) => {
+            if (rx.test(l)) {
+                total += 1;
+                console.log(`\n${file}:${idx + 1}`);
+                for (let j = Math.max(0, idx - context); j <= Math.min(lines.length - 1, idx + context); j += 1) {
+                    console.log(`${j === idx ? ">" : " "} ${String(j + 1).padStart(4)}| ${lines[j]}`);
+                }
+            }
+        });
+    }
+    console.log(`\n${total} match(es) across ${files.length} file(s)`);
+    return total;
+};
+
+const CODE_EXT_RE = /\.(m|c)?(ts|js)x?$/;
+// Tested against each directory NAME while descending, never against the root the
+// caller passed in — a root under .worktrees/ must still be scannable.
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git", "dist", "build", "coverage", ".next"]);
+
+const walk = (dir: string, out: string[]): void => {
+    // A fable-replace backup dir holds pre-sweep copies, so it ALWAYS contains the old
+    // name. Reporting it as a survivor is pure noise.
+    if (fs.existsSync(`${dir}/fable-replace-manifest.json`)) {
+        return;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = `${dir}/${entry.name}`;
+        if (entry.isDirectory()) {
+            if (SKIP_DIR_NAMES.has(entry.name)) {
+                continue;
+            }
+            walk(full, out);
+        } else if (entry.isFile()) {
+            out.push(full);
+        }
+    }
+};
+
+export interface LeftoverReport {
+    /** Matches in code — usually legitimate aliases and re-exports, but check them. */
+    code: string[];
+    /** Matches in prose (markdown, text). A rename that skipped these left the docs lying. */
+    docs: string[];
+}
+
+/**
+ * After a rename, find every place the OLD name still appears. Three of five trial
+ * sweeps shipped green code while leaving README/CLAUDE.md naming a symbol that no
+ * longer existed, so this splits code hits (often legitimate aliases) from prose hits
+ * (almost never legitimate).
+ */
+export const leftovers = ({ names: needles, dirs, quiet = false }: LeftoversParams): LeftoverReport => {
+    const report: LeftoverReport = { code: [], docs: [] };
+    const files: string[] = [];
+    for (const entry of dirs) {
+        if (!fs.existsSync(entry)) {
+            continue;
+        }
+        // A plain file is a legitimate target — the docs' own example passes README.md,
+        // and readdirSync on it used to throw ENOTDIR.
+        if (fs.statSync(entry).isDirectory()) {
+            walk(entry, files);
+        } else {
+            files.push(entry);
+        }
+    }
+    for (const file of files) {
+        let content: string;
+        try {
+            content = fs.readFileSync(file, "utf8");
+        } catch {
+            continue;
+        }
+        for (const needle of needles) {
+            const rx = needleRegex(needle);
+            if (!rx.test(content)) {
+                continue;
+            }
+            const lines = content
+                .split("\n")
+                .flatMap((l, i) => (rx.test(l) ? [`${file}:${i + 1}: ${l.trim().slice(0, 100)}`] : []));
+            const bucket = CODE_EXT_RE.test(file) ? report.code : report.docs;
+            for (const hit of lines) {
+                // one line matching two needles is ONE surviving line, not two
+                if (!bucket.includes(hit)) {
+                    bucket.push(hit);
+                }
+            }
+        }
+    }
+    if (!quiet && report.docs.length > 0) {
+        console.log(
+            `\n⚠ ${report.docs.length} PROSE mention(s) of ${needles.join(", ")} survive the sweep — the docs now name something that does not exist:`
+        );
+        for (const hit of report.docs.slice(0, 20)) {
+            console.log(`  ${hit}`);
+        }
+    }
+    if (!quiet && report.docs.length === 0 && report.code.length === 0) {
+        console.log(`leftovers: 0 hit(s) for ${needles.join(", ")} — nothing survives.`);
+    }
+    if (!quiet && report.code.length > 0) {
+        console.log(
+            `\n${report.code.length} code mention(s) remain (aliases and re-exports are legitimate — confirm each):`
+        );
+        for (const hit of report.code.slice(0, 10)) {
+            console.log(`  ${hit}`);
+        }
+    }
+    return report;
+};
+
+const IDENTIFIER_RE = /^[A-Za-z_$][\w$]*$/;
+
+/**
+ * Word-boundary anchoring is right for an identifier and WRONG for anything else.
+ * `\b@genesiscz/utils/Stopwatch\b` matches nothing at all, because the characters
+ * either side of the needle are already non-word — so a leftover import path silently
+ * reported zero hits, which is the worst possible failure in a safety check.
+ */
+const needleRegex = (needle: string, flags = ""): RegExp =>
+    new RegExp(IDENTIFIER_RE.test(needle) ? identifierPattern(needle) : escapeRegex(needle), flags);
+
+/**
+ * Occurrences per file, ready to paste into `expect:` / `count:`. Two independent
+ * trial runs hand-rolled `grep -o … | wc -l` loops for exactly this, then transcribed
+ * the numbers by hand — which is a silent-error step in the one place the whole
+ * verification contract rests on.
+ *
+ * A string pattern that looks like an identifier is matched on word boundaries (what
+ * you want for a symbol rename); any other string is matched literally. A RegExp is
+ * used as given, with the `g` flag forced on.
+ */
+export const countMatches = ({ files, pattern, quiet = false }: CountMatchesParams): Record<string, number> => {
+    const rx =
+        typeof pattern === "string"
+            ? needleRegex(pattern, "g")
+            : new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`);
+    const counts: Record<string, number> = {};
+    for (const file of files) {
+        if (!fs.existsSync(file)) {
+            console.log(`?? ${file} (missing)`);
+            continue;
+        }
+        counts[file] = (fs.readFileSync(file, "utf8").match(rx) ?? []).length;
+    }
+    // A file that DECLARES the same bare name matters, but not always the same way:
+    //  - it declares AND imports the name  -> a local wrapper shadowing the shared one.
+    //    Renaming its declaration changes an unrelated helper. Keep it out of the bucket.
+    //  - it declares and does NOT import it -> the definition you are probably renaming,
+    //    or an independent implementation. Only you can tell which.
+    // Reporting both as "unrelated" cried wolf on the source module itself.
+    const split =
+        typeof pattern === "string" && IDENTIFIER_RE.test(pattern)
+            ? shadowedFiles({ files: Object.keys(counts), name: pattern })
+            : { shadows: [], declarers: [] };
+    const { shadows, declarers } = split;
+    if (!quiet) {
+        const entries = Object.entries(counts);
+        const total = entries.reduce((sum, [, n]) => sum + n, 0);
+        const zero = entries.filter(([, n]) => n === 0);
+        console.log(`\ncountMatches ${String(rx)} — ${total} occurrence(s) in ${entries.length} file(s):`);
+        console.log(`const EXPECT: Record<string, number> = {`);
+        for (const [file, n] of entries) {
+            console.log(`\t${stringifyJson(file)}: ${n},`);
+        }
+        console.log(`};`);
+        if (shadows.length > 0) {
+            console.log(
+                `⚠ ${shadows.length} file(s) both IMPORT and DECLARE "${String(pattern)}" — a local wrapper. Renaming its declaration changes an unrelated helper:`
+            );
+            for (const file of shadows) {
+                console.log(`  ${file}`);
+            }
+        }
+        if (declarers.length > 0) {
+            console.log(
+                `· ${declarers.length} file(s) DECLARE "${String(pattern)}" without importing it — the definition you are renaming, or an independent implementation. Decide per file:`
+            );
+            for (const file of declarers) {
+                console.log(`  ${file}`);
+            }
+        }
+        if (zero.length > 0) {
+            console.log(
+                `⚠ ${zero.length} file(s) contain ZERO matches — a non-optional op on those is a guaranteed MISS:`
+            );
+            for (const [file] of zero) {
+                console.log(`  ${file}`);
+            }
+        }
+    }
+    return counts;
+};
+
+/**
+ * Split `files` by how they relate to the identifier `name`: `shadows` both import AND
+ * declare it (a local wrapper: renaming its declaration changes an unrelated helper),
+ * `declarers` declare it without importing it (the definition, or an independent one).
+ * countMatches prints this; renameSymbolAcross refuses the shadows unless told otherwise.
+ */
+export const shadowedFiles = ({ files, name }: ShadowedFilesParams): { shadows: string[]; declarers: string[] } => {
+    const shadows: string[] = [];
+    const declarers: string[] = [];
+    const declRe = new RegExp(`\\b(?:function|class|const|let|var|interface|type)\\s+${identifierPattern(name)}`);
+    const importRe = new RegExp(`import[^;]*${identifierPattern(name)}[^;]*from`, "s");
+    for (const file of files) {
+        let src: string;
+        try {
+            src = fs.readFileSync(file, "utf8");
+        } catch {
+            continue;
+        }
+        if (!declRe.test(src)) {
+            continue;
+        }
+        (importRe.test(src) ? shadows : declarers).push(file);
+    }
+    return { shadows, declarers };
+};
+
+/**
+ * Every file under `roots` whose CONTENT matches — the recon step that has to happen
+ * BEFORE countMatches/grepPreview, which both take an already-known file list.
+ *
+ * Without this you cannot start inside the documented API: you shell out to ripgrep
+ * for the file list first, which is exactly what the docs tell you not to do. Skips
+ * node_modules, build output, and fable-replace backup dirs.
+ */
+export const findFiles = ({ roots, containing, exts = [".ts", ".tsx"] }: FindFilesParams): string[] => {
+    // Without this, a forgotten `containing` returns [] — which reads as "no file holds
+    // the symbol" and quietly turns the whole sweep into a no-op.
+    if (containing === undefined || containing === "") {
+        throw new FableReplaceError(
+            'findFiles: "containing" is required (a literal string or a RegExp); it is the content filter, not an option',
+            2
+        );
+    }
+
+    const rx = typeof containing === "string" ? new RegExp(escapeRegex(containing)) : stateless(containing);
+    const all: string[] = [];
+    for (const root of roots) {
+        if (!fs.existsSync(root)) {
+            continue;
+        }
+        // A plain file is a legitimate root too (README.md, CLAUDE.md): readdirSync on
+        // it used to throw a bare ENOTDIR.
+        if (fs.statSync(root).isFile()) {
+            all.push(root);
+        } else {
+            walk(root, all);
+        }
+    }
+    return all
+        .filter((file) => exts.length === 0 || exts.some((ext) => file.endsWith(ext)))
+        .filter((file) => {
+            try {
+                return rx.test(fs.readFileSync(file, "utf8"));
+            } catch {
+                return false;
+            }
+        })
+        .sort();
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/rename-symbols.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/rename-symbols.ts
@@ -1,0 +1,75 @@
+/**
+ * fable-replace — RENAMING AN IDENTIFIER ACROSS MANY FILES.
+ *
+ *   renameSymbolAcross({ files, oldName: "oldName", newName: "newName" })
+ *
+ * The rename is word-boundary anchored, so `oldName` never matches inside
+ * `_oldName` or `oldNameSuffix`. Every listed file MUST contain the symbol: a file
+ * that does not is a MISS. When you are renaming several symbols that live in
+ * OVERLAPPING but different file sets, bucket the files per symbol rather than
+ * passing one list for all of them.
+ *
+ * A rename is not finished when the code is green. Sweep the markdown that names
+ * the symbol too (README, CLAUDE.md, docs), or you leave the docs lying.
+ */
+
+import { FableReplaceError, identifierPattern } from "./internal";
+import { shadowedFiles } from "./recon";
+import type { FileEdit, RegexOp, RenameSymbolAcrossParams, RenameSymbolParams, SameOpsAcrossParams } from "./types";
+
+/** Same set of ops applied to many files (e.g. rename a symbol across call sites). */
+export const sameOpsAcross = ({ files, ops, extra = {} }: SameOpsAcrossParams): FileEdit[] =>
+    files.map((file) => ({ file, ops, ...extra }));
+
+export const renameSymbol = ({ oldName, newName, expect }: RenameSymbolParams): RegexOp => ({
+    kind: "regex",
+    find: new RegExp(identifierPattern(oldName), "g"),
+    // A function, so a `$` in the new name is literal: as a replacement STRING, "$$foo"
+    // would have been written as "$foo".
+    replace: () => newName,
+    expect,
+    label: `rename ${oldName} → ${newName}`,
+});
+
+/**
+ * Word-boundary rename of an identifier in one file's ops form. Use with
+ * sameOpsAcross() for a cross-file rename:
+ *   sameOpsAcross({ files, ops: [renameSymbol({ oldName: "getLinkGate", newName: "getActionDisabledState" })] })
+ */
+/**
+ * The commonest sweep of all, in one call:
+ *   renameSymbolAcross({ files, oldName: "oldName", newName: "newName" })
+ * Equivalent to sameOpsAcross({ files, ops: [renameSymbol({ oldName, newName })] }). Every listed file
+ * MUST contain the symbol — a file that does not is a MISS, so bucket your file
+ * list by which symbol it actually holds rather than passing one list for several
+ * renames.
+ */
+export const renameSymbolAcross = ({
+    files,
+    oldName,
+    newName,
+    extra = {},
+    includeShadowed = false,
+}: RenameSymbolAcrossParams): FileEdit[] => {
+    // countMatches only WARNS about local wrappers; a caller piping its map straight in
+    // renamed one anyway. Refusing here makes the warning binding.
+    if (!includeShadowed) {
+        const candidates = Array.isArray(files) ? files : Object.keys(files);
+        const { shadows } = shadowedFiles({ files: candidates, name: oldName });
+        if (shadows.length > 0) {
+            throw new FableReplaceError(
+                `renameSymbolAcross: ${shadows.length} file(s) both import AND declare "${oldName}" (a local wrapper; renaming its declaration changes an unrelated helper):\n  ${shadows.join("\n  ")}\nDrop them from the file list, or pass includeShadowed: true on purpose.`,
+                2
+            );
+        }
+    }
+    // Accept the countMatches() map directly: zero-match files are dropped (they would
+    // MISS) and each file's expected count is pinned from the number you already
+    // measured, instead of being transcribed by hand.
+    if (Array.isArray(files)) {
+        return sameOpsAcross({ files, ops: [renameSymbol({ oldName, newName })], extra });
+    }
+    return Object.entries(files)
+        .filter(([, n]) => n > 0)
+        .map(([file, n]) => ({ file, ops: [renameSymbol({ oldName, newName, expect: n })], ...extra }));
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/replace-utils.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/replace-utils.ts
@@ -1,0 +1,59 @@
+/**
+ * fable-replace — verified, transactional batch editing utilities.
+ *
+ * This file is the BARREL. One import line still gets you everything:
+ *
+ *   import { run, renameSymbolAcross } from "${CLAUDE_PLUGIN_ROOT}/skills/fable-replace/scripts/replace-utils";
+ *
+ * The implementation is split by concern, so you can read the 200 lines that
+ * matter instead of all 1400. What is where:
+ *
+ *   types.ts               every op / edit / result shape. The vocabulary.
+ *   edit-one-file.ts       ops that transform ONE file's text: literal, regex,
+ *                          deleteBlock/replaceBlock, insert, fuzzy, applyOps.
+ *   comments.ts            comment and line sweeps: scanComments, dropComments
+ *                          (comment goes, code on the line stays), deleteLines
+ *                          (whole line goes).
+ *   rename-symbols.ts      cross-file identifier renames: renameSymbolAcross,
+ *                          renameSymbol, sameOpsAcross.
+ *   sweep-many-files.ts    the runner: run(), pre-flight guards, transaction,
+ *                          verifyCommand, dry-run diff.
+ *   backup-and-rollback.ts backupDir snapshots, drift-aware rollback().
+ *   recon.ts               grepPreview — look before you declare an op.
+ *   internal.ts            private helpers. Nothing to see.
+ *
+ * Design contract (the reason this exists instead of sed):
+ *  - Every operation is VERIFIED: a literal op with the default `count: 1` requires
+ *    the needle EXACTLY once; regex ops can pin an expected match count; block ops
+ *    require both anchors. Anything that does not hold is a MISS, never a silent
+ *    no-op.
+ *  - The batch is TRANSACTIONAL: everything is applied in memory and checked first
+ *    (including that every edited script still parses). A single required MISS
+ *    aborts the whole run and writes nothing.
+ *  - `dryRun` prints diffs and writes nothing.
+ *  - `backupDir` snapshots originals + a manifest before writing; `rollback(dir)`
+ *    restores byte-for-byte and refuses to clobber anything edited since.
+ *
+ * Runtime: bun (TypeScript directly). No dependencies outside node builtins.
+ */
+
+export {
+    backupDirInUse,
+    pruneScratch,
+    recordPostWriteHashes,
+    rollback,
+    scratchDir,
+    scratchRoot,
+    writeBackup,
+} from "./backup-and-rollback";
+export { applyDeleteLines, applyDropComments, deleteLines, dropComments, removeSpans, scanComments } from "./comments";
+export { all, applyOps, drop, dropJsdocStarting, fuzzyWhitespaceRegex, maybe, nearestHint } from "./edit-one-file";
+export { changedOnDisk, countOccurrences, FableReplaceError, nthIndexOf } from "./internal";
+export type { LeftoverReport } from "./recon";
+export { countMatches, findFiles, grepPreview, leftovers, shadowedFiles } from "./recon";
+export { renameSymbol, renameSymbolAcross, sameOpsAcross } from "./rename-symbols";
+export type { ParseSpecParams } from "./spec";
+export { parseSpec } from "./spec";
+export { looksGenerated, mergeFileEdits, run, simpleDiff } from "./sweep-many-files";
+export * from "./types";
+export { checkVerifyCommand, runVerifyCommand, trimOutput, verifyUnknownReason } from "./verify-command";

--- a/plugins/genesis-tools/skills/fable-replace/scripts/selftest.test.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/selftest.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The selftest is a standalone script so it can run from any checkout with plain `bun`.
+// This wrapper is what puts it under `bun run test` and CI. The two variables keep it
+// hermetic even if the lines inside selftest.ts that set them are ever moved.
+describe("fable-replace selftest", () => {
+    test("bun selftest.ts exits 0 and ends with ALL SELFTESTS PASSED", () => {
+        const root = join(tmpdir(), "fable-replace");
+        mkdirSync(root, { recursive: true });
+        const scratch = mkdtempSync(join(root, "selftest-wrapper-"));
+        try {
+            const result = spawnSync("bun", [join(import.meta.dir, "selftest.ts")], {
+                encoding: "utf8",
+                env: { ...process.env, GENESIS_TOOLS_HOME: scratch, TMPDIR: scratch },
+                timeout: 120_000,
+            });
+            if (result.status !== 0) {
+                console.error(result.stdout);
+                console.error(result.stderr);
+            }
+            expect(result.status).toBe(0);
+            expect(result.stdout.trim().split("\n").at(-1)).toBe("ALL SELFTESTS PASSED");
+        } finally {
+            rmSync(scratch, { recursive: true, force: true });
+        }
+    });
+});

--- a/plugins/genesis-tools/skills/fable-replace/scripts/selftest.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/selftest.ts
@@ -1,0 +1,3388 @@
+/**
+ * Self-test for replace-utils.ts. Run: bun selftest.ts
+ * Exercises every op kind, transactional abort, partial mode, dry-run,
+ * post-conditions, backup + rollback, delete/rename/create — against scratch
+ * files in a fresh temp dir. Must end with "ALL SELFTESTS PASSED".
+ */
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { collectApi } from "./api";
+import { writeBackup } from "./backup-and-rollback";
+import type { JournalEntry } from "./journal";
+import { parseJson, stringifyJson } from "./json";
+import * as barrel from "./replace-utils";
+import {
+    all,
+    applyOps,
+    changedOnDisk,
+    checkVerifyCommand,
+    countMatches,
+    countOccurrences,
+    deleteLines,
+    drop,
+    dropComments,
+    dropJsdocStarting,
+    FableReplaceError,
+    findFiles,
+    fuzzyWhitespaceRegex,
+    grepPreview,
+    leftovers,
+    looksGenerated,
+    maybe,
+    mergeFileEdits,
+    nearestHint,
+    nthIndexOf,
+    parseSpec,
+    pruneScratch,
+    renameSymbol,
+    renameSymbolAcross,
+    rollback,
+    run,
+    scanComments,
+    scratchDir,
+    scratchRoot,
+    shadowedFiles,
+    simpleDiff,
+} from "./replace-utils";
+import type { Op } from "./types";
+
+let failures = 0;
+const check = (name: string, cond: boolean, detail = ""): void => {
+    if (cond) {
+        console.log(`  ✓ ${name}`);
+    } else {
+        failures += 1;
+        console.error(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`);
+    }
+};
+
+// Hermetic: every CLI this file spawns resolves its journal home and its scratch root from
+// these two variables, so neither the standalone run nor `bun run test` can touch the real
+// ~/.genesis-tools or the real temp folder. Set before `tmp` below, which reads os.tmpdir().
+const hermeticRoot = scratchDir("selftest-home");
+process.env.GENESIS_TOOLS_HOME = hermeticRoot;
+process.env.TMPDIR = hermeticRoot;
+// Bun does not forward process.env mutations to spawned children (measured: a child of a
+// process that set X after startup sees X empty), so every CLI this file spawns gets the
+// hermetic env explicitly. Three standalone runs once wrote 48 lines into the real journal.
+const hermeticEnv = { ...process.env };
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fable-replace-selftest-"));
+const f = (name: string): string => path.join(tmp, name);
+const write = (name: string, content: string): string => {
+    fs.writeFileSync(f(name), content);
+    return f(name);
+};
+const read = (name: string): string => fs.readFileSync(f(name), "utf8");
+
+console.log(`scratch dir: ${tmp}\n`);
+
+// ── unit: helpers ────────────────────────────────────────────────────────────
+console.log("helpers");
+check("countOccurrences", countOccurrences("aXbXcX", "X") === 3);
+check("countOccurrences empty needle", countOccurrences("abc", "") === 0);
+check("nthIndexOf 2nd", nthIndexOf({ haystack: "aXbXc", needle: "X", n: 2 }) === 3);
+check("nthIndexOf missing", nthIndexOf({ haystack: "aXbXc", needle: "X", n: 3 }) === -1);
+check(
+    "simpleDiff shows change",
+    simpleDiff({ before: "a\nb\nc", after: "a\nB\nc" }).includes("- b") &&
+        simpleDiff({ before: "a\nb\nc", after: "a\nB\nc" }).includes("+ B")
+);
+
+// ── unit: applyOps ───────────────────────────────────────────────────────────
+console.log("applyOps");
+{
+    const r = applyOps("hello world", [{ find: "world", replace: "there" }]);
+    check("literal exact-once", r.content === "hello there" && r.results[0].status === "OK");
+}
+{
+    const r = applyOps("x x x", [{ find: "x", replace: "y" }]);
+    check("ambiguous literal is MISS", r.results[0].status === "MISS" && r.content === "x x x");
+}
+{
+    const r = applyOps("x x x", [all({ find: "x", replace: "y" })]);
+    check("count:all replaces every occurrence", r.content === "y y y");
+}
+{
+    const r = applyOps("x x x", [{ find: "x", replace: "y", count: 3 }]);
+    check("count:n exact", r.content === "y y y");
+}
+{
+    const r = applyOps("x x x", [{ find: "x", replace: "y", count: 2 }]);
+    check("count:n mismatch is MISS", r.results[0].status === "MISS");
+}
+{
+    const r = applyOps("abc", [maybe({ find: "zzz", replace: "q" })]);
+    check("optional non-match is SKIP", r.results[0].status === "SKIP" && r.content === "abc");
+}
+{
+    const r = applyOps("abc", [{ find: "abc", replace: "abc" }]);
+    check("no-op edit (find===replace) is MISS", r.results[0].status === "MISS");
+}
+{
+    const r = applyOps("useFoo(1) useFoo(2)", [
+        { kind: "regex", find: /useFoo\((\d)\)/g, replace: "useBar($1)", expect: 2 },
+    ]);
+    check("regex with expect", r.content === "useBar(1) useBar(2)");
+}
+{
+    const r = applyOps("useFoo(1)", [{ kind: "regex", find: /useFoo\((\d)\)/g, replace: "useBar($1)", expect: 2 }]);
+    check("regex expect mismatch is MISS", r.results[0].status === "MISS");
+}
+{
+    const r = applyOps("keep\n/**\n * junk\n * junk2\n */\nrest", [dropJsdocStarting({ fromPrefix: "/**\n * junk" })]);
+    check("dropJsdocStarting removes the block", r.content === "keep\nrest");
+}
+{
+    const r = applyOps("a START mid END b", [
+        { kind: "deleteBlock", from: "START", to: "END", keepFrom: true, keepTo: true },
+    ]);
+    check("deleteBlock keepFrom+keepTo (region between anchors goes, spaces included)", r.content === "a STARTEND b");
+}
+{
+    const r = applyOps("x A1x A2x", [{ kind: "deleteBlock", from: "A", to: "x", occurrence: 2 }]);
+    check("deleteBlock occurrence:2", r.content === "x A1x ");
+}
+{
+    const r = applyOps("head body", [{ kind: "replaceBlock", from: "head", to: "body", replace: "ALL" }]);
+    check("replaceBlock", r.content === "ALL");
+}
+{
+    const r = applyOps("import a;\ncode", [{ kind: "insertAfter", anchor: "import a;\n", text: "import b;\n" }]);
+    check("insertAfter", r.content === "import a;\nimport b;\ncode");
+}
+{
+    const r = applyOps("one two", [{ kind: "insertBefore", anchor: "two", text: "1.5 " }]);
+    check("insertBefore", r.content === "one 1.5 two");
+}
+{
+    const r = applyOps("a b", [
+        { find: "a", replace: "A" },
+        { find: "A b", replace: "A B" },
+    ]);
+    check("ops chain (later ops see earlier output)", r.content === "A B");
+}
+
+// ── integration: run() happy path with backup, then rollback ────────────────
+console.log("run(): happy path + rollback");
+{
+    write("one.ts", "const gate = getLinkGate(link);\ngetLinkGate(x);\n");
+    write("two.ts", "// old comment\nkeep();\n");
+    const backupDir = path.join(tmp, "backup1");
+    const report = await run({
+        edits: [
+            {
+                file: f("one.ts"),
+                ops: [all({ find: "getLinkGate(", replace: "getActionDisabledState(" })],
+                expectAfter: ["getActionDisabledState"],
+                absentAfter: ["getLinkGate"],
+            },
+            { file: f("two.ts"), ops: [drop({ find: "// old comment\n" })] },
+        ],
+        backupDir,
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("run ok", report.ok && report.written.length === 2);
+    check(
+        "one.ts rewritten",
+        read("one.ts") === "const gate = getActionDisabledState(link);\ngetActionDisabledState(x);\n"
+    );
+    check("two.ts comment dropped", read("two.ts") === "keep();\n");
+    rollback({ backupDir: backupDir });
+    check("rollback restored one.ts", read("one.ts").includes("getLinkGate(link)"));
+    check("rollback restored two.ts", read("two.ts") === "// old comment\nkeep();\n");
+}
+
+// ── integration: transactional abort — one MISS writes NOTHING ──────────────
+console.log("run(): transactional abort");
+{
+    write("a.ts", "alpha\n");
+    write("b.ts", "beta\n");
+    let threw = false;
+    try {
+        await run({
+            edits: [
+                { file: f("a.ts"), ops: [{ find: "alpha", replace: "ALPHA" }] },
+                { file: f("b.ts"), ops: [{ find: "DOES-NOT-EXIST", replace: "x" }] },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("aborted run throws", threw);
+    check("a.ts untouched despite its op being OK", read("a.ts") === "alpha\n");
+    check("b.ts untouched", read("b.ts") === "beta\n");
+}
+
+// ── integration: partial mode writes the clean files ────────────────────────
+console.log("run(): partial mode");
+{
+    let partialError: unknown = null;
+    try {
+        await run({
+            edits: [
+                { file: f("a.ts"), ops: [{ find: "alpha", replace: "ALPHA" }] },
+                { file: f("b.ts"), ops: [{ find: "DOES-NOT-EXIST", replace: "x" }] },
+            ],
+            verbose: false,
+            partial: true,
+            throwOnFailure: true,
+        });
+    } catch (err) {
+        partialError = err;
+    }
+    check(
+        "partial mode with a MISS still fails, code 1, after writing",
+        partialError instanceof FableReplaceError &&
+            partialError.code === 1 &&
+            partialError.message.includes("partial mode wrote 1 file(s)"),
+        String(partialError)
+    );
+    check("clean file written in partial mode", read("a.ts") === "ALPHA\n");
+    check("missed file untouched in partial mode", read("b.ts") === "beta\n");
+}
+
+// ── integration: dry run writes nothing ─────────────────────────────────────
+console.log("run(): dry run");
+{
+    write("dry.ts", "dry content\n");
+    const report = await run({
+        edits: [{ file: f("dry.ts"), ops: [{ find: "dry", replace: "wet" }] }],
+        dryRun: true,
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("dry run ok", report.ok && report.written.length === 0);
+    check("dry run wrote nothing", read("dry.ts") === "dry content\n");
+}
+
+// ── integration: post-condition failure aborts ──────────────────────────────
+console.log("run(): post-conditions");
+{
+    write("post.ts", "foo bar\n");
+    let threw = false;
+    try {
+        await run({
+            edits: [{ file: f("post.ts"), ops: [{ find: "foo", replace: "baz" }], absentAfter: ["bar"] }],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("absentAfter violation aborts", threw && read("post.ts") === "foo bar\n");
+}
+
+// ── integration: create, rename, delete ─────────────────────────────────────
+console.log("run(): file lifecycle");
+{
+    write("victim.ts", "bye\n");
+    const backupDir = path.join(tmp, "backup2");
+    const report = await run({
+        edits: [
+            {
+                file: f("new.ts"),
+                createWith: 'export const created = "FIND";\n',
+                ops: [{ find: "FIND", replace: "content" }],
+            },
+            { file: f("one.ts"), renameTo: f("renamed.ts") },
+            { file: f("victim.ts"), delete: true },
+        ],
+        backupDir,
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("lifecycle run ok", report.ok);
+    check("createWith + ops", read("new.ts") === 'export const created = "content";\n');
+    check("rename moved the file", !fs.existsSync(f("one.ts")) && fs.existsSync(f("renamed.ts")));
+    check("delete removed the file", !fs.existsSync(f("victim.ts")));
+    rollback({ backupDir: backupDir });
+    check("rollback deletes created file", !fs.existsSync(f("new.ts")));
+    check("rollback restores renamed source", fs.existsSync(f("one.ts")));
+}
+
+// ── comment scanner + higher-level ops ──────────────────────────────────────
+console.log("comment scanner + high-level ops");
+{
+    const src = `const a = "// not a comment";\n// real line comment\nconst b = \`tpl // still string \${x /* real block in interpolation */}\`;\n/* block\n comment */\ncode();\n`;
+    const spans = scanComments(src);
+    check(
+        "scanner skips comment-lookalikes in strings",
+        spans.every((s2) => !s2.text.includes("not a comment") && !s2.text.includes("still string"))
+    );
+    check(
+        "scanner finds line + block + interpolation comments",
+        spans.filter((s2) => s2.type === "line").length === 1 && spans.filter((s2) => s2.type === "block").length === 2
+    );
+}
+{
+    const src = "keep();\n// TODO old marker\nmore(); // trailing TODO old\n";
+    const r = dropComments(src, { containing: "TODO old" });
+    check(
+        "dropComments removes full-line comment incl. its line",
+        r.dropped === 2 && r.content === "keep();\nmore();\n"
+    );
+}
+{
+    const r = applyOps("a();\n// noise 1\nb();\n// noise 2\n", [
+        { kind: "dropComments", containing: "noise", expect: 2 },
+    ]);
+    check("dropComments op with expect", r.results[0].status === "OK" && r.content === "a();\nb();\n");
+}
+{
+    const r = applyOps("code();\n", [{ kind: "dropComments" } as never]);
+    check("dropComments without predicate refuses (never drop ALL)", r.results[0].status === "MISS");
+}
+{
+    const r = applyOps("keep\ndebugLog(1)\nkeep2\ndebugLog(2)\n", [
+        { kind: "deleteLines", containing: "debugLog", expect: 2 },
+    ]);
+    check("deleteLines", r.content === "keep\nkeep2\n");
+}
+{
+    const r = applyOps("if (x) {\n\t\tdoThing( a,  b );\n}", [
+        { kind: "fuzzy", find: "doThing( a, b );", replace: "doOther(a, b);" },
+    ]);
+    check("fuzzy whitespace-tolerant literal", r.content.includes("doOther(a, b);"));
+    check("fuzzyWhitespaceRegex matches across reindentation", fuzzyWhitespaceRegex("a b").test("a\n\t b"));
+}
+{
+    const r = applyOps("getFoo(); notGetFoo(); getFoo();", [
+        renameSymbol({ oldName: "getFoo", newName: "getBar", expect: 2 }),
+    ]);
+    check("renameSymbol respects word boundaries", r.content === "getBar(); notGetFoo(); getBar();");
+}
+
+// ── verifyCommand keeps the sweep on red ────────────────────────────────────
+console.log("run(): verifyCommand");
+{
+    write("vc.ts", "verify me\n");
+    const backupDir = path.join(tmp, "backup3");
+    const red = await run({
+        edits: [{ file: f("vc.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir,
+        verifyCommand: "exit 1",
+        verbose: false,
+        throwOnFailure: true,
+    }).catch((e: FableReplaceError) => e);
+    check("failing verifyCommand throws code 3", red instanceof FableReplaceError && red.code === 3, String(red));
+    check("failing verifyCommand keeps the sweep written", read("vc.ts") === "verified\n", read("vc.ts"));
+    check(
+        "the thrown error says the sweep is written and carries the verdict",
+        red instanceof FableReplaceError &&
+            red.message.includes("sweep WRITTEN") &&
+            red.report?.verify?.status === "fail" &&
+            red.report.verify.exitCode === 1,
+        String(red)
+    );
+    const undo = rollback({ backupDir });
+    check(
+        "the printed rollback restores it without --force",
+        undo.restored.length === 1 && read("vc.ts") === "verify me\n"
+    );
+
+    const ok = await run({
+        edits: [{ file: f("vc.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: path.join(tmp, "backup4"),
+        verifyCommand: "exit 0",
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("passing verifyCommand keeps the write", ok.ok && read("vc.ts") === "verified\n");
+    check("a passing verify is reported on the run", ok.verify?.status === "pass" && ok.verify.exitCode === 0);
+
+    // A check that rewrites files (a formatter) must not make the undo command fail with drift.
+    write("vc2.ts", "verify me\n");
+    const fmtDir = path.join(tmp, "backup-fmt");
+    const fmt = await run({
+        edits: [{ file: f("vc2.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: fmtDir,
+        verifyCommand: `printf 'formatted\\n' > ${f("vc2.ts")} && exit 1`,
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    const fmtUndo = rollback({ backupDir: fmtDir });
+    check(
+        "the undo works after a verify that rewrote the file",
+        fmt instanceof FableReplaceError &&
+            fmt.code === 3 &&
+            fmtUndo.drifted.length === 0 &&
+            read("vc2.ts") === "verify me\n",
+        `${String(fmt)} | drifted=${fmtUndo.drifted.length} | ${stringifyJson(read("vc2.ts"))}`
+    );
+
+    // Output limits: a pass shows a five-line tail, a fail shows head and tail, both save the rest.
+    write("vc3.ts", "verify me\n");
+    const tailDir = path.join(tmp, "backup-tail");
+    const long = await run({
+        edits: [{ file: f("vc3.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: tailDir,
+        verifyCommand: "seq 1 12",
+        verbose: false,
+    });
+    check(
+        "a passing verify shows only its last 5 lines plus a suppressed-count line",
+        long.verify?.shown.length === 6 &&
+            long.verify.shown[0].includes("7 earlier line(s) suppressed") &&
+            long.verify.shown[5] === "12",
+        stringifyJson(long.verify?.shown)
+    );
+    check(
+        "the whole verify output is saved beside the backup",
+        fs.readFileSync(path.join(tailDir, "verify-output.txt"), "utf8").trim().split("\n").length === 12
+    );
+    write("vc4.ts", "verify me\n");
+    const both = await run({
+        edits: [{ file: f("vc4.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: path.join(tmp, "backup-both"),
+        verifyCommand: "seq 1 200 && exit 1",
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    const bothShown = both instanceof FableReplaceError ? (both.report?.verify?.shown ?? []) : [];
+    check(
+        "a failing verify shows the first 40 and last 60 lines around an omitted marker",
+        bothShown.length === 101 &&
+            bothShown[0] === "1" &&
+            bothShown[40].includes("100 line(s) omitted") &&
+            bothShown[100] === "200",
+        `${bothShown.length} lines, [40]=${bothShown[40] ?? ""}`
+    );
+
+    // More output than the default 1 MB buffer must not read as a failure.
+    write("vc5.ts", "verify me\n");
+    const big = await run({
+        edits: [{ file: f("vc5.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: path.join(tmp, "backup-big"),
+        verifyCommand: `bun -e "process.stdout.write('a'.repeat(3000000))"`,
+        verbose: false,
+    });
+    check(
+        "3 MB of verify output is a pass, not ENOBUFS",
+        big.ok && big.verify?.status === "pass" && big.verify.outputChars === 3000000,
+        stringifyJson(big.verify?.status)
+    );
+
+    // A check that never returns is "unknown": still exit 3, never a test failure.
+    write("vc6.ts", "verify me\n");
+    const slow = await run({
+        edits: [{ file: f("vc6.ts"), ops: [{ find: "verify me", replace: "verified" }] }],
+        backupDir: path.join(tmp, "backup-slow"),
+        verifyCommand: "sleep 5",
+        verifyTimeoutMs: 300,
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a verify timeout is its own outcome: code 3, status unknown, timedOut",
+        slow instanceof FableReplaceError &&
+            slow.code === 3 &&
+            slow.report?.verify?.status === "unknown" &&
+            slow.report.verify.timedOut &&
+            slow.message.includes("could not be measured"),
+        String(slow)
+    );
+    check("the timed-out sweep stays written", read("vc6.ts") === "verified\n");
+
+    // A partial run with misses never reaches the check: exit 3 must mean everything declared landed.
+    write("vc7.ts", "verify me\n");
+    write("vc8.ts", "nothing here\n");
+    const part = await run({
+        edits: [
+            { file: f("vc7.ts"), ops: [{ find: "verify me", replace: "verified" }] },
+            { file: f("vc8.ts"), ops: [{ find: "absent needle", replace: "x" }] },
+        ],
+        backupDir: path.join(tmp, "backup-part"),
+        partial: true,
+        verifyCommand: "exit 1",
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a partial run with a MISS skips the verify and exits 1",
+        part instanceof FableReplaceError &&
+            part.code === 1 &&
+            part.report?.verify === undefined &&
+            read("vc7.ts") === "verified\n",
+        String(part)
+    );
+
+    // dryRun with a verify is refused before anything happens.
+    const dryVerify = await run({
+        edits: [{ file: f("vc7.ts"), ops: [{ find: "verified", replace: "verify me" }] }],
+        dryRun: true,
+        verifyCommand: "exit 0",
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "dryRun with a verifyCommand is a pre-flight error",
+        dryVerify instanceof FableReplaceError &&
+            dryVerify.code === 2 &&
+            dryVerify.message.includes("nothing to verify"),
+        String(dryVerify)
+    );
+}
+
+// ── verifyCommand refuses status-hiding shell operators ─────────────────────
+console.log("run(): verify command scanner");
+{
+    const refused = (cmd: string): string => checkVerifyCommand(cmd).refusal ?? "";
+    check("a pipe is refused", refused("bun run test | tail -3").includes("contains a pipe"));
+    check("a ; chain is refused", refused("bun run test; echo done").includes("chain"));
+    check("a newline is refused", refused("bun run test\necho done").includes("more than one line"));
+    check("a background & is refused", refused("bun run test &").includes("background"));
+    check("&& and || are allowed", refused("a && b || c") === "");
+    check("redirects are allowed", refused("bun run test 2>&1 >out.txt <in.txt &>all.txt") === "");
+    check(
+        "$( ), backticks and env prefixes are allowed",
+        refused("FOO=1 bun run test $(git rev-parse HEAD) `date`") === ""
+    );
+    check(
+        "a pipe inside single quotes is allowed",
+        refused("bash -c 'set -o pipefail; bun run test | tail -3'") === ""
+    );
+    check("a pipe inside double quotes is allowed", refused('bun test -t "a|b"') === "");
+    check("an escaped quote does not open a quoted region", refused('echo \\"x | cat').includes("contains a pipe"));
+    check(
+        "/dev/null warns instead of refusing",
+        checkVerifyCommand("bun run test 2>/dev/null").warning?.includes("/dev/null") === true &&
+            refused("bun run test 2>/dev/null") === ""
+    );
+    write("scan.ts", "scan me\n");
+    const piped = await run({
+        edits: [{ file: f("scan.ts"), ops: [{ find: "scan me", replace: "scanned" }] }],
+        backupDir: path.join(tmp, "backup-scan"),
+        verifyCommand: "exit 1 | cat",
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a piped verifyCommand is a pre-flight error and nothing is written",
+        piped instanceof FableReplaceError &&
+            piped.code === 2 &&
+            piped.message.includes("contains a pipe") &&
+            read("scan.ts") === "scan me\n",
+        String(piped)
+    );
+}
+
+// ── guard rails ─────────────────────────────────────────────────────────────
+console.log("guard rails");
+{
+    let threw = false;
+    try {
+        await run({
+            edits: [{ file: path.join(tmp, "node_modules", "x.ts"), ops: [{ find: "a", replace: "b" }] }],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("node_modules refused", threw);
+}
+{
+    let threw = false;
+    try {
+        await run({ edits: [{ file: f("a.ts") }], verbose: false, throwOnFailure: true });
+    } catch {
+        threw = true;
+    }
+    check("empty edit refused", threw);
+}
+{
+    let threw = false;
+    try {
+        await run({
+            edits: [
+                { file: f("a.ts"), ops: [maybe({ find: "q", replace: "r" })] },
+                { file: f("a.ts"), ops: [maybe({ find: "s", replace: "t" })] },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("duplicate file in batch refused", threw);
+}
+
+// ── regressions: the four defects found by the 2026-09-03 stress test ───────
+console.log("regressions (stress-test defects)");
+{
+    // 1. a /g predicate regex used to skip every other match (lastIndex carry-over)
+    const src4 = "log(1)\nlog(2)\nlog(3)\nlog(4)\nkeep\n";
+    const dl = deleteLines(src4, { kind: "deleteLines", matching: /log\(/g });
+    check("deleteLines with a /g regex removes EVERY match", dl.removed === 4, `removed ${dl.removed}`);
+    const dc = dropComments("// a1\nx;\n// a2\ny;\n// a3\nz;\n// a4\n", { matching: /a\d/g });
+    check("dropComments with a /g regex drops EVERY match", dc.dropped === 4, `dropped ${dc.dropped}`);
+    const shared = /DEBUG/g;
+    const across = [0, 1, 2, 3].map(
+        () => deleteLines("k\nDEBUG a\nDEBUG b\n", { kind: "deleteLines", matching: shared }).removed
+    );
+    check(
+        "one shared /g regex behaves the same across files",
+        across.every((n) => n === 2),
+        across.join(",")
+    );
+}
+{
+    // 2. renameTo used to clobber an unrelated existing file with no warning
+    write("rn-src.ts", "SOURCE\n");
+    write("rn-dst.ts", "PRECIOUS\n");
+    let threw = false;
+    try {
+        await run({
+            edits: [{ file: f("rn-src.ts"), ops: [{ find: "SOURCE", replace: "SRC" }], renameTo: f("rn-dst.ts") }],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw = true;
+    }
+    check("renameTo onto an existing file is refused", threw && read("rn-dst.ts") === "PRECIOUS\n", read("rn-dst.ts"));
+    await run({
+        edits: [
+            {
+                file: f("rn-src.ts"),
+                ops: [{ find: "SOURCE", replace: "SRC" }],
+                renameTo: f("rn-dst.ts"),
+                overwrite: true,
+            },
+        ],
+        verbose: false,
+        throwOnFailure: true,
+    });
+    check("overwrite:true allows it", read("rn-dst.ts") === "SRC\n" && !fs.existsSync(f("rn-src.ts")));
+    write("rn-a.ts", "A\n");
+    write("rn-b.ts", "B\n");
+    let threw2 = false;
+    try {
+        await run({
+            edits: [
+                { file: f("rn-a.ts"), ops: [{ find: "A", replace: "A2" }], renameTo: f("rn-x.ts") },
+                { file: f("rn-b.ts"), ops: [{ find: "B", replace: "B2" }], renameTo: f("rn-x.ts") },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        threw2 = true;
+    }
+    check("two edits renaming to the same path are refused", threw2);
+}
+{
+    // 3. an I/O failure mid-batch used to leave the batch half applied
+    for (let i = 0; i < 6; i += 1) {
+        write(`io${i}.ts`, `const v = "old";\n`);
+    }
+    fs.chmodSync(f("io3.ts"), 0o444);
+    let threw = false;
+    try {
+        await run({
+            edits: [0, 1, 2, 3, 4, 5].map((i) => ({
+                file: f(`io${i}.ts`),
+                ops: [{ find: `"old"`, replace: `"new"` }],
+            })),
+            verbose: false,
+            throwOnFailure: true,
+            backupDir: path.join(tmp, "iobk"),
+        });
+    } catch {
+        threw = true;
+    }
+    fs.chmodSync(f("io3.ts"), 0o644);
+    const allOld = [0, 1, 2, 3, 4, 5].every((i) => read(`io${i}.ts`).includes(`"old"`));
+    check(
+        "a failing write rolls the whole batch back",
+        threw && allOld,
+        [0, 1, 2, 3, 4, 5].map((i) => (read(`io${i}.ts`).includes("new") ? "new" : "old")).join(",")
+    );
+}
+{
+    // 4. regex literals used to desync the comment scanner for the rest of the file
+    const rx = "const RE = /\\/usr\\/bin\\//;\nconst keep = 1;\n";
+    check(
+        "a regex literal containing // is not a comment",
+        scanComments(rx).length === 0,
+        stringifyJson(scanComments(rx).map((s) => s.text))
+    );
+    const quoted = `const esc = /[&<>"']/g;\nconst u = new URL(h, "https://x/").href; // real\n`;
+    const spans = scanComments(quoted);
+    check(
+        "a regex literal containing a quote does not desync the file",
+        spans.length === 1 && spans[0].text === "// real",
+        stringifyJson(spans.map((s) => s.text))
+    );
+    const jsx = 'const d = mount(<Tabs t={t} />, "http://x/demo"); // tail\n';
+    check(
+        "JSX self-close is not a regex",
+        scanComments(jsx).length === 1,
+        stringifyJson(scanComments(jsx).map((s) => s.text))
+    );
+    const close = 'const d = <div>x</div>; const u = "http://x/"; // tail\n';
+    check(
+        "JSX closing tag is not a regex",
+        scanComments(close).length === 1,
+        stringifyJson(scanComments(close).map((s) => s.text))
+    );
+    const div = "const avg = total / count / 2; // ok\n";
+    check("division is still division", scanComments(div).length === 1);
+    const ret = "function f(s) { return /a\\/b/.test(s); } // ok\n";
+    check(
+        "a regex literal after `return` is skipped",
+        scanComments(ret).length === 1,
+        stringifyJson(scanComments(ret).map((s) => s.text))
+    );
+}
+
+// ── rollback safety (2026-09-03 edge-case pass) ─────────────────────────────
+console.log("rollback safety");
+{
+    // a hand edit made AFTER the sweep must never be silently overwritten
+    write("rb-hand.ts", "ORIGINAL\n");
+    const bd = path.join(tmp, "rb-hand-bk");
+    await run({
+        edits: [{ file: f("rb-hand.ts"), ops: [{ find: "ORIGINAL", replace: "SWEPT" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    fs.writeFileSync(f("rb-hand.ts"), "SWEPT\n// hand-written note\n");
+    const drifted = rollback({ backupDir: bd });
+    check(
+        "rollback skips a file changed after the sweep",
+        drifted.drifted.length === 1 && drifted.restored.length === 0 && read("rb-hand.ts").includes("hand-written"),
+        stringifyJson(read("rb-hand.ts"))
+    );
+    const forced = rollback({ backupDir: bd, force: true });
+    check(
+        "rollback({force:true}) restores it anyway",
+        forced.restored.length === 1 && read("rb-hand.ts") === "ORIGINAL\n",
+        stringifyJson(read("rb-hand.ts"))
+    );
+}
+{
+    // only the drifted file is skipped; its neighbours still roll back
+    write("rb-a.ts", "A\n");
+    write("rb-b.ts", "B\n");
+    const bd = path.join(tmp, "rb-pair-bk");
+    await run({
+        edits: [
+            { file: f("rb-a.ts"), ops: [{ find: "A", replace: "A2" }] },
+            { file: f("rb-b.ts"), ops: [{ find: "B", replace: "B2" }] },
+        ],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    fs.writeFileSync(f("rb-a.ts"), "A2 then hand-edited\n");
+    const rep = rollback({ backupDir: bd });
+    check(
+        "a drifted file does not block its neighbours",
+        rep.drifted.length === 1 &&
+            rep.restored.length === 1 &&
+            read("rb-b.ts") === "B\n" &&
+            read("rb-a.ts") === "A2 then hand-edited\n"
+    );
+}
+{
+    // reusing a backupDir would destroy the first snapshot — refuse before writing
+    write("rb-reuse.ts", "V1\n");
+    const bd = path.join(tmp, "rb-reuse-bk");
+    await run({
+        edits: [{ file: f("rb-reuse.ts"), ops: [{ find: "V1", replace: "V2" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    let threw = false;
+    try {
+        await run({
+            edits: [{ file: f("rb-reuse.ts"), ops: [{ find: "V2", replace: "V3" }] }],
+            verbose: false,
+            throwOnFailure: true,
+            backupDir: bd,
+        });
+    } catch {
+        threw = true;
+    }
+    check("a reused backupDir is refused in pre-flight", threw && read("rb-reuse.ts") === "V2\n", read("rb-reuse.ts"));
+    await run({
+        edits: [{ file: f("rb-reuse.ts"), ops: [{ find: "V2", replace: "V3" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+        backupOverwrite: true,
+    });
+    check("backupOverwrite:true allows deliberate reuse", read("rb-reuse.ts") === "V3\n");
+}
+{
+    // byte fidelity across CRLF / missing trailing newline / unicode
+    const shapes = {
+        "rb-crlf.ts": "a\r\nDROP\r\nb\r\n",
+        "rb-nonl.ts": "no trailing newline DROP",
+        "rb-uni.ts": "emoji 👍 DROP ünïcødé\n",
+    };
+    const bd = path.join(tmp, "rb-bytes-bk");
+    const before = Object.entries(shapes).map(([n, c]) => {
+        write(n, c);
+        return [n, fs.readFileSync(f(n))] as const;
+    });
+    await run({
+        edits: Object.keys(shapes).map((n) => ({ file: f(n), ops: [{ find: "DROP", replace: "X" }] })),
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    rollback({ backupDir: bd });
+    check(
+        "rollback is byte-exact across CRLF / no-newline / unicode",
+        before.every(([n, buf]) => buf.equals(fs.readFileSync(f(n))))
+    );
+}
+{
+    // the executable bit must survive a sweep and its rollback
+    const p = write("rb-exec.sh", "#!/bin/sh\necho old\n");
+    fs.chmodSync(p, 0o755);
+    const bd = path.join(tmp, "rb-exec-bk");
+    await run({
+        edits: [{ file: p, ops: [{ find: "echo old", replace: "echo new" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bd,
+    });
+    rollback({ backupDir: bd });
+    check(
+        "the executable bit survives sweep + rollback",
+        (fs.statSync(p).mode & 0o777) === 0o755,
+        (fs.statSync(p).mode & 0o777).toString(8)
+    );
+}
+
+{
+    // two stacked sweeps must unwind newest-first; the wrong order is caught as drift
+    write("rb-stack.ts", "V1\n");
+    const bkA = path.join(tmp, "rb-stack-a");
+    const bkB = path.join(tmp, "rb-stack-b");
+    await run({
+        edits: [{ file: f("rb-stack.ts"), ops: [{ find: "V1", replace: "V2" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bkA,
+    });
+    await run({
+        edits: [{ file: f("rb-stack.ts"), ops: [{ find: "V2", replace: "V3" }] }],
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: bkB,
+    });
+    const wrongOrder = rollback({ backupDir: bkA });
+    check(
+        "rolling back the older sweep first is refused",
+        wrongOrder.drifted.length === 1 && read("rb-stack.ts") === "V3\n",
+        read("rb-stack.ts")
+    );
+    rollback({ backupDir: bkB });
+    rollback({ backupDir: bkA });
+    check("newest-first unwinds both sweeps to the original", read("rb-stack.ts") === "V1\n", read("rb-stack.ts"));
+}
+
+// ── leftovers(): a rename is not finished when the code is green ────────────
+console.log("leftovers");
+{
+    fs.mkdirSync(f("lo/src"), { recursive: true });
+    fs.mkdirSync(f("lo/node_modules"), { recursive: true });
+    fs.writeFileSync(f("lo/src/code.ts"), 'export { newName as oldName } from "./x";\n');
+    fs.writeFileSync(f("lo/README.md"), "Call `oldName(x)` to format.\n");
+    fs.writeFileSync(f("lo/node_modules/noise.ts"), "const oldName = 1;\n");
+    const rep = leftovers({ names: ["oldName"], dirs: [f("lo")], quiet: true });
+    check(
+        "leftovers finds the prose mention",
+        rep.docs.length === 1 && rep.docs[0].includes("README.md"),
+        stringifyJson(rep.docs)
+    );
+    check(
+        "leftovers separates the legitimate code alias",
+        rep.code.length === 1 && rep.code[0].includes("code.ts"),
+        stringifyJson(rep.code)
+    );
+    check("leftovers skips node_modules", !rep.code.concat(rep.docs).some((h) => h.includes("node_modules")));
+    check(
+        "leftovers respects word boundaries",
+        leftovers({ names: ["oldNam"], dirs: [f("lo")], quiet: true }).docs.length === 0
+    );
+    // the root the caller passes may itself sit under a directory name we skip while
+    // descending (a git worktree, a build output). It must still be scannable.
+    fs.mkdirSync(f("lo/build/nested"), { recursive: true });
+    fs.writeFileSync(f("lo/build/nested/code.ts"), "const oldName = 1;\n");
+    check(
+        "a skipped directory name is skipped while descending",
+        leftovers({ names: ["oldName"], dirs: [f("lo")], quiet: true }).code.length === 1
+    );
+    check(
+        "but that same directory is scannable as an explicit root",
+        leftovers({ names: ["oldName"], dirs: [f("lo/build")], quiet: true }).code.length === 1
+    );
+}
+
+// ── countMatches(): the numbers `expect:` rests on ─────────────────────────
+console.log("countMatches");
+{
+    write("cm-a.ts", "oldName(1); oldName(2);\nconst x = _oldName;\n");
+    write("cm-b.ts", "nothing here\n");
+    const counts = countMatches({ files: [f("cm-a.ts"), f("cm-b.ts")], pattern: "oldName", quiet: true });
+    check("identifier pattern is word-boundary matched", counts[f("cm-a.ts")] === 2, String(counts[f("cm-a.ts")]));
+    check("a zero-match file is reported as zero, not omitted", counts[f("cm-b.ts")] === 0, stringifyJson(counts));
+    write("cm-c.ts", "a.b.c and a.b.c\n");
+    check(
+        "a non-identifier string is matched literally",
+        countMatches({ files: [f("cm-c.ts")], pattern: "a.b.c", quiet: true })[f("cm-c.ts")] === 2
+    );
+    check(
+        "a non-global RegExp still counts every match",
+        countMatches({ files: [f("cm-a.ts")], pattern: /oldName/, quiet: true })[f("cm-a.ts")] === 3
+    );
+}
+
+// ── dry-run diff output is bounded across the WHOLE run ────────────────────
+console.log("dry-run diff budget");
+{
+    const files = [0, 1, 2, 3, 4].map((i) => {
+        write(
+            `dd${i}.ts`,
+            `${Array.from({ length: 60 }, (_, n) => `const v${n} = ${i};`).join("\n")}\nconst TARGET = "old";\n`
+        );
+        return f(`dd${i}.ts`);
+    });
+    const logged: string[] = [];
+    const realLog = console.log;
+    console.log = (...args: unknown[]): void => {
+        logged.push(args.join(" "));
+    };
+    try {
+        await run({
+            edits: files.map((file) => ({ file, ops: [{ find: `"old"`, replace: `"new"` }] })),
+            verbose: false,
+            dryRun: true,
+            throwOnFailure: true,
+            maxTotalDiffLines: 12,
+        });
+    } finally {
+        console.log = realLog;
+    }
+    const joined = logged.join("\n");
+    check(
+        "the total diff budget suppresses later diffs",
+        joined.includes("diffs for") && joined.includes("suppressed"),
+        joined.slice(-200)
+    );
+    check("the dry-run verdict still prints after suppression", joined.includes("DRY RUN — nothing written"));
+    check(
+        "suppression wrote nothing",
+        files.every((p) => fs.readFileSync(p, "utf8").includes('"old"'))
+    );
+}
+
+// ── the documented two-symbol overlapping rename must actually RUN ─────────
+console.log("mergeFileEdits / overlapping renames");
+{
+    write("mf-both.ts", "renderCliKeyRow(); renderCliSection();\n");
+    write("mf-a.ts", "renderCliKeyRow();\n");
+    write("mf-b.ts", "renderCliSection();\n");
+    const both = [f("mf-both.ts")];
+    // exactly the shape SKILL.md documents — without the merge this is "listed twice"
+    let threwUnmerged = false;
+    try {
+        await run({
+            edits: [
+                ...renameSymbolAcross({
+                    files: [...both, f("mf-a.ts")],
+                    oldName: "renderCliKeyRow",
+                    newName: "renderCliKeyValueRow",
+                }),
+                ...renameSymbolAcross({
+                    files: [...both, f("mf-b.ts")],
+                    oldName: "renderCliSection",
+                    newName: "renderCliSectionHeader",
+                }),
+            ],
+            verbose: false,
+            throwOnFailure: true,
+            dryRun: true,
+        });
+    } catch {
+        threwUnmerged = true;
+    }
+    check("concatenating two renameSymbolAcross calls with an overlap is refused", threwUnmerged);
+    let mergedThrew = "";
+    try {
+        await run({
+            edits: mergeFileEdits([
+                ...renameSymbolAcross({
+                    files: [...both, f("mf-a.ts")],
+                    oldName: "renderCliKeyRow",
+                    newName: "renderCliKeyValueRow",
+                }),
+                ...renameSymbolAcross({
+                    files: [...both, f("mf-b.ts")],
+                    oldName: "renderCliSection",
+                    newName: "renderCliSectionHeader",
+                }),
+            ]),
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch (err) {
+        mergedThrew = String(err).split("\n")[0];
+    }
+    check("the merged batch runs without a pre-flight refusal", mergedThrew === "", mergedThrew);
+    check(
+        "mergeFileEdits makes the documented pattern run",
+        read("mf-both.ts") === "renderCliKeyValueRow(); renderCliSectionHeader();\n",
+        read("mf-both.ts")
+    );
+    check(
+        "the non-overlapping files renamed too",
+        read("mf-a.ts").includes("renderCliKeyValueRow") && read("mf-b.ts").includes("renderCliSectionHeader")
+    );
+    check(
+        "merge unions post-conditions",
+        mergeFileEdits([
+            { file: "x.ts", ops: [maybe({ find: "a", replace: "b" })], expectAfter: ["p"] },
+            { file: "x.ts", ops: [maybe({ find: "c", replace: "d" })], absentAfter: ["q"] },
+        ])[0].expectAfter?.length === 1
+    );
+    check(
+        "merge concatenates ops in order",
+        mergeFileEdits([
+            { file: "x.ts", ops: [maybe({ find: "a", replace: "b" })] },
+            { file: "x.ts", ops: [maybe({ find: "c", replace: "d" })] },
+        ])[0].ops?.length === 2
+    );
+    let conflicted = false;
+    try {
+        mergeFileEdits([
+            { file: "x.ts", ops: [maybe({ find: "a", replace: "b" })], renameTo: "y.ts" },
+            { file: "x.ts", ops: [maybe({ find: "c", replace: "d" })], renameTo: "z.ts" },
+        ]);
+    } catch {
+        conflicted = true;
+    }
+    check("merge refuses conflicting renameTo rather than guessing", conflicted);
+    let deleteConflict = false;
+    try {
+        mergeFileEdits([
+            { file: "x.ts", delete: true },
+            { file: "x.ts", ops: [maybe({ find: "a", replace: "b" })] },
+        ]);
+    } catch {
+        deleteConflict = true;
+    }
+    check("merge refuses a delete beside ops", deleteConflict);
+}
+
+// ── generated-file guard: catches output, not files that EMIT the marker ───
+console.log("generated-file guard");
+{
+    write(
+        "gen-real.ts",
+        "// This file was automatically generated by a tool.\n// You should NOT make any changes in this file.\nexport const routes = 1;\n"
+    );
+    write(
+        "gen-emitter.ts",
+        'export const header = "# my shell hook — auto-generated, do not edit";\nexport const x = 1;\n'
+    );
+    write("gen-plain.ts", "export const x = 1;\n");
+    fs.mkdirSync(f("gensub"), { recursive: true });
+    fs.writeFileSync(f("gensub/routeTree.gen.ts"), "export const t = 1;\n");
+    check(
+        "a real generated header is caught",
+        looksGenerated(f("gen-real.ts")) !== null,
+        String(looksGenerated(f("gen-real.ts")))
+    );
+    check("a *.gen.ts path is caught", looksGenerated(f("gensub/routeTree.gen.ts")) !== null);
+    check(
+        "a file that merely EMITS the marker in a string is NOT flagged",
+        looksGenerated(f("gen-emitter.ts")) === null,
+        String(looksGenerated(f("gen-emitter.ts")))
+    );
+    check("an ordinary file is not flagged", looksGenerated(f("gen-plain.ts")) === null);
+    let refused = false;
+    try {
+        await run({
+            edits: [
+                {
+                    file: f("gen-real.ts"),
+                    ops: [{ find: "export const routes = 1;", replace: "export const routes = 2;" }],
+                },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        refused = true;
+    }
+    check("the runner refuses a generated file", refused && read("gen-real.ts").includes("routes = 1"));
+    let overrideErr = "";
+    try {
+        await run({
+            edits: [
+                {
+                    file: f("gen-real.ts"),
+                    ops: [{ find: "export const routes = 1;", replace: "export const routes = 2;" }],
+                    allowGenerated: true,
+                },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch (err) {
+        overrideErr = String(err).split("\n")[0];
+    }
+    check(
+        "per-file allowGenerated overrides it without disarming the batch",
+        overrideErr === "" && read("gen-real.ts").includes("routes = 2"),
+        overrideErr || read("gen-real.ts")
+    );
+    // the per-file flag must NOT leak to a sibling edit in the same batch
+    write("gen-real2.ts", "// automatically generated, do not edit\nexport const q = 1;\n");
+    let siblingRefused = false;
+    try {
+        await run({
+            edits: [
+                { file: f("gen-real.ts"), ops: [{ find: "routes = 2", replace: "routes = 3" }], allowGenerated: true },
+                { file: f("gen-real2.ts"), ops: [{ find: "q = 1", replace: "q = 2" }] },
+            ],
+            verbose: false,
+            throwOnFailure: true,
+        });
+    } catch {
+        siblingRefused = true;
+    }
+    check(
+        "one file's allowGenerated does not disarm the guard for its siblings",
+        siblingRefused && read("gen-real2.ts").includes("q = 1")
+    );
+}
+
+// ── post-flight leftover gate + recon shadow warning ───────────────────────
+console.log("leftovers gate / shadow warning");
+{
+    fs.mkdirSync(f("lg/src"), { recursive: true });
+    fs.writeFileSync(f("lg/src/a.ts"), "export const oldName = 1;\n");
+    fs.writeFileSync(f("lg/README.md"), "Call `oldName()` first.\n");
+    let gated = "";
+    let gatedCode = 0;
+    try {
+        await run({
+            edits: renameSymbolAcross({ files: [f("lg/src/a.ts")], oldName: "oldName", newName: "newName" }),
+            verbose: false,
+            throwOnFailure: true,
+            backupDir: path.join(tmp, "lg-bk"),
+            leftoversCheck: { names: ["oldName"], dirs: [f("lg")] },
+        });
+    } catch (err) {
+        gated = String(err);
+        gatedCode = err instanceof FableReplaceError ? err.code : 0;
+    }
+    check("a stale prose mention fails the run", gated.includes("stale prose mention"), gated);
+    check("stale prose after a green sweep exits 3, because the code IS written", gatedCode === 3, String(gatedCode));
+    check("but the verified code is still written", fs.readFileSync(f("lg/src/a.ts"), "utf8").includes("newName"));
+    fs.writeFileSync(f("lg/README.md"), "Call `newName()` first.\n");
+    fs.writeFileSync(f("lg/src/b.ts"), "export const oldName = 2;\n");
+    const rep = await run({
+        edits: renameSymbolAcross({ files: [f("lg/src/b.ts")], oldName: "oldName", newName: "newName" }),
+        verbose: false,
+        throwOnFailure: true,
+        backupDir: path.join(tmp, "lg-bk2"),
+        leftoversCheck: { names: ["oldName"], dirs: [f("lg")] },
+    });
+    check("clean docs pass the gate", rep.ok === true);
+    check(
+        "the backup dir is not scanned as a survivor",
+        leftovers({ names: ["oldName"], dirs: [path.join(tmp, "lg-bk")], quiet: true }).code.length === 0
+    );
+}
+{
+    // countMatches must flag a file that DECLARES the same bare name
+    write("sh-consumer.ts", "import { fmt } from './x';\nfmt(); oldName();\n");
+    write("sh-owner.ts", "function oldName() { return 1; }\noldName();\n");
+    const counts = countMatches({ files: [f("sh-consumer.ts"), f("sh-owner.ts")], pattern: "oldName", quiet: true });
+    check("both files counted", counts[f("sh-consumer.ts")] === 1 && counts[f("sh-owner.ts")] === 2);
+    const printed: string[] = [];
+    const realLog = console.log;
+    console.log = (...a: unknown[]): void => {
+        printed.push(a.join(" "));
+    };
+    try {
+        countMatches({ files: [f("sh-consumer.ts"), f("sh-owner.ts")], pattern: "oldName" });
+    } finally {
+        console.log = realLog;
+    }
+    const joined = printed.join("\n");
+    // sh-owner declares but does not import, so it lands in the "decide per file"
+    // bucket rather than the wrapper bucket — see the declaration-split test below.
+    check(
+        "a locally-declaring file is surfaced during recon",
+        joined.includes("without importing it") && joined.includes("sh-owner.ts"),
+        joined.slice(-200)
+    );
+    check(
+        "a plain consumer is not surfaced as a declarer",
+        !joined.split("without importing it")[1]?.includes("sh-consumer.ts")
+    );
+}
+{
+    const a = scratchDir("x");
+    const b = scratchDir("x");
+    check("scratchDir returns a unique path per call", a !== b && fs.existsSync(a) && fs.existsSync(b));
+}
+
+// ── findFiles(): recon must be able to START inside the API ────────────────
+console.log("findFiles");
+{
+    fs.mkdirSync(f("ff/src/deep"), { recursive: true });
+    fs.mkdirSync(f("ff/src/node_modules/pkg"), { recursive: true });
+    fs.writeFileSync(f("ff/src/hit.ts"), "export const oldName = 1;\n");
+    fs.writeFileSync(f("ff/src/deep/hit.tsx"), "oldName();\n");
+    fs.writeFileSync(f("ff/src/miss.ts"), "export const other = 1;\n");
+    fs.writeFileSync(f("ff/src/notes.md"), "oldName is documented here\n");
+    fs.writeFileSync(f("ff/src/node_modules/pkg/hit.ts"), "oldName();\n");
+    const hits = findFiles({ roots: [f("ff")], containing: /\boldName\b/ });
+    check(
+        "findFiles finds matching .ts and .tsx",
+        hits.length === 2,
+        stringifyJson(hits.map((h) => h.split("/").pop()))
+    );
+    check("findFiles skips node_modules", !hits.some((h) => h.includes("node_modules")));
+    check("findFiles excludes non-listed extensions by default", !hits.some((h) => h.endsWith(".md")));
+    const withMd = findFiles({ roots: [f("ff")], containing: /\boldName\b/, exts: [".md"] });
+    check("findFiles honours an explicit extension list", withMd.length === 1 && withMd[0].endsWith("notes.md"));
+    check("findFiles accepts a literal string", findFiles({ roots: [f("ff")], containing: "oldName" }).length === 2);
+    check(
+        "findFiles output feeds countMatches",
+        countMatches({
+            files: findFiles({ roots: [f("ff")], containing: "oldName" }),
+            pattern: "oldName",
+            quiet: true,
+        })[f("ff/src/hit.ts")] === 1
+    );
+}
+
+// ── recon fixes found by the grok round ────────────────────────────────────
+console.log("recon: leftovers on files, needle anchoring, declaration split");
+{
+    fs.mkdirSync(f("gk/src"), { recursive: true });
+    fs.writeFileSync(f("gk/README.md"), "oldName is documented here\n");
+    fs.writeFileSync(f("gk/src/imp.ts"), 'import x from "@pkg/utils/Stopwatch";\n');
+    // a FILE path must be accepted — the docs' own example passes README.md
+    let viaFile: { code: string[]; docs: string[] } = { code: [], docs: [] };
+    let viaFileErr = "";
+    try {
+        viaFile = leftovers({ names: ["oldName"], dirs: [f("gk/src"), f("gk/README.md")], quiet: true });
+    } catch (err) {
+        viaFileErr = String(err).split("\n")[0];
+    }
+    check(
+        "leftovers accepts a file path, not just a directory",
+        viaFileErr === "" && viaFile.docs.length === 1,
+        viaFileErr || stringifyJson(viaFile.docs)
+    );
+    // a non-identifier needle must NOT be word-boundary wrapped, or it silently finds nothing
+    const viaPath = leftovers({ names: ["@pkg/utils/Stopwatch"], dirs: [f("gk/src")], quiet: true });
+    check("a non-identifier needle matches literally", viaPath.code.length === 1, stringifyJson(viaPath.code));
+    // one line matching two needles is ONE surviving line
+    fs.writeFileSync(f("gk/src/two.ts"), "aaa(); bbb();\n");
+    check(
+        "a line matching two needles is counted once",
+        leftovers({ names: ["aaa", "bbb"], dirs: [f("gk/src/two.ts")], quiet: true }).code.length === 1
+    );
+}
+{
+    // the declaration warning must not cry wolf on the definition being renamed
+    write("dw-wrapper.ts", 'import { fmt as _fmt } from "./x";\nfunction fmt() { return _fmt(); }\nfmt();\n');
+    write("dw-source.ts", "export function fmt() { return 1; }\n");
+    const printed: string[] = [];
+    const realLog = console.log;
+    console.log = (...a: unknown[]): void => {
+        printed.push(a.join(" "));
+    };
+    try {
+        countMatches({ files: [f("dw-wrapper.ts"), f("dw-source.ts")], pattern: "fmt" });
+    } finally {
+        console.log = realLog;
+    }
+    const joined = printed.join("\n");
+    const wrapperLine = joined.split("both IMPORT and DECLARE")[1]?.split("·")[0] ?? "";
+    const sourceLine = joined.split("without importing it")[1] ?? "";
+    check(
+        "a file that imports AND declares is flagged as a wrapper",
+        wrapperLine.includes("dw-wrapper.ts") && !wrapperLine.includes("dw-source.ts"),
+        wrapperLine.trim()
+    );
+    check(
+        "a file that only declares is reported separately, not as a shadow",
+        sourceLine.includes("dw-source.ts"),
+        sourceLine.trim()
+    );
+}
+{
+    // renameSymbolAcross must accept the countMatches map and drop zero-match files
+    write("rm-a.ts", "oldName(); oldName();\n");
+    write("rm-b.ts", "nothing\n");
+    const counts = countMatches({ files: [f("rm-a.ts"), f("rm-b.ts")], pattern: "oldName", quiet: true });
+    const edits = renameSymbolAcross({ files: counts, oldName: "oldName", newName: "newName" });
+    check(
+        "a counts map drops zero-match files",
+        edits.length === 1 && edits[0].file === f("rm-a.ts"),
+        stringifyJson(edits.map((e) => e.file))
+    );
+    await run({ edits, verbose: false, throwOnFailure: true });
+    check("and the pinned count applies", read("rm-a.ts") === "newName(); newName();\n", read("rm-a.ts"));
+}
+
+// ── line-oriented inserts and append ─────────────────────────────────────────
+console.log("insertLines / append");
+{
+    const r = applyOps("a\nb\nc\n", [{ kind: "insertLinesAfter", anchor: "b", text: "b2\nb3" }]);
+    check(
+        "insertLinesAfter puts whole lines under the anchor line",
+        r.content === "a\nb\nb2\nb3\nc\n",
+        stringifyJson(r.content)
+    );
+    const r2 = applyOps("a\n  b = 1;\nc\n", [{ kind: "insertLinesBefore", anchor: "= 1", text: "  // note" }]);
+    check(
+        "insertLinesBefore ignores where on the line the anchor sits",
+        r2.content === "a\n  // note\n  b = 1;\nc\n",
+        stringifyJson(r2.content)
+    );
+    const r2b = applyOps("a\nb\n", [{ kind: "insertLinesAfter", anchor: "a", text: "x\n" }]);
+    check(
+        "a trailing newline in the text is a real blank line (spec bodies rely on it)",
+        r2b.content === "a\nx\n\nb\n",
+        stringifyJson(r2b.content)
+    );
+    const r3 = applyOps("a\nb\nb\n", [{ kind: "insertLinesAfter", anchor: "b", text: "x" }]);
+    check(
+        "insertLines needs a unique anchor",
+        r3.results[0].status === "MISS" && (r3.results[0].reason ?? "").includes("2×")
+    );
+    const r6 = applyOps("a\nb\nc\nd\n", [{ kind: "insertLinesAfter", anchor: "b\nc", text: "X" }]);
+    check(
+        "insertLinesAfter with a multi-line anchor goes below the anchor's LAST line",
+        r6.content === "a\nb\nc\nX\nd\n",
+        stringifyJson(r6.content)
+    );
+    const r7 = applyOps("a\nb\nc\nd\n", [{ kind: "insertLinesBefore", anchor: "b\nc", text: "X" }]);
+    check(
+        "insertLinesBefore with a multi-line anchor goes above the anchor's FIRST line",
+        r7.content === "a\nX\nb\nc\nd\n",
+        stringifyJson(r7.content)
+    );
+    const r4 = applyOps("a", [{ kind: "append", text: "z" }]);
+    check("append adds the newline between and at the end", r4.content === "a\nz\n", stringifyJson(r4.content));
+    const r5 = applyOps("a\n", [{ kind: "append", text: "z\n" }]);
+    check("append never doubles a newline", r5.content === "a\nz\n", stringifyJson(r5.content));
+}
+
+// ── nearestHint: a MISS says where to look ──────────────────────────────────
+console.log("nearestHint");
+{
+    const src = "one\n    two = 2;\nthree\n";
+    check(
+        "already applied",
+        nearestHint({ content: src, needle: "two = 1;", replacement: "two = 2;" }).includes("already")
+    );
+    check("whitespace-only drift → fuzzy hint", nearestHint({ content: src, needle: "two=2;" }).includes("whitespace"));
+    check("case typo → case hint", nearestHint({ content: src, needle: "    Two = 2;" }).includes("case"));
+    check("divergence line named", nearestHint({ content: src, needle: "one\nnope" }).includes("diverges at line 2"));
+    check(
+        "zero-vs-some whitespace still counts as whitespace drift",
+        nearestHint({ content: "a = b;", needle: "a=b;" }).includes("whitespace")
+    );
+    check("nothing similar → re-read", nearestHint({ content: src, needle: "zebra crossing" }).includes("Re-read"));
+    const r = applyOps(src, [{ find: "two = 3;", replace: "two = 4;" }]);
+    check("literal MISS reason carries the hint", (r.results[0].reason ?? "").includes("needle not found."));
+}
+
+// ── parseSpec: the CLI's marker format ──────────────────────────────────────
+console.log("parseSpec");
+{
+    const edits = parseSpec({
+        text: [
+            "# comment",
+            "@@ a.ts",
+            "expect: after",
+            "absent: before",
+            "<<<",
+            "before",
+            "===",
+            "after",
+            ">>>",
+            "<<< count=all optional label=every one",
+            "x",
+            "===",
+            "y",
+            ">>>",
+            "<<< regex flags=i count=2",
+            "foo(\\d)",
+            "===",
+            "bar($1)",
+            ">>>",
+            "<<< after",
+            "anchor",
+            "===",
+            "line1",
+            "line2",
+            ">>>",
+            "<<< append",
+            "tail",
+            ">>>",
+            "<<< delete",
+            "gone",
+            ">>>",
+            "<<< block",
+            "/**",
+            "===",
+            " */",
+            "===",
+            ">>>",
+            "@@ b.ts",
+            "<<< create",
+            "fresh",
+            ">>>",
+        ].join("\n"),
+    });
+    check("two file sections", edits.length === 2 && edits[0].file === "a.ts" && edits[1].file === "b.ts");
+    check("post-conditions parsed", edits[0].expectAfter?.[0] === "after" && edits[0].absentAfter?.[0] === "before");
+    const ops = edits[0].ops ?? [];
+    check(
+        "literal op",
+        ops[0] !== undefined &&
+            "find" in ops[0] &&
+            ops[0].find === "before" &&
+            (ops[0] as { replace: string }).replace === "after"
+    );
+    check(
+        "count=all optional label",
+        "count" in ops[1] && ops[1].count === "all" && ops[1].optional === true && ops[1].label === "every one"
+    );
+    check(
+        "regex op with flags and pinned count",
+        ops[2].kind === "regex" &&
+            ops[2].find.flags.includes("i") &&
+            ops[2].find.flags.includes("g") &&
+            ops[2].expect === 2
+    );
+    check(
+        "after → insertLinesAfter with multi-line text",
+        ops[3].kind === "insertLinesAfter" && ops[3].text === "line1\nline2"
+    );
+    check("append", ops[4].kind === "append" && ops[4].text === "tail");
+    check(
+        "delete → literal with newline, empty replace",
+        "find" in ops[5] && ops[5].find === "gone\n" && (ops[5] as { replace: string }).replace === ""
+    );
+    check("block with empty replacement → deleteBlock", ops[6].kind === "deleteBlock");
+    check("create → createWith with trailing newline", edits[1].createWith === "fresh\n" && edits[1].ops === undefined);
+    let err = "";
+    try {
+        parseSpec({ text: "@@ a.ts\n<<< nope\nx\n===\ny\n>>>" });
+    } catch (e) {
+        err = String(e);
+    }
+    check("unknown modifier names the line", err.includes("line 2") && err.includes("nope"));
+    err = "";
+    try {
+        parseSpec({ text: "@@ a.ts\n<<<\nx\n" });
+    } catch (e) {
+        err = String(e);
+    }
+    check("unclosed block is an error", err.includes("never closed"));
+    err = "";
+    try {
+        parseSpec({ text: "<<<\nx\n===\ny\n>>>" });
+    } catch (e) {
+        err = String(e);
+    }
+    check("op before @@ is an error", err.includes("before any @@"));
+    const json = parseSpec({
+        text: '[{"file":"j.ts","ops":[{"kind":"regex","find":"a(\\\\d)","flags":"g","replace":"b$1"}]}]',
+    });
+    check(
+        "JSON spec with a regex op",
+        json[0].ops?.[0].kind === "regex" && (json[0].ops[0] as { find: RegExp }).find.source === "a(\\d)"
+    );
+}
+
+// ── cli.ts end to end ───────────────────────────────────────────────────────
+console.log("cli.ts");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("cli");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "t.ts"), "const a = 1;\nconst b = 2;\n");
+    const runCli = (spec: string, ...args: string[]): { status: number | null; out: string } => {
+        const p = spawnSync("bun", [cli, ...args], { cwd: dir, input: spec, encoding: "utf8", env: hermeticEnv });
+        return { status: p.status, out: `${p.stdout}\n${p.stderr}` };
+    };
+    const ok = runCli(
+        "@@ t.ts\n<<<\nconst a = 1;\n===\nconst a = 10;\n>>>\n<<< append\nexport {};\n>>>\n@@ n.ts\n<<< create\nexport const n = 1;\n>>>\n"
+    );
+    check(
+        "cli: ok run exits 0 and writes",
+        ok.status === 0 &&
+            read("cli/t.ts") === "const a = 10;\nconst b = 2;\nexport {};\n" &&
+            read("cli/n.ts") === "export const n = 1;\n",
+        ok.out
+    );
+    check(
+        "cli: ok run reports OK lines and a backup dir",
+        ok.out.includes("OK") && ok.out.includes("Backed up") && ok.out.includes("SWEEP COMPLETE")
+    );
+    const miss = runCli(
+        "@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n<<<\nconst zz = 9;\n===\nconst zz = 8;\n>>>\n"
+    );
+    check(
+        "cli: one MISS aborts the batch, exit 1, nothing written",
+        miss.status === 1 &&
+            read("cli/t.ts").includes("const b = 2;") &&
+            miss.out.includes("MISS") &&
+            miss.out.includes("wrote NOTHING")
+    );
+    const dry = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--dry");
+    check(
+        "cli: --dry prints a diff and writes nothing",
+        dry.status === 0 && dry.out.includes("+ const b = 3;") && read("cli/t.ts").includes("const b = 2;")
+    );
+    const clash = runCli("@@ t.ts\n<<< create\nx\n>>>\n");
+    check("cli: create refuses an existing file", clash.status === 1 && clash.out.includes("refuses to overwrite"));
+    const bad = runCli("@@ t.ts\n<<< wat\nx\n===\ny\n>>>\n");
+    check(
+        "cli: spec error exits 2 with the line",
+        bad.status === 2 && bad.out.includes("SPEC ERROR") && bad.out.includes("line 2")
+    );
+    const verify = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--verify", "exit 1");
+    const undoLine = verify.out.match(/--rollback "([^"]+)"/)?.[1];
+    check(
+        "cli: a red --verify keeps the write, exits 3 and prints the undo command",
+        verify.status === 3 &&
+            read("cli/t.ts").includes("const b = 3;") &&
+            verify.out.includes("SWEEP WRITTEN, VERIFY FAILED (exit 1)") &&
+            undoLine !== undefined,
+        `${String(verify.status)} ${verify.out.slice(-400)}`
+    );
+    const undone = runCli("", "--rollback", undoLine ?? "/nonexistent");
+    check(
+        "cli: the printed --rollback line restores the file",
+        undone.status === 0 && read("cli/t.ts").includes("const b = 2;"),
+        undone.out
+    );
+    const dryVerify = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--dry", "--verify", "exit 0");
+    check(
+        "cli: --dry with --verify is refused, exit 2, nothing written",
+        dryVerify.status === 2 &&
+            dryVerify.out.includes("nothing to verify") &&
+            read("cli/t.ts").includes("const b = 2;"),
+        dryVerify.out
+    );
+    const piped = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--verify", "bun run test | tail -3");
+    check(
+        "cli: --verify with a pipe is refused, exit 2, nothing written",
+        piped.status === 2 &&
+            piped.out.includes("contains a pipe") &&
+            piped.out.includes("pipefail") &&
+            read("cli/t.ts").includes("const b = 2;"),
+        piped.out
+    );
+    const devnull = runCli("@@ t.ts\n<<<\nconst b = 2;\n===\nconst b = 3;\n>>>\n", "--verify", "exit 0 2>/dev/null");
+    check(
+        "cli: --verify with /dev/null warns and still runs",
+        devnull.status === 0 &&
+            devnull.out.includes("WARNING") &&
+            devnull.out.includes("/dev/null") &&
+            read("cli/t.ts").includes("const b = 3;"),
+        devnull.out
+    );
+    const api = spawnSync("bun", [cli, "--api"], { encoding: "utf8" });
+    check(
+        "cli: --api lists params interfaces with docs",
+        api.status === 0 &&
+            api.stdout.includes("interface RunParams") &&
+            api.stdout.includes("interface LiteralOp") &&
+            api.stdout.includes("parseSpec = (")
+    );
+}
+// ── round 2: what ten stress-test agents tripped over ───────────────────────
+console.log("round 2: run() contract");
+{
+    let err: unknown = null;
+    try {
+        await run({
+            edits: [{ file: f("a.ts"), ops: [{ find: "ALPHA", replace: "A" }] }],
+            verbose: false,
+            ...({ dry: true } as object),
+        });
+    } catch (e) {
+        err = e;
+    }
+    check(
+        "an unknown option key is a pre-flight error (code 2) with a hint",
+        err instanceof FableReplaceError &&
+            err.code === 2 &&
+            err.message.includes('unknown option "dry"') &&
+            err.message.includes("dryRun"),
+        String(err)
+    );
+    err = null;
+    try {
+        await run({
+            edits: [{ file: f("a.ts"), ops: [{ find: "NOPE-NOPE", replace: "A" }] }],
+            verbose: false,
+            dryRun: true,
+        });
+    } catch (e) {
+        err = e;
+    }
+    check(
+        "a dry run with a MISS throws code 1 (default throwOnFailure)",
+        err instanceof FableReplaceError && err.code === 1 && err.message.includes("dry run"),
+        String(err)
+    );
+}
+
+console.log("round 2: ops");
+{
+    const r = applyOps("/** a */\nx\n/** a */\ny\n", [{ kind: "deleteBlock", from: "/** a", to: " */\n" }]);
+    check(
+        "deleteBlock with a non-unique from anchor is a MISS naming the lines",
+        r.results[0].status === "MISS" &&
+            (r.results[0].reason ?? "").includes("occurs 2×") &&
+            (r.results[0].reason ?? "").includes("lines 1, 3"),
+        r.results[0].reason
+    );
+    const r2 = applyOps("/** a */\nx\n/** a */\ny\n", [
+        { kind: "deleteBlock", from: "/** a", to: " */\n", occurrence: 2 },
+    ]);
+    check(
+        "…unless occurrence is given",
+        r2.results[0].status === "OK" && r2.content === "/** a */\nx\ny\n",
+        stringifyJson(r2.content)
+    );
+    const r3 = applyOps("a\n        foo();\n", [{ kind: "insertLinesAfter", anchor: "    foo();", text: "bar();" }]);
+    check(
+        "an indented anchor must match at the start of a line",
+        r3.results[0].status === "MISS" && (r3.results[0].reason ?? "").includes("never at the start of a line"),
+        r3.results[0].reason
+    );
+    const r4 = applyOps("a\n    foo();\n", [
+        { kind: "insertLinesAfter", anchor: "    foo();", text: "    foo();\n    bar();" },
+    ]);
+    check(
+        "repeating the anchor inside the inserted text is flagged in the report",
+        r4.results[0].status === "OK" &&
+            r4.results[0].desc.includes("⚠") &&
+            r4.results[0].desc.includes("KEEP the anchor"),
+        r4.results[0].desc
+    );
+    const r5 = applyOps("x\nx\nx\n", [{ find: "x", replace: "y", count: 2 }]);
+    check(
+        "count mismatch lists the lines found",
+        (r5.results[0].reason ?? "").includes("at line(s) 1, 2, 3"),
+        r5.results[0].reason
+    );
+    const r6 = applyOps("a1 a2 a3", [{ kind: "regex", find: /a\d/g, replace: "b", expect: 2 }]);
+    check(
+        "regex expect mismatch lists the lines found",
+        (r6.results[0].reason ?? "").includes("at line(s) 1, 1, 1"),
+        r6.results[0].reason
+    );
+    const accented = "Doručená";
+    check(
+        "NFD vs NFC needle gets a normalization hint",
+        nearestHint({ content: `${accented.normalize("NFC")}\n`, needle: accented.normalize("NFD") }).includes(
+            "Unicode normalization"
+        )
+    );
+}
+
+console.log("round 2: recon and rename guards");
+{
+    fs.mkdirSync(f("r2/src"), { recursive: true });
+    write("r2/src/lib.ts", "export const oldName = 1;\n");
+    write("r2/src/use.ts", 'import { oldName } from "./lib";\nconsole.log(oldName);\n');
+    write(
+        "r2/src/wrap.ts",
+        'import { oldName as base } from "./lib";\nconst oldName = () => base;\nexport { oldName };\n'
+    );
+    write("r2/README.md", "See oldName.\n");
+    const viaFileRoot = findFiles({ roots: [f("r2/README.md"), f("r2/src")], containing: "oldName", exts: [] });
+    check(
+        "findFiles accepts a plain file as a root",
+        viaFileRoot.includes(f("r2/README.md")) && viaFileRoot.length === 4,
+        stringifyJson(viaFileRoot)
+    );
+    const split = shadowedFiles({
+        files: [f("r2/src/lib.ts"), f("r2/src/use.ts"), f("r2/src/wrap.ts")],
+        name: "oldName",
+    });
+    check(
+        "shadowedFiles splits wrapper vs definer",
+        split.shadows.length === 1 &&
+            split.shadows[0].endsWith("wrap.ts") &&
+            split.declarers.length === 1 &&
+            split.declarers[0].endsWith("lib.ts")
+    );
+    let err: unknown = null;
+    try {
+        renameSymbolAcross({
+            files: [f("r2/src/use.ts"), f("r2/src/wrap.ts")],
+            oldName: "oldName",
+            newName: "newName",
+        });
+    } catch (e) {
+        err = e;
+    }
+    check(
+        "renameSymbolAcross refuses a shadowing wrapper (code 2)",
+        err instanceof FableReplaceError &&
+            err.code === 2 &&
+            err.message.includes("wrap.ts") &&
+            err.message.includes("includeShadowed"),
+        String(err)
+    );
+    const forced = renameSymbolAcross({
+        files: [f("r2/src/wrap.ts")],
+        oldName: "oldName",
+        newName: "newName",
+        includeShadowed: true,
+    });
+    check("…unless includeShadowed is passed", forced.length === 1);
+}
+
+console.log("round 2: rollback");
+{
+    write("r2-rb.ts", "ORIGINAL\n");
+    const bd = path.join(tmp, "r2-bk");
+    await run({
+        edits: [{ file: f("r2-rb.ts"), ops: [{ find: "ORIGINAL", replace: "SWEPT" }] }],
+        verbose: false,
+        backupDir: bd,
+    });
+    const first = rollback({ backupDir: bd });
+    const second = rollback({ backupDir: bd });
+    check(
+        "rolling back twice is a no-op, not drift",
+        first.restored.length === 1 &&
+            second.drifted.length === 0 &&
+            second.restored.length === 1 &&
+            read("r2-rb.ts") === "ORIGINAL\n",
+        stringifyJson(second)
+    );
+}
+
+console.log("round 2: spec parser");
+{
+    const edits = parseSpec({ text: "@@ a.md\n<<<\nx\n===\nline\n\\===\n\\>>>\nend\n>>>\n" });
+    const op = edits[0].ops?.[0] as { replace: string };
+    check("\\=== and \\>>> in a body are unescaped", op.replace === "line\n===\n>>>\nend", stringifyJson(op.replace));
+    const tryParse = (text: string): string => {
+        try {
+            parseSpec({ text });
+            return "";
+        } catch (e) {
+            return String(e);
+        }
+    };
+    const extra = tryParse("@@ a.md\n<<<\nx\n===\ny\n===\nz\n>>>\n");
+    check(
+        "an extra === names ITS line, not the op line",
+        extra.includes("spec line 6") && extra.includes("\\==="),
+        extra
+    );
+    check(
+        "a diff hunk header after a bare >>> is diagnosed",
+        tryParse("@@ a.md\n<<<\nx\n===\ny\n>>>\n@@ -1,2 +1,2 @@\n").includes("diff hunk header")
+    );
+    check("count=0 is a spec error", tryParse("@@ a.md\n<<< count=0\nx\n===\ny\n>>>\n").includes("positive"));
+    const badRx = tryParse("@@ a.md\n<<< regex\n(x\n===\ny\n>>>\n");
+    check(
+        "an invalid regex names the spec line",
+        badRx.includes("spec line 2") && badRx.includes("invalid regex"),
+        badRx
+    );
+    check(
+        "invalid flags name the spec line",
+        tryParse("@@ a.md\n<<< regex flags=q\nx\n===\ny\n>>>\n").includes("spec line 2")
+    );
+    const backspace = String.fromCharCode(8);
+    check(
+        "a control character in a body is a spec error with the printf hint",
+        tryParse(`@@ a.md\n<<< regex\n${backspace}old\n===\ny\n>>>\n`).includes("printf")
+    );
+    const warnings: string[] = [];
+    parseSpec({ text: "@@ a.md\n<<< after\nanchor\n===\n```ts\ncode\n>>>\n", onWarning: (m) => warnings.push(m) });
+    check(
+        "an unbalanced code fence warns about a bare >>>",
+        warnings.length === 1 && warnings[0].includes("\\>>>"),
+        stringifyJson(warnings)
+    );
+    const fragmentWarnings: string[] = [];
+    parseSpec({
+        text: "@@ doc.md\n<<< block\n# Old\n===\nold\n```\n===\n# New\n```sh\nnew\n```\n>>>\n",
+        onWarning: (m) => fragmentWarnings.push(m),
+    });
+    parseSpec({ text: "@@ a.md\n<<<\n```sh\n===\n```bash\n>>>\n", onWarning: (m) => fragmentWarnings.push(m) });
+    parseSpec({
+        text: "@@ a.md\n<<< after\nanchor\n===\ncode\n```\n>>>\n",
+        onWarning: (m) => fragmentWarnings.push(m),
+    });
+    check(
+        "a closing fence in a block end-anchor, a fence-only body and a body ending on a fence do not warn",
+        fragmentWarnings.length === 0,
+        stringifyJson(fragmentWarnings)
+    );
+    const truncated: string[] = [];
+    parseSpec({
+        text: "@@ doc.md\n<<< block\n# Old\n===\nold\n```\n===\n# New\n```sh\nnew\n>>>\n",
+        onWarning: (m) => truncated.push(m),
+    });
+    check(
+        "a block whose last body ends inside an open fence still warns, naming the fence line",
+        truncated.length === 1 && truncated[0].includes("opened at its line 2") && truncated[0].includes("\\>>>"),
+        stringifyJson(truncated)
+    );
+}
+
+console.log("round 2: cli");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("cli2");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "t.ts"), "const a = 1;\n");
+    const runCli = (spec: string, ...args: string[]): { status: number | null; out: string } => {
+        const p = spawnSync("bun", [cli, ...args], { cwd: dir, input: spec, encoding: "utf8", env: hermeticEnv });
+        return { status: p.status, out: `${p.stdout}\n${p.stderr}` };
+    };
+    const typo = runCli("@@ t.ts\n<<<\nconst a = 1;\n===\nconst a = 2;\n>>>\n", "--dyr");
+    check(
+        "cli: an unknown flag exits 2 and writes nothing",
+        typo.status === 2 && typo.out.includes('unknown argument "--dyr"') && read("cli2/t.ts") === "const a = 1;\n",
+        typo.out
+    );
+    const dryMiss = runCli("@@ t.ts\n<<<\nconst zz = 1;\n===\nconst zz = 2;\n>>>\n", "--dry");
+    check("cli: --dry with a MISS exits 1", dryMiss.status === 1 && dryMiss.out.includes("MISS"), dryMiss.out);
+    const missing = runCli("", "--spec", path.join(dir, "nope.txt"));
+    check(
+        "cli: a missing --spec file is a clean SPEC ERROR, exit 2",
+        missing.status === 2 && missing.out.includes("SPEC ERROR") && !missing.out.includes("    at "),
+        missing.out
+    );
+    const real = runCli("@@ t.ts\n<<<\nconst a = 1;\n===\nconst a = 2;\n>>>\n");
+    const bk = real.out.match(/Backed up 1 path\(s\) to (\S+)/)?.[1];
+    check("cli: a real run prints its backup dir", real.status === 0 && bk !== undefined, real.out);
+    const rb = runCli("", "--rollback", bk ?? "/nonexistent");
+    check(
+        "cli: --rollback restores from that dir",
+        rb.status === 0 && read("cli2/t.ts") === "const a = 1;\n" && rb.out.includes("restored"),
+        rb.out
+    );
+    const rbBad = runCli("", "--rollback", path.join(dir, "not-a-backup"));
+    check(
+        "cli: --rollback on a non-backup dir is a clean error, exit 2",
+        rbBad.status === 2 && rbBad.out.includes("ROLLBACK ERROR"),
+        rbBad.out
+    );
+    const api = spawnSync("bun", [cli, "--api"], { encoding: "utf8" });
+    const apiLines = api.stdout.split("\n");
+    check(
+        "cli: --api has no duplicate entries and no function bodies",
+        apiLines.filter((l) => l.startsWith("scratchDir = ")).length === 1 &&
+            !api.stdout.includes("mkdtempSync") &&
+            apiLines.length < 900,
+        String(apiLines.length)
+    );
+    const apiQ = spawnSync("bun", [cli, "--api", "rollback"], { encoding: "utf8" });
+    check(
+        "cli: --api <query> narrows to matching names",
+        apiQ.stdout.includes("rollback = (") && !apiQ.stdout.includes("interface LiteralOp"),
+        apiQ.stdout.slice(0, 200)
+    );
+}
+
+console.log("round 3: error payload and recon guards");
+{
+    write("rp-good.ts", "const a = 1;\n");
+    write("rp-bad.ts", "const b = 2;\n");
+    let caught: FableReplaceError | undefined;
+    try {
+        await run({
+            edits: [
+                { file: f("rp-good.ts"), ops: [{ find: "const a = 1;", replace: "const a = 9;" }] },
+                { file: f("rp-bad.ts"), ops: [{ find: "NOT THERE", replace: "x" }] },
+            ],
+            partial: true,
+        });
+    } catch (e) {
+        caught = e as FableReplaceError;
+    }
+
+    check("a partial failure throws with a report attached", caught?.report !== undefined, String(caught?.message));
+    check(
+        "the attached report carries missCount and written",
+        caught?.report?.missCount === 1 && caught?.report?.written.length === 1 && caught?.report?.ok === false,
+        stringifyJson({ miss: caught?.report?.missCount, written: caught?.report?.written.length })
+    );
+
+    let guarded = "";
+    try {
+        // The type says `containing` is required; a throwaway JS script can still omit it.
+        (findFiles as unknown as (p: { roots: string[] }) => string[])({ roots: [tmp] });
+    } catch (e) {
+        guarded = String(e);
+    }
+
+    check("findFiles without `containing` throws instead of returning []", guarded.includes("is required"), guarded);
+    check(
+        "findFiles with `containing` still works",
+        findFiles({ roots: [tmp], containing: "const a = 9;" }).length === 1
+    );
+
+    // A literal needle is a SUBSTRING match: less indentation than the file still matches
+    // (and the file's own indentation survives), more indentation MISSes. SKILL.md says so;
+    // this pins the asymmetry so the doc cannot drift away from the behaviour.
+    write("ind.ts", "function g() {\n    const v = 1;\n}\n");
+    const under = await run({
+        edits: [{ file: f("ind.ts"), ops: [{ find: "  const v = 1;", replace: "  const v = 2;" }] }],
+    });
+    check(
+        "an under-indented literal needle matches and keeps the file's indentation",
+        under.ok && read("ind.ts") === "function g() {\n    const v = 2;\n}\n",
+        stringifyJson(read("ind.ts"))
+    );
+    const over = await run({
+        edits: [{ file: f("ind.ts"), ops: [{ find: "      const v = 2;", replace: "x" }] }],
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "an over-indented literal needle MISSes with the whitespace hint",
+        read("ind.ts").includes("    const v = 2;"),
+        String(over)
+    );
+
+    const apiCli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const apiOut = spawnSync("bun", [apiCli, "--api", "rollback"], { encoding: "utf8" });
+    check(
+        "cli: --api names the import path, not just the defining file",
+        apiOut.stdout.includes('from "') &&
+            apiOut.stdout.includes("replace-utils") &&
+            apiOut.stdout.includes("## backup-and-rollback.ts"),
+        apiOut.stdout.split("\n").slice(0, 3).join(" | ")
+    );
+
+    // count=N used to re-search the MUTATED text, so a replacement containing the needle
+    // wrapped the first hit twice, skipped the second, and still reported OK ×2 of 2.
+    write("selfwrap.ts", "const a = oldName(1);\nconst b = oldName(2);\n");
+    const wrapped = await run({
+        edits: [{ file: f("selfwrap.ts"), ops: [{ find: "oldName", replace: "wrapper(oldName)", count: 2 }] }],
+    });
+    check(
+        "count=N with a self-containing replacement hits each occurrence once",
+        wrapped.ok && read("selfwrap.ts") === "const a = wrapper(oldName)(1);\nconst b = wrapper(oldName)(2);\n",
+        stringifyJson(read("selfwrap.ts"))
+    );
+
+    // An empty `containing` matched every line/comment and wiped the file, reporting OK.
+    const wipeLines = applyOps("a\nb\nc\n", [{ kind: "deleteLines", containing: "" } as unknown as Op]);
+    check(
+        "deleteLines with an empty `containing` refuses instead of wiping the file",
+        wipeLines.content === "a\nb\nc\n" && wipeLines.results[0].status === "MISS",
+        stringifyJson(wipeLines.results[0])
+    );
+    const wipeComments = applyOps("// keep\nx = 1; // also\n", [
+        { kind: "dropComments", containing: "" } as unknown as Op,
+    ]);
+    check(
+        "dropComments with an empty `containing` refuses instead of dropping all",
+        wipeComments.content === "// keep\nx = 1; // also\n" && wipeComments.results[0].status === "MISS",
+        stringifyJson(wipeComments.results[0])
+    );
+
+    // Inserted lines take the file's own line ending, so a CRLF file stays all-CRLF.
+    const crlf = applyOps("line1\r\nline2\r\nline3\r\n", [
+        { kind: "insertLinesAfter", anchor: "line2", text: "NEWLINE" } as unknown as Op,
+    ]);
+    check(
+        "an insert into a CRLF file uses CRLF",
+        crlf.content === "line1\r\nline2\r\nNEWLINE\r\nline3\r\n",
+        stringifyJson(crlf.content)
+    );
+    const appended = applyOps("line1\r\n", [{ kind: "append", text: "tail" } as unknown as Op]);
+    check(
+        "an append to a CRLF file uses CRLF",
+        appended.content === "line1\r\ntail\r\n",
+        stringifyJson(appended.content)
+    );
+
+    // A restore blocked on ONE file used to abandon every later entry, leaving swept
+    // content live. Each entry is now restored inside its own guard.
+    write("st-a.ts", "const a = 1;\n");
+    write("st-b.ts", "const b = 2;\n");
+    write("st-c.ts", "const c = 3;\n");
+    const strandDir = scratchDir("selftest-strand");
+    await run({
+        edits: [
+            { file: f("st-a.ts"), ops: [{ find: "const a = 1;", replace: "const a = 100;" }] },
+            { file: f("st-b.ts"), ops: [{ find: "const b = 2;", replace: "const b = 200;" }] },
+            { file: f("st-c.ts"), ops: [{ find: "const c = 3;", replace: "const c = 300;" }] },
+        ],
+        backupDir: strandDir,
+        verbose: false,
+    });
+    fs.chmodSync(f("st-b.ts"), 0o444);
+    const strandReport = rollback({ backupDir: strandDir, force: true });
+    check(
+        "a rollback blocked on one file still restores the others",
+        read("st-a.ts") === "const a = 1;\n" && read("st-c.ts") === "const c = 3;\n",
+        `${read("st-a.ts")} | ${read("st-c.ts")}`
+    );
+    check(
+        "the blocked file is named in the rollback report, not silently stranded",
+        strandReport.failed.length === 1 &&
+            strandReport.failed[0].file.endsWith("st-b.ts") &&
+            read("st-b.ts") === "const b = 200;\n",
+        stringifyJson(strandReport.failed)
+    );
+    fs.chmodSync(f("st-b.ts"), 0o644);
+
+    // A rename used to write a fresh 644 file, dropping the executable bit.
+    const modeSrc = write("mode-src.ts", "export const x = 1;\n");
+    fs.chmodSync(modeSrc, 0o750);
+    await run({
+        edits: [
+            {
+                file: modeSrc,
+                renameTo: f("mode-dst.ts"),
+                ops: [{ find: "export const x = 1;", replace: "export const x = 2;" }],
+            },
+        ],
+    });
+    check(
+        "renameTo carries the source file's permission bits",
+        (fs.statSync(f("mode-dst.ts")).mode & 0o777) === 0o750,
+        (fs.statSync(f("mode-dst.ts")).mode & 0o777).toString(8)
+    );
+
+    // Restoring a file that already matches the backup must be a no-op, not an mtime bump.
+    const quietDir = scratchDir("selftest-quiet-rollback");
+    write("quiet.ts", "const q = 1;\n");
+    await run({
+        edits: [{ file: f("quiet.ts"), ops: [{ find: "const q = 1;", replace: "const q = 2;" }] }],
+        backupDir: quietDir,
+    });
+    rollback({ backupDir: quietDir });
+    const mtimeAfterFirst = fs.statSync(f("quiet.ts")).mtimeMs;
+    rollback({ backupDir: quietDir, force: true });
+    check(
+        "a second rollback does not touch a file already at its original content",
+        fs.statSync(f("quiet.ts")).mtimeMs === mtimeAfterFirst,
+        `${mtimeAfterFirst} vs ${fs.statSync(f("quiet.ts")).mtimeMs}`
+    );
+
+    const parseErr = (text: string): string => {
+        try {
+            parseSpec({ text });
+            return "";
+        } catch (e) {
+            return String(e);
+        }
+    };
+
+    // `label=` eats the rest of the line: a modifier written after it silently vanished and
+    // the op ran as a plain literal, matching something unrelated and reporting OK.
+    const swallowed = parseErr("@@ a.md\n<<< label=see ticket 123, regex flags=g\nfo+\n===\nMATCHED\n>>>\n");
+    check(
+        "a modifier absorbed by label= is a spec error",
+        swallowed.includes("absorbed into the label") && swallowed.includes("spec line 2"),
+        swallowed
+    );
+    check(
+        "a quoted label keeps a modifier word as text",
+        (
+            parseSpec({ text: '@@ a.md\n<<< label="cleanup, regex noise"\nx\n===\ny\n>>>\n' })[0].ops?.[0] as {
+                label?: string;
+            }
+        ).label === "cleanup, regex noise"
+    );
+    check(
+        "label= last still works with a real modifier",
+        (
+            parseSpec({ text: "@@ a.md\n<<< regex flags=g label=free text\nx\n===\ny\n>>>\n" })[0].ops?.[0] as {
+                kind?: string;
+            }
+        ).kind === "regex"
+    );
+
+    // A spec pasted from two sources carries CRLF on some lines only; splitting on "\n"
+    // alone left "\r" on the markers and swallowed the next op into the previous body.
+    const mixed = parseSpec({
+        text: "@@ a.md\r\n<<<\r\nline one\r\n===\r\nline ONE\r\n>>>\r\n<<<\nline two\n===\nline TWO\n>>>\n",
+    });
+    check("a spec with mixed CRLF/LF keeps both ops", mixed[0].ops?.length === 2, stringifyJson(mixed[0].ops));
+
+    check(
+        "a marker spec starting with [ says so, naming line 1",
+        parseErr("[legacy] old feature\n<<<\nfoo\n===\nbar\n>>>\n").includes('spec line 1: the spec starts with "["'),
+        parseErr("[legacy] x\n")
+    );
+
+    fs.mkdirSync(f("a-dir"), { recursive: true });
+    const dirErr = await run({ edits: [{ file: f("a-dir"), ops: [{ find: "x", replace: "y" }] }] }).catch(
+        (e: FableReplaceError) => e
+    );
+    check(
+        "a directory as a target is a pre-flight error, not a raw EISDIR",
+        String(dirErr).includes("is a directory, not a file"),
+        String(dirErr)
+    );
+
+    // readFileSync(…,"utf8") decodes lossily, so one stray cp1252 byte used to come back as
+    // U+FFFD and get written into the file, far from the edit, reported as OK.
+    fs.writeFileSync(f("latin1.txt"), Buffer.from([0x6e, 0x65, 0x65, 0x64, 0x6c, 0x65, 0x0a, 0x34, 0x92, 0x0a]));
+    const beforeBytes = fs.readFileSync(f("latin1.txt"));
+    const encErr = (await run({
+        edits: [{ file: f("latin1.txt"), ops: [{ find: "needle", replace: "FOUND" }] }],
+    }).catch((e: FableReplaceError) => e)) as FableReplaceError;
+    const encReason = (encErr.report?.files ?? []).flatMap((file) => file.postConditionFailures).join(" ");
+    check(
+        "a file that is not valid UTF-8 is refused, not silently mangled",
+        fs.readFileSync(f("latin1.txt")).equals(beforeBytes) && encReason.includes("not valid UTF-8"),
+        encReason || String(encErr)
+    );
+
+    // The file is read once at plan time; a concurrent write between read and write used to
+    // be overwritten silently, with the sweep still reporting OK.
+    write("race.ts", "const r = 1;\n");
+    check(
+        "changedOnDisk is false while the file still holds what was read",
+        !changedOnDisk({ abs: f("race.ts"), expected: "const r = 1;\n" })
+    );
+    fs.writeFileSync(f("race.ts"), "SOMEONE ELSE WROTE THIS\n");
+    check("changedOnDisk catches a concurrent write", changedOnDisk({ abs: f("race.ts"), expected: "const r = 1;\n" }));
+    check(
+        "changedOnDisk treats a vanished file as changed",
+        changedOnDisk({ abs: f("gone-forever.ts"), expected: "" })
+    );
+    const raceOk = await run({
+        edits: [{ file: f("race.ts"), ops: [{ find: "SOMEONE ELSE WROTE THIS", replace: "SETTLED" }] }],
+    });
+    check("the guard does not break an ordinary sweep", raceOk.ok && read("race.ts") === "SETTLED\n", read("race.ts"));
+
+    // Two sweeps racing into one backupDir: the loser used to overwrite the winner's
+    // manifest, so its own files could never be rolled back while both reported success.
+    const sharedDir = scratchDir("selftest-shared-backup");
+    write("shareA.ts", "const a = 1;\n");
+    write("shareB.ts", "const b = 1;\n");
+    await run({
+        edits: [{ file: f("shareA.ts"), ops: [{ find: "const a = 1;", replace: "const a = 2;" }] }],
+        backupDir: sharedDir,
+    });
+    const sharedErr = await run({
+        edits: [{ file: f("shareB.ts"), ops: [{ find: "const b = 1;", replace: "const b = 2;" }] }],
+        backupDir: sharedDir,
+        backupOverwrite: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a second sweep may not share a backup dir",
+        sharedErr instanceof FableReplaceError && read("shareB.ts") === "const b = 1;\n",
+        String(sharedErr)
+    );
+    const overwrote = await run({
+        edits: [{ file: f("shareB.ts"), ops: [{ find: "const b = 1;", replace: "const b = 2;" }] }],
+        backupDir: sharedDir,
+        backupOverwrite: true,
+    });
+    check("backupOverwrite: true still works", overwrote.ok && read("shareB.ts") === "const b = 2;\n");
+}
+
+// ── scratch root and prune ──────────────────────────────────────────────────
+console.log("scratchDir() root + pruneScratch()");
+{
+    const root = scratchRoot();
+    const fresh = scratchDir("probe");
+    check(
+        "scratchDir lands under <tmp>/fable-replace/",
+        fresh.startsWith(`${root}${path.sep}`) && path.basename(fresh).startsWith(`probe-${process.pid}-`),
+        fresh
+    );
+    const age = (dir: string): string => {
+        const then = new Date(Date.now() - 25 * 3600 * 1000);
+        fs.utimesSync(dir, then, then);
+        return dir;
+    };
+    const finished = (dir: string): string => {
+        fs.writeFileSync(path.join(dir, "0000-x.ts"), "x".repeat(100));
+        fs.writeFileSync(path.join(dir, "fable-replace-manifest.json"), "{}");
+        return dir;
+    };
+    const oldWithManifest = age(finished(scratchDir("old")));
+    const youngWithManifest = finished(scratchDir("young"));
+    const oldNoManifest = scratchDir("scratch");
+    fs.writeFileSync(path.join(oldNoManifest, "notes.txt"), "keep");
+    age(oldNoManifest);
+    const oldEmpty = age(scratchDir("empty"));
+    const legacy = age(finished(fs.mkdtempSync(path.join(os.tmpdir(), "fable-replace-legacy-1-"))));
+    const current = age(finished(scratchDir("current")));
+    const foreignRoot = path.join(f("other-tmp"), "fable-replace");
+    fs.mkdirSync(foreignRoot, { recursive: true });
+    const foreign = age(finished(fs.mkdtempSync(path.join(foreignRoot, "old-"))));
+    const report = pruneScratch({ keep: [current] });
+    check("an old dir with a manifest is removed", !fs.existsSync(oldWithManifest));
+    check("a young dir survives", fs.existsSync(youngWithManifest));
+    check("an old dir without a manifest survives: not proven ours", fs.existsSync(oldNoManifest));
+    check("an old empty dir is removed", !fs.existsSync(oldEmpty));
+    check("a legacy fable-replace-* dir directly under the temp dir falls under the same gate", !fs.existsSync(legacy));
+    check("the current run's dir survives even when old", fs.existsSync(current));
+    check("the report counts what it removed", report.removed === 3 && report.bytes >= 200, stringifyJson(report));
+    check(
+        "the prune sweeps only the root this process writes to (TMPDIR), never another temp root",
+        report.roots.length === 1 && report.roots[0] === scratchRoot() && fs.existsSync(foreign),
+        stringifyJson(report.roots)
+    );
+    const many = Array.from({ length: 60 }, (_, i) => age(finished(scratchDir(`many${i}`))));
+    const capped = pruneScratch({ keep: [current] });
+    check(
+        "at most 50 removals per run, the rest wait for the next one",
+        capped.removed === 50 && many.filter((dir) => fs.existsSync(dir)).length === 10,
+        String(capped.removed)
+    );
+    pruneScratch({ keep: [current] });
+    fs.rmSync(current, { recursive: true, force: true });
+}
+
+// ── journal ─────────────────────────────────────────────────────────────────
+console.log("cli.ts journal");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("journal");
+    const home = f("journal-home");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+    const journalFile = path.join(home, ".genesis-tools", "fable-replace", "journal.jsonl");
+    const runJ = (
+        spec: string,
+        env: Record<string, string>,
+        ...args: string[]
+    ): { status: number | null; out: string } => {
+        const p = spawnSync("bun", [cli, ...args], {
+            cwd: dir,
+            input: spec,
+            encoding: "utf8",
+            env: { ...hermeticEnv, FABLE_REPLACE_HOME: home, ...env },
+        });
+        return { status: p.status, out: `${p.stdout}\n${p.stderr}` };
+    };
+    const lines = (): JournalEntry[] =>
+        fs.existsSync(journalFile)
+            ? fs
+                  .readFileSync(journalFile, "utf8")
+                  .split("\n")
+                  .filter((line) => line.trim() !== "")
+                  .map((line) => parseJson(line) as JournalEntry)
+            : [];
+    fs.writeFileSync(path.join(dir, "j.ts"), "const j = 1;\n");
+    runJ("@@ j.ts\n<<<\nconst j = 1;\n===\nconst j = 2;\n>>>\n", {});
+    runJ("@@ j.ts\n<<<\nconst nope = 1;\n===\nconst j = 3;\n>>>\n", {});
+    runJ("@@ j.ts\n<<< wat\nx\n===\ny\n>>>\n", {});
+    runJ("@@ j.ts\n<<<\nconst j = 2;\n===\nconst j = 3;\n>>>\n", {}, "--verify", "exit 0 | cat");
+    runJ("@@ j.ts\n<<<\nconst j = 2;\n===\nconst j = 3;\n>>>\n", {}, "--verify", "exit 1");
+    runJ("@@ j.ts\n<<<\nconst j = 3;\n===\nconst j = 4;\n>>>\n", {}, "--dry");
+    const all = lines();
+    const outcomes = all.map((e) => e.outcome);
+    check(
+        "one journal line per real run outcome, a written line before a verify, and nothing for --dry",
+        stringifyJson(outcomes) ===
+            stringifyJson(["ok", "miss", "spec-error", "pre-flight", "written", "verify-failed"]),
+        stringifyJson(outcomes)
+    );
+    const miss = all[1];
+    check(
+        "a MISS line carries its reason, the spec size and a token estimate",
+        miss?.missCount === 1 &&
+            (miss.reasons?.[0] ?? "").includes("const nope") &&
+            (miss.spec?.chars ?? 0) > 0 &&
+            miss.tokensEst?.spec === Math.round((miss.spec?.chars ?? 0) / 3.7),
+        stringifyJson(miss)
+    );
+    check(
+        "a spec error line carries the parser message",
+        all[2]?.specError?.includes("line 2") === true,
+        stringifyJson(all[2])
+    );
+    const vf = all[5];
+    check(
+        "a verify-failed line carries the verdict, the write count and the backup dir",
+        vf?.verify?.status === "fail" && vf.verify.exit === 1 && vf.backupDir !== undefined && vf.written === 1,
+        stringifyJson(vf)
+    );
+    check(
+        "the written line precedes the verify and names the same backup dir",
+        all[4]?.outcome === "written" && all[4].backupDir === vf?.backupDir,
+        stringifyJson(all[4])
+    );
+    check(
+        "the spec text is saved beside the backup, never in the journal",
+        vf?.backupDir !== undefined &&
+            fs.readFileSync(path.join(vf.backupDir, "spec.frspec"), "utf8").includes("const j = 2;") &&
+            !fs.readFileSync(journalFile, "utf8").includes("\\n===\\n")
+    );
+    check(
+        "every line carries what was printed and how long it took",
+        all.every((e) => (e.resultChars ?? 0) > 0 && (e.durationMs ?? -1) >= 0 && e.runId.length > 0),
+        stringifyJson(all.map((e) => [e.outcome, e.resultChars, e.durationMs]))
+    );
+    runJ("", {}, "--rollback", vf?.backupDir ?? "/nonexistent");
+    const rb = lines().at(-1);
+    check(
+        "a rollback is journaled with its counts",
+        rb?.kind === "rollback" && rb.rollback?.restored === 1,
+        stringifyJson(rb)
+    );
+
+    const history = runJ("", {}, "--history", "3");
+    check(
+        "--history prints the last N entries, one line each",
+        history.status === 0 && history.out.split("\n").filter((line) => /^\d{4}-\d{2}-\d{2} /.test(line)).length === 3,
+        history.out
+    );
+    const stats = runJ("", {}, "--stats", "1");
+    check(
+        "--stats prints counts, tokens and waste, and no dollar figure",
+        stats.status === 0 &&
+            stats.out.includes("runs, last 1 day(s): 5") &&
+            !/^\s+written\s+\d+$/m.test(stats.out) &&
+            stats.out.includes("chars ÷ 3.7") &&
+            !stats.out.includes("$") &&
+            stats.out.includes("wasted"),
+        stats.out
+    );
+
+    const home2 = f("journal-home2");
+    fs.mkdirSync(home2, { recursive: true });
+    const noOverride = Object.fromEntries(
+        Object.entries(process.env).filter(([name]) => name !== "FABLE_REPLACE_HOME")
+    );
+    spawnSync("bun", [cli], {
+        cwd: dir,
+        input: "@@ j.ts\n<<<\nconst nope = 1;\n===\nconst j = 9;\n>>>\n",
+        encoding: "utf8",
+        env: { ...noOverride, GENESIS_TOOLS_HOME: home2 },
+    });
+    check(
+        "GENESIS_TOOLS_HOME is honoured when FABLE_REPLACE_HOME is unset",
+        fs.existsSync(path.join(home2, ".genesis-tools", "fable-replace", "journal.jsonl"))
+    );
+
+    fs.writeFileSync(journalFile, "x".repeat(5 * 1024 * 1024 + 1));
+    runJ("@@ j.ts\n<<<\nconst nope = 1;\n===\nconst j = 9;\n>>>\n", {});
+    check(
+        "the journal rotates once past 5 MB",
+        fs.existsSync(path.join(home, ".genesis-tools", "fable-replace", "journal.1.jsonl")) &&
+            fs.statSync(journalFile).size < 4096
+    );
+
+    const blocked = f("journal-blocked");
+    fs.writeFileSync(blocked, "not a dir\n");
+    const warned = runJ("@@ j.ts\n<<<\nconst nope = 1;\n===\nconst j = 9;\n>>>\n", { FABLE_REPLACE_HOME: blocked });
+    check(
+        "a journal that cannot be written warns and leaves the exit code alone",
+        warned.status === 1 && warned.out.includes("journal: could not append"),
+        warned.out.slice(-300)
+    );
+
+    const planted = scratchDir("planted");
+    fs.writeFileSync(path.join(planted, "fable-replace-manifest.json"), "{}");
+    const stale = new Date(Date.now() - 25 * 3600 * 1000);
+    fs.utimesSync(planted, stale, stale);
+    const linesBeforeDry = lines().length;
+    runJ("@@ j.ts\n<<<\nconst j = 2;\n===\nconst j = 3;\n>>>\n", {}, "--dry");
+    check(
+        "a --dry run journals nothing and prunes nothing",
+        lines().length === linesBeforeDry && fs.existsSync(planted),
+        `${lines().length} vs ${linesBeforeDry}, planted exists=${fs.existsSync(planted)}`
+    );
+
+    const pruned = runJ("", {}, "--prune");
+    check(
+        "--prune reports what it swept and is journaled on its own line",
+        pruned.status === 0 &&
+            pruned.out.includes("pruned 1 ") &&
+            !fs.existsSync(planted) &&
+            lines().at(-1)?.kind === "prune",
+        `${pruned.out} ${stringifyJson(lines().at(-1))}`
+    );
+}
+
+// ── diagnostics: same-batch interference vs. a previous run (h_yvyxmctd) ─────
+console.log("diagnostics: consumed needle vs. applied before");
+{
+    const twice = applyOps("const value = 1;\n", [
+        { find: "const value = 1;", replace: "const value = 2;" },
+        { find: "const value = 1;", replace: "const value = 2;" },
+    ]);
+    check(
+        "a needle consumed by an earlier op of the batch is blamed on that op, not on a previous run",
+        twice.results[0].status === "OK" &&
+            twice.results[1].status === "MISS" &&
+            (twice.results[1].reason ?? "").includes("op 1 of this batch") &&
+            (twice.results[1].reason ?? "").includes("consumed") &&
+            !(twice.results[1].reason ?? "").includes("optional"),
+        twice.results[1].reason ?? ""
+    );
+    const before = applyOps("const value = 2;\n", [{ find: "const value = 1;", replace: "const value = 2;" }]);
+    check(
+        "a replacement that was on disk before the run keeps the re-run guidance",
+        before.results[0].status === "MISS" && (before.results[0].reason ?? "").includes("applied before"),
+        before.results[0].reason ?? ""
+    );
+
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("handoff");
+    fs.mkdirSync(dir, { recursive: true });
+    const runH = (spec: string): { status: number | null; out: string } => {
+        const p = spawnSync("bun", [cli], { cwd: dir, input: spec, encoding: "utf8", env: hermeticEnv });
+        return { status: p.status, out: `${p.stdout}\n${p.stderr}` };
+    };
+    fs.writeFileSync(path.join(dir, "doc.md"), "# Old\n```sh\nold\n```\n");
+    const fence = runH("@@ doc.md\n<<< block\n# Old\n===\nold\n```\n===\n# New\n```sh\nnew\n```\n>>>\n");
+    check(
+        "cli: a block replacement whose end anchor is a closing fence lands without a truncation warning",
+        fence.status === 0 && !fence.out.includes("WARNING") && read("handoff/doc.md") === "# New\n```sh\nnew\n```\n",
+        `${String(fence.status)} ${fence.out.slice(0, 300)}`
+    );
+    fs.writeFileSync(path.join(dir, "example.ts"), "const value = 1;\n");
+    const dup = runH(
+        "@@ example.ts\n<<<\nconst value = 1;\n===\nconst value = 2;\n>>>\n<<<\nconst value = 1;\n===\nconst value = 2;\n>>>\n"
+    );
+    check(
+        "cli: a duplicate op aborts the batch, leaves the disk untouched and names the earlier op",
+        dup.status === 1 &&
+            dup.out.includes("op 1 of this batch") &&
+            read("handoff/example.ts") === "const value = 1;\n",
+        `${String(dup.status)} ${dup.out.slice(0, 400)}`
+    );
+}
+
+// ── review round 1 (PR #371): backup reservation, created-file syntax, quoted undo ──
+console.log("review round 1 regressions");
+{
+    write("race-a.ts", "const a = 1;\n");
+    const raceDir = path.join(tmp, "race-backup");
+    writeBackup({ dir: raceDir, files: [f("race-a.ts")] });
+    const storedBefore = fs.readFileSync(path.join(raceDir, "0000-race-a.ts"), "utf8");
+    const manifestBefore = fs.readFileSync(path.join(raceDir, "fable-replace-manifest.json"), "utf8");
+    write("race-a.ts", "const a = 2;\n");
+    let refused = "";
+    try {
+        writeBackup({ dir: raceDir, files: [f("race-a.ts")] });
+    } catch (err) {
+        refused = String(err);
+    }
+    check(
+        "a second writer into one backup dir is refused before it copies, so the first snapshot is intact",
+        refused.includes("another sweep is using it") &&
+            fs.readFileSync(path.join(raceDir, "0000-race-a.ts"), "utf8") === storedBefore &&
+            fs.readFileSync(path.join(raceDir, "fable-replace-manifest.json"), "utf8") === manifestBefore,
+        refused
+    );
+
+    const badCreate = await run({
+        edits: [{ file: f("bad-new.ts"), createWith: "const x = ;\n" }],
+        verbose: false,
+    }).catch((e: FableReplaceError) => e);
+    check(
+        "a created .ts file that does not parse is refused and not written",
+        badCreate instanceof FableReplaceError &&
+            badCreate.code === 1 &&
+            (badCreate.report?.files[0]?.postConditionFailures ?? []).some((p) => p.includes("does not parse")) &&
+            !fs.existsSync(f("bad-new.ts")),
+        String(badCreate)
+    );
+
+    const spaceTmp = f("tmp with space");
+    fs.mkdirSync(spaceTmp, { recursive: true });
+    const spaceDir = f("space-cli");
+    fs.mkdirSync(spaceDir, { recursive: true });
+    fs.writeFileSync(path.join(spaceDir, "s.ts"), "const s = 1;\n");
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const red = spawnSync("bun", [cli, "--verify", "exit 1"], {
+        cwd: spaceDir,
+        input: "@@ s.ts\n<<<\nconst s = 1;\n===\nconst s = 2;\n>>>\n",
+        encoding: "utf8",
+        env: { ...hermeticEnv, TMPDIR: spaceTmp },
+    });
+    const quoted = `${red.stdout}\n${red.stderr}`.match(/--rollback "([^"]+)"/)?.[1];
+    const undone =
+        quoted === undefined
+            ? null
+            : spawnSync("bun", [cli, "--rollback", quoted], { cwd: spaceDir, encoding: "utf8", env: hermeticEnv });
+    check(
+        "the undo line quotes a backup path that contains a space, and that path restores",
+        red.status === 3 &&
+            quoted !== undefined &&
+            quoted.includes(" ") &&
+            undone?.status === 0 &&
+            fs.readFileSync(path.join(spaceDir, "s.ts"), "utf8") === "const s = 1;\n",
+        `${String(red.status)} ${quoted ?? "no quoted path"} ${undone?.stdout.slice(-200) ?? ""}`
+    );
+}
+
+// ── review round 2 (PR #371, CodeRabbit + eve): --api dir decoding, CRLF block anchors, nthIndexOf, /g regexes,
+// createWith on an existing file, the rollback guard and exit code ──
+console.log("review round 2 (PR #371)");
+check(
+    "nthIndexOf walks non-overlapping, like countOccurrences",
+    nthIndexOf({ haystack: "aaaa", needle: "aa", n: 2 }) === 2
+);
+check(
+    "nthIndexOf: no 3rd non-overlapping occurrence",
+    nthIndexOf({ haystack: "aaaa", needle: "aa", n: 3 }) === -1 && countOccurrences("aaaa", "aa") === 2
+);
+{
+    const crlf = "keep\r\n/**\r\n * junk\r\n * junk2\r\n */\r\nrest\r\n";
+    const r = applyOps(crlf, [dropJsdocStarting({ fromPrefix: "/**\n * junk" })]);
+    check(
+        "dropJsdocStarting lands on a CRLF file",
+        r.results[0].status === "OK" && r.content === "keep\r\nrest\r\n",
+        r.results[0].reason ?? stringifyJson(r.content)
+    );
+    const lf = applyOps("keep\n/**\n * junk\n */\nrest\n", [dropJsdocStarting({ fromPrefix: "/**\n * junk" })]);
+    check("dropJsdocStarting on an LF file is unchanged", lf.content === "keep\nrest\n");
+    const mixed = applyOps("a\nSTART\nx\nEND\nb\r\n", [{ kind: "deleteBlock", from: "START\n", to: "END\n" }]);
+    check(
+        "an LF anchor that exists literally in a mixed-ending file is still preferred",
+        mixed.content === "a\nb\r\n",
+        mixed.results[0].reason ?? stringifyJson(mixed.content)
+    );
+}
+fs.mkdirSync(f("g-rx"), { recursive: true });
+write("g-rx/one.ts", "needle();\nneedle();\n");
+write("g-rx/two.ts", "needle();\n");
+check(
+    "findFiles with a /g regex keeps every matching file",
+    findFiles({ roots: [f("g-rx")], containing: /needle/g }).length === 2
+);
+check(
+    "grepPreview with a /g regex counts every matching line",
+    grepPreview({ files: [f("g-rx/one.ts")], pattern: /needle/g, context: 0 }) === 2
+);
+{
+    const existing = write("exists.ts", "const keep = 1;\n");
+    let refused: FableReplaceError | undefined;
+    try {
+        await run({ edits: [{ file: existing, createWith: "const other = 2;\n" }], verbose: false });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "run(): createWith on an existing file is refused by the runner (code 1, nothing written)",
+        refused?.code === 1 &&
+            refused.report?.files[0]?.postConditionFailures[0]?.includes("refuses to overwrite") === true &&
+            read("exists.ts") === "const keep = 1;\n",
+        String(refused?.message)
+    );
+}
+{
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const spaced = f("dir with space/scripts");
+    fs.mkdirSync(spaced, { recursive: true });
+    for (const name of fs.readdirSync(here)) {
+        if (name.endsWith(".ts")) {
+            fs.copyFileSync(path.join(here, name), path.join(spaced, name));
+        }
+    }
+    const api = spawnSync("bun", [path.join(spaced, "cli.ts"), "--api", "run"], { encoding: "utf8", env: hermeticEnv });
+    const count = Number(api.stdout.match(/fable-replace API — (\d+) entr/)?.[1] ?? -1);
+    check(
+        "--api from a directory whose path contains a space still lists the modules",
+        api.status === 0 && count > 0,
+        `${String(api.status)} ${api.stdout.slice(0, 200)} ${api.stderr.slice(0, 200)}`
+    );
+}
+
+{
+    const a = write("rb-dir-a.ts", "const a = 1;\n");
+    const b = write("rb-dir-b.ts", "const b = 1;\n");
+    const backupDir = scratchDir("rb-dir");
+    await run({
+        edits: [
+            { file: a, ops: [{ find: "= 1", replace: "= 2" }] },
+            { file: b, ops: [{ find: "= 1", replace: "= 2" }] },
+        ],
+        backupDir,
+        verbose: false,
+    });
+    fs.rmSync(a);
+    fs.mkdirSync(a);
+    const partial = rollback({ backupDir });
+    check(
+        "rollback: a path that became a directory lands in report.failed and the later entry is still restored",
+        partial.failed.length === 1 &&
+            partial.failed[0].file === a &&
+            partial.restored.includes(b) &&
+            read("rb-dir-b.ts") === "const b = 1;\n",
+        stringifyJson(partial)
+    );
+}
+{
+    const cliDir = f("rb-cli");
+    fs.mkdirSync(cliDir, { recursive: true });
+    fs.writeFileSync(path.join(cliDir, "r.ts"), "const r = 1;\n");
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const swept = spawnSync("bun", [cli], {
+        cwd: cliDir,
+        input: "@@ r.ts\n<<<\nconst r = 1;\n===\nconst r = 2;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    const backupDir = `${swept.stdout}\n${swept.stderr}`.match(/Backed up 1 path\(s\) to (.+)/)?.[1]?.trim();
+    fs.chmodSync(path.join(cliDir, "r.ts"), 0o444);
+    const blocked =
+        backupDir === undefined
+            ? null
+            : spawnSync("bun", [cli, "--rollback", backupDir], { cwd: cliDir, encoding: "utf8", env: hermeticEnv });
+    fs.chmodSync(path.join(cliDir, "r.ts"), 0o644);
+    const retried =
+        backupDir === undefined
+            ? null
+            : spawnSync("bun", [cli, "--rollback", backupDir], { cwd: cliDir, encoding: "utf8", env: hermeticEnv });
+    check(
+        "cli --rollback exits 1 while a file could not be restored, then 0 once the cause is fixed",
+        swept.status === 0 &&
+            backupDir !== undefined &&
+            blocked?.status === 1 &&
+            blocked.stderr.includes("COULD NOT RESTORE") &&
+            retried?.status === 0 &&
+            fs.readFileSync(path.join(cliDir, "r.ts"), "utf8") === "const r = 1;\n",
+        `${String(swept.status)} ${backupDir ?? "no backup dir"} ${String(blocked?.status)} ${String(retried?.status)}`
+    );
+}
+
+// ── review round 3 (PR #371, eve): empty anchors, a recovery that restores only what it wrote, hash failures on the
+// written path, inline comment removal that keeps tokens apart, tokens instead of dollars ──
+console.log("review round 3 (PR #371)");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const hangDir = f("empty-anchor");
+    fs.mkdirSync(hangDir, { recursive: true });
+    fs.writeFileSync(path.join(hangDir, "e.ts"), "const e = 1;\n");
+    const markers = spawnSync("bun", [cli], {
+        cwd: hangDir,
+        input: "@@ e.ts\n<<< after\n===\nconst added = 2;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+        timeout: 20_000,
+    });
+    check(
+        "cli: an empty after/before anchor is a spec error, not a hang",
+        markers.status === 2 && markers.stderr.includes("anchor") && !markers.stdout.includes("Wrote"),
+        `${String(markers.status)} ${markers.signal ?? ""} ${markers.stderr.slice(0, 200)}`
+    );
+    const json = spawnSync("bun", [cli], {
+        cwd: hangDir,
+        input: stringifyJson([
+            { file: "e.ts", ops: [{ kind: "insertLinesAfter", anchor: "", text: "const added = 2;" }] },
+        ]),
+        encoding: "utf8",
+        env: hermeticEnv,
+        timeout: 20_000,
+    });
+    check(
+        "cli (JSON form): an empty anchor reaches the runner and is a MISS, not a hang",
+        json.status === 1 &&
+            json.stdout.includes("anchor is empty") &&
+            fs.readFileSync(path.join(hangDir, "e.ts"), "utf8") === "const e = 1;\n",
+        `${String(json.status)} ${json.signal ?? ""} ${json.stdout.slice(-300)}`
+    );
+    const block = applyOps("a\nb\n", [{ kind: "deleteBlock", from: "", to: "b" }]);
+    const inline = applyOps("a\nb\n", [{ kind: "insertAfter", anchor: "", text: "x" }]);
+    check(
+        "api: empty block and same-line anchors are a MISS instead of landing at offset 0",
+        block.results[0].status === "MISS" &&
+            block.content === "a\nb\n" &&
+            inline.results[0].status === "MISS" &&
+            inline.content === "a\nb\n",
+        `${block.results[0].reason ?? ""} | ${inline.results[0].reason ?? ""}`
+    );
+}
+{
+    const a = write("only-a.ts", "const a = 1;\n");
+    const b = write("only-b.ts", "const b = 1;\n");
+    const onlyDir = scratchDir("only");
+    await run({
+        edits: [
+            { file: a, ops: [{ find: "= 1", replace: "= 2" }] },
+            { file: b, ops: [{ find: "= 1", replace: "= 2" }] },
+        ],
+        backupDir: onlyDir,
+        verbose: false,
+    });
+    const partial = rollback({ backupDir: onlyDir, only: [a] });
+    check(
+        "rollback({ only }) restores the listed path and leaves the others alone and unreported",
+        read("only-a.ts") === "const a = 1;\n" &&
+            read("only-b.ts") === "const b = 2;\n" &&
+            partial.restored.length === 1 &&
+            !partial.restored.includes(b),
+        stringifyJson(partial)
+    );
+}
+{
+    for (let i = 0; i < 4; i += 1) {
+        write(`rec${i}.ts`, `const v${i} = "old";\n`);
+    }
+    fs.chmodSync(f("rec2.ts"), 0o444);
+    let message = "";
+    try {
+        await run({
+            edits: [0, 1, 2, 3].map((i) => ({ file: f(`rec${i}.ts`), ops: [{ find: `"old"`, replace: `"new"` }] })),
+            verbose: false,
+            backupDir: scratchDir("recover"),
+        });
+    } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+    }
+    fs.chmodSync(f("rec2.ts"), 0o644);
+    check(
+        "a failed write restores what this sweep wrote and reports the later files as never touched",
+        message.includes("write failed after 2 file(s)") &&
+            message.includes("1 later file(s) were never touched") &&
+            [0, 1, 2, 3].every((i) => read(`rec${i}.ts`).includes(`"old"`)),
+        message
+    );
+}
+{
+    const hashed = write("hash-a.ts", "const h = 1;\n");
+    const hashDir = scratchDir("hash");
+    const moved = f("hash-a.moved.ts");
+    const report = await run({
+        edits: [{ file: hashed, ops: [{ find: "= 1", replace: "= 2" }] }],
+        backupDir: hashDir,
+        verbose: false,
+        verifyCommand: `mv "${hashed}" "${moved}" && mkdir "${hashed}"`,
+    });
+    const undone = rollback({ backupDir: hashDir });
+    check(
+        "a verify that turned a tracked path into a directory: the run stays green, the hash is skipped, the rollback names the path",
+        report.ok && report.verify?.status === "pass" && undone.failed.length === 1 && undone.failed[0].file === hashed,
+        stringifyJson({ ok: report.ok, verify: report.verify?.status, failed: undone.failed })
+    );
+    fs.rmSync(hashed, { recursive: true, force: true });
+    fs.renameSync(moved, hashed);
+}
+{
+    const manifestFile = write("manifest-a.ts", "const m = 1;\n");
+    const manifestDir = scratchDir("manifest");
+    const manifestPath = path.join(manifestDir, "fable-replace-manifest.json");
+    let failure: FableReplaceError | undefined;
+    try {
+        await run({
+            edits: [{ file: manifestFile, ops: [{ find: "= 1", replace: "= 2" }] }],
+            backupDir: manifestDir,
+            verbose: false,
+            verifyCommand: `chmod 444 "${manifestPath}"`,
+        });
+    } catch (err) {
+        failure = err instanceof FableReplaceError ? err : undefined;
+    }
+    fs.chmodSync(manifestPath, 0o644);
+    check(
+        "a manifest the disk refuses after the write is a code-3 written-sweep failure carrying the report and backup dir",
+        failure?.code === 3 &&
+            failure.message.includes("backup manifest not updated") &&
+            failure.report?.backupDir === manifestDir &&
+            read("manifest-a.ts") === "const m = 2;\n",
+        `${String(failure?.code)} ${failure?.message ?? "no error"}`
+    );
+}
+{
+    const keep = (src: string): string => dropComments(src, { containing: "legacy" }).content;
+    check("inline comment removal keeps tokens apart", keep("return/*legacy*/value;\n") === "return value;\n");
+    check(
+        "inline comment removal never forms ++ or a line comment",
+        keep("a +/*legacy*/+b; x/*legacy*//y;\n") === "a + +b; x /y;\n"
+    );
+    check(
+        "inline comment removal adds nothing beside brackets and commas",
+        keep("f(/*legacy*/a,/*legacy*/b);\n") === "f(a,b);\n"
+    );
+}
+
+// ── review round 4 (PR #371, eve): absolute manifest paths under a relative --cwd, empty fuzzy and regex needles,
+// identifier boundaries and literal dollar names in renames ──
+console.log("review round 4 (PR #371)");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const parent = f("relcwd");
+    fs.mkdirSync(path.join(parent, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(parent, "sub", "r.ts"), "const r = 1;\n");
+    const swept = spawnSync("bun", [cli, "--cwd", "sub"], {
+        cwd: parent,
+        input: "@@ r.ts\n<<<\nconst r = 1;\n===\nconst r = 2;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    const backupDir = `${swept.stdout}\n${swept.stderr}`.match(/Backed up 1 path\(s\) to (.+)/)?.[1]?.trim();
+    const elsewhere = f("relcwd-elsewhere");
+    fs.mkdirSync(elsewhere, { recursive: true });
+    const undone =
+        backupDir === undefined
+            ? null
+            : spawnSync("bun", [cli, "--rollback", backupDir], { cwd: elsewhere, encoding: "utf8", env: hermeticEnv });
+    check(
+        "a relative --cwd records absolute paths, so the printed undo works from any directory",
+        swept.status === 0 &&
+            undone?.status === 0 &&
+            fs.readFileSync(path.join(parent, "sub", "r.ts"), "utf8") === "const r = 1;\n" &&
+            !fs.existsSync(path.join(elsewhere, "sub")),
+        `${String(swept.status)} ${backupDir ?? "no backup dir"} ${String(undone?.status)} ${undone?.stdout.slice(-200) ?? ""}`
+    );
+}
+{
+    const blankFuzzy = applyOps("abc", [{ kind: "fuzzy", find: "  \n ", replace: "x", count: "all" }]);
+    const emptyRegex = applyOps("abc", [{ kind: "regex", find: /(?:)/, replace: "x" }]);
+    check(
+        "api: a blank fuzzy needle and an empty regex are a MISS instead of matching between every character",
+        blankFuzzy.results[0].status === "MISS" &&
+            blankFuzzy.content === "abc" &&
+            emptyRegex.results[0].status === "MISS" &&
+            emptyRegex.content === "abc",
+        `${blankFuzzy.results[0].reason ?? ""} | ${emptyRegex.results[0].reason ?? ""}`
+    );
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("blank-needle");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "n.ts"), "const n = 1;\n");
+    const blank = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: "@@ n.ts\n<<< fuzzy\n   \n===\nconst n = 2;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+        timeout: 20_000,
+    });
+    check(
+        "cli: a whitespace-only fuzzy body is a spec error and nothing is written",
+        blank.status === 2 &&
+            blank.stderr.includes("first body is empty") &&
+            fs.readFileSync(path.join(dir, "n.ts"), "utf8") === "const n = 1;\n",
+        `${String(blank.status)} ${blank.stderr.slice(0, 200)}`
+    );
+}
+{
+    const r = applyOps("foo(); $foo(); foo$(); a$foo; foo;", [
+        renameSymbol({ oldName: "foo", newName: "bar", expect: 2 }),
+    ]);
+    check(
+        "renameSymbol stops at $ on either side",
+        r.content === "bar(); $foo(); foo$(); a$foo; bar;",
+        r.results[0].reason ?? r.content
+    );
+    const dollar = applyOps("const $foo = 1; use($foo);", [
+        renameSymbol({ oldName: "$foo", newName: "$$foo", expect: 2 }),
+    ]);
+    check(
+        "renameSymbol matches a $-name and writes a $$-name literally",
+        dollar.content === "const $$foo = 1; use($$foo);",
+        dollar.results[0].reason ?? dollar.content
+    );
+    fs.mkdirSync(f("dollar"), { recursive: true });
+    write("dollar/d.ts", "foo(); $foo(); foo$();\n");
+    const counts = countMatches({ files: [f("dollar/d.ts")], pattern: "foo", quiet: true });
+    check(
+        "countMatches uses the same identifier boundary as the rename",
+        counts[f("dollar/d.ts")] === 1,
+        stringifyJson(counts)
+    );
+}
+
+// ── review round 5 (PR #371, eve): an empty substring beside a regex, exclusive creates at the write, the barrel
+// exports everything --api lists ──
+console.log("review round 5 (PR #371)");
+{
+    const lines = applyOps("a\nDEBUG b\nc\n", [{ kind: "deleteLines", containing: "", matching: /DEBUG/ }]);
+    check(
+        "deleteLines: an empty substring beside a regex deletes only the regex hits",
+        lines.results[0].status === "OK" && lines.content === "a\nc\n",
+        `${lines.results[0].reason ?? ""} ${stringifyJson(lines.content)}`
+    );
+    const dropped = dropComments("// keep\nx(); // drop me\n", { containing: "", matching: /drop/ });
+    check(
+        "dropComments: an empty substring beside a regex drops only the regex hits",
+        dropped.dropped === 1 && dropped.content === "// keep\nx();\n",
+        stringifyJson(dropped)
+    );
+    check(
+        "dropComments: an empty substring alone is no predicate",
+        dropComments("// a\n// b\n", { containing: "" }).dropped === 0
+    );
+}
+{
+    const link = f("create-link.ts");
+    fs.symlinkSync(f("create-link-target.ts"), link);
+    let failure = "";
+    try {
+        await run({
+            edits: [{ file: link, createWith: "export const late = 1;\n" }],
+            verbose: false,
+            backupDir: scratchDir("wx"),
+        });
+    } catch (err) {
+        failure = err instanceof Error ? err.message : String(err);
+    }
+    check(
+        "a create target that exists at write time (a dangling symlink the plan cannot see) is refused with EEXIST, never truncated, and survives the recovery",
+        failure.includes("EEXIST") && fs.lstatSync(link).isSymbolicLink() && !fs.existsSync(f("create-link-target.ts")),
+        failure
+    );
+    const src = write("mv-src.ts", "const mv = 1;\n");
+    const dest = f("mv-dest.ts");
+    fs.symlinkSync(f("mv-dest-target.ts"), dest);
+    let renameFailure = "";
+    try {
+        await run({
+            edits: [{ file: src, ops: [{ find: "= 1", replace: "= 2" }], renameTo: dest }],
+            verbose: false,
+            backupDir: scratchDir("wx-mv"),
+        });
+    } catch (err) {
+        renameFailure = err instanceof Error ? err.message : String(err);
+    }
+    check(
+        "a rename target that exists at write time is refused and the source keeps its content",
+        renameFailure.includes("EEXIST") &&
+            read("mv-src.ts") === "const mv = 1;\n" &&
+            fs.lstatSync(dest).isSymbolicLink(),
+        renameFailure
+    );
+}
+{
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const barrelSource = fs.readFileSync(path.join(here, "replace-utils.ts"), "utf8");
+    const notExported = collectApi(here)
+        .filter((entry) => {
+            const mod = `./${entry.module.replace(/\.ts$/, "")}`;
+            if (!/^(interface|type|class) /.test(entry.signature)) {
+                return !(entry.name in barrel);
+            }
+
+            const star = barrelSource.includes(`export * from "${mod}"`);
+            const typed = new RegExp(`export type \\{[^}]*\\b${entry.name}\\b[^}]*\\} from "${mod}"`).test(
+                barrelSource
+            );
+            return !(star || typed);
+        })
+        .map((entry) => `${entry.module}:${entry.name}`);
+    check(
+        "every symbol --api lists is importable from the barrel it names",
+        notExported.length === 0,
+        notExported.join(", ")
+    );
+}
+
+// ── review round 6 (PR #371, eve): a delete checks drift, an exclusive create is tracked from its descriptor,
+// createWith "" is an empty file ──
+console.log("review round 6 (PR #371)");
+{
+    const hlA = write("hl-a.ts", "const hl = 1;\n");
+    const hlB = f("hl-b.ts");
+    fs.linkSync(hlA, hlB);
+    let message = "";
+    try {
+        await run({
+            edits: [
+                { file: hlA, ops: [{ find: "= 1", replace: "= 2" }] },
+                { file: hlB, delete: true },
+            ],
+            verbose: false,
+            backupDir: scratchDir("hl"),
+        });
+    } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+    }
+    check(
+        "a delete refuses a file whose bytes changed after planning (a hard link the earlier write altered) and the recovery keeps it",
+        message.includes("refusing to delete") && fs.existsSync(hlB) && read("hl-a.ts") === "const hl = 1;\n",
+        message
+    );
+}
+{
+    const c = write("wx-c.ts", "const c = 1;\n");
+    fs.chmodSync(c, 0o444);
+    const b = f("wx-b.ts");
+    let late = "";
+    try {
+        await run({
+            edits: [
+                { file: b, createWith: "export const b = 1;\n" },
+                { file: c, ops: [{ find: "= 1", replace: "= 2" }] },
+            ],
+            verbose: false,
+            backupDir: scratchDir("wx-late"),
+        });
+    } catch (err) {
+        late = err instanceof Error ? err.message : String(err);
+    }
+    fs.chmodSync(c, 0o644);
+    check(
+        "a file created exclusively before a later write failed is removed by the recovery",
+        late.includes("write failed after 1 file(s)") && !fs.existsSync(b) && read("wx-c.ts") === "const c = 1;\n",
+        late
+    );
+    const big = f("wx-big.txt");
+    await run({ edits: [{ file: big, createWith: "x".repeat(3_000_000) }], verbose: false });
+    check("an exclusive create writes every byte through the descriptor", fs.statSync(big).size === 3_000_000);
+}
+{
+    const empty = f("empty.txt");
+    await run({ edits: [{ file: empty, createWith: "" }], verbose: false });
+    check('createWith "" creates an empty file', fs.existsSync(empty) && fs.statSync(empty).size === 0);
+    let refused: FableReplaceError | undefined;
+    try {
+        await run({ edits: [{ file: f("both.ts"), delete: true, createWith: "" }], verbose: false });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        'delete:true with createWith "" is refused as a contradiction',
+        refused?.code === 2 && refused.message.includes("cannot be combined"),
+        String(refused?.message)
+    );
+}
+
+// ── review round 7 (PR #371, eve): protected rename destinations, modifiers a kind does not enforce, the dry-run
+// diff of a created file ──
+console.log("review round 7 (PR #371)");
+{
+    const src = write("mv-guard-src.ts", "const g = 1;\n");
+    let intoNodeModules: FableReplaceError | undefined;
+    try {
+        await run({
+            edits: [{ file: src, ops: [{ find: "= 1", replace: "= 2" }], renameTo: f("node_modules/pkg/g.ts") }],
+            verbose: false,
+        });
+    } catch (err) {
+        intoNodeModules = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "a rename into node_modules is refused in pre-flight",
+        intoNodeModules?.code === 2 &&
+            intoNodeModules.message.includes("node_modules") &&
+            read("mv-guard-src.ts") === "const g = 1;\n",
+        String(intoNodeModules?.message)
+    );
+    const generated = write(
+        "mv-guard-gen.ts",
+        "// This file was automatically generated by a tool.\n// You should NOT make any changes in this file.\nexport const routes = 1;\n"
+    );
+    let ontoGenerated: FableReplaceError | undefined;
+    try {
+        await run({
+            edits: [{ file: src, ops: [{ find: "= 1", replace: "= 2" }], renameTo: generated, overwrite: true }],
+            verbose: false,
+        });
+    } catch (err) {
+        ontoGenerated = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "a rename onto a generated file is refused without allowGenerated",
+        ontoGenerated?.code === 2 &&
+            ontoGenerated.message.includes("GENERATED") &&
+            read("mv-guard-gen.ts").includes("routes = 1"),
+        String(ontoGenerated?.message)
+    );
+    await run({
+        edits: [
+            {
+                file: src,
+                ops: [{ find: "= 1", replace: "= 2" }],
+                renameTo: generated,
+                overwrite: true,
+                allowGenerated: true,
+            },
+        ],
+        verbose: false,
+    });
+    check(
+        "allowGenerated lets the rename replace it",
+        read("mv-guard-gen.ts") === "const g = 2;\n" && !fs.existsSync(src)
+    );
+}
+{
+    const parseError = (text: string): string => {
+        try {
+            parseSpec({ text });
+            return "";
+        } catch (err) {
+            return err instanceof Error ? err.message : String(err);
+        }
+    };
+    check(
+        "count= on a block is a spec error",
+        parseError("@@ a.md\n<<< block count=2\nA\n===\nB\n===\n>>>\n").includes("count= is not enforced")
+    );
+    check(
+        "count= on after is a spec error",
+        parseError("@@ a.md\n<<< after count=1\nA\n===\nB\n>>>\n").includes("count= is not enforced")
+    );
+    check(
+        "flags= outside regex is a spec error",
+        parseError("@@ a.md\n<<< fuzzy flags=g\nA\n===\nB\n>>>\n").includes("flags= only applies to regex")
+    );
+    check(
+        "optional on append is a spec error",
+        parseError("@@ a.md\n<<< append optional\nA\n>>>\n").includes("optional has no meaning")
+    );
+    check("count= on delete still parses", parseError("@@ a.md\n<<< delete count=2\nA\n>>>\n") === "");
+}
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("dry-create");
+    fs.mkdirSync(dir, { recursive: true });
+    const dry = spawnSync("bun", [cli, "--dry"], {
+        cwd: dir,
+        input: "@@ fresh.ts\n<<< create\nexport const fresh = 1;\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        "--dry shows the whole content of a created file as additions",
+        dry.status === 0 &&
+            dry.stdout.includes("+ export const fresh = 1;") &&
+            !fs.existsSync(path.join(dir, "fresh.ts")),
+        `${String(dry.status)} ${dry.stdout.slice(-300)}`
+    );
+    const withOps = spawnSync("bun", [cli, "--dry"], {
+        cwd: dir,
+        input: "@@ made.ts\n<<< create\nconst seed = 1;\n>>>\n<<<\nseed = 1\n===\nseed = 2\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        "--dry shows a created-with-ops file against the empty baseline",
+        withOps.status === 0 &&
+            withOps.stdout.includes("+ const seed = 2;") &&
+            !withOps.stdout.includes("- const seed = 1;"),
+        `${String(withOps.status)} ${withOps.stdout.slice(-300)}`
+    );
+}
+
+// ── review round 8 (PR #371, eve): delete bodies anchor to a line start, a rename is syntax-checked as its
+// destination ──
+console.log("review round 8 (PR #371)");
+{
+    const mid = applyOps("notfoo\nfoo\n", [{ find: "foo\n", replace: "", wholeLines: true }]);
+    check(
+        "wholeLines: a needle inside a line is not a match, the line-start one is",
+        mid.results[0].status === "OK" && mid.content === "notfoo\n",
+        mid.results[0].reason ?? mid.content
+    );
+    const only = applyOps("notfoo\n", [{ find: "foo\n", replace: "", wholeLines: true }]);
+    check(
+        "wholeLines: a suffix-only occurrence is a MISS that says so",
+        only.results[0].status === "MISS" &&
+            only.content === "notfoo\n" &&
+            (only.results[0].reason ?? "").includes("start of a line"),
+        only.results[0].reason ?? ""
+    );
+    const multi = applyOps("xfoo\nbar\nfoo\nbar\n", [{ find: "foo\nbar\n", replace: "", wholeLines: true }]);
+    check(
+        "wholeLines: a multi-line body cannot start halfway through a line",
+        multi.results[0].status === "OK" && multi.content === "xfoo\nbar\n",
+        multi.results[0].reason ?? multi.content
+    );
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("delete-lines");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "d.ts"), "const notfoo = 1;\nfoo\nconst b = 2;\n");
+    const del = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: "@@ d.ts\n<<< delete\nfoo\n>>>\n",
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        "cli: <<< delete removes the whole line and never a suffix",
+        del.status === 0 && fs.readFileSync(path.join(dir, "d.ts"), "utf8") === "const notfoo = 1;\nconst b = 2;\n",
+        `${String(del.status)} ${del.stdout.slice(-200)}`
+    );
+}
+{
+    const words = write("note.txt", "just words, not code\n");
+    let refused: FableReplaceError | undefined;
+    try {
+        await run({ edits: [{ file: words, renameTo: f("note.ts") }], verbose: false });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "a rename-only edit to .ts is checked under the destination loader",
+        refused?.code === 1 &&
+            refused.report?.files[0]?.postConditionFailures[0]?.includes("does not parse as .ts") === true &&
+            fs.existsSync(words) &&
+            !fs.existsSync(f("note.ts")),
+        String(refused?.message)
+    );
+    const view = write("view.tsx", "export const view = <div />;\n");
+    let jsx: FableReplaceError | undefined;
+    try {
+        await run({ edits: [{ file: view, renameTo: f("view.ts") }], verbose: false });
+    } catch (err) {
+        jsx = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "a .tsx holding JSX renamed to .ts is refused",
+        jsx?.code === 1 &&
+            jsx.report?.files[0]?.postConditionFailures[0]?.includes("does not parse as .ts") === true &&
+            fs.existsSync(view),
+        String(jsx?.message)
+    );
+    const plain = write("ok.txt", "export const ok = 1;\n");
+    await run({ edits: [{ file: plain, renameTo: f("ok.ts") }], verbose: false });
+    check("a .txt holding valid TypeScript renames to .ts", fs.existsSync(f("ok.ts")) && !fs.existsSync(plain));
+}
+
+// ── review round 9 (PR #371, eve): an unknown op kind is refused at both doors, dropComments enforces expect
+// itself ──
+console.log("review round 9 (PR #371)");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("bad-kind");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "j.ts"), "const old = 1;\n");
+    const bad = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: stringifyJson([{ file: "j.ts", ops: [{ kind: "fuzxy", find: "old", replace: "new" }] }]),
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        "cli (JSON form): a misspelled op kind is a spec error, not a literal edit",
+        bad.status === 2 &&
+            bad.stderr.includes('unknown kind "fuzxy"') &&
+            fs.readFileSync(path.join(dir, "j.ts"), "utf8") === "const old = 1;\n",
+        `${String(bad.status)} ${bad.stderr.slice(0, 200)}`
+    );
+    const scripted = applyOps("const old = 1;\n", [{ kind: "fuzxy", find: "old", replace: "new" } as never]);
+    check(
+        "api: a misspelled op kind is a MISS, not a literal edit",
+        scripted.results[0].status === "MISS" &&
+            scripted.content === "const old = 1;\n" &&
+            (scripted.results[0].reason ?? "").includes("unknown op kind"),
+        scripted.results[0].reason ?? ""
+    );
+}
+{
+    let refused: FableReplaceError | undefined;
+    try {
+        dropComments("// legacy a\n// legacy b\n", { containing: "legacy", expect: 1 });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "dropComments enforces expect on a direct call",
+        refused?.code === 1 && refused.message.includes("expected 1 comment(s), found 2"),
+        String(refused?.message)
+    );
+    const asOp = applyOps("// legacy a\n// legacy b\n", [{ kind: "dropComments", containing: "legacy", expect: 1 }]);
+    check(
+        "the op form reports the same mismatch as a MISS and changes nothing",
+        asOp.results[0].status === "MISS" &&
+            asOp.content === "// legacy a\n// legacy b\n" &&
+            (asOp.results[0].reason ?? "").includes("found 2"),
+        asOp.results[0].reason ?? ""
+    );
+}
+
+// ── review round 10 (PR #371, eve): JSON field types are checked, deleteLines enforces expect itself, a spec that
+// cannot be read is journaled ──
+console.log("review round 10 (PR #371)");
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const dir = f("json-types");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "n.ts"), "const n = 1;\n");
+    const bad = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: '[{"file":"n.ts","delete":"false"}]',
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        'cli (JSON form): delete: "false" is a spec error, and the file survives',
+        bad.status === 2 &&
+            bad.stderr.includes("delete must be true or false") &&
+            fs.existsSync(path.join(dir, "n.ts")),
+        `${String(bad.status)} ${bad.stderr.slice(0, 200)}`
+    );
+    const overwrite = spawnSync("bun", [cli], {
+        cwd: dir,
+        input: '[{"file":"n.ts","renameTo":"m.ts","overwrite":"false"}]',
+        encoding: "utf8",
+        env: hermeticEnv,
+    });
+    check(
+        'cli (JSON form): overwrite: "false" is a spec error',
+        overwrite.status === 2 && overwrite.stderr.includes("overwrite must be true or false"),
+        `${String(overwrite.status)} ${overwrite.stderr.slice(0, 200)}`
+    );
+}
+{
+    let refused: FableReplaceError | undefined;
+    try {
+        deleteLines("a\nDEBUG 1\nDEBUG 2\n", { kind: "deleteLines", containing: "DEBUG", expect: 1 });
+    } catch (err) {
+        refused = err instanceof FableReplaceError ? err : undefined;
+    }
+    check(
+        "deleteLines enforces expect on a direct call",
+        refused?.code === 1 && refused.message.includes("expected 1 line(s), found 2"),
+        String(refused?.message)
+    );
+    const asOp = applyOps("a\nDEBUG 1\nDEBUG 2\n", [{ kind: "deleteLines", containing: "DEBUG", expect: 1 }]);
+    check(
+        "the deleteLines op reports the mismatch as a MISS and changes nothing",
+        asOp.results[0].status === "MISS" &&
+            asOp.content === "a\nDEBUG 1\nDEBUG 2\n" &&
+            (asOp.results[0].reason ?? "").includes("found 2"),
+        asOp.results[0].reason ?? ""
+    );
+}
+{
+    const cli = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+    const home = f("journal-spec-error");
+    fs.mkdirSync(home, { recursive: true });
+    const unreadable = spawnSync("bun", [cli, "--spec", f("does-not-exist.frspec")], {
+        encoding: "utf8",
+        env: { ...hermeticEnv, FABLE_REPLACE_HOME: home },
+    });
+    const journalFile = path.join(home, ".genesis-tools", "fable-replace", "journal.jsonl");
+    const journalLines = fs.existsSync(journalFile) ? fs.readFileSync(journalFile, "utf8").trim().split("\n") : [];
+    const last =
+        journalLines.length > 0 ? (parseJson(journalLines[journalLines.length - 1]) as JournalEntry) : undefined;
+    check(
+        "an unreadable --spec is journaled as spec-error",
+        unreadable.status === 2 && last?.outcome === "spec-error" && (last.message ?? "").includes("cannot read"),
+        `${String(unreadable.status)} ${stringifyJson(last)}`
+    );
+}
+
+// ── verdict ─────────────────────────────────────────────────────────────────
+fs.rmSync(tmp, { recursive: true, force: true });
+fs.rmSync(hermeticRoot, { recursive: true, force: true });
+if (failures > 0) {
+    console.error(`\n${failures} SELFTEST FAILURE(S)`);
+    process.exit(1);
+}
+console.log("\nALL SELFTESTS PASSED");

--- a/plugins/genesis-tools/skills/fable-replace/scripts/spec.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/spec.ts
@@ -1,0 +1,449 @@
+/**
+ * fable-replace — THE SPEC FORMAT the CLI reads. Zero escaping, heredoc-friendly,
+ * readable by any model. Git-conflict-marker shaped:
+ *
+ *   @@ src/foo.ts                 # start a file section (path relative to cwd, or absolute)
+ *   expect: newName(              # optional post-conditions for this file, repeatable
+ *   absent: oldName(
+ *   <<<                           # a literal replace op (exactly-once by default)
+ *   exact current text, indentation included
+ *   ===
+ *   replacement text
+ *   >>>
+ *   <<< count=all                 # every occurrence
+ *   <<< count=3                   # exactly three
+ *   <<< optional                  # SKIP instead of MISS when absent (re-runnable)
+ *   <<< label=drop legacy gate    # free text for the report (rest of the line)
+ *   <<< regex flags=gi            # find is a JS regex source, replace may use $1; count=N pins matches
+ *   <<< fuzzy                     # whitespace-insensitive literal
+ *   <<< after                     # insert whole lines AFTER the line containing the (unique) anchor
+ *   anchor text
+ *   ===
+ *   lines to insert
+ *   >>>
+ *   <<< before                    # same, before the line
+ *   <<< append                    # one body only: lines appended at end of file
+ *   <<< delete                    # one body only: these lines go, newline included
+ *   <<< block                     # three bodies: from === to === replacement (empty = delete the block)
+ *   <<< create                    # one body only: create the file with this content (must not exist)
+ *
+ * A body is the lines between the markers, joined with "\n", no trailing newline.
+ * Everything between `<<<` and `>>>` is raw: only a line that is exactly `===` or
+ * `>>>` is special there. Outside a block, blank lines and `#` comments are ignored.
+ * JSON is accepted too: a top-level array of FileEdit objects (regex ops carry
+ * `find` as a string plus optional `flags`).
+ */
+
+import { parseJson } from "./json";
+import type { FileEdit, Op } from "./types";
+
+export interface ParseSpecParams {
+    text: string;
+    /** Receives non-fatal warnings (an unbalanced code fence that hints at a bare >>> closing a block early). */
+    onWarning?: (message: string) => void;
+}
+
+interface Section {
+    file: string;
+    ops: Op[];
+    expectAfter: string[];
+    absentAfter: string[];
+    createWith?: string;
+}
+
+function fail(line: number, message: string): never {
+    throw new Error(`spec line ${line}: ${message}`);
+}
+
+const KINDS = new Set(["regex", "fuzzy", "before", "after", "append", "delete", "block", "create"]);
+/** The kinds whose `count=` is a checked contract; the others anchor on a unique line or have nothing to count. */
+const COUNTED_KINDS = new Set(["replace", "regex", "fuzzy", "delete"]);
+/** Every `kind` a JSON op object may carry (a literal op has none, or "replace"). */
+const OP_KINDS = new Set([
+    "replace",
+    "regex",
+    "fuzzy",
+    "deleteBlock",
+    "replaceBlock",
+    "insertBefore",
+    "insertAfter",
+    "insertLinesBefore",
+    "insertLinesAfter",
+    "append",
+    "dropComments",
+    "deleteLines",
+]);
+
+interface Modifiers {
+    kind: string;
+    count?: number | "all";
+    optional: boolean;
+    label?: string;
+    flags?: string;
+}
+
+const parseModifiers = (raw: string, line: number): Modifiers => {
+    const mods: Modifiers = { kind: "replace", optional: false };
+    let rest = raw.trim();
+    const labelAt = rest.indexOf("label=");
+    if (labelAt !== -1) {
+        const labelText = rest.slice(labelAt + "label=".length).trim();
+        // `label=` takes the REST of the line, so a modifier written AFTER it was silently
+        // absorbed: `<<< label=see ticket, regex flags=g` ran as a LITERAL search, matched
+        // something unrelated once, and reported OK. Quote the label to keep such a word.
+        const quoted =
+            labelText.length > 1 &&
+            ((labelText.startsWith('"') && labelText.endsWith('"')) ||
+                (labelText.startsWith("'") && labelText.endsWith("'")));
+        if (!quoted) {
+            const swallowed = labelText
+                .split(/\s+/)
+                .find((t) => KINDS.has(t) || t === "optional" || /^(count|flags)=/.test(t));
+            if (swallowed !== undefined) {
+                fail(
+                    line,
+                    `"${swallowed}" was absorbed into the label: label= takes the whole rest of the line. Put label= LAST (<<< regex flags=g label=your text). If the word really belongs to the label, quote it: label="your text"`
+                );
+            }
+        }
+
+        mods.label = quoted ? labelText.slice(1, -1) : labelText;
+        rest = rest.slice(0, labelAt);
+    }
+    for (const token of rest.split(/\s+/).filter((t) => t.length > 0)) {
+        const [key, value] = token.includes("=") ? token.split("=", 2) : [token, undefined];
+        if (value === undefined && KINDS.has(key)) {
+            if (mods.kind !== "replace") {
+                fail(line, `two op kinds on one marker: ${mods.kind} and ${key}`);
+            }
+            mods.kind = key;
+        } else if (key === "optional" && value === undefined) {
+            mods.optional = true;
+        } else if (key === "count" && value !== undefined) {
+            if (value === "all") {
+                mods.count = "all";
+            } else if (/^\d+$/.test(value) && Number(value) > 0) {
+                mods.count = Number(value);
+            } else {
+                fail(line, `count must be a positive number or "all", got "${value}"`);
+            }
+        } else if (key === "flags" && value !== undefined) {
+            mods.flags = value;
+        } else {
+            fail(
+                line,
+                `unknown modifier "${token}". Known: ${[...KINDS].join(", ")}, count=N|all, optional, flags=…, label=…`
+            );
+        }
+    }
+    // A modifier the kind does not enforce used to be accepted and dropped, so a declared
+    // constraint read as verified while nothing checked it.
+    if (mods.count !== undefined && !COUNTED_KINDS.has(mods.kind)) {
+        fail(
+            line,
+            `count= is not enforced for ${mods.kind}: before/after/block need a unique anchor, append/create have nothing to count. Remove it.`
+        );
+    }
+    if (mods.flags !== undefined && mods.kind !== "regex") {
+        fail(line, `flags= only applies to regex, not ${mods.kind}`);
+    }
+    if (mods.optional && (mods.kind === "append" || mods.kind === "create")) {
+        fail(line, `optional has no meaning for ${mods.kind}: it cannot miss`);
+    }
+    return mods;
+};
+
+const partsNeeded = (kind: string): number => {
+    switch (kind) {
+        case "append":
+        case "delete":
+        case "create":
+            return 1;
+        case "block":
+            return 3;
+        default:
+            return 2;
+    }
+};
+
+const compileRegex = ({ source, flags, line }: { source: string; flags: string; line: number }): RegExp => {
+    try {
+        return new RegExp(source, flags.includes("g") ? flags : `${flags}g`);
+    } catch (err) {
+        return fail(line, `invalid regex or flags: ${err instanceof Error ? err.message : String(err)}`);
+    }
+};
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: the parser refuses control characters in a spec on purpose
+const CONTROL_CHAR = /[\x00-\x08\x0B\x0C\x0E-\x1F]/;
+
+const buildOp = (mods: Modifiers, parts: string[], line: number, section: Section): void => {
+    const need = partsNeeded(mods.kind);
+    if (parts.length !== need) {
+        fail(line, `${mods.kind} needs ${need} bod${need === 1 ? "y" : "ies"} (separated by ===), got ${parts.length}`);
+    }
+    for (const [k, part] of parts.entries()) {
+        const bad = part.match(CONTROL_CHAR);
+        if (bad !== null) {
+            const code = `0x${bad[0].charCodeAt(0).toString(16).padStart(2, "0")}`;
+            fail(
+                line,
+                `body ${k + 1} contains a control character (${code}). That is a shell escaping artifact: zsh's echo turns \\b into a backspace. Build spec text with printf '%s\\n', never echo.`
+            );
+        }
+    }
+    const [a, b, c] = parts;
+    const emptyFirst = mods.kind === "fuzzy" ? a.trim() === "" : a === "";
+    if (emptyFirst && mods.kind !== "create" && mods.kind !== "append") {
+        // An empty needle or anchor matches everywhere or nowhere; the runner refuses it
+        // too, but a spec error names the line before anything is planned.
+        fail(line, `${mods.kind}: the first body is empty, so there is nothing to find, delete or anchor on`);
+    }
+
+    const common = { optional: mods.optional, label: mods.label };
+    switch (mods.kind) {
+        case "replace":
+            section.ops.push({ find: a, replace: b, count: mods.count, ...common });
+            return;
+        case "regex": {
+            section.ops.push({
+                kind: "regex",
+                find: compileRegex({ source: a, flags: mods.flags ?? "g", line }),
+                replace: b,
+                expect: typeof mods.count === "number" ? mods.count : undefined,
+                ...common,
+            });
+            return;
+        }
+        case "fuzzy":
+            section.ops.push({ kind: "fuzzy", find: a, replace: b, count: mods.count, ...common });
+            return;
+        case "before":
+        case "after":
+            section.ops.push({
+                kind: mods.kind === "before" ? "insertLinesBefore" : "insertLinesAfter",
+                anchor: a,
+                text: b,
+                ...common,
+            });
+            return;
+        case "append":
+            section.ops.push({ kind: "append", text: a, label: mods.label });
+            return;
+        case "delete":
+            section.ops.push({
+                find: `${a}\n`,
+                replace: "",
+                count: mods.count,
+                wholeLines: true,
+                ...common,
+                label: mods.label ?? `delete "${a.split("\n")[0].trim().slice(0, 44)}"`,
+            });
+            return;
+        case "block":
+            section.ops.push(
+                c.length === 0
+                    ? { kind: "deleteBlock", from: a, to: b, ...common }
+                    : { kind: "replaceBlock", from: a, to: b, replace: c, ...common }
+            );
+            return;
+        case "create":
+            if (section.createWith !== undefined) {
+                fail(line, "create given twice for one file");
+            }
+            section.createWith = a.endsWith("\n") ? a : `${a}\n`;
+            return;
+        default:
+            fail(line, `unhandled kind ${mods.kind}`);
+    }
+};
+
+const toFileEdit = (section: Section): FileEdit => {
+    const edit: FileEdit = { file: section.file };
+    if (section.ops.length > 0) {
+        edit.ops = section.ops;
+    }
+    if (section.createWith !== undefined) {
+        edit.createWith = section.createWith;
+    }
+    if (section.expectAfter.length > 0) {
+        edit.expectAfter = section.expectAfter;
+    }
+    if (section.absentAfter.length > 0) {
+        edit.absentAfter = section.absentAfter;
+    }
+    return edit;
+};
+
+const fromJson = (text: string): FileEdit[] => {
+    const raw = parseJson(text);
+    if (!Array.isArray(raw)) {
+        throw new Error("JSON spec must be an array of FileEdit objects");
+    }
+    return raw.map((edit) => {
+        if (edit === null || typeof edit !== "object" || Array.isArray(edit)) {
+            throw new Error("every JSON spec entry must be a FileEdit object");
+        }
+
+        // TypeScript casts do not check external input. "delete": "false" is a truthy
+        // string, and the runner used to delete the file on it.
+        const fields = edit as Record<string, unknown>;
+        const typeErrors: string[] = [];
+        if (typeof fields.file !== "string" || fields.file === "") {
+            typeErrors.push("file must be a non-empty string");
+        }
+        for (const name of ["delete", "overwrite", "allowGenerated"]) {
+            if (fields[name] !== undefined && typeof fields[name] !== "boolean") {
+                typeErrors.push(`${name} must be true or false, got ${String(fields[name])} (${typeof fields[name]})`);
+            }
+        }
+        for (const name of ["renameTo", "createWith"]) {
+            if (fields[name] !== undefined && typeof fields[name] !== "string") {
+                typeErrors.push(`${name} must be a string`);
+            }
+        }
+        if (fields.ops !== undefined && !Array.isArray(fields.ops)) {
+            typeErrors.push("ops must be an array");
+        }
+        if (typeErrors.length > 0) {
+            throw new Error(`${String(fields.file ?? "?")}: ${typeErrors.join("; ")}`);
+        }
+
+        const e = edit as FileEdit;
+        const rawOps = ((edit as { ops?: unknown }).ops ?? []) as Array<Record<string, unknown>>;
+        const ops = rawOps.map((op, index) => {
+            // A misspelled kind used to fall through to the literal branch and edit an exact
+            // occurrence, reporting OK for an op nobody wrote.
+            if (op.kind !== undefined && !OP_KINDS.has(String(op.kind))) {
+                throw new Error(
+                    `${String(e.file)}: op ${index + 1} has unknown kind "${String(op.kind)}". Known: ${[...OP_KINDS].join(", ")}`
+                );
+            }
+
+            return op.kind === "regex" && typeof op.find === "string"
+                ? ({ ...op, find: new RegExp(op.find, typeof op.flags === "string" ? op.flags : "g") } as unknown as Op)
+                : (op as unknown as Op);
+        });
+        return { ...e, ops };
+    });
+};
+
+/** Parse the marker format (or a JSON array) into FileEdits for `run()`. Throws with a line number on any malformed input. */
+export const parseSpec = ({ text, onWarning }: ParseSpecParams): FileEdit[] => {
+    const trimmed = text.trimStart();
+    if (trimmed.startsWith("[")) {
+        try {
+            return fromJson(trimmed);
+        } catch (err) {
+            // A marker spec whose first line happens to start with "[" (a changelog entry,
+            // a markdown link) used to surface a bare JSON error naming no spec line.
+            fail(
+                1,
+                `the spec starts with "[", so it was read as the JSON form: ${String(err)}. A marker spec must start with an "@@ <path>" header.`
+            );
+        }
+    }
+    // A spec pasted from two sources can carry CRLF on some lines only. Splitting on "\n"
+    // alone left a "\r" on the markers, so "===" and ">>>" stopped being recognised and the
+    // next op was swallowed into the previous body — one op silently became none.
+    const lines = text.split(/\r\n|\n/);
+    const sections: Section[] = [];
+    let current: Section | null = null;
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i];
+        const lineNo = i + 1;
+        if (line.startsWith("@@")) {
+            const file = line.slice(2).trim();
+            if (file.length === 0) {
+                fail(lineNo, "@@ needs a file path");
+            }
+            if (/^[-+]\d/.test(file)) {
+                fail(
+                    lineNo,
+                    `"${line.slice(0, 40)}" looks like a diff hunk header, not a file path. A body line that was exactly >>> closed the previous block early; write such a line as \\>>>`
+                );
+            }
+            current = { file, ops: [], expectAfter: [], absentAfter: [] };
+            sections.push(current);
+            i += 1;
+            continue;
+        }
+        if (line.startsWith("<<<")) {
+            if (current === null) {
+                fail(lineNo, "op before any @@ file line");
+            }
+            const mods = parseModifiers(line.slice(3), lineNo);
+            const parts: string[] = [];
+            const separatorLines: number[] = [];
+            let body: string[] = [];
+            let closed = false;
+            i += 1;
+            while (i < lines.length) {
+                const inner = lines[i];
+                if (inner === "===") {
+                    parts.push(body.join("\n"));
+                    body = [];
+                    separatorLines.push(i + 1);
+                } else if (inner === ">>>") {
+                    parts.push(body.join("\n"));
+                    closed = true;
+                    i += 1;
+                    break;
+                } else if (inner === "\\===" || inner === "\\>>>") {
+                    // A body line that must be exactly === or >>> carries one leading backslash.
+                    body.push(inner.slice(1));
+                } else {
+                    body.push(inner);
+                }
+                i += 1;
+            }
+            if (!closed) {
+                fail(lineNo, "block never closed with >>>");
+            }
+            const need = partsNeeded(mods.kind);
+            if (parts.length > need) {
+                fail(
+                    separatorLines[need - 1] ?? lineNo,
+                    `${mods.kind} takes ${need} bod${need === 1 ? "y" : "ies"}, but this line is exactly === and starts body ${need + 1}. A body line that must be exactly === is written \\===`
+                );
+            }
+            // A bare >>> inside a NON-final body already fails ("takes N bodies"), so only the
+            // LAST body can be truncated silently. Only that body is inspected, and only a fence
+            // left OPEN with content after it counts: the anchors of a `block` op are fragments
+            // and may legitimately end on a closing fence alone, and a body that IS a fence line
+            // (replacing ```sh with ```bash) is complete.
+            const lastLines = (parts[parts.length - 1] ?? "").split("\n");
+            const fenceLines = lastLines.map((l, idx) => (l.startsWith("```") ? idx : -1)).filter((idx) => idx !== -1);
+            const openedAt = fenceLines.length % 2 === 1 ? fenceLines[fenceLines.length - 1] : -1;
+            if (openedAt !== -1 && openedAt < lastLines.length - 1) {
+                onWarning?.(
+                    `spec line ${lineNo}: the last body of this block ends inside a code fence opened at its line ${openedAt + 1}. If a body line was exactly >>> it closed the block early and the rest was dropped; write such a line as \\>>>`
+                );
+            }
+            buildOp(mods, parts, lineNo, current);
+            continue;
+        }
+        const cond = line.match(/^(expect|absent):\s?(.*)$/);
+        if (cond !== null) {
+            if (current === null) {
+                fail(lineNo, `${cond[1]}: before any @@ file line`);
+            }
+            (cond[1] === "expect" ? current.expectAfter : current.absentAfter).push(cond[2]);
+            i += 1;
+            continue;
+        }
+        if (line.trim().length === 0 || line.trimStart().startsWith("#")) {
+            i += 1;
+            continue;
+        }
+        fail(
+            lineNo,
+            `unexpected text outside a block: "${line.slice(0, 60)}". Lines outside <<< >>> must be @@ file, expect:, absent:, # comment, or blank. If this line belongs to the previous block, a body line was exactly >>> or === and closed it early: write such lines as \\>>> or \\===`
+        );
+    }
+    if (sections.length === 0) {
+        throw new Error("spec has no @@ file sections");
+    }
+    return sections.map(toFileEdit);
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/sweep-many-files.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/sweep-many-files.ts
@@ -1,0 +1,908 @@
+/**
+ * fable-replace — THE RUNNER. Applying a batch of FileEdits across many files,
+ * transactionally.
+ *
+ * Every file is read and every op applied IN MEMORY first. Only if all required ops
+ * matched, all post-conditions held and every edited script still parses does
+ * anything get written. One required MISS aborts the whole batch.
+ *
+ * It also refuses, in pre-flight: node_modules paths, machine-generated files, a
+ * renameTo onto an existing file, and a reused backupDir.
+ *
+ * `verifyCommand` runs your project's own check after a successful write. USE IT. Every
+ * op reporting OK only proves the ops you DECLARED matched; it cannot know about a call
+ * site your recon never found. A red check keeps the sweep written and exits 3: rolling
+ * back would restore the very needles a re-sent spec matches, and the loop that follows
+ * costs a full-context round trip per turn. The files stay; the undo command is printed.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { backupDirInUse, recordPostWriteHashes, rollback, writeBackup } from "./backup-and-rollback";
+import { scanComments } from "./comments";
+import { applyOps } from "./edit-one-file";
+import { COLORS, changedOnDisk, FableReplaceError, paint, preview } from "./internal";
+import { leftovers } from "./recon";
+import type { FileEdit, FileResult, RunParams, RunReport, SimpleDiffParams, VerifyResult } from "./types";
+import { checkVerifyCommand, runVerifyCommand, verifyUnknownReason } from "./verify-command";
+
+/**
+ * Roll a failed sweep back and return the files the rollback itself could NOT restore.
+ * Those still hold the rejected content, so the caller must name them: an exit code
+ * alone reads as a routine failure, and the user trusts "or not at all".
+ */
+const strandedByRollback = ({ backupDir, touched }: { backupDir: string; touched: string[] }): string[] => {
+    // Only the paths this sweep wrote. A file the changed-on-disk guard refused holds someone
+    // else's write, and a file after the failure was never touched: restoring either from
+    // the snapshot would destroy exactly what the guard protected.
+    console.error(paint(COLORS.miss, `rolling back the ${touched.length} path(s) this sweep wrote.`));
+    const report = rollback({ backupDir, force: true, only: touched });
+    return report.failed.map((f) => f.file);
+};
+
+const CLI_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "cli.ts");
+
+/**
+ * The failure block a reader must not misread. Its first sentence answers the only
+ * question that matters after a red check: the files ARE written. A rollback here would
+ * restore the originals, and the model's instinct to re-send the whole spec would then
+ * succeed, go red again, and loop. Keeping the files makes a blind re-send MISS instead,
+ * which is a hard stop with a hint.
+ */
+const printVerifyFailure = ({
+    verify,
+    written,
+    backupDir,
+}: {
+    verify: VerifyResult;
+    written: string[];
+    backupDir?: string;
+}): void => {
+    const verdict =
+        verify.status === "fail"
+            ? `VERIFY FAILED (exit ${String(verify.exitCode)})`
+            : `VERIFY UNKNOWN (${verifyUnknownReason(verify)})`;
+    console.error(
+        paint(
+            COLORS.miss,
+            `\nSWEEP WRITTEN, ${verdict}. The ${written.length} file(s) above hold the sweep. Do NOT re-send this spec.`
+        )
+    );
+    console.error("Fix forward with a small follow-up spec, or undo everything with:");
+    console.error(
+        backupDir === undefined
+            ? "  (no backup dir: this run used --no-backup, so undo it with git: `git diff`, then `git stash push -- <files>`)"
+            : `  bun "${CLI_PATH}" --rollback "${backupDir}"`
+    );
+    for (const line of verify.shown) {
+        console.error(`  ${line}`);
+    }
+    if (verify.outputFile !== undefined) {
+        console.error(paint(COLORS.dim, `full verify output: ${verify.outputFile}`));
+    }
+};
+
+/**
+ * Line diff for dry runs. Patience-style: it trims the common prefix/suffix, then
+ * splits the remaining window on lines that occur exactly once on BOTH sides and
+ * recurses. That keeps two edits 40 lines apart as two small hunks instead of one
+ * 40-line block, which used to overstate the blast radius of a multi-hit sweep.
+ */
+const diffRegion = (a: string[], b: string[], aStart: number, out: string[], depth = 0): void => {
+    let prefix = 0;
+    while (prefix < a.length && prefix < b.length && a[prefix] === b[prefix]) {
+        prefix += 1;
+    }
+    let suffix = 0;
+    while (
+        suffix < a.length - prefix &&
+        suffix < b.length - prefix &&
+        a[a.length - 1 - suffix] === b[b.length - 1 - suffix]
+    ) {
+        suffix += 1;
+    }
+    const aMid = a.slice(prefix, a.length - suffix);
+    const bMid = b.slice(prefix, b.length - suffix);
+    if (aMid.length === 0 && bMid.length === 0) {
+        return;
+    }
+    const midStart = aStart + prefix;
+
+    // find a unique common anchor line to split on (patience diff)
+    if (depth < 40 && aMid.length > 0 && bMid.length > 0) {
+        const countIn = (arr: string[]): Map<string, number> => {
+            const m = new Map<string, number>();
+            for (const l of arr) {
+                m.set(l, (m.get(l) ?? 0) + 1);
+            }
+            return m;
+        };
+        const ca = countIn(aMid);
+        const cb = countIn(bMid);
+        let anchorA = -1;
+        let anchorB = -1;
+        for (let i = 0; i < aMid.length; i += 1) {
+            const line = aMid[i];
+            if (line.trim() === "" || ca.get(line) !== 1 || cb.get(line) !== 1) {
+                continue;
+            }
+            anchorA = i;
+            anchorB = bMid.indexOf(line);
+            break;
+        }
+        if (anchorA !== -1 && anchorB !== -1) {
+            diffRegion(aMid.slice(0, anchorA), bMid.slice(0, anchorB), midStart, out, depth + 1);
+            diffRegion(aMid.slice(anchorA + 1), bMid.slice(anchorB + 1), midStart + anchorA + 1, out, depth + 1);
+            return;
+        }
+    }
+
+    out.push(`@@ line ${midStart + 1} (−${aMid.length} +${bMid.length}) @@`);
+    for (const l of aMid) {
+        out.push(`- ${l}`);
+    }
+    for (const l of bMid) {
+        out.push(`+ ${l}`);
+    }
+};
+
+export const simpleDiff = ({ before, after, maxLines = 200 }: SimpleDiffParams): string => {
+    const out: string[] = [];
+    diffRegion(before.split("\n"), after.split("\n"), 0, out);
+    if (out.length === 0) {
+        return "(no line-level change)";
+    }
+    if (out.length > maxLines) {
+        const hidden = out.length - maxLines;
+        return [...out.slice(0, maxLines), `… (${hidden} more diff lines)`].join("\n");
+    }
+    return out.join("\n");
+};
+
+// A sweep that edits generated output looks perfect and typechecks, then vanishes on
+// the next codegen run. SKILL.md always said "never point ops at generated files";
+// this makes the rule mechanical instead of advisory.
+const GENERATED_PATH_RE =
+    /(^|[/\\])(dist|build|out|coverage)[/\\]|\.(gen|generated)\.[cm]?[jt]sx?$|\.pb\.[cm]?[jt]s$|_pb2?\.[cm]?[jt]s$/;
+
+const GENERATED_HEADER_RE =
+    /@generated|code generated by|automatically generated|auto-generated|do not (make any changes|edit|modify)/i;
+
+/** Why `file` looks machine-generated, or null when it does not. */
+export const looksGenerated = (file: string): string | null => {
+    if (GENERATED_PATH_RE.test(file)) {
+        return "path looks generated";
+    }
+    if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) {
+        return null;
+    }
+    const head = fs.readFileSync(file, "utf8").split("\n").slice(0, 60).join("\n");
+    // In source files only a REAL COMMENT counts. A hand-written module whose job is
+    // to EMIT "auto-generated, do not edit" into some other file must not be mistaken
+    // for generated output — src/zsh/lib/hook-generator.ts is exactly that, and a raw
+    // substring sniff flagged it.
+    const haystack = SCRIPT_EXT_RE.test(file)
+        ? scanComments(head)
+              .map((span) => span.text)
+              .join("\n")
+        : head;
+    const hit = haystack.match(GENERATED_HEADER_RE);
+    return hit === null ? null : `header comment says "${hit[0]}"`;
+};
+
+const SCRIPT_EXT_RE = /\.(m|c)?(ts|js)x?$/;
+
+/**
+ * Did the ops turn parseable source into unparseable source? A post-condition is a
+ * substring test and cannot see structure, so a dropped brace passes `expectAfter`
+ * and still breaks the file. This catches that before anything is written.
+ * Returns the parser message, or null when the file is fine (or was already broken,
+ * or is not a script, or Bun's transpiler is unavailable).
+ */
+const brokeSyntax = (file: string, before: string, after: string): string | null => {
+    if (!SCRIPT_EXT_RE.test(file) || before === after) {
+        return null;
+    }
+    const Transpiler = (
+        globalThis as { Bun?: { Transpiler?: new (o: { loader: string }) => { scan: (s: string) => unknown } } }
+    ).Bun?.Transpiler;
+    if (Transpiler === undefined) {
+        return null;
+    }
+    const tp = new Transpiler({ loader: file.endsWith("x") ? "tsx" : "ts" });
+    try {
+        tp.scan(before);
+    } catch {
+        return null; // already unparseable before the sweep — not our doing
+    }
+    try {
+        tp.scan(after);
+        return null;
+    } catch (err) {
+        // Bun's BuildMessage carries the position; without the line number the reader
+        // has to bisect a 700-line file by hand to find which op broke it.
+        const pos = (err as { position?: { line?: number; column?: number; lineText?: string } }).position;
+        const where =
+            pos?.line === undefined
+                ? ""
+                : ` at line ${pos.line + 1}${pos.column === undefined ? "" : `:${pos.column + 1}`}${pos.lineText === undefined ? "" : ` → "${pos.lineText.trim().slice(0, 100)}"`}`;
+        return `${String(err).split("\n")[0].slice(0, 120)}${where}`;
+    }
+};
+
+const validateEdit = (edit: FileEdit): string | null => {
+    // Presence, not truthiness: createWith "" is a legitimate empty file.
+    const creates = edit.createWith !== undefined;
+    if (edit.delete && (edit.ops?.length || edit.renameTo || creates)) {
+        return "delete:true cannot be combined with ops/renameTo/createWith";
+    }
+    if (!edit.delete && !edit.ops?.length && !edit.renameTo && !creates) {
+        return "edit has no ops, no delete, no renameTo, no createWith — nothing to do";
+    }
+    return null;
+};
+
+/**
+ * Execute a batch of file edits.
+ *
+ * Transactional by default: every file is processed IN MEMORY first; if any
+ * required op misses or a post-condition fails, NOTHING is written and the
+ * process exits non-zero (or throws with `throwOnFailure`). Pass `partial: true`
+ * to write the files that fully passed anyway.
+ *
+ * `--dry` on argv (or `dryRun: true`) prints diffs and writes nothing.
+ */
+const KNOWN_RUN_KEYS = [
+    "dryRun",
+    "backupDir",
+    "backupOverwrite",
+    "cwd",
+    "partial",
+    "verbose",
+    "showDiff",
+    "maxDiffLines",
+    "maxTotalDiffLines",
+    "allowNodeModules",
+    "allowGenerated",
+    "syntaxCheck",
+    "throwOnFailure",
+    "verifyCommand",
+    "verifyTimeoutMs",
+    "onWritten",
+    "leftoversCheck",
+];
+
+/** A known key sharing a prefix or a substring with the typo, for the "did you mean" hint. */
+const closestRunKey = (typo: string): string | undefined => {
+    const lower = typo.toLowerCase();
+    return KNOWN_RUN_KEYS.find(
+        (k) => k.toLowerCase().startsWith(lower.slice(0, 3)) || lower.includes(k.toLowerCase().slice(0, 4))
+    );
+};
+
+export const run = async ({ edits, ...opts }: RunParams): Promise<RunReport> => {
+    const dryRun = opts.dryRun || process.argv.includes("--dry");
+    const verbose = opts.verbose ?? true;
+    const throwOnFailure = opts.throwOnFailure ?? true;
+    const bail = (message: string, code: 1 | 2 | 3, report?: RunReport): never => {
+        if (throwOnFailure) {
+            throw new FableReplaceError(message, code, report);
+        }
+        process.exit(code);
+    };
+    const cwd = opts.cwd ?? process.cwd();
+    const maxDiffLines = opts.maxDiffLines ?? 200;
+    // Per-file caps are not enough on a 50-file sweep: the total output overruns any
+    // terminal or log you would `tail`, and a truncated tail reads as a finished report.
+    let diffBudget = opts.maxTotalDiffLines ?? 2000;
+    let diffsSuppressed = 0;
+
+    // Absolute whatever `cwd` is: a relative --cwd used to persist "sub/file.ts" in the
+    // manifest, so the printed undo command restored against the caller's directory.
+    const resolve = (p: string): string => path.resolve(cwd, p);
+
+    // ── pre-flight validation ──────────────────────────────────────────────
+    const preflightErrors: string[] = [];
+    // An unknown option is a typo that would otherwise do nothing: `dry: true` instead of
+    // `dryRun: true` once nearly turned a preview into a real write.
+    for (const key of Object.keys(opts)) {
+        if (!KNOWN_RUN_KEYS.includes(key)) {
+            const hint = closestRunKey(key);
+            preflightErrors.push(
+                `unknown option "${key}"${hint ? ` — did you mean "${hint}"?` : ""}. Known: ${KNOWN_RUN_KEYS.join(", ")}`
+            );
+        }
+    }
+    const seen = new Set<string>();
+    const renameTargets = new Map<string, string>();
+    for (const edit of edits) {
+        const abs = resolve(edit.file);
+        if (seen.has(abs)) {
+            preflightErrors.push(
+                `${edit.file}: listed twice in one batch — merge the ops into one FileEdit, or wrap the batch in mergeFileEdits()`
+            );
+        }
+        seen.add(abs);
+        if (!opts.allowNodeModules && abs.includes(`${path.sep}node_modules${path.sep}`)) {
+            preflightErrors.push(
+                `${edit.file}: refusing to edit inside node_modules (set allowNodeModules to override)`
+            );
+        }
+        if (opts.allowGenerated !== true && edit.allowGenerated !== true && !edit.delete) {
+            const why = looksGenerated(abs);
+            if (why !== null) {
+                preflightErrors.push(
+                    `${edit.file}: refusing to edit a GENERATED file (${why}) — the next codegen run discards the change. Fix the generator, or pass allowGenerated: true.`
+                );
+            }
+        }
+        const structural = validateEdit(edit);
+        if (structural) {
+            preflightErrors.push(`${edit.file}: ${structural}`);
+        }
+        if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) {
+            // Reading it threw a bare EISDIR from deep inside the runner.
+            preflightErrors.push(`${edit.file}: is a directory, not a file`);
+        }
+        if (edit.renameTo) {
+            const target = resolve(edit.renameTo);
+            const claimedBy = renameTargets.get(target);
+            if (claimedBy !== undefined) {
+                preflightErrors.push(`${edit.file}: renames to ${edit.renameTo}, which ${claimedBy} also claims`);
+            }
+            renameTargets.set(target, edit.file);
+            // The destination is a write to a protected path as much as the source is.
+            if (!opts.allowNodeModules && target.includes(`${path.sep}node_modules${path.sep}`)) {
+                preflightErrors.push(
+                    `${edit.file}: refusing to rename into node_modules (${edit.renameTo}; set allowNodeModules to override)`
+                );
+            }
+            if (opts.allowGenerated !== true && edit.allowGenerated !== true && target !== abs) {
+                const why = looksGenerated(target);
+                if (why !== null) {
+                    preflightErrors.push(
+                        `${edit.file}: refusing to rename onto a GENERATED path ${edit.renameTo} (${why}) — pass allowGenerated: true.`
+                    );
+                }
+            }
+            if (target !== abs && fs.existsSync(target) && !edit.overwrite) {
+                preflightErrors.push(
+                    `${edit.file}: renameTo target already exists: ${edit.renameTo} — set overwrite: true to replace it`
+                );
+            }
+        }
+    }
+    for (const [target, claimedBy] of renameTargets) {
+        if (seen.has(target)) {
+            preflightErrors.push(`${claimedBy}: renameTo target is also edited in this batch: ${target}`);
+        }
+    }
+    if (opts.backupDir !== undefined && opts.backupOverwrite !== true && !dryRun) {
+        const inUse = backupDirInUse(opts.backupDir);
+        if (inUse !== null) {
+            preflightErrors.push(
+                `backupDir ${opts.backupDir} already holds a manifest from ${inUse} — reusing it OVERWRITES that snapshot: the original file content stored there becomes UNRECOVERABLE and a later rollback lands on the intermediate version. If you are RE-RUNNING this sweep, point backupDir at a fresh directory (scratchDir()); a dry run never writes one, so this always means an earlier real run. backupOverwrite: true is a one-way door; pass it only when the old snapshot is worthless.`
+            );
+        }
+    }
+    if (opts.verifyCommand !== undefined) {
+        const { refusal, warning } = checkVerifyCommand(opts.verifyCommand);
+        if (refusal !== undefined) {
+            preflightErrors.push(refusal);
+        } else if (warning !== undefined) {
+            console.error(paint(COLORS.skip, `WARNING: ${warning}`));
+        }
+    }
+
+    if (dryRun && opts.verifyCommand !== undefined) {
+        preflightErrors.push(
+            "--dry together with a verify command: a dry run writes nothing, so there is nothing to verify and a green result would be a lie. Drop one of the two."
+        );
+    }
+    if (preflightErrors.length > 0) {
+        for (const e of preflightErrors) {
+            console.error(paint(COLORS.miss, `PRE-FLIGHT: ${e}`));
+        }
+        bail(`fable-replace pre-flight failed:\n${preflightErrors.join("\n")}`, 2);
+    }
+
+    // ── phase 1: apply everything in memory ────────────────────────────────
+    interface Planned {
+        edit: FileEdit;
+        abs: string;
+        result: FileResult;
+        before: string | null;
+        after: string | null;
+        /** The bytes read from disk, so the write phase can prove they are still there. */
+        diskBefore: string | null;
+    }
+    const planned: Planned[] = [];
+
+    for (const edit of edits) {
+        const abs = resolve(edit.file);
+        const fileResult: FileResult = {
+            file: edit.file,
+            action: "unchanged",
+            ops: [],
+            postConditionFailures: [],
+            changed: false,
+        };
+
+        if (edit.delete) {
+            // The bytes at plan time, so the write phase can refuse to delete a file someone
+            // changed in between: the same guard an ordinary edit gets.
+            let bytesAtPlan: string | null = null;
+            if (!fs.existsSync(abs)) {
+                fileResult.action = "failed-read";
+                fileResult.postConditionFailures.push("delete requested but file does not exist");
+            } else {
+                fileResult.action = "deleted";
+                fileResult.changed = true;
+                bytesAtPlan = fs.readFileSync(abs, "utf8");
+            }
+            planned.push({ edit, abs, result: fileResult, before: null, after: null, diskBefore: bytesAtPlan });
+            continue;
+        }
+
+        let before: string;
+        let diskBefore: string | null = null;
+        if (fs.existsSync(abs)) {
+            if (edit.createWith !== undefined) {
+                // Only the CLI used to refuse this, so a library caller got a silent no-op that
+                // reported ok. Both doors share the refusal here.
+                fileResult.action = "failed-read";
+                fileResult.postConditionFailures.push(
+                    'createWith ("<<< create") refuses to overwrite an existing file. Use replace ops on it instead.'
+                );
+                planned.push({ edit, abs, result: fileResult, before: null, after: null, diskBefore: null });
+                continue;
+            }
+
+            // Read the BYTES and prove they survive a UTF-8 round trip. readFileSync(…,"utf8")
+            // decodes lossily, so one stray cp1252 byte (0x92 in a legacy doc) came back as
+            // U+FFFD and was written into the file, changing bytes nowhere near the edit and
+            // still reporting OK. A file we cannot represent exactly is a file we must not
+            // rewrite at all.
+            const raw = fs.readFileSync(abs);
+            before = raw.toString("utf8");
+            if (!Buffer.from(before, "utf8").equals(raw)) {
+                fileResult.action = "failed-read";
+                fileResult.postConditionFailures.push(
+                    "not valid UTF-8 — refusing to rewrite it, because every invalid byte would silently become U+FFFD. Fix the encoding first (iconv), or edit it with a byte-aware tool."
+                );
+                planned.push({ edit, abs, result: fileResult, before: null, after: null, diskBefore: null });
+                continue;
+            }
+
+            diskBefore = before;
+        } else if (edit.createWith !== undefined) {
+            before = edit.createWith;
+            fileResult.action = "created";
+        } else {
+            fileResult.action = "failed-read";
+            fileResult.postConditionFailures.push("file does not exist (use createWith to create)");
+            planned.push({ edit, abs, result: fileResult, before: null, after: null, diskBefore: null });
+            continue;
+        }
+
+        const { content: after, results } = applyOps(before, edit.ops ?? []);
+        fileResult.ops = results;
+        fileResult.changed = after !== before || fileResult.action === "created" || Boolean(edit.renameTo);
+        if (fileResult.action !== "created") {
+            fileResult.action = edit.renameTo ? "renamed" : fileResult.changed ? "edited" : "unchanged";
+        }
+
+        for (const expected of edit.expectAfter ?? []) {
+            if (!after.includes(expected)) {
+                fileResult.postConditionFailures.push(`expectAfter not satisfied: "${preview(expected)}"`);
+            }
+        }
+        for (const absent of edit.absentAfter ?? []) {
+            if (after.includes(absent)) {
+                fileResult.postConditionFailures.push(`absentAfter violated, still present: "${preview(absent)}"`);
+            }
+        }
+        if (opts.syntaxCheck !== false) {
+            // A created file has no "before" on disk: its baseline is the empty file, or the
+            // check would compare the new content against itself and never run. A rename is
+            // checked as its DESTINATION: a .txt renamed to .ts, or a .tsx holding JSX renamed
+            // to .ts, must parse under the new loader even when no op touched the bytes.
+            const created = fileResult.action === "created";
+            const checkPath = edit.renameTo ? resolve(edit.renameTo) : abs;
+            const relanguaged = checkPath !== abs && path.extname(checkPath) !== path.extname(abs);
+            const broke = brokeSyntax(checkPath, created || relanguaged ? "" : before, after);
+            if (broke !== null) {
+                fileResult.postConditionFailures.push(
+                    created
+                        ? `the created content does not parse: ${broke}`
+                        : relanguaged
+                          ? `does not parse as ${path.extname(checkPath)} at ${edit.renameTo}: ${broke}`
+                          : `ops produced unparseable source: ${broke}`
+                );
+            }
+        }
+
+        // A created file's "before" for the diff is the empty file, not its own seed: the
+        // dry run must show what lands on disk.
+        planned.push({
+            edit,
+            abs,
+            result: fileResult,
+            before: fileResult.action === "created" ? "" : before,
+            after,
+            diskBefore,
+        });
+    }
+
+    // ── phase 2: report ────────────────────────────────────────────────────
+    let missCount = 0;
+    for (const plan of planned) {
+        const header = `${paint(COLORS.bold, plan.edit.file)} ${paint(COLORS.dim, `(${plan.result.action})`)}`;
+        console.log(header);
+        for (const op of plan.result.ops) {
+            if (op.status === "OK") {
+                if (verbose) {
+                    const declared = op.expected === undefined ? "" : ` of ${String(op.expected)} declared`;
+                    const where =
+                        op.lines === undefined || op.lines.length === 0
+                            ? ""
+                            : ` @ ${op.lines.slice(0, 8).join(",")}${op.lines.length > 8 ? ",…" : ""}`;
+                    console.log(
+                        `  ${paint(COLORS.ok, "OK  ")} ${op.desc}${op.found !== undefined ? paint(COLORS.dim, ` ×${op.found}${declared}${where}`) : ""}`
+                    );
+                }
+            } else if (op.status === "SKIP") {
+                console.log(`  ${paint(COLORS.skip, "SKIP")} ${op.desc} ${paint(COLORS.dim, `— ${op.reason ?? ""}`)}`);
+            } else {
+                missCount += 1;
+                console.log(`  ${paint(COLORS.miss, "MISS")} ${op.desc} ${paint(COLORS.dim, `— ${op.reason ?? ""}`)}`);
+            }
+        }
+        for (const failure of plan.result.postConditionFailures) {
+            missCount += 1;
+            console.log(`  ${paint(COLORS.miss, "POST")} ${failure}`);
+        }
+        if (
+            (dryRun || opts.showDiff === true) &&
+            plan.before !== null &&
+            plan.after !== null &&
+            plan.before !== plan.after
+        ) {
+            if (diffBudget > 0) {
+                const text = simpleDiff({
+                    before: plan.before,
+                    after: plan.after,
+                    maxLines: Math.min(maxDiffLines, diffBudget),
+                });
+                diffBudget -= text.split("\n").length;
+                console.log(paint(COLORS.dim, text));
+            } else {
+                diffsSuppressed += 1;
+            }
+        }
+    }
+
+    const failed = missCount > 0;
+
+    // ── phase 3: write (or not) ────────────────────────────────────────────
+    const written: string[] = [];
+    const touched: string[] = [];
+    // A new file is created exclusively and joins `touched` the moment its descriptor
+    // exists: a write that fails after creation (ENOSPC) leaves a partial file the recovery
+    // must remove, while an EEXIST never adds the foreign path.
+    const writeNew = (file: string, text: string): void => {
+        const fd = fs.openSync(file, "wx");
+        touched.push(file);
+        try {
+            const data = Buffer.from(text, "utf8");
+            let offset = 0;
+            while (offset < data.length) {
+                offset += fs.writeSync(fd, data, offset, data.length - offset);
+            }
+        } finally {
+            fs.closeSync(fd);
+        }
+    };
+    let leftoverProse = 0;
+    let verify: VerifyResult | undefined;
+    // The hashes are metadata about a sweep that IS on disk. A failure here (a verify
+    // command that turned a tracked path into a directory, a manifest the disk refuses)
+    // used to surface as a generic exit 1 with no undo command, as if nothing was written.
+    const recordHashesOrBail = (): void => {
+        if (opts.backupDir === undefined) {
+            return;
+        }
+
+        try {
+            recordPostWriteHashes(opts.backupDir);
+        } catch (err) {
+            console.error(
+                paint(COLORS.miss, `\nSWEEP WRITTEN, but the backup manifest could not be updated: ${String(err)}`)
+            );
+            if (verify !== undefined && verify.status !== "pass") {
+                printVerifyFailure({ verify, written, backupDir: opts.backupDir });
+            } else {
+                console.error(`  The ${written.length} file(s) hold the sweep. Undo everything with:`);
+                console.error(`  bun "${CLI_PATH}" --rollback "${opts.backupDir}"`);
+            }
+
+            bail(
+                `fable-replace: sweep WRITTEN, backup manifest not updated (${String(err)}) — ${written.length} file(s) hold the swept content`,
+                3,
+                {
+                    ok: false,
+                    files: planned.map((p) => p.result),
+                    written,
+                    missCount,
+                    backupDir: opts.backupDir,
+                    verify,
+                }
+            );
+        }
+    };
+    if (dryRun) {
+        if (diffsSuppressed > 0) {
+            console.log(
+                paint(
+                    COLORS.skip,
+                    `\n… diffs for ${diffsSuppressed} more file(s) suppressed after the ${opts.maxTotalDiffLines ?? 2000}-line total budget. Raise maxTotalDiffLines, or narrow the batch.`
+                )
+            );
+        }
+        console.log(
+            paint(
+                COLORS.bold,
+                `\nDRY RUN — nothing written. ${failed ? `${missCount} MISS(es) to fix.` : "All ops OK."}`
+            )
+        );
+    } else if (failed && !opts.partial) {
+        console.log(
+            paint(
+                COLORS.miss,
+                `\nABORTED — ${missCount} MISS(es); transactional mode wrote NOTHING. Fix the ops and re-run.`
+            )
+        );
+    } else {
+        const writable = planned.filter(
+            (p) =>
+                p.result.changed &&
+                p.result.ops.every((o) => o.status !== "MISS") &&
+                p.result.postConditionFailures.length === 0
+        );
+        if (opts.backupDir && writable.length > 0) {
+            const paths = writable.flatMap((p) => {
+                const targets = [p.abs];
+                if (p.edit.renameTo) {
+                    targets.push(resolve(p.edit.renameTo));
+                }
+                return targets;
+            });
+            writeBackup({ dir: opts.backupDir, files: paths, overwrite: opts.backupOverwrite === true });
+            console.log(paint(COLORS.dim, `\nBacked up ${paths.length} path(s) to ${opts.backupDir}`));
+        }
+        try {
+            for (const plan of writable) {
+                // Everything was read into memory at plan time. If someone else wrote the
+                // file in between, overwriting or deleting it now silently destroys their work
+                // and still reports OK, so prove the bytes are the ones the plan saw. The
+                // refused path never joins `touched`, so the recovery leaves it alone too.
+                if (plan.diskBefore !== null && changedOnDisk({ abs: plan.abs, expected: plan.diskBefore })) {
+                    throw new Error(
+                        `${plan.edit.file} changed on disk after it was read — refusing to ${plan.edit.delete ? "delete" : "overwrite"} someone else's write. Re-run the sweep.`
+                    );
+                }
+
+                if (plan.edit.delete) {
+                    touched.push(plan.abs);
+                    fs.rmSync(plan.abs);
+                    written.push(`${plan.edit.file} (deleted)`);
+                    continue;
+                }
+
+                const target = plan.edit.renameTo ? resolve(plan.edit.renameTo) : plan.abs;
+                // A rename used to write a fresh 644 file, so a 750 script came back
+                // world-readable and no longer executable. Carry the source's mode over.
+                const sourceMode = fs.existsSync(plan.abs) ? fs.statSync(plan.abs).mode : undefined;
+                fs.mkdirSync(path.dirname(target), { recursive: true });
+                // The plan proved a created file and a non-overwriting rename target absent.
+                // "wx" proves it again at the write itself: a path that appeared in between,
+                // or a dangling symlink existsSync cannot see, fails with EEXIST instead of
+                // being truncated, and stays out of `touched`, so the recovery never deletes it.
+                const mustBeNew =
+                    plan.result.action === "created" || (target !== plan.abs && plan.edit.overwrite !== true);
+                if (mustBeNew) {
+                    writeNew(target, plan.after ?? "");
+                } else {
+                    touched.push(target);
+                    fs.writeFileSync(target, plan.after ?? "");
+                }
+
+                if (target !== plan.abs) {
+                    touched.push(plan.abs);
+                }
+                if (plan.edit.renameTo && target !== plan.abs && fs.existsSync(plan.abs)) {
+                    if (sourceMode !== undefined) {
+                        fs.chmodSync(target, sourceMode & 0o7777);
+                    }
+
+                    fs.rmSync(plan.abs);
+                }
+                written.push(plan.edit.renameTo ? `${plan.edit.file} → ${plan.edit.renameTo}` : plan.edit.file);
+            }
+        } catch (err) {
+            // An I/O failure (EACCES, ENOSPC, a read-only file) leaves the batch half
+            // applied. Transactional means transactional: undo what already landed.
+            const notReached = Math.max(0, writable.length - written.length - 1);
+            const later = notReached > 0 ? `; ${notReached} later file(s) were never touched` : "";
+            console.error(paint(COLORS.miss, `\nWRITE FAILED after ${written.length} file(s): ${String(err)}${later}`));
+            const stranded = opts.backupDir ? strandedByRollback({ backupDir: opts.backupDir, touched }) : written;
+            if (!opts.backupDir) {
+                console.error(
+                    paint(COLORS.miss, "no backupDir — the batch is HALF APPLIED. Fix the cause, then re-run.")
+                );
+            }
+
+            const tail =
+                stranded.length > 0
+                    ? ` — ${stranded.length} file(s) still hold the swept content: ${stranded.join(", ")}`
+                    : "";
+            bail(`fable-replace: write failed after ${written.length} file(s): ${String(err)}${later}${tail}`, 1);
+        }
+        const suffix = failed
+            ? paint(COLORS.skip, ` (partial mode: ${missCount} MISS(es) elsewhere — this run still FAILS, exit 1)`)
+            : "";
+        console.log(paint(COLORS.bold, `\nWrote ${written.length} file(s).`) + suffix);
+        if (written.length > 0) {
+            recordHashesOrBail();
+            opts.onWritten?.({ written, backupDir: opts.backupDir });
+        }
+
+        if (opts.verifyCommand !== undefined && written.length > 0) {
+            if (failed) {
+                // A check against a knowingly half-applied tree only produces noise, and
+                // exit 3 must mean everything declared landed.
+                console.log(
+                    paint(
+                        COLORS.skip,
+                        `verify skipped: ${missCount} MISS(es) — a check against a partly applied tree proves nothing.`
+                    )
+                );
+            } else {
+                console.log(paint(COLORS.dim, `verify: ${opts.verifyCommand}`));
+                const result = runVerifyCommand({
+                    command: opts.verifyCommand,
+                    cwd,
+                    backupDir: opts.backupDir,
+                    timeoutMs: opts.verifyTimeoutMs,
+                });
+                verify = result;
+                // The check may have rewritten files (a formatter, codegen). The hashes the
+                // rollback compares against must describe what is on disk NOW, or the undo
+                // command printed on failure refuses with "changed since the sweep".
+                recordHashesOrBail();
+
+                if (result.status !== "pass") {
+                    printVerifyFailure({ verify: result, written, backupDir: opts.backupDir });
+                    const verdict =
+                        result.status === "fail"
+                            ? `verify failed (exit ${String(result.exitCode)})`
+                            : `verify could not be measured (${verifyUnknownReason(result)})`;
+                    bail(
+                        `fable-replace: sweep WRITTEN, ${verdict} — ${written.length} file(s) hold the swept content`,
+                        3,
+                        {
+                            ok: false,
+                            files: planned.map((p) => p.result),
+                            written,
+                            missCount,
+                            backupDir: opts.backupDir,
+                            verify: result,
+                        }
+                    );
+                }
+
+                for (const line of result.shown) {
+                    console.log(paint(COLORS.dim, `  ${line}`));
+                }
+            }
+        }
+
+        // The MISS path is loud; the OK path used to be inferred from the absence of
+        // a MISS line. Say plainly that the sweep landed.
+        // A rename is not finished when the code is green. Relying on the caller to
+        // remember a post-sweep leftover scan failed in a real trial: the agent ran one,
+        // scoped it to src/ only, and shipped three docs naming a symbol it had removed.
+        if (opts.leftoversCheck !== undefined && written.length > 0) {
+            const { names, dirs } = opts.leftoversCheck;
+            const found = leftovers({ names, dirs: dirs ?? [cwd] });
+            if (found.docs.length > 0) {
+                leftoverProse = found.docs.length;
+            }
+        }
+
+        if (!failed && leftoverProse === 0) {
+            const opsOk = planned.reduce((sum, p) => sum + p.result.ops.filter((o) => o.status === "OK").length, 0);
+            const verified = verify !== undefined ? ", verify passed (exit 0)" : "";
+            console.log(
+                paint(COLORS.ok, `SWEEP COMPLETE: ${written.length} file(s) written, ${opsOk} op(s) OK${verified}.`)
+            );
+        } else if (!failed) {
+            console.error(
+                paint(
+                    COLORS.miss,
+                    `SWEEP INCOMPLETE: the code landed and verified, but ${leftoverProse} prose mention(s) survive. The docs now name something that does not exist. Fix them — do NOT re-run this sweep.`
+                )
+            );
+        }
+    }
+
+    const report: RunReport = {
+        ok: !failed && leftoverProse === 0,
+        files: planned.map((p) => p.result),
+        written,
+        missCount,
+        backupDir: opts.backupDir,
+        verify,
+    };
+
+    if (failed || leftoverProse > 0) {
+        // A dry run with misses is a failed rehearsal: `--dry && real` must not proceed.
+        // A partial run with misses wrote the good files but is still not a success.
+        const what = dryRun
+            ? `fable-replace: dry run has ${missCount} MISS(es)`
+            : missCount > 0
+              ? `fable-replace: ${missCount} MISS(es) — ${opts.partial ? `partial mode wrote ${written.length} file(s)` : "nothing written"}`
+              : `fable-replace: ${leftoverProse} stale prose mention(s) after a green sweep`;
+        // Stale prose after a green sweep leaves the code WRITTEN, so it is a 3, like a
+        // red verify; exit 1 means nothing (or not everything) landed.
+        bail(what, dryRun || missCount > 0 ? 1 : 3, report);
+    }
+
+    return report;
+};
+
+/**
+ * Merge FileEdits that target the same file into one, so two independent sweeps can
+ * be concatenated even when their file lists overlap:
+ *
+ *   run(mergeFileEdits([
+ *     ...renameSymbolAcross(filesA, "oldA", "newA"),
+ *     ...renameSymbolAcross(filesB, "oldB", "newB"),
+ *   ]))
+ *
+ * Without this, a file appearing in both lists is two FileEdits and pre-flight
+ * refuses the batch. Ops are concatenated in order and post-conditions are unioned.
+ * Anything that cannot be merged unambiguously (two different `renameTo`, a delete
+ * beside ops) throws rather than guessing. Merging is by the exact `file` string.
+ */
+export const mergeFileEdits = (edits: FileEdit[]): FileEdit[] => {
+    const byFile = new Map<string, FileEdit>();
+    for (const edit of edits) {
+        const existing = byFile.get(edit.file);
+        if (existing === undefined) {
+            byFile.set(edit.file, { ...edit, ops: [...(edit.ops ?? [])] });
+            continue;
+        }
+        for (const field of ["delete", "renameTo", "createWith"] as const) {
+            const a = existing[field];
+            const b = edit[field];
+            if (a !== undefined && b !== undefined && a !== b) {
+                throw new Error(
+                    `mergeFileEdits: ${edit.file} has conflicting "${field}" values (${String(a)} vs ${String(b)})`
+                );
+            }
+        }
+        if ((existing.delete === true && edit.ops?.length) || (edit.delete === true && existing.ops?.length)) {
+            throw new Error(`mergeFileEdits: ${edit.file} is both deleted and edited in the same batch`);
+        }
+        byFile.set(edit.file, {
+            ...existing,
+            ...Object.fromEntries(Object.entries(edit).filter(([, v]) => v !== undefined)),
+            ops: [...(existing.ops ?? []), ...(edit.ops ?? [])],
+            expectAfter: [...(existing.expectAfter ?? []), ...(edit.expectAfter ?? [])],
+            absentAfter: [...(existing.absentAfter ?? []), ...(edit.absentAfter ?? [])],
+        });
+    }
+    return [...byFile.values()];
+};

--- a/plugins/genesis-tools/skills/fable-replace/scripts/tsconfig.json
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"noEmit": true,
+		"target": "es2022",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"types": ["bun"],
+		"skipLibCheck": true
+	},
+	"include": ["*.ts"]
+}

--- a/plugins/genesis-tools/skills/fable-replace/scripts/types.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/types.ts
@@ -1,0 +1,493 @@
+/**
+ * fable-replace — the vocabulary. Every op shape, edit shape and result shape.
+ * Pure types, zero imports, zero behaviour. Read this first to learn what can be
+ * declared; read the module that owns each behaviour to learn what it does.
+ */
+
+/**
+ * Literal find/replace. The workhorse — behaves like the Edit tool:
+ * with `count: 1` (default) the needle must occur exactly once in the file;
+ * `count: n` requires exactly n occurrences (all are replaced);
+ * `count: "all"` replaces every occurrence and requires at least one.
+ */
+export interface LiteralOp {
+    kind?: "replace";
+    /** Exact text to find — copy it verbatim from the file, indentation included. */
+    find: string;
+    replace: string;
+    /** Occurrence contract. Default 1 = "exactly once". */
+    count?: number | "all";
+    /** Match only where the needle STARTS a line, what `<<< delete` compiles to: "foo" never matches inside "notfoo". */
+    wholeLines?: boolean;
+    /** If true, a non-match is reported as SKIP instead of MISS and doesn't fail the run. */
+    optional?: boolean;
+    /** Free-text tag shown in the report instead of a needle preview. */
+    label?: string;
+}
+
+/** Regex find/replace. `find` MUST carry the `g` flag when you expect multiple matches. */
+export interface RegexOp {
+    kind: "regex";
+    find: RegExp;
+    /** Replacement string ($1 etc. supported) or replacer function. */
+    replace: string | ((substring: string, ...args: unknown[]) => string);
+    /** Require exactly this many matches. Omit = require at least one. */
+    expect?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/**
+ * Delete everything between two anchors. The engine finds the `occurrence`-th
+ * (default first) `from`, then the FIRST `to` after it.
+ * `keepFrom`/`keepTo` (default false) keep the anchor text itself.
+ */
+export interface DeleteBlockOp {
+    kind: "deleteBlock";
+    from: string;
+    to: string;
+    keepFrom?: boolean;
+    keepTo?: boolean;
+    /** 1-based occurrence of `from` to anchor on. Default 1. */
+    occurrence?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/** Like deleteBlock but substitutes `replace` for the removed region. */
+export interface ReplaceBlockOp {
+    kind: "replaceBlock";
+    from: string;
+    to: string;
+    replace: string;
+    keepFrom?: boolean;
+    keepTo?: boolean;
+    occurrence?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/**
+ * Insert `text` immediately before/after the unique `anchor`, at that CHARACTER
+ * position on the same line. Nothing is added around it: a trailing comment needs
+ * its own leading space, a new line needs its own "\n". For whole lines under or
+ * above the anchor's line use InsertLinesOp instead.
+ */
+export interface InsertOp {
+    kind: "insertBefore" | "insertAfter";
+    anchor: string;
+    /** Inserted verbatim. */
+    text: string;
+    /** 1-based occurrence of the anchor. Default 1; anchor must occur at least that many times. */
+    occurrence?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/**
+ * Insert whole LINES before/after the line that contains the unique `anchor`.
+ * The line-oriented cousin of InsertOp: "put this block under that line" without
+ * caring where on the line the anchor sits. The anchor line itself stays exactly as
+ * it was: never repeat it inside `text`. An anchor that starts with whitespace must
+ * match at the start of a line, so a wrong indentation is a MISS, not a match.
+ */
+export interface InsertLinesOp {
+    kind: "insertLinesBefore" | "insertLinesAfter";
+    anchor: string;
+    /** One or more lines, inserted literally: a trailing "\n" adds a blank line after the block. */
+    text: string;
+    optional?: boolean;
+    label?: string;
+}
+
+/** Append lines at the end of the file. Literal like insertLines; the file always ends with one newline. */
+export interface AppendOp {
+    kind: "append";
+    text: string;
+    label?: string;
+}
+
+export type Op =
+    | LiteralOp
+    | RegexOp
+    | DeleteBlockOp
+    | ReplaceBlockOp
+    | InsertOp
+    | InsertLinesOp
+    | AppendOp
+    | DropCommentsOp
+    | DeleteLinesOp
+    | FuzzyOp;
+
+export interface FileEdit {
+    /** Path to the file (absolute, or relative to `opts.cwd` / process.cwd()). */
+    file: string;
+    /** Applied in order. Later ops see the output of earlier ones. */
+    ops?: Op[];
+    /** Delete the file as part of the batch (ops must be absent). */
+    delete?: boolean;
+    /** Rename/move the file after ops are applied. */
+    renameTo?: string;
+    /** Allow `renameTo` to replace an existing file. Off by default — it is data loss. */
+    overwrite?: boolean;
+    /** Edit this file even though it looks generated. Per-file, so one false positive does not disarm the guard for the whole batch. */
+    allowGenerated?: boolean;
+    /** Create the file with this content if it does not exist (ops then apply on top). */
+    createWith?: string;
+    /** Substrings that MUST be present after all ops ran. */
+    expectAfter?: string[];
+    /** Substrings that MUST NOT be present after all ops ran. */
+    absentAfter?: string[];
+}
+
+export interface RunOptions {
+    /** Preview only: print diffs, write nothing. Also enabled by `--dry` on argv. */
+    dryRun?: boolean;
+    /** Snapshot originals + manifest here before writing; enables `rollback()`. */
+    backupDir?: string;
+    /** Allow reusing a backupDir that already holds a manifest. Off: reuse loses the first snapshot. */
+    backupOverwrite?: boolean;
+    /** Resolve relative FileEdit.file paths against this directory. */
+    cwd?: string;
+    /**
+     * Write the files that fully passed even when other files have misses. Default false
+     * (transactional). A partial run with misses is still a FAILURE: `run()` throws (or
+     * exits 1) AFTER writing, and `report.ok` is false.
+     */
+    partial?: boolean;
+    /** Print per-op OK lines too (MISS/SKIP always print). Default true. */
+    verbose?: boolean;
+    /** Print the per-file diff on a REAL run too (dry runs always print it). Default false. */
+    showDiff?: boolean;
+    /** Max diff lines printed per file in dry runs. Default 200. */
+    maxDiffLines?: number;
+    /** Total diff lines across the WHOLE dry run before diffs are suppressed. Default 2000. */
+    maxTotalDiffLines?: number;
+    /** Allow editing paths containing node_modules (off by default on purpose). */
+    allowNodeModules?: boolean;
+    /** Allow editing files that look machine-generated (off by default on purpose). */
+    allowGenerated?: boolean;
+    /** Parse every edited .ts/.tsx/.js/.jsx after the ops and fail the file if the sweep broke it. Default on. */
+    syntaxCheck?: boolean;
+    /**
+     * Default true: every failure throws a `FableReplaceError` whose `code` is the exit
+     * code (1 misses/verify/partial, 2 pre-flight), so a script can catch it and read
+     * the report. `false` calls `process.exit(code)` instead; the CLI does that.
+     */
+    throwOnFailure?: boolean;
+    /**
+     * Shell command executed AFTER a successful write (e.g. "tsgo --noEmit" or
+     * "bun run test path/to/suite"), captured, with stdin closed. A non-zero exit fails
+     * the run with code 3 and the sweep STAYS WRITTEN: rolling back would restore the
+     * very needles a re-sent spec matches, and that loop costs a full-context round trip
+     * per turn. The undo command is printed instead; `report.verify` carries the verdict.
+     * A script that wants atomic behaviour writes `catch { rollback({ backupDir }) }`.
+     * Skipped when the run has misses (`partial`), refused together with `dryRun`.
+     */
+    verifyCommand?: string;
+    /** Backstop for a hung check, in milliseconds. Default 15 minutes; there is no CLI flag. */
+    verifyTimeoutMs?: number;
+    /**
+     * Called once, right after the files are on disk and before any verify runs. The CLI
+     * journals a "written" line here, so a check killed by a timeout still leaves a trace.
+     */
+    onWritten?: (info: { written: string[]; backupDir?: string }) => void;
+    /**
+     * After a successful write, scan `dirs` (default: cwd) for `names` and FAIL the run
+     * when any survive in prose. The code is left written — a stale doc is a follow-up
+     * edit, not a reason to roll back a green sweep.
+     */
+    leftoversCheck?: { names: string[]; dirs?: string[] };
+}
+
+export interface OpResult {
+    status: "OK" | "MISS" | "SKIP";
+    /** Human description of the op. */
+    desc: string;
+    /** Why it missed (only for MISS/SKIP). */
+    reason?: string;
+    /** How many occurrences were found (literal/regex ops). */
+    found?: number;
+    /** The count the op DECLARED (count / expect), echoed back so a green run still proves the contract. */
+    expected?: number | "all";
+    /** 1-based line numbers the op acted on, when it works line-wise (dropComments, deleteLines). */
+    lines?: number[];
+}
+
+export interface FileResult {
+    file: string;
+    action: "edited" | "unchanged" | "deleted" | "renamed" | "created" | "failed-read";
+    ops: OpResult[];
+    postConditionFailures: string[];
+    /** Content before/after (in memory) — present for edited files. */
+    changed: boolean;
+}
+
+export interface RunReport {
+    ok: boolean;
+    files: FileResult[];
+    written: string[];
+    missCount: number;
+    backupDir?: string;
+    /** The captured verify verdict, when a verifyCommand ran. */
+    verify?: VerifyResult;
+}
+
+export interface RunVerifyParams {
+    /** The shell command, run through `sh -c` with cwd set. */
+    command: string;
+    cwd: string;
+    /** Where `verify-output.txt` (the whole output) is written; none without a backup dir. */
+    backupDir?: string;
+    /** Default 15 minutes. */
+    timeoutMs?: number;
+}
+
+export interface VerifyResult {
+    command: string;
+    /**
+     * "pass" = exit 0. "fail" = a real non-zero exit. "unknown" = no exit status at all
+     * (a signal, the timeout, output over the capture buffer): the sweep is on disk and
+     * the verdict could not be measured, which is never reported as a test failure.
+     */
+    status: "pass" | "fail" | "unknown";
+    exitCode: number | null;
+    signal: string | null;
+    timedOut: boolean;
+    /** The output exceeded the capture buffer (ENOBUFS). */
+    buffered: boolean;
+    ms: number;
+    /** Size of the whole captured output (stdout then stderr). */
+    outputChars: number;
+    /** The lines a reader is shown: the last 5 on a pass, head and tail on anything else. */
+    shown: string[];
+    /** The saved whole output, when a backup dir existed. */
+    outputFile?: string;
+    /** The spawn error message, when there was one. */
+    error?: string;
+}
+
+export interface CommentSpan {
+    /** Absolute start offset of the comment (including the // or slash-star). */
+    start: number;
+    /** Absolute end offset (exclusive). Line comments end BEFORE the newline. */
+    end: number;
+    /** The raw comment text, delimiters included. */
+    text: string;
+    type: "line" | "block";
+    /** 1-based line the comment starts on. */
+    line: number;
+}
+
+export interface DropCommentsOptions {
+    /** Only drop comments whose text contains this substring. */
+    containing?: string;
+    /** Only drop comments whose text matches this regex. */
+    matching?: RegExp;
+    /** Restrict to line or block comments. Default both. */
+    scope?: "line" | "block" | "both";
+    /** Require exactly this many comments to be dropped. */
+    expect?: number;
+}
+
+/** Op form of dropComments, usable inside a FileEdit. */
+export interface DropCommentsOp extends DropCommentsOptions {
+    kind: "dropComments";
+    optional?: boolean;
+    label?: string;
+}
+
+/** Delete every full line containing a substring / matching a regex. */
+export interface DeleteLinesOp {
+    kind: "deleteLines";
+    containing?: string;
+    matching?: RegExp;
+    /** Require exactly this many lines removed. Omit = at least one. */
+    expect?: number;
+    optional?: boolean;
+    label?: string;
+}
+
+/**
+ * Fuzzy variant of a literal op (exactly-once contract, whitespace-insensitive on the
+ * FIND side only). `replace` is written verbatim, indentation and line endings included.
+ */
+export interface FuzzyOp {
+    kind: "fuzzy";
+    find: string;
+    replace: string;
+    /** Occurrence contract, like LiteralOp. Default 1 = exactly once. */
+    count?: number | "all";
+    optional?: boolean;
+    label?: string;
+}
+
+export interface RollbackReport {
+    restored: string[];
+    /** Paths skipped because they changed after the sweep wrote them. */
+    drifted: string[];
+    /** Paths the restore itself could not write, with the reason. These still hold the swept content. */
+    failed: { file: string; error: string }[];
+}
+
+// ── parameter objects ────────────────────────────────────────────────────────
+// Every exported function with more than two inputs takes ONE object, so a call
+// reads as prose and the --api dump shows every field with its doc.
+
+/** `run({ edits, ...options })`: the batch plus every RunOptions field. */
+export interface RunParams extends RunOptions {
+    edits: FileEdit[];
+}
+
+export interface PruneParams {
+    /** Only dirs older than this are candidates. Default 12 hours. */
+    ttlMs?: number;
+    /** Cap per run, so a huge backlog is worked off over several runs. Default 50. */
+    maxRemovals?: number;
+    /** Dirs never touched, whatever their age: the current run's backup dir. */
+    keep?: string[];
+    /** The clock, for tests. */
+    now?: number;
+}
+
+export interface PruneReport {
+    scanned: number;
+    removed: number;
+    /** Sum of the file sizes in the removed dirs. */
+    bytes: number;
+    /** The `<tmp>/fable-replace` root that was swept: one, the temp dir this process writes to. */
+    roots: string[];
+}
+
+export interface RollbackParams {
+    backupDir: string;
+    /** Restore files that changed after the sweep wrote them too. Default false. */
+    force?: boolean;
+    /**
+     * Restore only these paths (as recorded in the manifest); every other entry is left
+     * alone and not reported. The write-failure recovery passes the paths it actually wrote.
+     */
+    only?: string[];
+}
+
+export interface GrepPreviewParams {
+    files: string[];
+    /** A JS RegExp (lookahead works) or a literal string. */
+    pattern: string | RegExp;
+    /** Lines of context around each match. Default 2. */
+    context?: number;
+}
+
+export interface LeftoversParams {
+    /** Old names to hunt for. Identifiers are matched on word boundaries, anything else literally. */
+    names: string[];
+    /** Directories or files to scan. node_modules, build output and backup dirs are skipped. */
+    dirs: string[];
+    /** Suppress the printed summary. Default false. */
+    quiet?: boolean;
+}
+
+export interface CountMatchesParams {
+    files: string[];
+    /** An identifier-looking string is matched on word boundaries; other strings literally; a RegExp as given (g forced). */
+    pattern: string | RegExp;
+    quiet?: boolean;
+}
+
+export interface FindFilesParams {
+    roots: string[];
+    /** Content filter: literal string or RegExp. REQUIRED — omitting it throws, rather than returning an empty list that reads as "no matches". */
+    containing: string | RegExp;
+    /** File extensions to keep. Default [".ts", ".tsx"]; [] keeps every file. */
+    exts?: string[];
+}
+
+export interface SameOpsAcrossParams {
+    files: string[];
+    ops: Op[];
+    /** Extra FileEdit fields (expectAfter, absentAfter, …) applied to every file. */
+    extra?: Partial<FileEdit>;
+}
+
+export interface RenameSymbolParams {
+    oldName: string;
+    newName: string;
+    /** Pin the match count for this one file. */
+    expect?: number;
+}
+
+export interface RenameSymbolAcrossParams {
+    /** A file list, or the map countMatches() returned (zero-match files are dropped, counts are pinned). */
+    files: string[] | Record<string, number>;
+    oldName: string;
+    newName: string;
+    extra?: Partial<FileEdit>;
+    /**
+     * A file that both IMPORTS and DECLARES `oldName` is a local wrapper; renaming its
+     * declaration changes an unrelated helper, so such files are refused (thrown, code 2)
+     * unless this is true. Drop them from `files` instead when in doubt.
+     */
+    includeShadowed?: boolean;
+}
+
+export interface ShadowedFilesParams {
+    files: string[];
+    /** The identifier being renamed. */
+    name: string;
+}
+
+/** Sugar for a literal op: `all` (every occurrence) and `maybe` (optional). */
+export interface LiteralSugarParams {
+    find: string;
+    replace: string;
+    label?: string;
+}
+
+export interface DropParams {
+    /** Exact chunk to delete; must occur exactly once. */
+    find: string;
+    label?: string;
+}
+
+export interface DropJsdocParams {
+    /** The opening lines of the JSDoc block to delete, e.g. "/**\n * Legacy parity". */
+    fromPrefix: string;
+    label?: string;
+}
+
+export interface NearestHintParams {
+    content: string;
+    needle: string;
+    /** When given, a needle whose replacement is already present is reported as "already applied". */
+    replacement?: string;
+    /**
+     * The content BEFORE any op of this batch ran (what is on disk). With it, a replacement
+     * that is present in `content` but absent here is blamed on an earlier op of the batch,
+     * not on a previous run.
+     */
+    original?: string;
+    /** The most recent earlier op of the batch that changed the content, for the blame line. */
+    producedBy?: { index: number; desc: string };
+}
+
+export interface NthIndexOfParams {
+    haystack: string;
+    needle: string;
+    /** 1-based occurrence. */
+    n: number;
+}
+
+export interface SimpleDiffParams {
+    before: string;
+    after: string;
+    /** Cap on printed lines. Default 200. */
+    maxLines?: number;
+}
+/** `writeBackup({ dir, files, overwrite })`: snapshot the originals before a sweep writes. */
+export interface WriteBackupParams {
+    dir: string;
+    /** Absolute paths to snapshot; a path that does not exist is recorded as "created by this sweep". */
+    files: string[];
+    /** Replace a manifest left by an earlier sweep in the same dir. Default false, which is a loud refusal. */
+    overwrite?: boolean;
+}

--- a/plugins/genesis-tools/skills/fable-replace/scripts/verify-command.ts
+++ b/plugins/genesis-tools/skills/fable-replace/scripts/verify-command.ts
@@ -1,0 +1,227 @@
+/**
+ * fable-replace — RUNNING THE VERIFY COMMAND, the check a sweep runs after it wrote.
+ *
+ * The command is captured, never inherited. That lets the CLI trim what the reader sees
+ * (a green test run is a five-line summary, not 300 lines), save the whole output beside
+ * the backup, and tell three outcomes apart: exit 0 is a pass; a real non-zero exit is a
+ * fail; no exit status at all (a signal, the timeout, more output than the buffer holds)
+ * is "unknown", which means the sweep is on disk and the verdict could not be measured.
+ * That is neither a pass nor a test failure, and it is never reported as one.
+ *
+ * A red verify never rolls the sweep back. The reasons live in sweep-many-files.ts.
+ */
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { stringifyJson } from "./json";
+import type { RunVerifyParams, VerifyResult } from "./types";
+
+/** A fixed backstop, not a flag: one more flag is one more thing to get wrong. */
+export const VERIFY_TIMEOUT_MS = 15 * 60 * 1000;
+/** Well above any test runner's output. The 1 MB default turned a green suite into ENOBUFS. */
+const VERIFY_MAX_BUFFER = 64 * 1024 * 1024;
+const PASS_TAIL_LINES = 5;
+const FAIL_HEAD_LINES = 40;
+const FAIL_TAIL_LINES = 60;
+/** One line can be a 50 KB JSON blob; the reader gets its start. */
+const MAX_LINE_CHARS = 500;
+export const VERIFY_OUTPUT_FILE = "verify-output.txt";
+
+const clip = (line: string): string =>
+    line.length <= MAX_LINE_CHARS ? line : `${line.slice(0, MAX_LINE_CHARS)}… (+${line.length - MAX_LINE_CHARS} chars)`;
+
+/** Head and tail around an omitted-lines marker; the whole output when it is short enough. */
+export const trimOutput = ({ lines, head, tail }: { lines: string[]; head: number; tail: number }): string[] => {
+    if (lines.length <= head + tail) {
+        return lines.map(clip);
+    }
+
+    const omitted = lines.length - head - tail;
+    return [...lines.slice(0, head).map(clip), `… ${omitted} line(s) omitted …`, ...lines.slice(-tail).map(clip)];
+};
+
+const REFUSALS = {
+    pipe: "contains a pipe.\nA pipeline reports the LAST command's exit code, so a failing test reads as PASS\n(/bin/sh), and `set -o pipefail` reports FAIL when `head` closes the pipe early.\nBoth lie. Drop the pipe: this CLI already trims the output for you.\nIf you truly need one, own the exit code yourself:\n  --verify \"bash -c 'set -o pipefail; <your pipeline>'\"",
+    chain: "contains a `;` chain. Only the LAST command's exit code is reported, so `a; b` turns a red `a` into a green verify. Chain with `&&`, or run one command.",
+    newline:
+        "spans more than one line. Only the LAST line's exit code is reported, so an earlier red line reads as PASS. Chain with `&&`, or run one command.",
+    background:
+        "contains a background `&`. A backgrounded command returns 0 immediately, so the check never reaches a verdict. Run it in the foreground.",
+};
+
+/**
+ * Refuse only the shell operators that can hide a non-zero exit status: a pipe, a `;`
+ * chain, a newline, a background `&`. Redirects, `$( )`, backticks and `VAR=1` prefixes
+ * cannot change the status of the command whose status is read, so they pass. `&&`
+ * and `||` pass too. Anything inside single or double quotes is opaque, which is the
+ * escape hatch: `bash -c 'set -o pipefail; …'` names the risk in the command itself.
+ *
+ * A quote-state scanner, not a shell parser: a pipe inside `$( )` is refused as well.
+ * That false positive is cheaper than a parser. Measured on this machine: `exit 7 | cat`
+ * is status 0 under /bin/sh, and `bash -o pipefail` turns `rg | head` into a false FAIL.
+ */
+export const checkVerifyCommand = (command: string): { refusal?: string; warning?: string } => {
+    let single = false;
+    let double = false;
+    let unquoted = "";
+    let found: keyof typeof REFUSALS | undefined;
+    for (let i = 0; i < command.length && found === undefined; i += 1) {
+        const ch = command[i];
+        const next = command[i + 1];
+        if (single) {
+            if (ch === "'") {
+                single = false;
+            }
+
+            continue;
+        }
+
+        if (ch === "\\") {
+            i += 1;
+            continue;
+        }
+
+        if (double) {
+            if (ch === '"') {
+                double = false;
+            }
+
+            continue;
+        }
+
+        if (ch === "'") {
+            single = true;
+            continue;
+        }
+
+        if (ch === '"') {
+            double = true;
+            continue;
+        }
+
+        unquoted += ch;
+        if (ch === "|") {
+            if (next === "|") {
+                unquoted += next;
+                i += 1;
+                continue;
+            }
+
+            found = "pipe";
+        } else if (ch === ";") {
+            found = "chain";
+        } else if (ch === "\n") {
+            found = "newline";
+        } else if (ch === "&") {
+            if (next === "&" || next === ">") {
+                unquoted += next;
+                i += 1;
+                continue;
+            }
+
+            const prev = command[i - 1];
+            if (prev === ">" || prev === "<") {
+                continue;
+            }
+
+            found = "background";
+        }
+    }
+
+    if (found !== undefined) {
+        return { refusal: `--verify ${stringifyJson(command)} ${REFUSALS[found]}\nNothing was written.` };
+    }
+
+    if (unquoted.includes("/dev/null")) {
+        return {
+            warning: `--verify ${stringifyJson(command)} sends output to /dev/null: the check still runs, but the lines needed to fix forward are discarded. Drop the redirect; the CLI trims the output itself.`,
+        };
+    }
+
+    return {};
+};
+
+/** Why a verify has no exit status, in the reader's words. */
+export const verifyUnknownReason = (verify: VerifyResult): string => {
+    if (verify.timedOut) {
+        return `timed out after ${Math.round(verify.ms / 1000)} s`;
+    }
+
+    if (verify.buffered) {
+        return "its output exceeded the 64 MB capture buffer";
+    }
+
+    if (verify.signal !== null) {
+        return `killed by ${verify.signal}`;
+    }
+
+    return verify.error ?? "no exit status";
+};
+
+/**
+ * Run the verify command through the shell with both streams captured and stdin closed
+ * (the CLI already consumed its own stdin for the spec, and an interactive prompt inside
+ * a check would hang the sweep). Returns the verdict plus the lines to show. It prints
+ * nothing itself, so the caller owns the order of the narration.
+ */
+export const runVerifyCommand = ({
+    command,
+    cwd,
+    backupDir,
+    timeoutMs = VERIFY_TIMEOUT_MS,
+}: RunVerifyParams): VerifyResult => {
+    const started = Date.now();
+    const child = spawnSync(command, {
+        shell: true,
+        cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf8",
+        maxBuffer: VERIFY_MAX_BUFFER,
+        timeout: timeoutMs,
+    });
+    const ms = Date.now() - started;
+    // Separate pipes cannot interleave the two streams. stdout first, then stderr, which
+    // keeps a test runner's summary (stderr for `bun test`) at the tail where a reader looks.
+    const output = `${child.stdout ?? ""}${child.stderr ?? ""}`;
+    const errorCode = (child.error as { code?: string } | undefined)?.code;
+    const status: VerifyResult["status"] = child.status === 0 ? "pass" : child.status === null ? "unknown" : "fail";
+
+    let outputFile: string | undefined;
+    if (backupDir !== undefined) {
+        try {
+            fs.mkdirSync(backupDir, { recursive: true });
+            outputFile = path.join(backupDir, VERIFY_OUTPUT_FILE);
+            fs.writeFileSync(outputFile, output);
+        } catch (err) {
+            console.error(`could not save the verify output: ${String(err)}`);
+            outputFile = undefined;
+        }
+    }
+
+    const lines = output.length === 0 ? [] : output.replace(/\n$/, "").split("\n");
+    let shown: string[];
+    if (status === "pass") {
+        shown = lines.slice(-PASS_TAIL_LINES).map(clip);
+        if (lines.length > PASS_TAIL_LINES) {
+            const where = outputFile === undefined ? "" : ` (full output: ${outputFile})`;
+            shown.unshift(`… ${lines.length - PASS_TAIL_LINES} earlier line(s) suppressed${where}`);
+        }
+    } else {
+        shown = trimOutput({ lines, head: FAIL_HEAD_LINES, tail: FAIL_TAIL_LINES });
+    }
+
+    return {
+        command,
+        status,
+        exitCode: child.status,
+        signal: child.signal ?? null,
+        timedOut: errorCode === "ETIMEDOUT",
+        buffered: errorCode === "ENOBUFS",
+        ms,
+        outputChars: output.length,
+        shown,
+        outputFile,
+        error: child.error === undefined ? undefined : String(child.error.message ?? child.error),
+    };
+};

--- a/src/utils/bun/preload-test-tmpdir.test.ts
+++ b/src/utils/bun/preload-test-tmpdir.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+
+const PRELOAD = resolve(import.meta.dir, "preload-test-tmpdir.ts");
+
+/**
+ * The preload cannot be imported here (it runs before any test module loads, and a second
+ * import would install a second root), so the first test asserts the invariants it
+ * maintains from inside a process it already configured, and the second drives a child
+ * `bun test` with the preload on a scratch suite to watch what happens at exit.
+ */
+describe("test tmpdir preload", () => {
+    test("this process's temp dir is a private gt-test-tmp root, and the sandbox home lives inside it", () => {
+        expect(basename(tmpdir())).toStartWith("gt-test-tmp-");
+        expect(process.env.GENESIS_TOOLS_HOME?.startsWith(tmpdir())).toBe(true);
+    });
+
+    test("a run removes its root, green or red, and stale siblings are swept", () => {
+        const parent = mkdtempSync(join(tmpdir(), "tmpdir-preload-parent-"));
+        const suite = mkdtempSync(join(tmpdir(), "tmpdir-preload-suite-"));
+        writeFileSync(
+            join(suite, "green.test.ts"),
+            [
+                'import { expect, test } from "bun:test";',
+                'import { mkdtempSync } from "node:fs";',
+                'import { tmpdir } from "node:os";',
+                'import { join } from "node:path";',
+                'test("fixtures land in the root", () => {',
+                '    expect(mkdtempSync(join(tmpdir(), "fixture-"))).toContain("gt-test-tmp-");',
+                "});",
+                "",
+            ].join("\n")
+        );
+        writeFileSync(
+            join(suite, "red.test.ts"),
+            [
+                'import { expect, test } from "bun:test";',
+                'test("fails on purpose", () => {',
+                "    expect(1).toBe(2);",
+                "});",
+                "",
+            ].join("\n")
+        );
+        const stale = join(parent, "gt-test-tmp-stale");
+        const young = join(parent, "gt-test-tmp-young");
+        mkdirSync(stale);
+        mkdirSync(young);
+        const sevenHoursAgo = new Date(Date.now() - 7 * 60 * 60 * 1000);
+        utimesSync(stale, sevenHoursAgo, sevenHoursAgo);
+
+        const run = (file: string) =>
+            spawnSync("bun", ["test", "--preload", PRELOAD, file], {
+                cwd: suite,
+                encoding: "utf8",
+                env: { ...process.env, TMPDIR: parent, TMP: parent, TEMP: parent },
+            });
+
+        const green = run("green.test.ts");
+        if (green.status !== 0) {
+            console.error(green.stdout, green.stderr);
+        }
+        expect(green.status).toBe(0);
+        expect(readdirSync(parent).filter((name) => name.startsWith("gt-test-tmp-"))).toEqual(["gt-test-tmp-young"]);
+
+        const red = run("red.test.ts");
+        expect(red.status).not.toBe(0);
+        expect(readdirSync(parent).filter((name) => name.startsWith("gt-test-tmp-"))).toEqual(["gt-test-tmp-young"]);
+    });
+});

--- a/src/utils/bun/preload-test-tmpdir.ts
+++ b/src/utils/bun/preload-test-tmpdir.ts
@@ -1,0 +1,89 @@
+import { afterAll } from "bun:test";
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env } from "@genesiscz/utils/env";
+
+/**
+ * Give every test process its own temp root, and remove it when the run is green.
+ *
+ * 799 call sites in the suite do `mkdtempSync(join(tmpdir(), "<prefix>-"))` and most never
+ * remove the dir. Measured 2026-09-07 15:05: 17,949 entries and 1.45 GB in the per-user
+ * temp folder, 4,880 of them `gt-test-home-*` from the sandbox preload alone, 6,568
+ * distinct prefixes in all, growing by about 1,100 entries per ten minutes while agents
+ * ran tests. Fixing that at every call site is the wrong altitude.
+ *
+ * `os.tmpdir()` reads TMPDIR (TEMP and TMP on Windows) on every call, so pointing the
+ * variable at one fresh root here, before any test module loads, moves every fixture, the
+ * `gt-test-home` sandbox and every child that inherits the environment into one
+ * directory. One `rmSync` at exit then covers all of them.
+ *
+ * Rules:
+ *  - Removed in a global `afterAll`, once per test process, green or red. `bun test` fires
+ *    neither the `exit` nor the `beforeExit` event (measured on 1.3.13), and no hook sees
+ *    the run's verdict, so "keep the evidence on red" is not available. A failed
+ *    assertion is in the transcript; the fixture dir was never what anyone read.
+ *  - Stale sibling roots (older than 6 h; no test process lives that long) are swept at
+ *    the same point, at most 200 per process, so a KILLED run (no afterAll) cannot
+ *    accumulate forever. Only the `gt-test-tmp-` prefix is ever touched: nothing else in
+ *    the temp folder is ours.
+ *  - Listed right after the sqlite-vec preload in bunfig.toml, BEFORE the sandbox preload,
+ *    so the sandbox home lands inside this root.
+ *
+ * Known gap: Bun does not forward process.env mutations to children spawned without an
+ * explicit `env`, so such a child still writes to the real temp folder. A test that spawns
+ * passes `env: { ...process.env }` when that matters.
+ */
+const PREFIX = "gt-test-tmp-";
+const STALE_AFTER_MS = 6 * 60 * 60 * 1000;
+const MAX_SWEEP = 200;
+
+const realTmpdir = tmpdir();
+const root = mkdtempSync(join(realTmpdir, PREFIX));
+for (const name of ["TMPDIR", "TMP", "TEMP"]) {
+    // Writes straight through to process.env, which is what os.tmpdir() reads.
+    env.testing.set(name, root);
+}
+
+const sweepStale = (): void => {
+    let names: string[];
+    try {
+        names = readdirSync(realTmpdir);
+    } catch {
+        // The temp folder itself is unreadable: nothing to sweep, nothing to report.
+        return;
+    }
+
+    let removed = 0;
+    for (const name of names) {
+        if (removed >= MAX_SWEEP) {
+            break;
+        }
+
+        if (!name.startsWith(PREFIX)) {
+            continue;
+        }
+
+        const dir = join(realTmpdir, name);
+        if (dir === root) {
+            continue;
+        }
+
+        try {
+            // A live run's root keeps a fresh mtime: every fixture created inside it touches it.
+            if (Date.now() - statSync(dir).mtimeMs < STALE_AFTER_MS) {
+                continue;
+            }
+
+            rmSync(dir, { recursive: true, force: true });
+            removed += 1;
+        } catch {
+            // Vanished under us, or refused by the filesystem: the next run tries again.
+        }
+    }
+};
+
+afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+    sweepStale();
+});


### PR DESCRIPTION
## What

Ports the `fable-replace` skill (verified, transactional find and replace for agents) into the `genesis-tools` plugin as `plugins/genesis-tools/skills/fable-replace/`, then changes four things a 70-hour session measured as expensive or misleading, and fixes the test-fixture leak that was filling the temp folder.

## Why (measured in session 3db71b09, 399 CLI calls, 933 ops)

- 38 failed calls each re-sent the whole spec; the round trips they forced cost about 10x the text.
- `--verify` streamed whole test outputs into the tool result (15K chars for one green run) and a red check rolled every file back, which invites the model to re-send the spec against the restored originals and loop.
- Weak models never used `--verify` and chained `; bun run test | tail -3` instead, which reports `tail`'s exit code.
- No outcome was recorded anywhere; backup dirs were never pruned.
- The temp folder held 17,949 entries (1.45 GB), 4,880 of them `gt-test-home-*` from the test sandbox preload, none of it from fable-replace (93 dirs, 1.5 MB).

## Changes, one per commit

1. Port, behaviour unchanged: biome format, one `json.ts` helper instead of 41 bare `JSON` calls, `${CLAUDE_PLUGIN_ROOT}` paths, hermetic selftest (`GENESIS_TOOLS_HOME` and `TMPDIR` pinned; bun does not forward `process.env` mutations to children, so every spawn passes the env explicitly), a `selftest.test.ts` wrapper so CI runs it, the skill tsconfig wired into `typecheck:all`.
2. A red `--verify` keeps the sweep written and exits **3** (new code: written, but something after the write is unhappy; stale prose moved there too). The output is captured: a pass shows its last 5 lines, a fail the first 40 and last 60 plus `verify-output.txt` beside the backup. `status === null` (timeout, signal, ENOBUFS) is `verify-unknown`, never a test failure. Post-write hashes are recorded again after the check, so the printed `--rollback` line works after a formatter-style check. `--dry --verify` is refused; a partial run with misses skips the check.
3. `--verify` refuses, in pre-flight, a `|` (not `||`), a `;`, a newline or a background `&` outside quotes: both `/bin/sh` and `pipefail` lie about a pipeline's exit code. `2>/dev/null` only warns. Escape hatch: `bash -c 'set -o pipefail; …'`.
4. Journal: one JSON line per run, rollback and prune at `~/.genesis-tools/fable-replace/journal.jsonl` (`GENESIS_TOOLS_HOME` or `FABLE_REPLACE_HOME` move it), with outcome, MISS reasons, spec size and hash, printed chars, token estimates, verify verdict. `--history [N]`, `--stats [days]`. The spec text is saved beside the backup, never in the journal.
5. Every scratch dir lands under `<tmp>/fable-replace/`; every run prunes that root (age-only, 12 h, manifest-gated, at most 50, never the current run's dir); `--prune` runs it now.
6. A block end-anchor that is a closing fence no longer triggers the truncation warning, and a needle consumed by an earlier op of the same batch is blamed on that op instead of "applied before" (handoff h_yvyxmctd).
7. `fix(test)`: a `[test].preload` gives every test process one temp root and removes it at the end of the run; stale roots are swept after 6 h. 209 tests across `src/ai-spend` and `src/handoff` now leave zero new top-level temp entries.
8. Plugin version 1.0.55.

## Verification

- `bun plugins/genesis-tools/skills/fable-replace/scripts/selftest.ts` ends with `ALL SELFTESTS PASSED` after every commit (about 90 new checks).
- `bun run test plugins/genesis-tools/skills/fable-replace src/utils/bun src/ai-spend src/handoff` green.
- `bunx biome check plugins/genesis-tools/skills/fable-replace` clean; `bunx tsgo --noEmit` and `bunx tsgo -p plugins/genesis-tools/skills/fable-replace/scripts/tsconfig.json --noEmit` clean.
- Shell proofs: a red `--verify 'exit 1'` sweep gives exit 3, the file keeps the sweep, the printed `--rollback` line restores it; a `--verify 'bun run test | tail -3'` sweep gives exit 2 with the file untouched.

## Follow-up (not in this PR)

- GenesisClaude `user/skills/fable-replace` becomes a thin shim pointing at this copy after the merge.
- The pid-safety CI guard takes over 60 s in a worktree of this repo; unrelated to these files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `fable-replace` tool for precise, transactional edits across files.
  - Supports replacements, insertions, deletions, comment cleanup, symbol renaming, file creation, and renames.
  - Added dry runs, backups, rollback, verification commands, diffs, history, statistics, and detailed diagnostics.
  - Added API discovery and reconnaissance tools to preview matches and identify affected files.

- **Documentation**
  - Added comprehensive usage guidance, CLI examples, operation references, and rollback documentation.

- **Chores**
  - Updated the marketplace and `genesis-tools` plugin version to 1.0.55.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->