### PR TITLE
feat(github): merge --squash defaults the subject to the PR title (#N) and the body to one bullet per commit

### DIFF
--- a/src/github/README.md
+++ b/src/github/README.md
@@ -54,7 +54,9 @@ tools github get https://github.com/owner/repo/blob/main/src/index.ts --clipboar
 tools github merge 123 --rebase           # stack-safe: restack+FF (preserves SHAs) + restack children
 tools github merge 123 --rebase --no-restack  # legacy GitHub rewrite rebase (breaks cascades)
 tools github merge 123 --ff-only          # true FF (base ref → head SHA; keeps commit SHAs)
-tools github merge 123 --squash --delete-branch --subject "feat: ship (#123)"
+tools github merge 123 --squash --delete-branch   # subject = PR title (#123), body = one bullet per commit
+tools github merge 123 --squash --dry-run         # print the generated squash message, merge nothing
+tools github merge 123 --squash --subject "feat: ship (#123)" --body "* one\n* two"   # explicit values win
 tools github merge https://github.com/owner/repo/pull/123 --merge --delete-remote
 
 # Cache + rate limit status
@@ -109,6 +111,16 @@ GitHub only auto-retargets dependent PRs when a branch is deleted via the **web 
 
 Exactly one of `--merge`, `--rebase`, `--squash`, or `--ff-only` is required.
 All progress logs go to stdout.
+
+**`--squash` writes a real commit message by default.** Without `--subject` the
+subject is the PR title plus ` (#N)` (not doubled when the title already ends
+with it). Without `--body` the body is every PR commit subject, oldest first,
+as `* <subject>` bullets separated by single newlines (all pages are fetched,
+so a 300-commit PR lists 300 bullets). The CLI prints the message and says
+which part was generated and which came from a flag. Commit text is passed to
+the GitHub API as data, never through a shell. `--merge` is unchanged: no
+default message is generated there. `--dry-run` resolves the PR, lists
+dependents, prints the squash message and stops before any write.
 
 Run any subcommand with `--help` for its full option list. The most common flags (`--format ai|json`, `--limit`, `--last`, `--no-bots`, `--min-reactions`, `--stats`, `--clipboard`) work across multiple subcommands.
 

--- a/src/github/README.md
+++ b/src/github/README.md
@@ -113,10 +113,12 @@ Exactly one of `--merge`, `--rebase`, `--squash`, or `--ff-only` is required.
 All progress logs go to stdout.
 
 **`--squash` writes a real commit message by default.** Without `--subject` the
-subject is the PR title plus ` (#N)` (not doubled when the title already ends
-with it). Without `--body` the body is every PR commit subject, oldest first,
-as `* <subject>` bullets separated by single newlines (all pages are fetched,
-so a 300-commit PR lists 300 bullets). The CLI prints the message and says
+subject is the PR title, a space, and `(#N)` (not doubled when the title already
+ends with it). Without `--body` the body is every PR commit subject, oldest
+first, as `* <subject>` bullets separated by single newlines. The PR-commits
+endpoint stops at 250 commits, so past that the compare endpoint is walked
+page by page; if the collected count still differs from the PR's own commit
+count the merge refuses rather than write a short body. The CLI prints the message and says
 which part was generated and which came from a flag. Commit text is passed to
 the GitHub API as data, never through a shell. `--merge` is unchanged: no
 default message is generated there. `--dry-run` resolves the PR, lists

--- a/src/github/commands/merge.ts
+++ b/src/github/commands/merge.ts
@@ -207,6 +207,7 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
                     rebaseMode: result.rebaseMode ?? null,
                     squashMessage: result.squashMessage ?? null,
                     headRestack: result.headRestack ?? null,
+                    dependentsFound: result.dependentsFound,
                     dependents: result.retargeted,
                     dependentsRestacked: result.dependentsRestacked,
                     branchDeleted: result.branchDeleted,

--- a/src/github/commands/merge.ts
+++ b/src/github/commands/merge.ts
@@ -137,11 +137,19 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
     const { log } = logger.scoped("github:merge");
 
     const dryRun = Boolean(options.dryRun);
+    const jsonMode = options.format === "json";
     log.info(
         { owner, repo, number, method, deleteBranch, dryRun, noRestack: Boolean(options.noRestack) },
         "safe merge start"
     );
-    out.println(
+    // In JSON mode stdout carries only the result object; progress goes to the logger (stderr + file).
+    const progress = jsonMode
+        ? (message: string) => log.info(message)
+        : (message: string) => {
+              out.println(message);
+              log.debug(message);
+          };
+    progress(
         chalk.bold(
             `Safe merge ${owner}/${repo}#${number} (${method}${deleteBranch ? ", delete-branch after retarget" : ""}${
                 dryRun ? ", dry run" : ""
@@ -159,10 +167,7 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
         commitTitle: options.subject,
         commitMessage: options.body,
         dryRun,
-        log: (message) => {
-            out.println(message);
-            log.debug(message);
-        },
+        log: progress,
     });
 
     log.info(

--- a/src/github/commands/merge.ts
+++ b/src/github/commands/merge.ts
@@ -1,6 +1,7 @@
 // Safe PR merge command — retargets stack dependents before optional branch delete.
 
 import { resolveMergeMethod, type SafeMergeResult, safeMergePull } from "@app/github/lib/merge";
+import { describeSquashMessage } from "@app/github/lib/squash-message";
 import { detectRepoFromGit, parseGitHubUrl } from "@genesiscz/utils/github/url-parser";
 import { SafeJSON } from "@genesiscz/utils/json";
 import { logger, out } from "@genesiscz/utils/logger";
@@ -25,6 +26,8 @@ export interface MergeCommandOptions {
     deleteRemote?: boolean;
     subject?: string;
     body?: string;
+    /** Resolve the PR and show the squash message, then stop before any write. */
+    dryRun?: boolean;
     format?: "text" | "json";
     verbose?: boolean;
 }
@@ -32,11 +35,32 @@ export interface MergeCommandOptions {
 function formatTextSummary(result: SafeMergeResult): string {
     const lines: string[] = [];
     lines.push("");
-    lines.push(chalk.green(`✔ MERGED ${result.owner}/${result.repo}#${result.number} (${result.method})`));
+
+    if (result.dryRun) {
+        lines.push(
+            chalk.yellow(
+                `○ DRY RUN ${result.owner}/${result.repo}#${result.number} (${result.method}) — nothing merged`
+            )
+        );
+    } else {
+        lines.push(chalk.green(`✔ MERGED ${result.owner}/${result.repo}#${result.number} (${result.method})`));
+    }
+
     lines.push(`  title:  ${result.title}`);
     lines.push(`  head:   ${result.headRef}`);
     lines.push(`  base:   ${result.baseRef}`);
     lines.push(`  sha:    ${result.mergeSha || "(n/a)"}`);
+
+    if (result.squashMessage) {
+        for (const line of describeSquashMessage(result.squashMessage)) {
+            lines.push(`  ${line}`);
+        }
+    }
+
+    if (result.dryRun) {
+        lines.push(`  dependents found: ${result.dependentsFound.length}`);
+        return lines.join("\n");
+    }
 
     if (result.rebaseMode) {
         lines.push(`  rebase: ${result.rebaseMode}`);
@@ -112,10 +136,16 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
     const { owner, repo, number } = parsed;
     const { log } = logger.scoped("github:merge");
 
-    log.info({ owner, repo, number, method, deleteBranch, noRestack: Boolean(options.noRestack) }, "safe merge start");
+    const dryRun = Boolean(options.dryRun);
+    log.info(
+        { owner, repo, number, method, deleteBranch, dryRun, noRestack: Boolean(options.noRestack) },
+        "safe merge start"
+    );
     out.println(
         chalk.bold(
-            `Safe merge ${owner}/${repo}#${number} (${method}${deleteBranch ? ", delete-branch after retarget" : ""})`
+            `Safe merge ${owner}/${repo}#${number} (${method}${deleteBranch ? ", delete-branch after retarget" : ""}${
+                dryRun ? ", dry run" : ""
+            })`
         )
     );
 
@@ -128,6 +158,7 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
         noRestack: Boolean(options.noRestack),
         commitTitle: options.subject,
         commitMessage: options.body,
+        dryRun,
         log: (message) => {
             out.println(message);
             log.debug(message);
@@ -138,7 +169,10 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
         {
             number: result.number,
             mergeSha: result.mergeSha,
+            dryRun: Boolean(result.dryRun),
             rebaseMode: result.rebaseMode,
+            squashTitleGenerated: result.squashMessage?.titleGenerated,
+            squashBodyGenerated: result.squashMessage?.bodyGenerated,
             headRestacked: Boolean(result.headRestack?.rebased),
             dependentsRetargeted: result.retargeted.length,
             dependentsRestacked: result.dependentsRestacked.length,
@@ -164,7 +198,9 @@ export async function mergeCommand(input: string, options: MergeCommandOptions):
                     headRef: result.headRef,
                     baseRef: result.baseRef,
                     mergeSha: result.mergeSha,
+                    dryRun: Boolean(result.dryRun),
                     rebaseMode: result.rebaseMode ?? null,
+                    squashMessage: result.squashMessage ?? null,
                     headRestack: result.headRestack ?? null,
                     dependents: result.retargeted,
                     dependentsRestacked: result.dependentsRestacked,
@@ -212,8 +248,15 @@ export function createMergeCommand(): Command {
             "After retargeting dependents, delete the remote head branch (never passes delete to the merge API)"
         )
         .option("--delete-remote", "Alias for --delete-branch")
-        .option("--subject <title>", "Commit title (merge/squash commit_title; ignored for --ff-only)")
-        .option("--body <text>", "Commit message body (merge/squash commit_message; ignored for --ff-only)")
+        .option(
+            "--subject <title>",
+            "Commit title (merge/squash commit_title; ignored for --ff-only). --squash defaults to the PR title plus (#N)"
+        )
+        .option(
+            "--body <text>",
+            "Commit message body (merge/squash commit_message; ignored for --ff-only). --squash defaults to one '* <subject>' bullet per PR commit"
+        )
+        .option("--dry-run", "Resolve the PR, print the squash message and dependents, then stop before any write")
         .option("-f, --format <format>", "Output format: text|json", "text")
         .option("-v, --verbose", "Verbose logging (reserved)")
         .action(async (input: string, opts: MergeCommandOptions) => {

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -73,13 +73,14 @@ function makeMock(opts: {
                     baseRef: dep.baseRef,
                     headSha: dep.headSha ?? "dddddddddddddddddddddddddddddddddddddddd",
                     baseSha: opts.pr.baseSha,
+                    commitCount: 1,
                     htmlUrl: dep.htmlUrl,
                 };
             }
             return { ...opts.pr, number, merged };
         },
-        async listPullCommits(_owner, _repo, number) {
-            calls.push({ op: "listPullCommits", args: [number] });
+        async listPullCommits(_owner, _repo, pr) {
+            calls.push({ op: "listPullCommits", args: [pr.number] });
             return (opts.commits ?? []).map((c) => ({ ...c }));
         },
         async listOpenPullsByBase(_owner, _repo, base) {
@@ -216,6 +217,7 @@ function basePr(over: Partial<PullRef> = {}): PullRef {
         baseRef: "main",
         headSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         baseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        commitCount: 1,
         htmlUrl: "https://github.com/o/r/pull/1",
         ...over,
     };

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -523,6 +523,31 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
         expect(retargetCalls[0].args).toEqual([2, "main"]);
     });
 
+    test("an explicit --body skips the commit fetch, so a failing collector can never block it", async () => {
+        const { client, calls } = makeMock({ pr: basePr(), commits: [] });
+        client.listPullCommits = async () => {
+            throw new Error("Could not collect every PR commit");
+        };
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method: "squash",
+            commitMessage: "* hand-written",
+            client,
+        });
+
+        expect(calls.map((c) => c.op)).not.toContain("listPullCommits");
+        expect(calls.find((c) => c.op === "mergePull")?.args[1]).toEqual({
+            method: "squash",
+            commitTitle: "PR A (#1)",
+            commitMessage: "* hand-written",
+        });
+        expect(result.squashMessage?.titleGenerated).toBe(true);
+        expect(result.squashMessage?.bodyGenerated).toBe(false);
+    });
+
     test("passes explicit squash subject/body through to merge API unchanged", async () => {
         const { client, calls } = makeMock({
             pr: basePr(),

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
     type DependentPull,
     type MergeGitHubClient,
+    type MergeMethod,
     type MergePullOptions,
     type MergePullResult,
     type PullRef,
@@ -697,6 +698,63 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
             commitMessage: undefined,
         });
         expect(result.squashMessage).toBeUndefined();
+    });
+
+    test.each([
+        ["squash", false],
+        ["merge", false],
+        ["rebase", false],
+        ["rebase", true],
+        ["ff-only", false],
+    ] as Array<
+        [MergeMethod, boolean]
+    >)("dry run with method=%s noRestack=%s reaches no irreversible primitive", async (method, noRestack) => {
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            commits: [{ sha: "1111111", subject: "one" }],
+            dependents: [dep({ number: 2 })],
+        });
+        // Every write throws: a dry run that reaches one fails loudly instead of passing quietly.
+        const armed = (op: string) => async () => {
+            throw new Error(`dry run reached ${op}`);
+        };
+        client.mergePull = armed("mergePull");
+        client.fastForwardBase = armed("fastForwardBase");
+        client.updatePullBase = armed("updatePullBase");
+        client.unstack = armed("unstack");
+        client.deleteBranch = armed("deleteBranch");
+        const restack: StackRestackOps = { restackBranch: armed("restackBranch") };
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 1,
+            method,
+            noRestack,
+            deleteBranch: true,
+            dryRun: true,
+            client,
+            restack,
+        });
+
+        expect(result.dryRun).toBe(true);
+        expect(result.mergeSha).toBe("");
+        expect(result.dependentsFound.map((d) => d.number)).toEqual([2]);
+        const reads = new Set(["getPull", "listOpenPullsByBase", "listPullCommits"]);
+        expect(calls.every((c) => reads.has(c.op))).toBe(true);
+    });
+
+    test("the same armed spies fire on a real rebase, so the dry-run control is not vacuous", async () => {
+        const { client } = makeMock({ pr: basePr() });
+        const restack: StackRestackOps = {
+            restackBranch: async () => {
+                throw new Error("dry run reached restackBranch");
+            },
+        };
+
+        await expect(
+            safeMergePull({ owner: "o", repo: "r", number: 1, method: "rebase", client, restack })
+        ).rejects.toThrow(/reached restackBranch/);
     });
 
     test("dry run resolves the squash message and dependents but never writes", async () => {

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -9,6 +9,7 @@ import {
     safeMergePull,
 } from "./merge";
 import { NATIVE_STACK_BASE_ERROR } from "./native-stack";
+import type { PullCommitSubject } from "./squash-message";
 import type { RestackBranchInput, RestackBranchResult, StackRestackOps } from "./stack-restack";
 
 type CallLog = Array<{ op: string; args: unknown[] }>;
@@ -18,6 +19,8 @@ function makeMock(opts: {
     dependents?: DependentPull[];
     /** Dependents returned after merge (defaults to pre-merge list). */
     postMergeDependents?: DependentPull[];
+    /** Commit subjects returned by listPullCommits (oldest first). */
+    commits?: PullCommitSubject[];
     mergeResult?: MergePullResult;
     /** Fail updatePullBase for these PR numbers. */
     failRetarget?: number[];
@@ -74,6 +77,10 @@ function makeMock(opts: {
                 };
             }
             return { ...opts.pr, number, merged };
+        },
+        async listPullCommits(_owner, _repo, number) {
+            calls.push({ op: "listPullCommits", args: [number] });
+            return (opts.commits ?? []).map((c) => ({ ...c }));
         },
         async listOpenPullsByBase(_owner, _repo, base) {
             calls.push({ op: "listOpenPullsByBase", args: [base] });
@@ -514,10 +521,13 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
         expect(retargetCalls[0].args).toEqual([2, "main"]);
     });
 
-    test("passes squash subject/body through to merge API", async () => {
-        const { client, calls } = makeMock({ pr: basePr() });
+    test("passes explicit squash subject/body through to merge API unchanged", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            commits: [{ sha: "1111111", subject: "ignored: explicit values win" }],
+        });
 
-        await safeMergePull({
+        const result = await safeMergePull({
             owner: "o",
             repo: "r",
             number: 1,
@@ -533,6 +543,120 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
             commitTitle: "feat: ship it (#1)",
             commitMessage: "commit one\ncommit two",
         });
+        expect(result.squashMessage?.titleGenerated).toBe(false);
+        expect(result.squashMessage?.bodyGenerated).toBe(false);
+    });
+
+    test("squash without --subject/--body sends PR title (#N) and one bullet per commit", async () => {
+        const logs: string[] = [];
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 42, title: "feat: widgets — bigger and `better`" }),
+            commits: [
+                { sha: "1111111", subject: "feat(widgets): add the frame" },
+                { sha: "2222222", subject: 'fix(widgets): "quoted" subject with $HOME and `ticks`' },
+                { sha: "3333333", subject: "chore: trailing whitespace   " },
+            ],
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 42,
+            method: "squash",
+            client,
+            log: (m) => logs.push(m),
+        });
+
+        const mergeCall = calls.find((c) => c.op === "mergePull");
+        expect(mergeCall?.args[1]).toEqual({
+            method: "squash",
+            commitTitle: "feat: widgets — bigger and `better` (#42)",
+            commitMessage:
+                "* feat(widgets): add the frame\n" +
+                '* fix(widgets): "quoted" subject with $HOME and `ticks`\n' +
+                "* chore: trailing whitespace",
+        });
+        expect(result.squashMessage).toEqual({
+            title: "feat: widgets — bigger and `better` (#42)",
+            body:
+                "* feat(widgets): add the frame\n" +
+                '* fix(widgets): "quoted" subject with $HOME and `ticks`\n' +
+                "* chore: trailing whitespace",
+            titleGenerated: true,
+            bodyGenerated: true,
+            commitCount: 3,
+        });
+        // The commit list is fetched before the merge call, never after.
+        const ops = calls.map((c) => c.op);
+        expect(ops.indexOf("listPullCommits")).toBeLessThan(ops.indexOf("mergePull"));
+        expect(logs.some((l) => l.includes("squash subject (generated from PR title)"))).toBe(true);
+        expect(logs.some((l) => l.includes("squash body (generated from 3 commit subject(s))"))).toBe(true);
+    });
+
+    test("squash keeps a PR title that already ends with (#N) and honours only one of the overrides", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 7, title: "fix: thing (#7)" }),
+            commits: [{ sha: "1111111", subject: "fix: thing" }],
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 7,
+            method: "squash",
+            commitMessage: "",
+            client,
+        });
+
+        const mergeCall = calls.find((c) => c.op === "mergePull");
+        expect(mergeCall?.args[1]).toEqual({ method: "squash", commitTitle: "fix: thing (#7)", commitMessage: "" });
+        expect(result.squashMessage?.titleGenerated).toBe(true);
+        expect(result.squashMessage?.bodyGenerated).toBe(false);
+    });
+
+    test("--merge does not list commits and sends no generated message", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr(),
+            commits: [{ sha: "1111111", subject: "would be a bullet under --squash" }],
+        });
+
+        const result = await safeMergePull({ owner: "o", repo: "r", number: 1, method: "merge", client });
+
+        expect(calls.map((c) => c.op)).not.toContain("listPullCommits");
+        expect(calls.find((c) => c.op === "mergePull")?.args[1]).toEqual({
+            method: "merge",
+            commitTitle: undefined,
+            commitMessage: undefined,
+        });
+        expect(result.squashMessage).toBeUndefined();
+    });
+
+    test("dry run resolves the squash message and dependents but never writes", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 5, title: "feat: five" }),
+            commits: [{ sha: "1111111", subject: "one" }],
+            dependents: [dep({ number: 6 })],
+        });
+
+        const result = await safeMergePull({
+            owner: "o",
+            repo: "r",
+            number: 5,
+            method: "squash",
+            deleteBranch: true,
+            dryRun: true,
+            client,
+        });
+
+        const ops = calls.map((c) => c.op);
+        expect(ops).toEqual(["getPull", "listOpenPullsByBase", "listPullCommits"]);
+        expect(result.dryRun).toBe(true);
+        expect(result.mergeSha).toBe("");
+        expect(result.squashMessage?.title).toBe("feat: five (#5)");
+        expect(result.squashMessage?.body).toBe("* one");
+        expect(result.dependentsFound.map((d) => d.number)).toEqual([6]);
+        expect(result.retargeted).toEqual([]);
+        expect(result.branchDeleted).toBe(false);
     });
 
     test("detects child closed after retarget (simulates the gh bug path)", async () => {

--- a/src/github/lib/merge.test.ts
+++ b/src/github/lib/merge.test.ts
@@ -205,6 +205,8 @@ function makeRestackMock(opts?: {
     return { restack, calls };
 }
 
+const HEAD_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
 function basePr(over: Partial<PullRef> = {}): PullRef {
     return {
         number: 1,
@@ -215,7 +217,7 @@ function basePr(over: Partial<PullRef> = {}): PullRef {
         mergeable: true,
         headRef: "branch-a",
         baseRef: "main",
-        headSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        headSha: HEAD_SHA,
         baseSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         commitCount: 1,
         htmlUrl: "https://github.com/o/r/pull/1",
@@ -543,6 +545,7 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
             method: "squash",
             commitTitle: "PR A (#1)",
             commitMessage: "* hand-written",
+            expectedHeadSha: HEAD_SHA,
         });
         expect(result.squashMessage?.titleGenerated).toBe(true);
         expect(result.squashMessage?.bodyGenerated).toBe(false);
@@ -569,6 +572,7 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
             method: "squash",
             commitTitle: "feat: ship it (#1)",
             commitMessage: "commit one\ncommit two",
+            expectedHeadSha: HEAD_SHA,
         });
         expect(result.squashMessage?.titleGenerated).toBe(false);
         expect(result.squashMessage?.bodyGenerated).toBe(false);
@@ -602,6 +606,8 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
                 "* feat(widgets): add the frame\n" +
                 '* fix(widgets): "quoted" subject with $HOME and `ticks`\n' +
                 "* chore: trailing whitespace",
+            // Bound to the head the commits were read from: a push in between fails the merge.
+            expectedHeadSha: HEAD_SHA,
         });
         expect(result.squashMessage).toEqual({
             title: "feat: widgets — bigger and `better` (#42)",
@@ -636,9 +642,44 @@ describe("safeMergePull — stack retarget order (cli/cli#1168)", () => {
         });
 
         const mergeCall = calls.find((c) => c.op === "mergePull");
-        expect(mergeCall?.args[1]).toEqual({ method: "squash", commitTitle: "fix: thing (#7)", commitMessage: "" });
+        expect(mergeCall?.args[1]).toEqual({
+            method: "squash",
+            commitTitle: "fix: thing (#7)",
+            commitMessage: "",
+            expectedHeadSha: HEAD_SHA,
+        });
         expect(result.squashMessage?.titleGenerated).toBe(true);
         expect(result.squashMessage?.bodyGenerated).toBe(false);
+    });
+
+    test("a head pushed after the commit list was read fails the squash instead of inheriting the body", async () => {
+        const { client, calls } = makeMock({
+            pr: basePr({ number: 9, title: "feat: nine" }),
+            commits: [{ sha: "1111111", subject: "one" }],
+            dependents: [dep({ number: 10 })],
+        });
+        const originalMerge = client.mergePull;
+        client.mergePull = async (owner, repo, number, options) => {
+            // GitHub answers 409 when `sha` no longer matches the head.
+            if (
+                options.expectedHeadSha !== undefined &&
+                options.expectedHeadSha !== "ffffffffffffffffffffffffffffffffffffffff"
+            ) {
+                calls.push({ op: "mergePull", args: [number, options] });
+                throw new Error("Head branch was modified. Review and try the merge again.");
+            }
+
+            return originalMerge(owner, repo, number, options);
+        };
+
+        await expect(safeMergePull({ owner: "o", repo: "r", number: 9, method: "squash", client })).rejects.toThrow(
+            /Head branch was modified/
+        );
+
+        const ops = calls.map((c) => c.op);
+        expect(ops).toContain("mergePull");
+        expect(ops).not.toContain("updatePullBase");
+        expect(ops).not.toContain("deleteBranch");
     });
 
     test("--merge does not list commits and sends no generated message", async () => {

--- a/src/github/lib/merge.ts
+++ b/src/github/lib/merge.ts
@@ -544,8 +544,14 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
     let squashMessage: SquashMessage | undefined;
 
     if (method === "squash") {
-        logLine(log, `Listing commits of #${number} for the squash message...`);
-        const commits = await client.listPullCommits(owner, repo, pr, log);
+        // An explicit --body needs no commit list, so a failing collector can never block it.
+        let commits: PullCommitSubject[] = [];
+
+        if (commitMessage === undefined) {
+            logLine(log, `Listing commits of #${number} for the squash message...`);
+            commits = await client.listPullCommits(owner, repo, pr, log);
+        }
+
         squashMessage = buildSquashMessage({
             number: pr.number,
             title: pr.title,

--- a/src/github/lib/merge.ts
+++ b/src/github/lib/merge.ts
@@ -82,6 +82,12 @@ export interface MergePullOptions {
     method: GithubApiMergeMethod;
     commitTitle?: string;
     commitMessage?: string;
+    /**
+     * Head SHA the PR must still be at for the merge to go through. A squash
+     * body lists the commits read BEFORE the merge, so a push in between must
+     * fail the merge instead of landing under a message that omits it.
+     */
+    expectedHeadSha?: string;
 }
 
 export interface MergePullResult {
@@ -363,6 +369,7 @@ export function createOctokitMergeClient(): MergeGitHubClient {
                         merge_method: options.method,
                         commit_title: options.commitTitle,
                         commit_message: options.commitMessage,
+                        sha: options.expectedHeadSha,
                     }),
                 { label: `PUT /repos/${owner}/${repo}/pulls/${number}/merge (${options.method})` }
             );
@@ -656,6 +663,8 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
             method: method as GithubApiMergeMethod,
             commitTitle: squashMessage?.title ?? commitTitle,
             commitMessage: squashMessage?.body ?? commitMessage,
+            // The generated body describes pr.headSha; a newer head must fail the merge, not inherit the message.
+            ...(squashMessage ? { expectedHeadSha: pr.headSha } : {}),
         });
     }
 

--- a/src/github/lib/merge.ts
+++ b/src/github/lib/merge.ts
@@ -31,6 +31,7 @@ import {
     parsePullStackNumber,
     posixShellSingleQuote,
 } from "./native-stack";
+import { buildSquashMessage, commitSubjectOf, type PullCommitSubject, type SquashMessage } from "./squash-message";
 
 /** GitHub API merge methods plus local-ref fast-forward. */
 export type MergeMethod = "merge" | "rebase" | "squash" | "ff-only";
@@ -85,6 +86,8 @@ export interface MergePullResult {
 export interface MergeGitHubClient {
     getPull(owner: string, repo: string, number: number): Promise<PullRef>;
     listOpenPullsByBase(owner: string, repo: string, base: string): Promise<DependentPull[]>;
+    /** Every commit on the PR in GitHub's order (oldest first), across all pages. */
+    listPullCommits(owner: string, repo: string, number: number): Promise<PullCommitSubject[]>;
     mergePull(owner: string, repo: string, number: number, options: MergePullOptions): Promise<MergePullResult>;
     /**
      * True fast-forward: move `baseRef` to `headSha` only if base is an ancestor
@@ -120,6 +123,11 @@ export interface SafeMergeOptions {
     noRestack?: boolean;
     commitTitle?: string;
     commitMessage?: string;
+    /**
+     * Resolve the PR and derive the squash message, then stop before any write
+     * (no merge, no retarget, no branch delete).
+     */
+    dryRun?: boolean;
     /** Progress / decision logs (caller routes to stdout). */
     log?: (message: string) => void;
     client?: MergeGitHubClient;
@@ -160,6 +168,10 @@ export interface SafeMergeResult {
     mergeSha: string;
     /** How the merge was applied when method=rebase (stack-safe path). */
     rebaseMode?: "stack-safe-ff" | "api-rewrite";
+    /** The squash commit message that was (or, on dry run, would be) sent. */
+    squashMessage?: SquashMessage;
+    /** True when nothing was written: the run stopped before the merge call. */
+    dryRun?: boolean;
     headRestack?: RestackBranchResult;
     dependentsFound: DependentPull[];
     retargeted: RetargetResult[];
@@ -206,6 +218,31 @@ function retargetRow(input: {
     }
 
     return row;
+}
+
+/**
+ * Walk a page-numbered GitHub list to its end. A page shorter than `perPage`
+ * is the last one; a large PR is never silently cut at page one.
+ */
+export async function collectPages<T>(
+    fetchPage: (page: number, perPage: number) => Promise<T[]>,
+    perPage = 100
+): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+
+    while (true) {
+        const data = await fetchPage(page, perPage);
+        results.push(...data);
+
+        if (data.length < perPage) {
+            break;
+        }
+
+        page++;
+    }
+
+    return results;
 }
 
 /**
@@ -283,6 +320,25 @@ export function createOctokitMergeClient(): MergeGitHubClient {
             }
 
             return results;
+        },
+
+        async listPullCommits(owner, repo, number) {
+            const commits = await collectPages(async (page, perPage) => {
+                const { data } = await withRetry(
+                    () =>
+                        octokit.rest.pulls.listCommits({
+                            owner,
+                            repo,
+                            pull_number: number,
+                            per_page: perPage,
+                            page,
+                        }),
+                    { label: `GET /repos/${owner}/${repo}/pulls/${number}/commits (page ${page})` }
+                );
+                return data;
+            });
+
+            return commits.map((commit) => ({ sha: commit.sha, subject: commitSubjectOf(commit.commit.message) }));
         },
 
         async mergePull(owner, repo, number, options) {
@@ -432,6 +488,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         noRestack = false,
         commitTitle,
         commitMessage,
+        dryRun = false,
         log,
     } = options;
     const client = options.client ?? createOctokitMergeClient();
@@ -470,6 +527,47 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         for (const dep of dependents) {
             logLine(log, `  dependent #${dep.number} "${dep.title}" (${dep.headRef} → ${dep.baseRef})`);
         }
+    }
+
+    let squashMessage: SquashMessage | undefined;
+
+    if (method === "squash") {
+        logLine(log, `Listing commits of #${number} for the squash message...`);
+        const commits = await client.listPullCommits(owner, repo, number);
+        squashMessage = buildSquashMessage({
+            number: pr.number,
+            title: pr.title,
+            commits,
+            commitTitle,
+            commitMessage,
+        });
+        const titleSource = squashMessage.titleGenerated ? "generated from PR title" : "--subject";
+        const bodySource = squashMessage.bodyGenerated
+            ? `generated from ${squashMessage.commitCount} commit subject(s)`
+            : "--body";
+        logLine(log, `  squash subject (${titleSource}): ${squashMessage.title}`);
+        logLine(log, `  squash body (${bodySource}): ${squashMessage.commitCount} line(s)`);
+    }
+
+    if (dryRun) {
+        logLine(log, "Dry run: stopping before the merge call (nothing written)");
+        return {
+            owner,
+            repo,
+            number: pr.number,
+            title: pr.title,
+            method,
+            headRef: pr.headRef,
+            baseRef: pr.baseRef,
+            mergeSha: "",
+            squashMessage,
+            dryRun: true,
+            dependentsFound: dependents,
+            retargeted: [],
+            dependentsRestacked: [],
+            branchDeleted: false,
+            remainingWork: [],
+        };
     }
 
     // Tip of the PR head before any rewrite — used as --onto oldBase for children.
@@ -538,8 +636,8 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         }
         mergeResult = await client.mergePull(owner, repo, number, {
             method: method as GithubApiMergeMethod,
-            commitTitle,
-            commitMessage,
+            commitTitle: squashMessage?.title ?? commitTitle,
+            commitMessage: squashMessage?.body ?? commitMessage,
         });
     }
 
@@ -849,6 +947,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
         baseRef: pr.baseRef,
         mergeSha: mergeResult.sha || effectiveHeadSha,
         rebaseMode,
+        squashMessage,
         headRestack,
         dependentsFound: toRetarget,
         retargeted,

--- a/src/github/lib/merge.ts
+++ b/src/github/lib/merge.ts
@@ -31,7 +31,13 @@ import {
     parsePullStackNumber,
     posixShellSingleQuote,
 } from "./native-stack";
-import { buildSquashMessage, commitSubjectOf, type PullCommitSubject, type SquashMessage } from "./squash-message";
+import {
+    buildSquashMessage,
+    collectPullCommits,
+    commitSubjectOf,
+    type PullCommitSubject,
+    type SquashMessage,
+} from "./squash-message";
 
 /** GitHub API merge methods plus local-ref fast-forward. */
 export type MergeMethod = "merge" | "rebase" | "squash" | "ff-only";
@@ -49,6 +55,8 @@ export interface PullRef {
     headSha: string;
     /** Tip SHA of the base branch at PR resolution time. */
     baseSha: string;
+    /** Number of commits on the PR as GitHub counts them. */
+    commitCount: number;
     htmlUrl: string;
     /** GitHub native stack number, or null when the PR is not stacked. */
     stackNumber?: number | null;
@@ -86,8 +94,13 @@ export interface MergePullResult {
 export interface MergeGitHubClient {
     getPull(owner: string, repo: string, number: number): Promise<PullRef>;
     listOpenPullsByBase(owner: string, repo: string, base: string): Promise<DependentPull[]>;
-    /** Every commit on the PR in GitHub's order (oldest first), across all pages. */
-    listPullCommits(owner: string, repo: string, number: number): Promise<PullCommitSubject[]>;
+    /** Every commit on the PR, oldest first. Throws rather than return a partial list. */
+    listPullCommits(
+        owner: string,
+        repo: string,
+        pr: PullRef,
+        log?: (message: string) => void
+    ): Promise<PullCommitSubject[]>;
     mergePull(owner: string, repo: string, number: number, options: MergePullOptions): Promise<MergePullResult>;
     /**
      * True fast-forward: move `baseRef` to `headSha` only if base is an ancestor
@@ -221,31 +234,6 @@ function retargetRow(input: {
 }
 
 /**
- * Walk a page-numbered GitHub list to its end. A page shorter than `perPage`
- * is the last one; a large PR is never silently cut at page one.
- */
-export async function collectPages<T>(
-    fetchPage: (page: number, perPage: number) => Promise<T[]>,
-    perPage = 100
-): Promise<T[]> {
-    const results: T[] = [];
-    let page = 1;
-
-    while (true) {
-        const data = await fetchPage(page, perPage);
-        results.push(...data);
-
-        if (data.length < perPage) {
-            break;
-        }
-
-        page++;
-    }
-
-    return results;
-}
-
-/**
  * Create the default Octokit-backed client.
  */
 export function createOctokitMergeClient(): MergeGitHubClient {
@@ -275,6 +263,7 @@ export function createOctokitMergeClient(): MergeGitHubClient {
                 baseRef: data.base.ref,
                 headSha: data.head.sha,
                 baseSha: data.base.sha,
+                commitCount: data.commits,
                 htmlUrl: data.html_url,
                 stackNumber: parsePullStackNumber(data),
             };
@@ -322,23 +311,46 @@ export function createOctokitMergeClient(): MergeGitHubClient {
             return results;
         },
 
-        async listPullCommits(owner, repo, number) {
-            const commits = await collectPages(async (page, perPage) => {
-                const { data } = await withRetry(
-                    () =>
-                        octokit.rest.pulls.listCommits({
-                            owner,
-                            repo,
-                            pull_number: number,
-                            per_page: perPage,
-                            page,
-                        }),
-                    { label: `GET /repos/${owner}/${repo}/pulls/${number}/commits (page ${page})` }
-                );
-                return data;
-            });
+        async listPullCommits(owner, repo, pr, log) {
+            const basehead = `${pr.baseSha}...${pr.headSha}`;
 
-            return commits.map((commit) => ({ sha: commit.sha, subject: commitSubjectOf(commit.commit.message) }));
+            return collectPullCommits({
+                expectedCount: pr.commitCount,
+                log,
+                async listPullCommitsPage(page, perPage) {
+                    const { data } = await withRetry(
+                        () =>
+                            octokit.rest.pulls.listCommits({
+                                owner,
+                                repo,
+                                pull_number: pr.number,
+                                per_page: perPage,
+                                page,
+                            }),
+                        { label: `GET /repos/${owner}/${repo}/pulls/${pr.number}/commits (page ${page})` }
+                    );
+
+                    return data.map((commit) => ({ sha: commit.sha, subject: commitSubjectOf(commit.commit.message) }));
+                },
+                async compareCommitsPage(page, perPage) {
+                    const { data } = await withRetry(
+                        () =>
+                            octokit.rest.repos.compareCommitsWithBasehead({
+                                owner,
+                                repo,
+                                basehead,
+                                per_page: perPage,
+                                page,
+                            }),
+                        { label: `GET /repos/${owner}/${repo}/compare/${basehead} (page ${page})` }
+                    );
+
+                    return data.commits.map((commit) => ({
+                        sha: commit.sha,
+                        subject: commitSubjectOf(commit.commit.message),
+                    }));
+                },
+            });
         },
 
         async mergePull(owner, repo, number, options) {
@@ -533,7 +545,7 @@ export async function safeMergePull(options: SafeMergeOptions): Promise<SafeMerg
 
     if (method === "squash") {
         logLine(log, `Listing commits of #${number} for the squash message...`);
-        const commits = await client.listPullCommits(owner, repo, number);
+        const commits = await client.listPullCommits(owner, repo, pr, log);
         squashMessage = buildSquashMessage({
             number: pr.number,
             title: pr.title,

--- a/src/github/lib/squash-message.test.ts
+++ b/src/github/lib/squash-message.test.ts
@@ -1,12 +1,35 @@
 import { describe, expect, test } from "bun:test";
-import { collectPages } from "./merge";
 import {
     buildSquashMessage,
+    collectPages,
+    collectPullCommits,
     commitSubjectOf,
     defaultSquashBody,
     defaultSquashTitle,
     describeSquashMessage,
+    type PullCommitSubject,
 } from "./squash-message";
+
+/** A page fetcher over a fixed list, with an optional hard cap like GitHub's 250 on pulls/{n}/commits. */
+function pagedSource(
+    total: number,
+    cap = Number.POSITIVE_INFINITY
+): {
+    fetch: (page: number, perPage: number) => Promise<PullCommitSubject[]>;
+    pages: number[];
+} {
+    const pages: number[] = [];
+    const all = Array.from({ length: total }, (_, i) => ({ sha: `sha${i}`, subject: `c${i}` }));
+    const visible = all.slice(0, Math.min(total, cap));
+
+    return {
+        pages,
+        async fetch(page, perPage) {
+            pages.push(page);
+            return visible.slice((page - 1) * perPage, page * perPage);
+        },
+    };
+}
 
 describe("defaultSquashTitle", () => {
     test("appends (#N) once", () => {
@@ -132,5 +155,59 @@ describe("collectPages", () => {
 
         expect(requested).toEqual([1, 2]);
         expect(items).toEqual([0, 1]);
+    });
+});
+
+describe("collectPullCommits", () => {
+    test("a PR under the cap comes straight from the PR commits endpoint", async () => {
+        const list = pagedSource(120);
+        const compare = pagedSource(120);
+        const logs: string[] = [];
+
+        const commits = await collectPullCommits({
+            expectedCount: 120,
+            listPullCommitsPage: list.fetch,
+            compareCommitsPage: compare.fetch,
+            log: (m) => logs.push(m),
+        });
+
+        expect(commits).toHaveLength(120);
+        expect(list.pages).toEqual([1, 2]);
+        expect(compare.pages).toEqual([]);
+        expect(logs).toEqual([]);
+    });
+
+    test("a 300-commit PR is walked through the compare endpoint once the 250 cap shows", async () => {
+        const list = pagedSource(300, 250);
+        const compare = pagedSource(300);
+        const logs: string[] = [];
+
+        const commits = await collectPullCommits({
+            expectedCount: 300,
+            listPullCommitsPage: list.fetch,
+            compareCommitsPage: compare.fetch,
+            log: (m) => logs.push(m),
+        });
+
+        expect(list.pages).toEqual([1, 2, 3]);
+        // 300 is three exactly full pages, so the walk needs a fourth, empty page to know it is done.
+        expect(compare.pages).toEqual([1, 2, 3, 4]);
+        expect(commits).toHaveLength(300);
+        expect(commits[0].subject).toBe("c0");
+        expect(commits[299].subject).toBe("c299");
+        expect(logs[0]).toContain("returned 250 of 300 commits");
+    });
+
+    test("a count that still does not match throws instead of producing a short body", async () => {
+        const list = pagedSource(300, 250);
+        const compare = pagedSource(280);
+
+        await expect(
+            collectPullCommits({
+                expectedCount: 300,
+                listPullCommitsPage: list.fetch,
+                compareCommitsPage: compare.fetch,
+            })
+        ).rejects.toThrow(/PR reports 300, compare returned 280.*--body/);
     });
 });

--- a/src/github/lib/squash-message.test.ts
+++ b/src/github/lib/squash-message.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { collectPages } from "./merge";
+import {
+    buildSquashMessage,
+    commitSubjectOf,
+    defaultSquashBody,
+    defaultSquashTitle,
+    describeSquashMessage,
+} from "./squash-message";
+
+describe("defaultSquashTitle", () => {
+    test("appends (#N) once", () => {
+        expect(defaultSquashTitle("feat: thing", 12)).toBe("feat: thing (#12)");
+        expect(defaultSquashTitle("feat: thing (#12)", 12)).toBe("feat: thing (#12)");
+        expect(defaultSquashTitle("  feat: thing  ", 12)).toBe("feat: thing (#12)");
+    });
+
+    test("a different PR number in the title is not treated as the suffix", () => {
+        expect(defaultSquashTitle("revert: undo (#11)", 12)).toBe("revert: undo (#11) (#12)");
+    });
+});
+
+describe("commitSubjectOf", () => {
+    test("takes the first line only, trimmed, for LF and CRLF bodies", () => {
+        expect(commitSubjectOf("fix: one\n\nlong body\nmore")).toBe("fix: one");
+        expect(commitSubjectOf("fix: crlf\r\nbody")).toBe("fix: crlf");
+        expect(commitSubjectOf("  padded  ")).toBe("padded");
+    });
+
+    test("an empty message still yields a subject", () => {
+        expect(commitSubjectOf("")).toBe("(no subject)");
+        expect(commitSubjectOf("\n\nbody only")).toBe("(no subject)");
+    });
+});
+
+describe("defaultSquashBody", () => {
+    test("one bullet per commit, original order, single newlines, no blank lines", () => {
+        const body = defaultSquashBody([
+            { sha: "1", subject: "first" },
+            { sha: "2", subject: 'second "quoted" `ticked` $VAR' },
+            { sha: "3", subject: "third" },
+        ]);
+        expect(body).toBe('* first\n* second "quoted" `ticked` $VAR\n* third');
+        expect(body).not.toContain("\n\n");
+    });
+
+    test("no commits gives an empty body", () => {
+        expect(defaultSquashBody([])).toBe("");
+    });
+});
+
+describe("buildSquashMessage", () => {
+    const commits = [
+        { sha: "1", subject: "a" },
+        { sha: "2", subject: "b" },
+    ];
+
+    test("generates both parts when nothing is given", () => {
+        expect(buildSquashMessage({ number: 3, title: "t", commits })).toEqual({
+            title: "t (#3)",
+            body: "* a\n* b",
+            titleGenerated: true,
+            bodyGenerated: true,
+            commitCount: 2,
+        });
+    });
+
+    test("an explicit subject or body wins, independently", () => {
+        const onlyTitle = buildSquashMessage({ number: 3, title: "t", commits, commitTitle: "custom" });
+        expect(onlyTitle.title).toBe("custom");
+        expect(onlyTitle.titleGenerated).toBe(false);
+        expect(onlyTitle.body).toBe("* a\n* b");
+        expect(onlyTitle.bodyGenerated).toBe(true);
+
+        const onlyBody = buildSquashMessage({ number: 3, title: "t", commits, commitMessage: "mine" });
+        expect(onlyBody.title).toBe("t (#3)");
+        expect(onlyBody.body).toBe("mine");
+        expect(onlyBody.bodyGenerated).toBe(false);
+    });
+
+    test("an empty --subject falls back to the generated title, an empty --body is kept", () => {
+        const built = buildSquashMessage({ number: 3, title: "t", commits, commitTitle: "", commitMessage: "" });
+        expect(built.title).toBe("t (#3)");
+        expect(built.titleGenerated).toBe(true);
+        expect(built.body).toBe("");
+        expect(built.bodyGenerated).toBe(false);
+    });
+});
+
+describe("describeSquashMessage", () => {
+    test("names the source of each part and prints every body line", () => {
+        const lines = describeSquashMessage(buildSquashMessage({ number: 9, title: "t", commits: [] }));
+        expect(lines[0]).toBe(
+            "Squash commit message (subject generated from the PR title; body generated from 0 commit subject(s)):"
+        );
+        expect(lines[1]).toBe("  t (#9)");
+        expect(lines[2]).toBe("  (empty body)");
+
+        const explicit = describeSquashMessage(
+            buildSquashMessage({ number: 9, title: "t", commits: [], commitTitle: "s", commitMessage: "l1\nl2" })
+        );
+        expect(explicit).toEqual([
+            "Squash commit message (subject from --subject; body from --body):",
+            "  s",
+            "  l1",
+            "  l2",
+        ]);
+    });
+});
+
+describe("collectPages", () => {
+    test("keeps requesting pages until one comes back short", async () => {
+        const requested: number[] = [];
+        const items = await collectPages(async (page, perPage) => {
+            requested.push(page);
+            const count = page < 3 ? perPage : 3;
+            return Array.from({ length: count }, (_, i) => `p${page}-${i}`);
+        }, 100);
+
+        expect(requested).toEqual([1, 2, 3]);
+        expect(items).toHaveLength(203);
+        expect(items[0]).toBe("p1-0");
+        expect(items[202]).toBe("p3-2");
+    });
+
+    test("an exactly full last page costs one extra empty request, never a truncation", async () => {
+        const requested: number[] = [];
+        const items = await collectPages(async (page, perPage) => {
+            requested.push(page);
+            return page === 1 ? Array.from({ length: perPage }, (_, i) => i) : [];
+        }, 2);
+
+        expect(requested).toEqual([1, 2]);
+        expect(items).toEqual([0, 1]);
+    });
+});

--- a/src/github/lib/squash-message.ts
+++ b/src/github/lib/squash-message.ts
@@ -1,0 +1,87 @@
+// Default squash commit message: PR title plus " (#N)" as the subject, and the
+// PR's commit subjects in original order as "* <subject>" bullets, one newline
+// apart. Pure; the caller fetches the commits and decides whether to use it.
+
+export interface PullCommitSubject {
+    sha: string;
+    /** First line of the commit message. */
+    subject: string;
+}
+
+export interface SquashMessageInput {
+    number: number;
+    title: string;
+    commits: PullCommitSubject[];
+    /** Explicit --subject; wins over the generated one. */
+    commitTitle?: string;
+    /** Explicit --body; wins over the generated one. */
+    commitMessage?: string;
+}
+
+export interface SquashMessage {
+    title: string;
+    body: string;
+    /** True when the title came from the PR title, not from --subject. */
+    titleGenerated: boolean;
+    /** True when the body came from the commit list, not from --body. */
+    bodyGenerated: boolean;
+    /** Number of commit subjects folded into the generated body. */
+    commitCount: number;
+}
+
+/** First line of a commit message, trimmed; never empty. */
+export function commitSubjectOf(message: string): string {
+    const first = message.split(/\r?\n/, 1)[0]?.trim() ?? "";
+    return first.length > 0 ? first : "(no subject)";
+}
+
+/** `title (#N)` unless the title already carries that exact suffix. */
+export function defaultSquashTitle(title: string, number: number): string {
+    const trimmed = title.trim();
+    const suffix = `(#${number})`;
+
+    if (trimmed.endsWith(suffix)) {
+        return trimmed;
+    }
+
+    return `${trimmed} ${suffix}`;
+}
+
+/** One `* <subject>` bullet per commit, single newline between bullets, no blank lines. */
+export function defaultSquashBody(commits: PullCommitSubject[]): string {
+    return commits.map((c) => `* ${commitSubjectOf(c.subject)}`).join("\n");
+}
+
+export function buildSquashMessage(input: SquashMessageInput): SquashMessage {
+    const title = input.commitTitle || defaultSquashTitle(input.title, input.number);
+    const body = input.commitMessage ?? defaultSquashBody(input.commits);
+
+    return {
+        title,
+        body,
+        titleGenerated: !input.commitTitle,
+        bodyGenerated: input.commitMessage === undefined,
+        commitCount: input.commits.length,
+    };
+}
+
+/** Lines the CLI prints so the user can inspect a generated message before trusting it. */
+export function describeSquashMessage(message: SquashMessage): string[] {
+    const lines: string[] = [];
+    const titleSource = message.titleGenerated ? "generated from the PR title" : "from --subject";
+    const bodySource = message.bodyGenerated
+        ? `generated from ${message.commitCount} commit subject(s)`
+        : "from --body";
+    lines.push(`Squash commit message (subject ${titleSource}; body ${bodySource}):`);
+    lines.push(`  ${message.title}`);
+
+    if (message.body.length === 0) {
+        lines.push("  (empty body)");
+    } else {
+        for (const line of message.body.split("\n")) {
+            lines.push(`  ${line}`);
+        }
+    }
+
+    return lines;
+}

--- a/src/github/lib/squash-message.ts
+++ b/src/github/lib/squash-message.ts
@@ -52,6 +52,69 @@ export function defaultSquashBody(commits: PullCommitSubject[]): string {
     return commits.map((c) => `* ${commitSubjectOf(c.subject)}`).join("\n");
 }
 
+export interface CollectPullCommitsInput {
+    /** `commits` from the PR object: the authoritative count. */
+    expectedCount: number;
+    /** Page of `GET /pulls/{n}/commits` (GitHub caps the whole listing at 250). */
+    listPullCommitsPage: (page: number, perPage: number) => Promise<PullCommitSubject[]>;
+    /** Page of `GET /compare/{base}...{head}`, which paginates past 250. */
+    compareCommitsPage: (page: number, perPage: number) => Promise<PullCommitSubject[]>;
+    log?: (message: string) => void;
+}
+
+/**
+ * Every commit of a PR, oldest first. The PR-commits endpoint stops at 250
+ * commits no matter how it is paged, so when it comes back short of the PR's
+ * own commit count the compare endpoint is walked instead. A count that still
+ * does not match is an error: a squash body must never silently drop commits.
+ */
+export async function collectPullCommits(input: CollectPullCommitsInput): Promise<PullCommitSubject[]> {
+    const listed = await collectPages(input.listPullCommitsPage);
+
+    if (listed.length >= input.expectedCount) {
+        return listed;
+    }
+
+    input.log?.(
+        `  PR commits endpoint returned ${listed.length} of ${input.expectedCount} commits (250 cap); walking the compare endpoint`
+    );
+    const compared = await collectPages(input.compareCommitsPage);
+
+    if (compared.length !== input.expectedCount) {
+        throw new Error(
+            `Could not collect every PR commit for the squash body: PR reports ${input.expectedCount}, ` +
+                `compare returned ${compared.length}. Pass --body to supply the message yourself.`
+        );
+    }
+
+    return compared;
+}
+
+/**
+ * Walk a page-numbered GitHub list to its end. A page shorter than `perPage`
+ * is the last one.
+ */
+export async function collectPages<T>(
+    fetchPage: (page: number, perPage: number) => Promise<T[]>,
+    perPage = 100
+): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+
+    while (true) {
+        const data = await fetchPage(page, perPage);
+        results.push(...data);
+
+        if (data.length < perPage) {
+            break;
+        }
+
+        page++;
+    }
+
+    return results;
+}
+
 export function buildSquashMessage(input: SquashMessageInput): SquashMessage {
     const title = input.commitTitle || defaultSquashTitle(input.title, input.number);
     const body = input.commitMessage ?? defaultSquashBody(input.commits);


### PR DESCRIPTION
## What

`tools github merge --squash` now writes a real commit message when no `--subject` / `--body` is given, and gains `--dry-run`.

- **Subject**: PR title + ` (#N)`. Not doubled when the title already ends with `(#N)`.
- **Body**: every PR commit subject, oldest first, as `* <subject>` bullets with a single newline between them. All pages are fetched (shared `collectPages` helper), so a large PR is never cut at page one.
- **Explicit flags win**: `--subject` and `--body` are passed through unchanged, independently.
- **The CLI reports the source of each part** ("subject generated from the PR title; body from --body") and prints the full message so it can be inspected. The `--format json` result carries `squashMessage` with `titleGenerated` / `bodyGenerated`.
- **`--dry-run`** resolves the PR, lists dependents, prints the squash message and stops before any write (no merge, no retarget, no branch delete).
- `--merge`, `--rebase`, `--ff-only` are unchanged: no commit list fetch, no generated message.
- Commit text goes to the GitHub API as data. No shell ever sees it.

## Why

Handoff `h_9g42mhpg`. Squash-merging a long branch by hand meant pasting 29 bullets into `--body`, and forgetting the flags produced GitHub's auto-text.

## Validation

- `bun run test src/github/lib/merge.test.ts src/github/lib/squash-message.test.ts` → 38 pass, 0 fail.
- `bunx biome check` clean, `tsgo --noEmit` clean for `src/github`.
- Live read-only proof: `bun run src/github/index.ts merge 368 --squash --dry-run` printed the expected subject and 29 bullets for PR #368 and wrote nothing. PR #368 was not merged, commented on, or modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merge command dry-run support to preview pull request metadata, dependent changes, and squash commit details without performing writes.
  * Added automatic squash commit message generation from pull request titles and commit subjects.
  * Added support for explicitly overriding generated squash commit titles and bodies.
  * Text and JSON outputs now report dry-run status and squash message details.

* **Documentation**
  * Expanded merge documentation with squash merge examples, dry-run usage, and message-generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->