### PR TITLE
feat(handoff): recipient harness targeting, readable names, mismatch warnings and opt-in list filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ It registers **27 tools across 4 capability groups**:
 | Capability | Tools | Purpose |
 |------------|-------|---------|
 | `question_answer` | `question_answer` | Capture a question and your complete answer to the local question store, reviewable later with `tools question log` / `tools question tail`. |
-| `handoff` | `handoff_post`, `handoff_get`, `handoff_list`, `handoff_action` | Cross-agent task handoff: post a task list, claim it, check items off with proof, finish. |
+| `handoff` | `handoff_post`, `handoff_get`, `handoff_list`, `handoff_action` | Cross-agent task handoff: post a task list, address it to a session or a harness (`target.agent`: claude / codex / grok / copilot), fetch it by id or readable name, claim it, check items off with proof, finish. A session that is not the intended recipient gets a warning, never a block. |
 | `annotate` | `annotate_image` | Annotate an image (arrows, boxes, labels) for review. |
 | `boards` | 21 `boards_*` tools | Dev-dashboard annotation boards: create and compose boards, push screenshot sets, list and answer work, wait for new annotations. |
 

--- a/src/claude/mcp/server.ts
+++ b/src/claude/mcp/server.ts
@@ -100,13 +100,22 @@ const SERVER_INSTRUCTIONS =
     '("ok", "thanks", "continue"), or trivial lookups not worth preserving.\n\n' +
     "HANDOFFS (cross-agent task handoff): `handoff_post` creates. `handoff_get` reads. `handoff_list` lists. " +
     "`handoff_action` changes. To delegate work, handoff_post {title, tasks} → copy the returned `paste` block " +
-    'into the receiving agent\'s chat. Receiving agent: handoff_get {id} (default include:["tasks"] — full task ' +
-    "array) → claim (claim: true) → work the tasks " +
+    "into the receiving agent's chat. Address it with target {sessionId|sessionName|agent}, where agent is the " +
+    "intended RECIPIENT harness (claude | codex | grok | copilot), and give it a readable name (or let one be " +
+    'derived from the title) so it can be fetched as handoff_get {name: "fix-active-filter"}; a name shared by ' +
+    "several handoffs is refused with the candidate ids instead of guessing. " +
+    'Receiving agent: handoff_get {id or name} (default include:["tasks"] — full task ' +
+    "array) → READ warnings[] FIRST: it fires when the handoff is addressed to another session or another " +
+    "harness, and then the task is not yours — do not work it unless your user explicitly says to. It is a " +
+    "warning, never a block, and a session whose own identity cannot be detected is told the check was " +
+    "unverifiable rather than being called a mismatch. → claim (claim: true) → work the tasks " +
     "→ handoff_action check_task with proof per task (deny_task with reason for tasks you can't do; " +
     "uncheck_task keeps prior proof) → " +
     'finish_handoff when all resolved. Pass include:["events"] on handoff_get for a bare {events, info} ' +
     "activity trace (editId-free; each event carries `outcome` — a refused action is journaled with " +
     "outcome.applied false and the reason, so the trace never reads as though it happened). " +
+    "handoff_list is never recipient-filtered by default; agent: '<harness>' and session: '<id-or-name>' are " +
+    "opt-in filters on the intended recipient, usable alone or together. " +
     "Poster edits anytime from its own session via handoff_action " +
     "(add_tasks/modify_task/modify_handoff/cancel_handoff); from other sessions pass the editId. Progress is " +
     'live on the dev-dashboard /qa "Agent tasks" tab (SSE via /api/qa/stream type=handoff).\n\n' +

--- a/src/claude/mcp/tools/handoff.ts
+++ b/src/claude/mcp/tools/handoff.ts
@@ -4,6 +4,7 @@ import { SafeJSON } from "@genesiscz/utils/json";
 
 export interface HandoffPostArgs {
     title: string;
+    name?: string;
     description?: string;
     tasks: HandoffTaskInput[];
     target?: HandoffTarget;
@@ -11,7 +12,8 @@ export interface HandoffPostArgs {
 }
 
 export interface HandoffGetArgs {
-    id: string;
+    id?: string;
+    name?: string;
     claim?: boolean;
     unclaim?: boolean;
     include?: string[];
@@ -23,11 +25,14 @@ export interface HandoffListArgs {
     mine?: boolean;
     open?: boolean;
     project?: string;
+    agent?: string;
+    session?: string;
     include?: string[];
 }
 
 export interface HandoffActionArgs {
-    id: string;
+    id?: string;
+    name?: string;
     editId?: string;
     actions: HandoffActionInput[];
     include?: string[];
@@ -58,15 +63,26 @@ export async function handleHandoffAction(args: HandoffActionArgs, deps: Handoff
 export const HANDOFF_POST_DESCRIPTION =
     "Create a handoff — a task list for ANOTHER agent session (cross-repo/cross-project ok). Give title and " +
     "tasks (each has text and optional acceptanceCriteria); optional description (context body), target " +
-    "{sessionId|sessionName}, and refs. Returns the handoff with final task ids, an editId (edit credential " +
-    "for other sessions — your own session edits without it), and a `paste` block: paste it into the " +
-    "receiving agent's chat. To change anything later, call handoff_action.";
+    "{sessionId|sessionName|agent}, refs, and name. target.agent names the INTENDED RECIPIENT harness " +
+    "(claude | codex | grok | copilot) — a session on another harness gets a warning telling it not to work " +
+    "the handoff; it never says who wrote it (that is postedBy). name is a readable slug the receiver can " +
+    "fetch by (handoff_get { name }); omit it and it is derived from the title. Returns the handoff with " +
+    "final task ids, an editId (edit credential for other sessions — your own session edits without it), and " +
+    "a `paste` block: paste it into the receiving agent's chat. To change anything later, call handoff_action.";
 
 export const HANDOFF_GET_DESCRIPTION =
-    "Read a handoff by id (from a paste block or handoff_list). Pass claim: true to claim it for this " +
+    "Read a handoff by id (from a paste block or handoff_list) or by its readable name — pass either as id, " +
+    "or the name as name. A unique name resolves; a name carried by several handoffs is refused WITH the " +
+    "candidate ids so you re-call with the id you meant; passing an id and a name that disagree is an error. " +
+    "ALWAYS read warnings[] first: it fires when the handoff is addressed to another session (explicit " +
+    "target sessionId) or another harness (target.agent), and then this task is NOT yours — do not work it " +
+    "unless your user explicitly tells you to. A warning is not a block: user-authorized cross-target work " +
+    "stays possible, and a caller whose own identity cannot be detected is told the check was unverifiable " +
+    "rather than being called a mismatch. Pass claim: true to claim it for this " +
     "session before working, unclaim: true to release it. Several sessions may claim the same handoff " +
     "(co-owning). If your session IS the target sessionId it auto-claims (response says so; undo with " +
-    "unclaim: true). If this session posted the handoff (same sessionId — sessions are ephemeral, identity " +
+    "unclaim: true) — except under a target.agent this session is not, which never auto-claims. If this " +
+    "session posted the handoff (same sessionId — sessions are ephemeral, identity " +
     "is per-session not per-human), the response also returns your editId; if the posting session is gone " +
     "and the editId is lost, your user can read it on the dev-dashboard /qa Agent-tasks tab. info[] always " +
     "states where you stand and the one next step. After claiming, record work via handoff_action check_task. " +
@@ -75,15 +91,22 @@ export const HANDOFF_GET_DESCRIPTION =
     "returns {events, info} without the handoff envelope.";
 
 export const HANDOFF_LIST_DESCRIPTION =
-    "List recent handoffs, newest-updated first — ALL projects by default; project: '<name>' narrows. " +
+    "List recent handoffs, newest-updated first — ALL projects by default and NEVER filtered by recipient " +
+    "unless you ask; project: '<name>' narrows. " +
     "open: true → only unresolved (not done/cancelled); mine: true → posted by, claimed by, or targeted at " +
-    "this session; limit (default 20) + offset page through. Open rows are detailed, claimed rows concise. " +
+    "this session; limit (default 20) + offset page through. Two opt-in recipient filters, usable alone or " +
+    "together: agent: 'codex' keeps handoffs whose target.agent is that harness (spellings are canonical, so " +
+    "'claude-code' finds 'claude'), and session: '<id-or-name>' keeps handoffs whose target.sessionId matches " +
+    "exactly or by leading-segment abbreviation, or whose target.sessionName matches. Both read the INTENDED " +
+    "RECIPIENT, never the poster. Each row carries name, target and warnings[] (present only when this " +
+    "session is not the intended recipient). Open rows are detailed, claimed rows concise. " +
     'Optional include: ["tasks"] adds a task array per row with proof PREVIEWS (answer clipped, context dropped, ' +
     "id lists capped) — call handoff_get for full proofs. Other include values are ignored with an info line. " +
-    "Use the id with handoff_get.";
+    "Use the id or the name with handoff_get.";
 
 export const HANDOFF_ACTION_DESCRIPTION =
-    "Change a handoff — tasks and lifecycle (claim/unclaim also exist as a convenience on handoff_get; " +
+    "Change a handoff, addressed by id or by readable name (same resolution rules as handoff_get) — tasks " +
+    "and lifecycle (claim/unclaim also exist as a convenience on handoff_get; " +
     'identical effect). Ordered actions array; every action is an object { action: "<verb>", …verb fields } ' +
     "(payload-less verbs may be bare strings). Claimer verbs (be claimed, or start with {action:'claim'}): " +
     "claim, unclaim, check_task {taskId, proof:{answer, commitIds?, context?}}, uncheck_task {taskId} " +
@@ -91,7 +114,7 @@ export const HANDOFF_ACTION_DESCRIPTION =
     "deny_task {taskId, reason}, undeny_task {taskId}, comment {text}, finish_handoff (rejected unless every " +
     "task is checked or denied — force: true overrides; undo via reopen_handoff). Poster verbs (from the " +
     "posting session, or with editId): add_tasks {tasks:[…]}, modify_task {taskId, text?, acceptanceCriteria?}, " +
-    "modify_handoff {title?, description?, target?, refs?}, deny_task, undeny_task, check_task, comment, " +
+    "modify_handoff {title?, name?, description?, target?, refs?}, deny_task, undeny_task, check_task, comment, " +
     "cancel_handoff, reopen_handoff (undoes finish OR cancel; also allowed for the claimer whose own finish " +
     "closed it). attach_file {path, taskId?, note?} attaches a local file (screenshot, log) to the handoff or " +
     "a task. Common short forms are accepted as aliases (done/finish→finish_handoff, check→check_task, " +
@@ -126,10 +149,15 @@ const TASK_ITEM_SCHEMA = {
 const TARGET_SCHEMA = {
     type: "object",
     description:
-        "address a specific session: exact sessionId auto-claims on its first get; sessionName only nudges (names aren't unique)",
+        "who this handoff is FOR: exact sessionId auto-claims on its first get; sessionName only nudges (names aren't unique); agent names the recipient harness. Never describes the poster — that is postedBy",
     properties: {
         sessionId: { type: "string", description: "exact receiving sessionId — auto-claims on its first handoff_get" },
         sessionName: { type: "string", description: "receiving session's name — nudge only, never auto-claims" },
+        agent: {
+            type: "string",
+            description:
+                "intended RECIPIENT harness — claude | codex | grok | copilot. A session on another harness is warned off and never auto-claims. Undocumented values are stored as given but can never raise a warning",
+        },
     },
 } as const;
 
@@ -137,6 +165,11 @@ export const HANDOFF_POST_INPUT_SCHEMA = {
     type: "object",
     properties: {
         title: { type: "string", description: "short imperative title of the work being handed off" },
+        name: {
+            type: "string",
+            description:
+                "readable name the receiver can fetch by (handoff_get { name }) — slugified (lowercase, hyphens); omit it and a slug of the title is used. Not the target session's name",
+        },
         description: { type: "string", description: "markdown body — the why/context the worker needs" },
         tasks: { type: "array", minItems: 1, items: TASK_ITEM_SCHEMA, description: "the checkable task list (≥1)" },
         target: TARGET_SCHEMA,
@@ -154,7 +187,13 @@ export const HANDOFF_GET_INPUT_SCHEMA = {
     properties: {
         id: {
             type: "string",
-            description: "the handoff id from a paste block or handoff_list — h_ prefix optional, whitespace ok",
+            description:
+                "the handoff id from a paste block or handoff_list — h_ prefix optional, whitespace ok; a readable name is accepted here too",
+        },
+        name: {
+            type: "string",
+            description:
+                "readable name instead of an id — a unique name resolves, an ambiguous one is refused with the candidate ids, and a name that disagrees with a supplied id is an error",
         },
         claim: {
             type: "boolean",
@@ -163,7 +202,6 @@ export const HANDOFF_GET_INPUT_SCHEMA = {
         unclaim: { type: "boolean", description: "release ONLY this session's claim (no-op if not claimed)" },
         include: INCLUDE_PROP,
     },
-    required: ["id"],
 } as const;
 
 export const HANDOFF_LIST_INPUT_SCHEMA = {
@@ -177,6 +215,16 @@ export const HANDOFF_LIST_INPUT_SCHEMA = {
         },
         open: { type: "boolean", description: "only unresolved handoffs (status open or claimed)" },
         project: { type: "string", description: "narrow to one project (default: all projects)" },
+        agent: {
+            type: "string",
+            description:
+                "opt-in — only handoffs whose target.agent is this harness (claude | codex | grok | copilot; spellings canonicalized). Off by default; combines with session",
+        },
+        session: {
+            type: "string",
+            description:
+                "opt-in — only handoffs whose target.sessionId matches this id (exactly or by leading-segment abbreviation) or whose target.sessionName matches it. Off by default; combines with agent",
+        },
         include: {
             type: "array",
             items: { type: "string" },
@@ -191,7 +239,11 @@ export const HANDOFF_ACTION_INPUT_SCHEMA = {
     properties: {
         id: {
             type: "string",
-            description: "the handoff id — h_ prefix optional, whitespace ok",
+            description: "the handoff id — h_ prefix optional, whitespace ok; a readable name resolves here too",
+        },
+        name: {
+            type: "string",
+            description: "readable name instead of an id — same resolution rules as handoff_get",
         },
         editId: {
             type: "string",
@@ -285,6 +337,11 @@ export const HANDOFF_ACTION_INPUT_SCHEMA = {
                                 description: "modify_task: replacement acceptance criteria",
                             },
                             title: { type: "string", description: "modify_handoff: replacement title" },
+                            name: {
+                                type: "string",
+                                description:
+                                    "modify_handoff: replacement readable name (slugified); null or an empty string clears it. A title edit never renames",
+                            },
                             description: { type: "string", description: "modify_handoff: replacement description" },
                             target: TARGET_SCHEMA,
                             refs: {
@@ -299,5 +356,5 @@ export const HANDOFF_ACTION_INPUT_SCHEMA = {
             },
         },
     },
-    required: ["id", "actions"],
+    required: ["actions"],
 } as const;

--- a/src/claude/mcp/tools/handoff.ts
+++ b/src/claude/mcp/tools/handoff.ts
@@ -338,7 +338,7 @@ export const HANDOFF_ACTION_INPUT_SCHEMA = {
                             },
                             title: { type: "string", description: "modify_handoff: replacement title" },
                             name: {
-                                type: "string",
+                                type: ["string", "null"],
                                 description:
                                     "modify_handoff: replacement readable name (slugified); null or an empty string clears it. A title edit never renames",
                             },

--- a/src/dev-dashboard/lib/handoff-types.ts
+++ b/src/dev-dashboard/lib/handoff-types.ts
@@ -29,18 +29,21 @@ export interface HandoffGetResponse {
     handoff: PublicHandoff;
     editId?: string;
     info: string[];
+    /** Recipient warnings for the calling identity — absent when there is nothing to say. */
+    warnings?: string[];
 }
 
 export interface HandoffActionResponse {
     handoff: PublicHandoff;
     results: HandoffActionResult[];
     info: string[];
+    warnings?: string[];
 }
 
 export interface HandoffPostResponse {
     handoff: PublicHandoff;
     editId: string;
-    paste: { _agent: string; id: string; title: string; tasks: string };
+    paste: { _agent: string; id: string; title: string; tasks: string; name?: string };
     info: string[];
 }
 

--- a/src/dev-dashboard/server/routes/handoff.ts
+++ b/src/dev-dashboard/server/routes/handoff.ts
@@ -52,6 +52,8 @@ export function handoffRoutes(): RouteDef[] {
                             offset: offsetRaw !== null ? Number.parseInt(offsetRaw, 10) : undefined,
                             open: ctx.query.get("open") === "1",
                             project: ctx.query.get("project") ?? undefined,
+                            agent: ctx.query.get("agent") ?? undefined,
+                            session: ctx.query.get("session") ?? undefined,
                         },
                         deps
                     );
@@ -69,7 +71,8 @@ export function handoffRoutes(): RouteDef[] {
                 try {
                     const deps = await dashboardDeps();
                     const id = ctx.query.get("id") ?? "";
-                    const res = getHandoff({ id }, deps);
+                    const name = ctx.query.get("name") ?? undefined;
+                    const res = getHandoff({ id, name }, deps);
 
                     return { kind: "json", status: 200, body: res };
                 } catch (err) {
@@ -121,9 +124,14 @@ export function handoffRoutes(): RouteDef[] {
             handler: async (ctx) => {
                 try {
                     const deps = await dashboardDeps();
-                    const body = await ctx.readJson<{ id?: string; editId?: string; actions?: HandoffActionInput[] }>();
+                    const body = await ctx.readJson<{
+                        id?: string;
+                        name?: string;
+                        editId?: string;
+                        actions?: HandoffActionInput[];
+                    }>();
                     const res = executeHandoffActions(
-                        { id: body.id ?? "", editId: body.editId, actions: body.actions ?? [] },
+                        { id: body.id ?? "", name: body.name, editId: body.editId, actions: body.actions ?? [] },
                         deps
                     );
 
@@ -141,6 +149,7 @@ export function handoffRoutes(): RouteDef[] {
                     const deps = await dashboardDeps();
                     const body = await ctx.readJson<{
                         title?: string;
+                        name?: string;
                         description?: string;
                         tasks?: HandoffTaskInput[];
                         target?: HandoffTarget;
@@ -149,6 +158,7 @@ export function handoffRoutes(): RouteDef[] {
                     const res = postHandoff(
                         {
                             title: body.title ?? "",
+                            name: body.name,
                             description: body.description,
                             tasks: body.tasks ?? [],
                             target: body.target,

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffDialogs.tsx
@@ -141,7 +141,9 @@ export function HandoffCreateDialog({
     const [title, setTitle] = useState("");
     const [description, setDescription] = useState("");
     const [tasks, setTasks] = useState<TaskDraft[]>([{ text: "", acceptanceCriteria: "" }]);
+    const [name, setName] = useState("");
     const [targetName, setTargetName] = useState("");
+    const [targetAgent, setTargetAgent] = useState("");
     const [refs, setRefs] = useState("");
 
     const setTask = (index: number, patch: Partial<TaskDraft>): void => {
@@ -157,9 +159,10 @@ export function HandoffCreateDialog({
     const submit = (): void => {
         const payload: {
             title: string;
+            name?: string;
             description?: string;
             tasks: HandoffTaskInput[];
-            target?: { sessionName: string };
+            target?: { sessionName?: string; agent?: string };
             refs?: string[];
         } = {
             title: title.trim(),
@@ -178,8 +181,15 @@ export function HandoffCreateDialog({
             payload.description = description.trim();
         }
 
-        if (targetName.trim().length > 0) {
-            payload.target = { sessionName: targetName.trim() };
+        if (name.trim().length > 0) {
+            payload.name = name.trim();
+        }
+
+        if (targetName.trim().length > 0 || targetAgent.trim().length > 0) {
+            payload.target = {
+                ...(targetName.trim().length > 0 ? { sessionName: targetName.trim() } : {}),
+                ...(targetAgent.trim().length > 0 ? { agent: targetAgent.trim() } : {}),
+            };
         }
 
         const refList = refs
@@ -198,7 +208,9 @@ export function HandoffCreateDialog({
                 setTitle("");
                 setDescription("");
                 setTasks([{ text: "", acceptanceCriteria: "" }]);
+                setName("");
                 setTargetName("");
+                setTargetAgent("");
                 setRefs("");
             },
         });
@@ -320,6 +332,30 @@ export function HandoffCreateDialog({
                                 </Button>
                             </div>
                             <div className="grid gap-4 sm:grid-cols-2">
+                                <div>
+                                    <Label className={LABEL_CLASS} htmlFor="handoff-create-name">
+                                        Readable name (optional)
+                                    </Label>
+                                    <Input
+                                        id="handoff-create-name"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        className={INPUT_CLASS}
+                                        placeholder="derived from the title"
+                                    />
+                                </div>
+                                <div>
+                                    <Label className={LABEL_CLASS} htmlFor="handoff-create-agent">
+                                        Target harness (optional)
+                                    </Label>
+                                    <Input
+                                        id="handoff-create-agent"
+                                        value={targetAgent}
+                                        onChange={(e) => setTargetAgent(e.target.value)}
+                                        className={INPUT_CLASS}
+                                        placeholder="claude | codex | grok | copilot"
+                                    />
+                                </div>
                                 <div>
                                     <Label className={LABEL_CLASS} htmlFor="handoff-create-target">
                                         Target session name (optional)

--- a/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
+++ b/src/dev-dashboard/ui/src/components/handoff/HandoffTab.tsx
@@ -71,10 +71,14 @@ function HandoffRow({
                         → {row.claimedBy.map((c) => c.sessionName ?? c.sessionId ?? "unnamed").join(", ")}
                     </span>
                 ) : null}
-                {row.target !== undefined ? (
+                {row.name !== undefined ? <span>{row.name}</span> : null}
+                {row.target?.sessionName !== undefined || row.target?.sessionId !== undefined ? (
                     <span className="rounded border border-[var(--dd-border)] px-1 py-px">
                         @{row.target.sessionName ?? row.target.sessionId}
                     </span>
+                ) : null}
+                {row.target?.agent !== undefined ? (
+                    <span className="rounded border border-[var(--dd-border)] px-1 py-px">{row.target.agent}</span>
                 ) : null}
                 <span>{row.ageHours < 24 ? `${row.ageHours}h` : `${Math.round(row.ageHours / 24)}d`}</span>
             </div>

--- a/src/dev-dashboard/ui/src/components/handoff/useHandoffApi.ts
+++ b/src/dev-dashboard/ui/src/components/handoff/useHandoffApi.ts
@@ -82,6 +82,7 @@ export function useHandoffCreate() {
     return useMutation({
         mutationFn: (input: {
             title: string;
+            name?: string;
             description?: string;
             tasks: HandoffTaskInput[];
             target?: HandoffTarget;

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -10,12 +10,23 @@ import { appendHandoffEvents } from "./log-store";
 import { isEventsOnlyInclude, type ProjectedHandoff, parseIncludeSections, projectHandoff } from "./project";
 import {
     catchUpHandoffs,
+    findHandoffsByName,
     getEventOutcome,
     getHandoffById,
     listHandoffEvents,
     listHandoffRows,
     openHandoffModel,
 } from "./read-model";
+import {
+    agentFilterMatches,
+    HANDOFF_AGENTS_LIST,
+    handoffNameFor,
+    isKnownAgent,
+    normalizeHandoffName,
+    normalizeTargetInput,
+    recipientCheck,
+    sessionFilterMatches,
+} from "./targeting";
 import type {
     Handoff,
     HandoffActionInput,
@@ -176,6 +187,7 @@ function stateInfo(h: Handoff, by: HandoffEventBy): string[] {
 function pasteAgentText(id: string): string {
     return (
         `You have been handed a task list. Call the genesis-tools MCP tool handoff_get with { id: "${id}" } to read it, ` +
+        "then check its `warnings` — if it says the handoff is addressed to another session or harness, stop and ask your user before working it. " +
         `then claim it by calling handoff_get again with { id: "${id}", claim: true } before working. ` +
         'Check each finished task off with handoff_action { id, actions: [{ action: "check_task", taskId, proof: { answer, commitIds } }] }. ' +
         'To refuse a task you can\'t do, send { action: "deny_task", taskId, reason }. ' +
@@ -185,12 +197,69 @@ function pasteAgentText(id: string): string {
     );
 }
 
+const REF_REQUIRED =
+    'Pass id or name — e.g. handoff_get { id: "h_x1y2z3ab" } or handoff_get { name: "fix-active-filter" }.';
+
+/**
+ * Resolve a handoff from an id, a readable name, or an `id` field that holds
+ * either. Deterministic on purpose: an id always wins, a unique name resolves,
+ * and an ambiguous name is refused WITH its candidates. Picking the newest of
+ * several same-named handoffs would silently work the wrong one.
+ */
+function resolveHandoffRef(db: Database, input: { id?: string; name?: string }): Handoff {
+    const rawId = typeof input.id === "string" ? input.id.trim() : "";
+    const rawName = typeof input.name === "string" ? input.name.trim() : "";
+
+    if (rawId.length === 0 && rawName.length === 0) {
+        throw new Error(REF_REQUIRED);
+    }
+
+    const byId = rawId.length > 0 ? getHandoffById(db, normalizeHandoffId(rawId)) : null;
+
+    if (byId !== null) {
+        const wanted = normalizeHandoffName(rawName);
+
+        if (wanted !== undefined && byId.name !== wanted) {
+            throw new Error(
+                `The id and the name point at different handoffs: ${byId.id} is called "${byId.name ?? "(unnamed)"}", not "${wanted}". Pass one of them, not both.`
+            );
+        }
+
+        return byId;
+    }
+
+    // The `id` field also accepts a name, so a paste of either resolves.
+    const lookup = normalizeHandoffName(rawName.length > 0 ? rawName : rawId);
+    const matches = lookup !== undefined ? findHandoffsByName(db, lookup) : [];
+
+    if (matches.length === 1) {
+        return matches[0];
+    }
+
+    if (matches.length > 1) {
+        const candidates = matches.map((h) => `${h.id} (${h.status}, updated ${h.updatedTs}) "${h.title}"`).join("; ");
+        throw new Error(
+            `Name "${lookup}" is ambiguous — ${matches.length} handoffs carry it: ${candidates}. Re-call with the id of the one you mean.`
+        );
+    }
+
+    if (rawId.length > 0) {
+        throw new Error(
+            `No handoff ${normalizeHandoffId(rawId)} — re-check the paste block or call handoff_list to find it.`
+        );
+    }
+
+    throw new Error(`No handoff named "${lookup ?? rawName}" — call handoff_list to see what exists.`);
+}
+
 // ---------------------------------------------------------------------------
 // handoff_post
 // ---------------------------------------------------------------------------
 
 export interface PostHandoffInput {
     title: string;
+    /** Readable slug this handoff can also be fetched by. Defaults to a slug of the title. */
+    name?: string;
     description?: string;
     tasks: HandoffTaskInput[];
     target?: HandoffTarget;
@@ -200,7 +269,7 @@ export interface PostHandoffInput {
 export interface PostHandoffResponse {
     handoff: PublicHandoff;
     editId: string;
-    paste: { _agent: string; id: string; title: string; tasks: string };
+    paste: { _agent: string; id: string; title: string; tasks: string; name?: string };
     info: string[];
 }
 
@@ -229,16 +298,20 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
         tasks,
         by,
     };
+    const name = handoffNameFor({ name: input.name, title });
+
+    if (name !== undefined) {
+        event.name = name;
+    }
 
     if (input.description !== undefined && input.description.trim().length > 0) {
         event.description = input.description;
     }
 
-    if (
-        input.target !== undefined &&
-        (input.target.sessionId !== undefined || input.target.sessionName !== undefined)
-    ) {
-        event.target = input.target;
+    const target = normalizeTargetInput(input.target);
+
+    if (target !== undefined) {
+        event.target = target;
     }
 
     if (input.refs !== undefined && input.refs.length > 0) {
@@ -255,7 +328,33 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
             throw new Error(`handoff_post failed to fold ${event.id} — check ~/.genesis-tools/logs for details.`);
         }
 
-        log.info({ id: handoff.id, tasks: handoff.tasks.length, by: by.sessionId }, "handoff posted");
+        log.info(
+            {
+                id: handoff.id,
+                name: handoff.name,
+                tasks: handoff.tasks.length,
+                by: by.sessionId,
+                targetAgent: target?.agent,
+            },
+            "handoff posted"
+        );
+
+        const info = [
+            "Posted. Copy `paste` into the target agent's chat.",
+            "You can edit from this session anytime via handoff_action (no editId needed).",
+        ];
+
+        if (handoff.name !== undefined) {
+            info.push(
+                `Readable name: "${handoff.name}" — receivers can also call handoff_get { name: "${handoff.name}" }.`
+            );
+        }
+
+        if (target?.agent !== undefined && !isKnownAgent(target.agent)) {
+            info.push(
+                `target.agent "${target.agent}" is not a documented harness (${HANDOFF_AGENTS_LIST}) — it is stored as given, but no recipient warning can ever fire for it.`
+            );
+        }
 
         return {
             handoff: publicHandoff(handoff, deps.base),
@@ -265,11 +364,9 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
                 id: handoff.id,
                 title: handoff.title,
                 tasks: `0/${handoff.tasks.length}`,
+                ...(handoff.name !== undefined ? { name: handoff.name } : {}),
             },
-            info: [
-                "Posted. Copy `paste` into the target agent's chat.",
-                "You can edit from this session anytime via handoff_action (no editId needed).",
-            ],
+            info,
         };
     });
 }
@@ -279,7 +376,10 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
 // ---------------------------------------------------------------------------
 
 export interface GetHandoffInput {
-    id: string;
+    /** Handoff id, or a readable name — both resolve here. */
+    id?: string;
+    /** Readable name, when you would rather not overload `id`. */
+    name?: string;
     claim?: boolean;
     unclaim?: boolean;
     /** MCP section scoping. Omit → full PublicHandoff (HTTP). MCP handlers default to ["tasks"]. */
@@ -290,6 +390,8 @@ export type GetHandoffFullResponse = {
     handoff: PublicHandoff;
     editId?: string;
     info: string[];
+    /** Recipient warnings for the CALLING session — absent when there is nothing to say. */
+    warnings?: string[];
 };
 
 export type GetHandoffScopedResponse =
@@ -297,10 +399,12 @@ export type GetHandoffScopedResponse =
           handoff: ProjectedHandoff;
           editId?: string;
           info: string[];
+          warnings?: string[];
       }
     | {
           events: HandoffPublicEvent[];
           info: string[];
+          warnings?: string[];
       };
 
 export type GetHandoffResponse = GetHandoffFullResponse | GetHandoffScopedResponse;
@@ -313,21 +417,18 @@ export function getHandoff(input: Omit<GetHandoffInput, "include">, deps?: Hando
 export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetHandoffResponse {
     if (input.claim === true && input.unclaim === true) {
         throw new Error(
-            `Pass either claim: true or unclaim: true, not both — e.g. handoff_get { id: "${input.id}", claim: true }.`
+            `Pass either claim: true or unclaim: true, not both — e.g. handoff_get { id: "${input.id ?? input.name}", claim: true }.`
         );
     }
 
     const sections = input.include !== undefined ? parseIncludeSections(input.include) : null;
-    const id = normalizeHandoffId(String(input.id ?? ""));
     const by = buildBy(deps);
 
     return withDb(deps, (db) => {
         catchUpHandoffs(db, deps.base);
-        const existing = getHandoffById(db, id);
-
-        if (existing === null) {
-            throw new Error(`No handoff ${id} — re-check the paste block or call handoff_list to find it.`);
-        }
+        const existing = resolveHandoffRef(db, input);
+        const id = existing.id;
+        const recipient = recipientCheck({ target: existing.target, by });
 
         const events: HandoffEvent[] = [];
         const extraInfo: string[] = [];
@@ -335,12 +436,21 @@ export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetH
         let claimUid: string | undefined;
         let unclaimUid: string | undefined;
 
-        const autoClaim =
-            input.unclaim !== true &&
+        const addressedToThisSession =
             existing.target?.sessionId !== undefined &&
             targetMatchesSession(existing.target.sessionId, by.sessionId) &&
             !isClaimedBy(existing, by) &&
             (existing.status === "open" || existing.status === "claimed");
+
+        // A session-id hit under a harness the handoff is NOT addressed to must not
+        // claim silently: the poster named two recipients and only one of them is us.
+        const autoClaim = input.unclaim !== true && addressedToThisSession && recipient.agent !== "mismatch";
+
+        if (input.unclaim !== true && addressedToThisSession && recipient.agent === "mismatch") {
+            extraInfo.push(
+                `NOT auto-claimed: the target sessionId names this session, but the handoff is addressed to harness "${existing.target?.agent}". Claim explicitly only if your user asks you to.`
+            );
+        }
 
         if (autoClaim) {
             autoClaimUid = generateEventUid();
@@ -399,10 +509,11 @@ export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetH
         }
 
         const info = [...extraInfo, ...stateInfo(handoff, by)];
+        const warnings = recipient.warnings.length > 0 ? { warnings: recipient.warnings } : {};
 
         if (sections !== null && isEventsOnlyInclude(sections)) {
             const { events: publicEvents } = listHandoffEvents({ db, handoffId: id });
-            return { events: publicEvents, info };
+            return { events: publicEvents, info, ...warnings };
         }
 
         const full = publicHandoff(handoff, deps.base);
@@ -415,6 +526,7 @@ export function getHandoff(input: GetHandoffInput, deps: HandoffDeps = {}): GetH
         const response = {
             handoff: sections === null ? full : projectHandoff({ handoff: full, sections, events: projectedEvents }),
             info,
+            ...warnings,
         } as GetHandoffFullResponse | Extract<GetHandoffScopedResponse, { handoff: unknown }>;
 
         // editId recovery: ONLY the posting session (or the dashboard owner) ever sees it (§3).
@@ -436,6 +548,10 @@ export interface ListHandoffsInput {
     mine?: boolean;
     open?: boolean;
     project?: string;
+    /** Opt-in: only handoffs whose INTENDED RECIPIENT harness is this one. Never the poster's. */
+    agent?: string;
+    /** Opt-in: only handoffs whose INTENDED RECIPIENT session is this id (or abbreviation) or name. */
+    session?: string;
     /** Only `"tasks"` is honored on list rows; other values no-op with an info line. */
     include?: string[];
 }
@@ -485,6 +601,19 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
             );
         }
 
+        // Opt-in only: with neither flag the listing stays exactly what it was.
+        const agentFilter = input.agent !== undefined && input.agent.trim().length > 0 ? input.agent.trim() : undefined;
+        const sessionFilter =
+            input.session !== undefined && input.session.trim().length > 0 ? input.session.trim() : undefined;
+
+        if (agentFilter !== undefined) {
+            rows = rows.filter((h) => agentFilterMatches(h.target, agentFilter));
+        }
+
+        if (sessionFilter !== undefined) {
+            rows = rows.filter((h) => sessionFilterMatches(h.target, sessionFilter));
+        }
+
         const total = rows.length;
         const page = rows.slice(offset, offset + limit);
         const now = Date.now();
@@ -501,8 +630,17 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
                 ageHours: Math.round(((now - new Date(h.createdTs).getTime()) / 3_600_000) * 10) / 10,
             };
 
+            if (h.name !== undefined) {
+                row.name = h.name;
+            }
+
             if (h.target !== undefined) {
                 row.target = h.target;
+                const recipient = recipientCheck({ target: h.target, by });
+
+                if (recipient.warnings.length > 0) {
+                    row.warnings = recipient.warnings;
+                }
             }
 
             if (h.claimedBy.length > 0) {
@@ -541,6 +679,20 @@ export function listHandoffs(input: ListHandoffsInput = {}, deps: HandoffDeps = 
         });
 
         const info: string[] = [`${total} handoff${total === 1 ? "" : "s"} matched; showing ${page.length}.`];
+
+        if (agentFilter !== undefined) {
+            info.push(
+                isKnownAgent(agentFilter)
+                    ? `Filtered to handoffs addressed to harness "${agentFilter}" — the intended recipient, not the poster.`
+                    : `agent filter "${agentFilter}" is not a documented harness (${HANDOFF_AGENTS_LIST}) — matched as literal text against target.agent.`
+            );
+        }
+
+        if (sessionFilter !== undefined) {
+            info.push(
+                `Filtered to handoffs addressed to session "${sessionFilter}" — matches target.sessionId (exactly or by leading-segment abbreviation) or target.sessionName.`
+            );
+        }
 
         if (proofsClipped) {
             info.push("Task proofs are previews on list — call handoff_get for the full proof.");
@@ -627,7 +779,10 @@ function asStringArray(value: unknown): string[] | undefined {
 }
 
 export interface ExecuteActionsInput {
-    id: string;
+    /** Handoff id, or a readable name — both resolve here. */
+    id?: string;
+    /** Readable name, when you would rather not overload `id`. */
+    name?: string;
     editId?: string;
     actions: HandoffActionInput[];
     /** MCP section scoping. Omit → full PublicHandoff (HTTP). MCP handlers default to ["tasks"]. */
@@ -638,12 +793,15 @@ export type ExecuteActionsFullResponse = {
     handoff: PublicHandoff;
     results: HandoffActionResult[];
     info: string[];
+    /** Recipient warnings for the CALLING session — absent when there is nothing to say. */
+    warnings?: string[];
 };
 
 export type ExecuteActionsScopedResponse = {
     handoff: ProjectedHandoff;
     results: HandoffActionResult[];
     info: string[];
+    warnings?: string[];
 };
 
 export type ExecuteActionsResponse = ExecuteActionsFullResponse | ExecuteActionsScopedResponse;
@@ -665,17 +823,14 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
     }
 
     const sections = input.include !== undefined ? parseIncludeSections(input.include) : null;
-    const id = normalizeHandoffId(String(input.id ?? ""));
     const editId = normalizeEditId(input.editId);
     const by = buildBy(deps);
 
     return withDb(deps, (db) => {
         catchUpHandoffs(db, deps.base);
-        const existing = getHandoffById(db, id);
-
-        if (existing === null) {
-            throw new Error(`No handoff ${id} — re-check the paste block or call handoff_list to find it.`);
-        }
+        const existing = resolveHandoffRef(db, input);
+        const id = existing.id;
+        const recipient = recipientCheck({ target: existing.target, by });
 
         const stamp = (): { ts: string; uid: string; id: string; by: HandoffEventBy; editId?: string } => ({
             ts: nowIso(deps),
@@ -757,6 +912,7 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
             handoff: sections === null ? full : projectHandoff({ handoff: full, sections, events: projectedEvents }),
             results,
             info: stateInfo(handoff, by),
+            ...(recipient.warnings.length > 0 ? { warnings: recipient.warnings } : {}),
         } as ExecuteActionsResponse;
     });
 }
@@ -1083,19 +1239,51 @@ function parseAction(
             const title =
                 typeof payload.title === "string" && payload.title.trim().length > 0 ? payload.title : undefined;
             const description = typeof payload.description === "string" ? payload.description : undefined;
+            // An object that carries nothing usable clears the target, same as null.
             const target =
                 payload.target === null
                     ? null
-                    : payload.target !== null && typeof payload.target === "object"
-                      ? (payload.target as HandoffTarget)
+                    : payload.target !== undefined && typeof payload.target === "object"
+                      ? (normalizeTargetInput(payload.target) ?? null)
                       : undefined;
             const refs = asStringArray(payload.refs);
+            let name: string | null | undefined;
 
-            if (title === undefined && description === undefined && target === undefined && refs === undefined) {
+            if ("name" in payload) {
+                if (payload.name === null || (typeof payload.name === "string" && payload.name.trim().length === 0)) {
+                    name = null;
+                } else if (typeof payload.name !== "string") {
+                    return shapeFail(
+                        index,
+                        verb,
+                        'modify_handoff: name must be a string, or null to clear it — e.g. { action: "modify_handoff", name: "fix-active-filter" }.'
+                    );
+                } else {
+                    const slug = normalizeHandoffName(payload.name);
+
+                    if (slug === undefined) {
+                        return shapeFail(
+                            index,
+                            verb,
+                            `modify_handoff: name "${payload.name}" has no letters or digits to build a name from — try something like "fix-active-filter".`
+                        );
+                    }
+
+                    name = slug;
+                }
+            }
+
+            if (
+                title === undefined &&
+                name === undefined &&
+                description === undefined &&
+                target === undefined &&
+                refs === undefined
+            ) {
                 return shapeFail(
                     index,
                     verb,
-                    'modify_handoff needs at least one of title/description/target/refs — e.g. { action: "modify_handoff", title: "…" }. Tasks are edited via modify_task/add_tasks.'
+                    'modify_handoff needs at least one of title/name/description/target/refs — e.g. { action: "modify_handoff", title: "…" }. Tasks are edited via modify_task/add_tasks.'
                 );
             }
 
@@ -1106,6 +1294,7 @@ function parseAction(
                     ev: "modify_handoff",
                     ...stamp(),
                     ...(title !== undefined ? { title } : {}),
+                    ...(name !== undefined ? { name } : {}),
                     ...(description !== undefined ? { description } : {}),
                     ...(target !== undefined ? { target } : {}),
                     ...(refs !== undefined ? { refs } : {}),

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -354,8 +354,12 @@ export function postHandoff(input: PostHandoffInput, deps: HandoffDeps = {}): Po
         ];
 
         if (handoff.name !== undefined) {
+            // A title-derived name can already be taken; promising a lookup that will be refused as ambiguous helps nobody.
+            const clashes = findHandoffsByName(db, handoff.name).filter((h) => h.id !== handoff.id);
             info.push(
-                `Readable name: "${handoff.name}" — receivers can also call handoff_get { name: "${handoff.name}" }.`
+                clashes.length === 0
+                    ? `Readable name: "${handoff.name}" — receivers can also call handoff_get { name: "${handoff.name}" }.`
+                    : `Readable name "${handoff.name}" is already carried by ${clashes.map((h) => h.id).join(", ")} — handoff_get { name } will be refused as ambiguous. Hand out the id, or rename via handoff_action modify_handoff { name }.`
             );
         }
 

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -228,6 +228,14 @@ function resolveHandoffRef(db: Database, input: { id?: string; name?: string }):
         return byId;
     }
 
+    // An `h_`-prefixed value is an id claim (no slug can carry an underscore). Beside a
+    // name it must resolve as an id: a stale id never falls back to whatever the name finds.
+    if (rawId.startsWith("h_") && rawName.length > 0) {
+        throw new Error(
+            `No handoff ${rawId} — the id does not resolve, so the name "${rawName}" is not used. Re-call with just the one you mean.`
+        );
+    }
+
     // The `id` field also accepts a name, so a paste of either resolves.
     const lookup = normalizeHandoffName(rawName.length > 0 ? rawName : rawId);
     const matches = lookup !== undefined ? findHandoffsByName(db, lookup) : [];

--- a/src/handoff/executor.ts
+++ b/src/handoff/executor.ts
@@ -233,6 +233,15 @@ function resolveHandoffRef(db: Database, input: { id?: string; name?: string }):
     const matches = lookup !== undefined ? findHandoffsByName(db, lookup) : [];
 
     if (matches.length === 1) {
+        // Both fields were names: the one not used for the lookup must name the same handoff.
+        const other = rawName.length > 0 && rawId.length > 0 ? normalizeHandoffName(rawId) : undefined;
+
+        if (other !== undefined && other !== lookup) {
+            throw new Error(
+                `The id and the name point at different handoffs: "${rawId}" is not "${lookup}". Pass one of them, not both.`
+            );
+        }
+
         return matches[0];
     }
 
@@ -830,7 +839,6 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
         catchUpHandoffs(db, deps.base);
         const existing = resolveHandoffRef(db, input);
         const id = existing.id;
-        const recipient = recipientCheck({ target: existing.target, by });
 
         const stamp = (): { ts: string; uid: string; id: string; by: HandoffEventBy; editId?: string } => ({
             ts: nowIso(deps),
@@ -901,6 +909,9 @@ export function executeHandoffActions(input: ExecuteActionsInput, deps: HandoffD
             "handoff actions executed"
         );
 
+        // Checked against the FOLDED target: a modify_handoff that retargets in this
+        // batch must produce (or clear) the warning in this same response.
+        const recipient = recipientCheck({ target: handoff.target, by });
         const full = publicHandoff(handoff, deps.base);
         let projectedEvents: HandoffPublicEvent[] | undefined;
 

--- a/src/handoff/fold.ts
+++ b/src/handoff/fold.ts
@@ -252,6 +252,10 @@ export function applyHandoffEvent(
             updatedTs: event.ts,
         };
 
+        if (event.name !== undefined) {
+            next.name = event.name;
+        }
+
         if (event.description !== undefined) {
             next.description = event.description;
         }
@@ -625,6 +629,16 @@ export function applyHandoffEvent(
 
             if (event.title !== undefined && event.title.trim().length > 0) {
                 next.title = event.title;
+            }
+
+            // A title edit never renames: agents were handed the old name and
+            // must keep resolving it until the poster says otherwise.
+            if (event.name !== undefined) {
+                if (event.name === null) {
+                    delete next.name;
+                } else {
+                    next.name = event.name;
+                }
             }
 
             if (event.description !== undefined) {

--- a/src/handoff/handoff-name.test.ts
+++ b/src/handoff/handoff-name.test.ts
@@ -124,6 +124,22 @@ describe("resolving by name", () => {
         expect(getHandoff({ id: "beta-work", name: "Beta Work" }, env.depsFor(WORKER)).handoff.id).toBe(b.id);
     });
 
+    test("a stale h_ id beside a name never falls back to the name, even one spelled like the id", () => {
+        const env = freshEnv();
+        // A handoff whose readable name is the slug of a stale id: the one case where
+        // the two-name comparison alone would agree.
+        postHandoff({ title: "h_deadbeef", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+
+        expect(() => getHandoff({ id: "h_deadbeef", name: "h-deadbeef" }, env.depsFor(WORKER))).toThrow(
+            /No handoff h_deadbeef — the id does not resolve/
+        );
+        expect(() => getHandoff({ id: "h_deadbeef", name: "beta-work" }, env.depsFor(WORKER))).toThrow(
+            /No handoff h_deadbeef/
+        );
+        // Alone, the same value still resolves as a name, as documented.
+        expect(getHandoff({ name: "h-deadbeef" }, env.depsFor(WORKER)).handoff.name).toBe("h-deadbeef");
+    });
+
     test("an unknown name and an unknown id fail differently, and both say where to look", () => {
         const env = freshEnv();
 

--- a/src/handoff/handoff-name.test.ts
+++ b/src/handoff/handoff-name.test.ts
@@ -72,7 +72,13 @@ describe("resolving by name", () => {
     test("a duplicate name is refused with its candidates instead of silently picking one", () => {
         const env = freshEnv();
         const first = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
-        const second = postHandoff({ title: "Ship the fix", tasks: [{ text: "two" }] }, env.depsFor(POSTER)).handoff;
+        const secondPost = postHandoff({ title: "Ship the fix", tasks: [{ text: "two" }] }, env.depsFor(POSTER));
+        const second = secondPost.handoff;
+
+        // The poster is told at post time, instead of the receiver finding out at lookup time.
+        const nameInfo = secondPost.info.find((line) => line.includes("Readable name")) ?? "";
+        expect(nameInfo).toContain(`already carried by ${first.id}`);
+        expect(nameInfo).toContain("refused as ambiguous");
 
         expect(() => getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER))).toThrow(/ambiguous/);
 

--- a/src/handoff/handoff-name.test.ts
+++ b/src/handoff/handoff-name.test.ts
@@ -103,6 +103,21 @@ describe("resolving by name", () => {
         expect(getHandoff({ id: a.id, name: "alpha-work" }, env.depsFor(WORKER)).handoff.id).toBe(a.id);
     });
 
+    test("two names that disagree are refused too, even when one arrives in the id field", () => {
+        const env = freshEnv();
+        postHandoff({ title: "Alpha work", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+        const b = postHandoff({ title: "Beta work", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(() => getHandoff({ id: "alpha-work", name: "beta-work" }, env.depsFor(WORKER))).toThrow(
+            /point at different handoffs/
+        );
+        expect(() =>
+            executeHandoffActions({ id: "alpha-work", name: "beta-work", actions: ["claim"] }, env.depsFor(WORKER))
+        ).toThrow(/point at different handoffs/);
+        // The same name twice is one reference, not a conflict.
+        expect(getHandoff({ id: "beta-work", name: "Beta Work" }, env.depsFor(WORKER)).handoff.id).toBe(b.id);
+    });
+
     test("an unknown name and an unknown id fail differently, and both say where to look", () => {
         const env = freshEnv();
 
@@ -208,5 +223,27 @@ describe("names survive edits and reach handoff_action", () => {
         );
         expect(res.results[0].ok).toBe(true);
         expect(res.handoff.target).toEqual({ agent: "grok" });
+    });
+
+    test("the action response warns from the target AFTER the batch, not before it", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+        const codexWorker = { ...byFor("sess-codex", "codex-worker"), agent: "codex" };
+
+        // Untargeted → retargeted away from the caller: the warning appears in this response.
+        const away = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", target: { agent: "grok" } }] },
+            env.depsFor(POSTER)
+        );
+        expect(away.results[0].ok).toBe(true);
+        expect((away.warnings ?? []).join(" ")).toContain('targets harness "grok"');
+
+        // Mismatched → retargeted to the caller: the stale warning is gone from this response.
+        const back = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", target: { agent: "codex" } }] },
+            env.depsFor({ ...codexWorker, sessionId: POSTER.sessionId })
+        );
+        expect(back.results[0].ok).toBe(true);
+        expect(back.warnings).toBeUndefined();
     });
 });

--- a/src/handoff/handoff-name.test.ts
+++ b/src/handoff/handoff-name.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "bun:test";
+import { executeHandoffActions, getHandoff, listHandoffs, postHandoff } from "./executor";
+import { generateEditId, generateEventUid, generateHandoffId } from "./ids";
+import { appendHandoffEvents } from "./log-store";
+import { byFor, freshEnv } from "./test-utils";
+import type { HandoffEvent } from "./types";
+
+const POSTER = byFor("sess-poster", "poster");
+const WORKER = byFor("sess-worker", "worker");
+
+describe("naming a handoff", () => {
+    test("a name is derived from the title when none is given", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            { title: "Fix e2e Active-filter semantics", tasks: [{ text: "one" }] },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.name).toBe("fix-e2e-active-filter-semantics");
+        expect(res.paste.name).toBe("fix-e2e-active-filter-semantics");
+        expect(res.info.join(" ")).toContain("Readable name");
+    });
+
+    test("a supplied name wins and is slugified", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            { title: "Fix e2e Active-filter semantics", name: "Active Filter", tasks: [{ text: "one" }] },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.name).toBe("active-filter");
+    });
+
+    test("the name is distinct from the target session name", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            {
+                title: "Ship the fix",
+                name: "ship-the-fix",
+                tasks: [{ text: "one" }],
+                target: { sessionName: "gt-worker" },
+            },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.name).toBe("ship-the-fix");
+        expect(res.handoff.target?.sessionName).toBe("gt-worker");
+    });
+});
+
+describe("resolving by name", () => {
+    test("a unique name resolves, through the name field and through id", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+        // Agents paste whatever they were handed into `id`; a name has to work there too.
+        expect(getHandoff({ id: "ship-the-fix" }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+        // The un-slugged form a human would type resolves as well.
+        expect(getHandoff({ name: "Ship The Fix" }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+    });
+
+    test("the id path is unchanged and still wins", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(getHandoff({ id: posted.id }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+        // The `h_` prefix stays optional.
+        expect(getHandoff({ id: posted.id.slice(2) }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+    });
+
+    test("a duplicate name is refused with its candidates instead of silently picking one", () => {
+        const env = freshEnv();
+        const first = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+        const second = postHandoff({ title: "Ship the fix", tasks: [{ text: "two" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(() => getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER))).toThrow(/ambiguous/);
+
+        try {
+            getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER));
+            throw new Error("expected an ambiguity error");
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            expect(message).toContain(first.id);
+            expect(message).toContain(second.id);
+            expect(message).toContain("Re-call with the id");
+        }
+
+        // Disambiguation by id keeps working for both.
+        expect(getHandoff({ id: first.id }, env.depsFor(WORKER)).handoff.tasks[0].text).toBe("one");
+        expect(getHandoff({ id: second.id }, env.depsFor(WORKER)).handoff.tasks[0].text).toBe("two");
+    });
+
+    test("an id and a name that disagree is an error, never a silent pick", () => {
+        const env = freshEnv();
+        const a = postHandoff({ title: "Alpha work", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+        postHandoff({ title: "Beta work", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+
+        expect(() => getHandoff({ id: a.id, name: "beta-work" }, env.depsFor(WORKER))).toThrow(
+            /point at different handoffs/
+        );
+        // Agreeing values resolve normally.
+        expect(getHandoff({ id: a.id, name: "alpha-work" }, env.depsFor(WORKER)).handoff.id).toBe(a.id);
+    });
+
+    test("an unknown name and an unknown id fail differently, and both say where to look", () => {
+        const env = freshEnv();
+
+        expect(() => getHandoff({ name: "nothing-here" }, env.depsFor(WORKER))).toThrow(
+            /No handoff named "nothing-here"/
+        );
+        expect(() => getHandoff({ id: "h_zzzzzzzz" }, env.depsFor(WORKER))).toThrow(/No handoff h_zzzzzzzz/);
+        expect(() => getHandoff({}, env.depsFor(WORKER))).toThrow(/Pass id or name/);
+    });
+
+    test("recipient warnings apply after a name lookup exactly as after an id lookup", () => {
+        const env = freshEnv();
+        postHandoff({ title: "Codex only", tasks: [{ text: "one" }], target: { agent: "codex" } }, env.depsFor(POSTER));
+
+        const byName = getHandoff({ name: "codex-only" }, env.depsFor(WORKER));
+        expect((byName.warnings ?? []).join(" ")).toContain("another harness");
+    });
+
+    test("a legacy handoff has no name, keeps working by id, and is not found by name", () => {
+        const env = freshEnv();
+        const id = generateHandoffId();
+        const legacy: HandoffEvent = {
+            ev: "post",
+            ts: new Date().toISOString(),
+            uid: generateEventUid(),
+            id,
+            editId: generateEditId(),
+            title: "Legacy handoff",
+            tasks: [{ text: "one" }],
+            by: POSTER,
+        };
+        appendHandoffEvents([legacy], env.base);
+
+        expect(getHandoff({ id }, env.depsFor(WORKER)).handoff.name).toBeUndefined();
+        expect(listHandoffs({}, env.depsFor(WORKER)).handoffs[0].name).toBeUndefined();
+        expect(() => getHandoff({ name: "legacy-handoff" }, env.depsFor(WORKER))).toThrow(/No handoff named/);
+    });
+});
+
+describe("names survive edits and reach handoff_action", () => {
+    test("handoff_action resolves by name too", () => {
+        const env = freshEnv();
+        postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+
+        const res = executeHandoffActions({ id: "ship-the-fix", actions: [{ action: "claim" }] }, env.depsFor(WORKER));
+        expect(res.results[0].ok).toBe(true);
+        expect(res.handoff.claimedBy).toHaveLength(1);
+    });
+
+    test("modify_handoff renames, and the new name is what resolves", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        const res = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", name: "Active Filter" }] },
+            env.depsFor(POSTER)
+        );
+        expect(res.results[0].ok).toBe(true);
+        expect(res.handoff.name).toBe("active-filter");
+        expect(getHandoff({ name: "active-filter" }, env.depsFor(WORKER)).handoff.id).toBe(posted.id);
+        expect(() => getHandoff({ name: "ship-the-fix" }, env.depsFor(WORKER))).toThrow(/No handoff named/);
+    });
+
+    test("an empty name clears it; a title edit never renames", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        const retitled = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", title: "Something else entirely" }] },
+            env.depsFor(POSTER)
+        );
+        expect(retitled.handoff.title).toBe("Something else entirely");
+        expect(retitled.handoff.name).toBe("ship-the-fix");
+
+        const cleared = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", name: "" }] },
+            env.depsFor(POSTER)
+        );
+        expect(cleared.results[0].ok).toBe(true);
+        expect(cleared.handoff.name).toBeUndefined();
+    });
+
+    test("a name with nothing to slug is refused rather than clearing the name", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        const res = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", name: "!!!" }] },
+            env.depsFor(POSTER)
+        );
+        expect(res.results[0].ok).toBe(false);
+        expect(res.results[0].error).toContain("no letters or digits");
+        expect(res.handoff.name).toBe("ship-the-fix");
+    });
+
+    test("modify_handoff can retarget the recipient harness", () => {
+        const env = freshEnv();
+        const posted = postHandoff({ title: "Ship the fix", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        const res = executeHandoffActions(
+            { id: posted.id, actions: [{ action: "modify_handoff", target: { agent: "Grok" } }] },
+            env.depsFor(POSTER)
+        );
+        expect(res.results[0].ok).toBe(true);
+        expect(res.handoff.target).toEqual({ agent: "grok" });
+    });
+});

--- a/src/handoff/project.ts
+++ b/src/handoff/project.ts
@@ -49,6 +49,7 @@ export function parseIncludeSections(raw: unknown): HandoffIncludeSection[] {
 export type HandoffCoreProjection = {
     id: string;
     title: string;
+    name?: string;
     description?: string;
     status: Handoff["status"];
     project: string | null;
@@ -96,6 +97,10 @@ export function projectHandoff({
         createdTs: handoff.createdTs,
         updatedTs: handoff.updatedTs,
     };
+
+    if (handoff.name !== undefined) {
+        core.name = handoff.name;
+    }
 
     if (handoff.description !== undefined) {
         core.description = handoff.description;

--- a/src/handoff/read-model.ts
+++ b/src/handoff/read-model.ts
@@ -43,6 +43,7 @@ function createTables(db: Database): { eventsTableCreated: boolean } {
     db.exec(`CREATE TABLE IF NOT EXISTS handoffs (
         id                     TEXT PRIMARY KEY,
         title                  TEXT NOT NULL,
+        name                   TEXT,
         description            TEXT,
         status                 TEXT NOT NULL DEFAULT 'open',
         tasks                  TEXT NOT NULL,
@@ -92,6 +93,9 @@ function createTables(db: Database): { eventsTableCreated: boolean } {
     );
     // Who finished it — needed for the reopen-by-finisher credential (§2 reopen_handoff).
     ensureColumn(db, "handoffs", "finished_by", "ALTER TABLE handoffs ADD COLUMN finished_by TEXT");
+    // Readable name (nullable: every handoff posted before names existed has none).
+    ensureColumn(db, "handoffs", "name", "ALTER TABLE handoffs ADD COLUMN name TEXT");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_handoffs_name ON handoffs(name);");
 
     return { eventsTableCreated: !hadEventsTable && tableExists(db, "handoff_events") };
 }
@@ -121,6 +125,7 @@ export function openHandoffModel(dbPath?: string): Database {
 interface HandoffRow {
     id: string;
     title: string;
+    name: string | null;
     description: string | null;
     status: string;
     tasks: string;
@@ -185,6 +190,10 @@ function rowToHandoff(row: HandoffRow): Handoff {
         updatedTs: row.updated_ts,
     };
 
+    if (row.name !== null) {
+        handoff.name = row.name;
+    }
+
     if (row.description !== null) {
         handoff.description = row.description;
     }
@@ -209,15 +218,16 @@ function rowToHandoff(row: HandoffRow): Handoff {
 }
 
 const UPSERT_SQL = `INSERT OR REPLACE INTO handoffs
-    (id, title, description, status, tasks, target, refs, posted_by_context, posted_by_session_id,
+    (id, title, name, description, status, tasks, target, refs, posted_by_context, posted_by_session_id,
      posted_by_session_name, project, claimed_by, comments, edit_id, created_ts, updated_ts,
      finished_ts, attachments, finished_by)
-    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
+    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`;
 
 function upsertHandoff(db: Database, h: Handoff): void {
     db.prepare(UPSERT_SQL).run(
         h.id,
         h.title,
+        h.name ?? null,
         h.description ?? null,
         h.status,
         SafeJSON.stringify(h.tasks, { strict: true }),
@@ -241,6 +251,16 @@ function upsertHandoff(db: Database, h: Handoff): void {
 export function getHandoffById(db: Database, id: string): Handoff | null {
     const row = db.query("SELECT * FROM handoffs WHERE id = ?").get(id) as HandoffRow | null;
     return row ? rowToHandoff(row) : null;
+}
+
+/**
+ * Every handoff carrying this exact name, newest-updated first. Duplicates are
+ * legal (two posters can pick the same slug), so this returns a list and the
+ * caller decides — silently taking the newest would work the wrong handoff.
+ */
+export function findHandoffsByName(db: Database, name: string): Handoff[] {
+    const rows = db.query("SELECT * FROM handoffs WHERE name = ? ORDER BY updated_ts DESC").all(name) as HandoffRow[];
+    return rows.map(rowToHandoff);
 }
 
 export function listHandoffRows(db: Database, opts: { statuses?: string[]; project?: string } = {}): Handoff[] {

--- a/src/handoff/recipient.test.ts
+++ b/src/handoff/recipient.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "bun:test";
+import { executeHandoffActions, getHandoff, listHandoffs, postHandoff } from "./executor";
+import { generateEditId, generateEventUid, generateHandoffId } from "./ids";
+import { appendHandoffEvents } from "./log-store";
+import { byFor, freshEnv } from "./test-utils";
+import type { HandoffEvent, HandoffEventBy } from "./types";
+
+function on(agent: string, sessionId: string | null, sessionName: string | null = null): HandoffEventBy {
+    return { ...byFor(sessionId, sessionName), agent };
+}
+
+const POSTER = on("claude-code", "sess-poster", "poster");
+const CODEX_WORKER = on("codex", "sess-codex", "codex-worker");
+const CLAUDE_WORKER = on("claude-code", "sess-claude", "claude-worker");
+const GROK_WORKER = on("grok", "sess-grok", "grok-worker");
+const FACELESS = on("unknown", null, "headless");
+
+describe("recipient agent on handoff_post", () => {
+    test("the documented harnesses are accepted and stored on the target, not on postedBy", () => {
+        const env = freshEnv();
+
+        for (const agent of ["claude", "codex", "grok"]) {
+            const res = postHandoff(
+                { title: `work for ${agent}`, tasks: [{ text: "do it" }], target: { agent } },
+                env.depsFor(POSTER)
+            );
+
+            expect(res.handoff.target?.agent).toBe(agent);
+            // The author's harness is a separate fact and must survive untouched.
+            expect(res.handoff.postedBy.agent).toBe("claude-code");
+            expect(res.handoff.postedByContext.agent).toBe("claude-code");
+        }
+    });
+
+    test("a session target still works, alone and beside an agent", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            {
+                title: "addressed twice",
+                tasks: [{ text: "do it" }],
+                target: { sessionId: "sess-codex", sessionName: "codex-worker", agent: "Codex" },
+            },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.target).toEqual({
+            sessionId: "sess-codex",
+            sessionName: "codex-worker",
+            agent: "codex",
+        });
+    });
+
+    test("an undocumented harness is stored as given, with an info line saying warnings cannot fire", () => {
+        const env = freshEnv();
+        const res = postHandoff(
+            { title: "for a future host", tasks: [{ text: "do it" }], target: { agent: "Borg" } },
+            env.depsFor(POSTER)
+        );
+
+        expect(res.handoff.target?.agent).toBe("borg");
+        expect(res.info.join(" ")).toContain("not a documented harness");
+    });
+});
+
+describe("recipient warnings on handoff_get", () => {
+    function postedForCodex(env: ReturnType<typeof freshEnv>) {
+        return postHandoff(
+            { title: "codex work", tasks: [{ text: "one" }], target: { agent: "codex" } },
+            env.depsFor(POSTER)
+        ).handoff;
+    }
+
+    test("the intended harness sees no warning", () => {
+        const env = freshEnv();
+        const handoff = postedForCodex(env);
+        const res = getHandoff({ id: handoff.id }, env.depsFor(CODEX_WORKER));
+
+        expect(res.warnings).toBeUndefined();
+    });
+
+    test("another harness is warned off, and the warning names the override", () => {
+        const env = freshEnv();
+        const handoff = postedForCodex(env);
+        const res = getHandoff({ id: handoff.id }, env.depsFor(CLAUDE_WORKER));
+
+        const text = (res.warnings ?? []).join(" ");
+        expect(text).toContain("This task is for another harness");
+        expect(text).toContain("unless your user explicitly asks");
+    });
+
+    test("a warning never blocks — user-authorized cross-target work still claims and checks", () => {
+        const env = freshEnv();
+        const handoff = postedForCodex(env);
+        const claimed = getHandoff({ id: handoff.id, claim: true }, env.depsFor(GROK_WORKER));
+
+        expect(claimed.handoff.claimedBy).toHaveLength(1);
+        expect(claimed.warnings?.length).toBeGreaterThan(0);
+
+        const acted = executeHandoffActions(
+            { id: handoff.id, actions: [{ action: "check_task", taskId: "t1", proof: { answer: "did it anyway" } }] },
+            env.depsFor(GROK_WORKER)
+        );
+        expect(acted.results[0].ok).toBe(true);
+        // The action response keeps warning, so the mismatch is not lost after the claim.
+        expect((acted.warnings ?? []).join(" ")).toContain("another harness");
+    });
+
+    test("a caller with no detectable identity is told the check was unverifiable", () => {
+        const env = freshEnv();
+        const handoff = postHandoff(
+            { title: "codex work", tasks: [{ text: "one" }], target: { sessionId: "sess-codex", agent: "codex" } },
+            env.depsFor(POSTER)
+        ).handoff;
+        const res = getHandoff({ id: handoff.id }, env.depsFor(FACELESS));
+
+        const text = (res.warnings ?? []).join(" ");
+        expect(text).toContain("unverifiable");
+        expect(text).not.toContain("Recipient mismatch");
+    });
+
+    test("a legacy untargeted handoff warns nobody", () => {
+        const env = freshEnv();
+        const handoff = postHandoff({ title: "open to anyone", tasks: [{ text: "one" }] }, env.depsFor(POSTER)).handoff;
+
+        expect(getHandoff({ id: handoff.id }, env.depsFor(CODEX_WORKER)).warnings).toBeUndefined();
+        expect(getHandoff({ id: handoff.id }, env.depsFor(FACELESS)).warnings).toBeUndefined();
+    });
+
+    test("a legacy record stored before targeting existed still reads and warns about nothing", () => {
+        const env = freshEnv();
+        const id = generateHandoffId();
+        // Written the way the log looked before target.agent and name existed.
+        const legacy: HandoffEvent = {
+            ev: "post",
+            ts: new Date().toISOString(),
+            uid: generateEventUid(),
+            id,
+            editId: generateEditId(),
+            title: "legacy handoff",
+            tasks: [{ text: "one" }],
+            by: POSTER,
+        };
+        appendHandoffEvents([legacy], env.base);
+
+        const res = getHandoff({ id }, env.depsFor(CODEX_WORKER));
+        expect(res.handoff.title).toBe("legacy handoff");
+        expect(res.handoff.name).toBeUndefined();
+        expect(res.handoff.target).toBeUndefined();
+        expect(res.warnings).toBeUndefined();
+    });
+});
+
+describe("auto-claim under a mismatched recipient", () => {
+    test("a session target still auto-claims when the harness agrees", () => {
+        const env = freshEnv();
+        const handoff = postHandoff(
+            { title: "for codex", tasks: [{ text: "one" }], target: { sessionId: "sess-codex", agent: "codex" } },
+            env.depsFor(POSTER)
+        ).handoff;
+
+        const res = getHandoff({ id: handoff.id }, env.depsFor(CODEX_WORKER));
+        expect(res.info.join(" ")).toContain("Auto-claimed");
+        expect(res.handoff.claimedBy).toHaveLength(1);
+    });
+
+    test("a session-id hit under the wrong harness never claims silently", () => {
+        const env = freshEnv();
+        const handoff = postHandoff(
+            {
+                title: "contradictory address",
+                tasks: [{ text: "one" }],
+                // The poster named a claude session but addressed the codex harness.
+                target: { sessionId: "sess-claude", agent: "codex" },
+            },
+            env.depsFor(POSTER)
+        ).handoff;
+
+        const res = getHandoff({ id: handoff.id }, env.depsFor(CLAUDE_WORKER));
+        expect(res.handoff.claimedBy).toEqual([]);
+        expect(res.handoff.status).toBe("open");
+        expect(res.info.join(" ")).toContain("NOT auto-claimed");
+        expect((res.warnings ?? []).join(" ")).toContain("another harness");
+    });
+});
+
+describe("handoff_list recipient filters", () => {
+    function seeded() {
+        const env = freshEnv();
+        postHandoff(
+            { title: "for codex", tasks: [{ text: "one" }], target: { agent: "codex", sessionId: "sess-codex" } },
+            env.depsFor(POSTER)
+        );
+        postHandoff(
+            { title: "for claude", tasks: [{ text: "one" }], target: { agent: "claude", sessionId: "sess-claude" } },
+            env.depsFor(POSTER)
+        );
+        postHandoff(
+            { title: "for a named session", tasks: [{ text: "one" }], target: { sessionName: "gt-worker" } },
+            env.depsFor(POSTER)
+        );
+        postHandoff({ title: "for anybody", tasks: [{ text: "one" }] }, env.depsFor(POSTER));
+        return env;
+    }
+
+    test("the default listing is unfiltered", () => {
+        const env = seeded();
+        const res = listHandoffs({}, env.depsFor(CODEX_WORKER));
+
+        expect(res.handoffs).toHaveLength(4);
+        expect(res.info.join(" ")).not.toContain("Filtered to handoffs");
+    });
+
+    test("the agent filter keeps only the intended harness", () => {
+        const env = seeded();
+        const res = listHandoffs({ agent: "codex" }, env.depsFor(POSTER));
+
+        expect(res.handoffs.map((h) => h.title)).toEqual(["for codex"]);
+        expect(res.info.join(" ")).toContain("intended recipient, not the poster");
+    });
+
+    test("the session filter matches an id or a session name", () => {
+        const env = seeded();
+
+        expect(listHandoffs({ session: "sess-claude" }, env.depsFor(POSTER)).handoffs.map((h) => h.title)).toEqual([
+            "for claude",
+        ]);
+        expect(listHandoffs({ session: "gt-worker" }, env.depsFor(POSTER)).handoffs.map((h) => h.title)).toEqual([
+            "for a named session",
+        ]);
+    });
+
+    test("both filters together narrow to their intersection", () => {
+        const env = seeded();
+
+        expect(
+            listHandoffs({ agent: "codex", session: "sess-codex" }, env.depsFor(POSTER)).handoffs.map((h) => h.title)
+        ).toEqual(["for codex"]);
+        expect(listHandoffs({ agent: "codex", session: "sess-claude" }, env.depsFor(POSTER)).handoffs).toHaveLength(0);
+    });
+
+    test("an undocumented filter value says so instead of pretending to match a harness", () => {
+        const env = seeded();
+        const res = listHandoffs({ agent: "borg" }, env.depsFor(POSTER));
+
+        expect(res.handoffs).toHaveLength(0);
+        expect(res.info.join(" ")).toContain("not a documented harness");
+    });
+
+    test("rows carry the name, the recipient target and per-row warnings", () => {
+        const env = seeded();
+        const rows = listHandoffs({}, env.depsFor(GROK_WORKER)).handoffs;
+        const codexRow = rows.find((h) => h.title === "for codex");
+
+        expect(codexRow?.name).toBe("for-codex");
+        expect(codexRow?.target?.agent).toBe("codex");
+        expect((codexRow?.warnings ?? []).join(" ")).toContain("another harness");
+        expect(rows.find((h) => h.title === "for anybody")?.warnings).toBeUndefined();
+    });
+});

--- a/src/handoff/targeting.test.ts
+++ b/src/handoff/targeting.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import {
+    agentFilterMatches,
+    canonicalAgent,
+    handoffNameFor,
+    isKnownAgent,
+    MAX_HANDOFF_NAME_LENGTH,
+    normalizeAgentInput,
+    normalizeHandoffName,
+    normalizeTargetInput,
+    recipientCheck,
+    sessionFilterMatches,
+} from "./targeting";
+import { byFor } from "./test-utils";
+import type { HandoffEventBy } from "./types";
+
+const FULL = "cd4e9457-105b-45f5-829d-9c4f554df36a";
+const LEADING_SEGMENT = "cd4e9457";
+
+function on(agent: string, sessionId: string | null, sessionName: string | null = null): HandoffEventBy {
+    return { ...byFor(sessionId, sessionName), agent };
+}
+
+describe("harness names", () => {
+    test("the runtime's claude-code and a poster's claude are the same harness", () => {
+        // AgentRuntimeContext.agent says "claude-code"; humans and tool schemas say
+        // "claude". Without this they would read as a mismatch against each other.
+        expect(canonicalAgent("claude-code")).toBe("claude");
+        expect(canonicalAgent("Claude")).toBe("claude");
+        expect(canonicalAgent("codex")).toBe("codex");
+        expect(canonicalAgent("grok")).toBe("grok");
+        expect(canonicalAgent("copilot")).toBe("copilot");
+    });
+
+    test("an undocumented name is not a harness", () => {
+        expect(canonicalAgent("borg")).toBeNull();
+        expect(canonicalAgent("")).toBeNull();
+        expect(canonicalAgent(null)).toBeNull();
+        expect(isKnownAgent("borg")).toBe(false);
+    });
+
+    test("input normalization keeps an undocumented name instead of dropping it", () => {
+        expect(normalizeAgentInput("  CODEX ")).toBe("codex");
+        expect(normalizeAgentInput("Claude-Code")).toBe("claude");
+        expect(normalizeAgentInput("Borg")).toBe("borg");
+        expect(normalizeAgentInput("   ")).toBeUndefined();
+        expect(normalizeAgentInput(42)).toBeUndefined();
+    });
+});
+
+describe("target normalization", () => {
+    test("both doors store one shape", () => {
+        expect(
+            normalizeTargetInput({ sessionId: " sess-alpha ", sessionName: " worker ", agent: "Claude-Code" })
+        ).toEqual({ sessionId: "sess-alpha", sessionName: "worker", agent: "claude" });
+    });
+
+    test("an agent alone is a valid target", () => {
+        expect(normalizeTargetInput({ agent: "codex" })).toEqual({ agent: "codex" });
+    });
+
+    test("nothing usable normalizes to undefined", () => {
+        expect(normalizeTargetInput({ sessionId: "   " })).toBeUndefined();
+        expect(normalizeTargetInput({})).toBeUndefined();
+        expect(normalizeTargetInput(null)).toBeUndefined();
+        expect(normalizeTargetInput("codex")).toBeUndefined();
+    });
+});
+
+describe("handoff names", () => {
+    test("a name is a slug and can never look like an id", () => {
+        expect(normalizeHandoffName("Fix e2e Active-filter semantics")).toBe("fix-e2e-active-filter-semantics");
+        // `h_` survives id normalization; slugging turns the underscore into a hyphen,
+        // so no name can collide with the id namespace.
+        expect(normalizeHandoffName("h_abc")).toBe("h-abc");
+        expect(normalizeHandoffName("  --Trim Me--  ")).toBe("trim-me");
+    });
+
+    test("a name with nothing to slug is no name", () => {
+        expect(normalizeHandoffName("!!!")).toBeUndefined();
+        expect(normalizeHandoffName("")).toBeUndefined();
+        expect(normalizeHandoffName(undefined)).toBeUndefined();
+    });
+
+    test("long names are capped without a trailing hyphen", () => {
+        const slug = normalizeHandoffName(`${"a".repeat(40)} ${"b".repeat(40)}`);
+        expect(slug).toBeDefined();
+        expect((slug as string).length).toBeLessThanOrEqual(MAX_HANDOFF_NAME_LENGTH);
+        expect(slug).not.toEndWith("-");
+    });
+
+    test("a supplied name wins over the title, and the title is the default", () => {
+        expect(handoffNameFor({ name: "Pick Me", title: "Some Title" })).toBe("pick-me");
+        expect(handoffNameFor({ name: undefined, title: "Some Title" })).toBe("some-title");
+        expect(handoffNameFor({ name: "!!!", title: "Some Title" })).toBe("some-title");
+    });
+});
+
+describe("recipientCheck", () => {
+    test("an untargeted handoff warns about nothing", () => {
+        const check = recipientCheck({ target: undefined, by: on("codex", "sess-beta") });
+        expect(check).toEqual({ agent: "not-targeted", session: "not-targeted", warnings: [] });
+    });
+
+    test("the intended harness gets no warning", () => {
+        const check = recipientCheck({ target: { agent: "codex" }, by: on("codex", "sess-alpha") });
+        expect(check.agent).toBe("match");
+        expect(check.warnings).toEqual([]);
+    });
+
+    test("another harness is told to stop, and how its user can override", () => {
+        const check = recipientCheck({ target: { agent: "codex" }, by: on("claude-code", "sess-alpha") });
+        expect(check.agent).toBe("mismatch");
+        const text = check.warnings.join(" ");
+        expect(text).toContain('targets harness "codex"');
+        expect(text).toContain('this session runs "claude"');
+        expect(text).toContain("This task is for another harness");
+        expect(text).toContain("unless your user explicitly asks");
+        expect(text).toContain("claim it explicitly");
+    });
+
+    test("an undetectable caller harness is unverifiable, never a mismatch", () => {
+        const check = recipientCheck({ target: { agent: "codex" }, by: on("unknown", "sess-alpha") });
+        expect(check.agent).toBe("unverifiable");
+        const text = check.warnings.join(" ");
+        expect(text).toContain("unverifiable");
+        expect(text).not.toContain("mismatch");
+    });
+
+    test("an undocumented target harness is unverifiable in both directions", () => {
+        const check = recipientCheck({ target: { agent: "borg" }, by: on("codex", "sess-alpha") });
+        expect(check.agent).toBe("unverifiable");
+        expect(check.warnings.join(" ")).toContain("not a documented harness");
+    });
+
+    test("an explicit target sessionId that is not ours is a mismatch", () => {
+        const check = recipientCheck({ target: { sessionId: "sess-alpha" }, by: on("claude-code", "sess-beta") });
+        expect(check.session).toBe("mismatch");
+        const text = check.warnings.join(" ");
+        expect(text).toContain('targets sessionId "sess-alpha"');
+        expect(text).toContain("This task is for another session");
+    });
+
+    test("an abbreviated target sessionId still names this session", () => {
+        const check = recipientCheck({ target: { sessionId: LEADING_SEGMENT }, by: on("claude-code", FULL) });
+        expect(check.session).toBe("match");
+        expect(check.warnings).toEqual([]);
+    });
+
+    test("no sessionId of our own means unverifiable, never a mismatch", () => {
+        const check = recipientCheck({ target: { sessionId: "sess-alpha" }, by: on("claude-code", null) });
+        expect(check.session).toBe("unverifiable");
+        const text = check.warnings.join(" ");
+        expect(text).toContain("unverifiable");
+        expect(text).not.toContain("mismatch");
+    });
+
+    test("a differing sessionName is a hint, not a mismatch — names are not unique", () => {
+        const check = recipientCheck({
+            target: { sessionName: "gt-worker" },
+            by: on("claude-code", "sess-beta", "other-worker"),
+        });
+        expect(check.session).toBe("unverifiable");
+        expect(check.warnings.join(" ")).toContain("not unique");
+    });
+
+    test("a matching sessionName is a match", () => {
+        const check = recipientCheck({
+            target: { sessionName: "gt-worker" },
+            by: on("claude-code", "sess-beta", "gt-worker"),
+        });
+        expect(check.session).toBe("match");
+        expect(check.warnings).toEqual([]);
+    });
+});
+
+describe("list filter semantics", () => {
+    test("the agent filter compares canonical harness names", () => {
+        expect(agentFilterMatches({ agent: "claude" }, "claude-code")).toBe(true);
+        expect(agentFilterMatches({ agent: "claude" }, "codex")).toBe(false);
+        expect(agentFilterMatches(undefined, "codex")).toBe(false);
+        expect(agentFilterMatches({ sessionId: "sess-alpha" }, "codex")).toBe(false);
+    });
+
+    test("an undocumented filter value falls back to literal text", () => {
+        expect(agentFilterMatches({ agent: "borg" }, "Borg")).toBe(true);
+        expect(agentFilterMatches({ agent: "borg" }, "codex")).toBe(false);
+    });
+
+    test("the session filter matches an id in either abbreviation direction, or the name", () => {
+        expect(sessionFilterMatches({ sessionId: FULL }, FULL)).toBe(true);
+        expect(sessionFilterMatches({ sessionId: LEADING_SEGMENT }, FULL)).toBe(true);
+        expect(sessionFilterMatches({ sessionId: FULL }, LEADING_SEGMENT)).toBe(true);
+        expect(sessionFilterMatches({ sessionId: FULL }, "cd4e9458")).toBe(false);
+        expect(sessionFilterMatches({ sessionName: "gt-worker" }, "GT-Worker")).toBe(true);
+        expect(sessionFilterMatches({ sessionName: "gt-worker" }, "other")).toBe(false);
+        expect(sessionFilterMatches(undefined, "gt-worker")).toBe(false);
+    });
+});

--- a/src/handoff/targeting.test.ts
+++ b/src/handoff/targeting.test.ts
@@ -32,6 +32,20 @@ describe("harness names", () => {
         expect(canonicalAgent("copilot")).toBe("copilot");
     });
 
+    test("inherited object keys are not harnesses either", () => {
+        // A plain-object alias table would answer Object.prototype members.
+        for (const key of ["constructor", "__proto__", "toString", "hasOwnProperty"]) {
+            expect(canonicalAgent(key)).toBeNull();
+            expect(isKnownAgent(key)).toBe(false);
+            expect(normalizeAgentInput(key)).toBe(key.toLowerCase());
+        }
+
+        const by = on("claude-code", "sess-me");
+        const check = recipientCheck({ target: { agent: "constructor" }, by });
+        expect(check.agent).toBe("unverifiable");
+        expect(check.warnings.join(" ")).toContain('"constructor", which is not a documented harness');
+    });
+
     test("an undocumented name is not a harness", () => {
         expect(canonicalAgent("borg")).toBeNull();
         expect(canonicalAgent("")).toBeNull();

--- a/src/handoff/targeting.ts
+++ b/src/handoff/targeting.ts
@@ -1,0 +1,297 @@
+/**
+ * Who a handoff is FOR, and what it is called.
+ *
+ * Recipient identity is deliberately separate from author identity. `postedBy`
+ * and `postedByContext.agent` say which harness WROTE the handoff; `target.agent`
+ * says which harness should WORK it. Reading one for the other would make every
+ * codex task look addressed to the claude session that filed it.
+ *
+ * Nothing here blocks: a mismatch produces a warning line and the caller decides.
+ * User-authorized cross-target work stays possible on purpose — the agent is told
+ * to stop, not prevented from continuing when its user says to.
+ */
+
+import { targetMatchesSession } from "./fold";
+import type { HandoffEventBy, HandoffTarget } from "./types";
+
+/** Documented recipient harness names — the values `target.agent` compares against. */
+export const HANDOFF_AGENTS = ["claude", "codex", "grok", "copilot"] as const;
+
+export type HandoffAgent = (typeof HANDOFF_AGENTS)[number];
+
+export const HANDOFF_AGENTS_LIST = HANDOFF_AGENTS.join(", ");
+
+/**
+ * Spelling → canonical harness. The runtime context calls the Claude host
+ * "claude-code" (AgentRuntimeContext.agent) while posters write "claude", so the
+ * two must land on the same value or every claude session would read as a
+ * mismatch against every claude-targeted handoff.
+ */
+const AGENT_ALIASES: Record<string, HandoffAgent> = {
+    claude: "claude",
+    "claude-code": "claude",
+    claude_code: "claude",
+    claudecode: "claude",
+    "claude-cli": "claude",
+    codex: "codex",
+    "codex-cli": "codex",
+    grok: "grok",
+    "grok-cli": "grok",
+    copilot: "copilot",
+    "github-copilot": "copilot",
+};
+
+/** Canonical harness name, or null when the value names no documented harness. */
+export function canonicalAgent(raw: string | null | undefined): HandoffAgent | null {
+    if (typeof raw !== "string") {
+        return null;
+    }
+
+    return AGENT_ALIASES[raw.trim().toLowerCase()] ?? null;
+}
+
+export function isKnownAgent(raw: string | null | undefined): boolean {
+    return canonicalAgent(raw) !== null;
+}
+
+/**
+ * Stored form of a supplied recipient harness: the canonical name when the value
+ * is documented, the trimmed lowercase form otherwise. An undocumented name is
+ * kept rather than rejected so a harness added later survives a round trip; it
+ * simply can never prove a mismatch (see recipientCheck).
+ */
+export function normalizeAgentInput(raw: unknown): string | undefined {
+    if (typeof raw !== "string") {
+        return undefined;
+    }
+
+    const trimmed = raw.trim().toLowerCase();
+
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    return canonicalAgent(trimmed) ?? trimmed;
+}
+
+/**
+ * The one place a caller-supplied target is cleaned up: trimmed session fields
+ * plus a normalized recipient harness. Both the post door and the modify_handoff
+ * door go through it, so `{ agent: "Claude-Code" }` cannot be stored one way
+ * here and another way there.
+ */
+export function normalizeTargetInput(raw: unknown): HandoffTarget | undefined {
+    if (raw === null || typeof raw !== "object") {
+        return undefined;
+    }
+
+    const input = raw as { sessionId?: unknown; sessionName?: unknown; agent?: unknown };
+    const target: HandoffTarget = {};
+
+    if (typeof input.sessionId === "string" && input.sessionId.trim().length > 0) {
+        target.sessionId = input.sessionId.trim();
+    }
+
+    if (typeof input.sessionName === "string" && input.sessionName.trim().length > 0) {
+        target.sessionName = input.sessionName.trim();
+    }
+
+    const agent = normalizeAgentInput(input.agent);
+
+    if (agent !== undefined) {
+        target.agent = agent;
+    }
+
+    return Object.keys(target).length > 0 ? target : undefined;
+}
+
+export const MAX_HANDOFF_NAME_LENGTH = 60;
+
+/**
+ * A handoff name is a slug: lowercase, alphanumeric, hyphen-separated. Slugging
+ * is what keeps a name from ever colliding with an id — `_` is not alphanumeric,
+ * so no slug can start with the `h_` prefix `normalizeHandoffId` produces.
+ */
+export function normalizeHandoffName(raw: unknown): string | undefined {
+    if (typeof raw !== "string") {
+        return undefined;
+    }
+
+    const slug = raw
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+
+    if (slug.length === 0) {
+        return undefined;
+    }
+
+    return slug.slice(0, MAX_HANDOFF_NAME_LENGTH).replace(/-+$/g, "");
+}
+
+/**
+ * The name a new handoff gets: the supplied one, else derived from the title.
+ * Derivation happens HERE and not in the fold, so the final name is written into
+ * the post event. The fold stays a pure copy, and a later title edit never
+ * silently renames a handoff other agents were told to look up by name.
+ */
+export function handoffNameFor({ name, title }: { name?: unknown; title: string }): string | undefined {
+    return normalizeHandoffName(name) ?? normalizeHandoffName(title);
+}
+
+/** What the recipient check concluded for one dimension of the target. */
+export type RecipientStatus = "not-targeted" | "match" | "mismatch" | "unverifiable";
+
+export interface RecipientCheck {
+    agent: RecipientStatus;
+    session: RecipientStatus;
+    /** Human-readable lines for the caller. Empty when nothing is worth saying. */
+    warnings: string[];
+}
+
+const ANOTHER_HARNESS = "This task is for another harness — do not work on it unless your user explicitly asks you to.";
+
+const ANOTHER_SESSION = "This task is for another session — do not work on it unless your user explicitly asks you to.";
+
+function checkAgent(target: HandoffTarget | undefined, by: HandoffEventBy, warnings: string[]): RecipientStatus {
+    const wanted = target?.agent;
+
+    if (wanted === undefined || wanted.trim().length === 0) {
+        return "not-targeted";
+    }
+
+    const wantedCanonical = canonicalAgent(wanted);
+
+    if (wantedCanonical === null) {
+        warnings.push(
+            `⚠️ Recipient unverifiable: this handoff targets harness "${wanted}", which is not a documented harness (${HANDOFF_AGENTS_LIST}). No match or mismatch can be proven — ask your user who it is for.`
+        );
+        return "unverifiable";
+    }
+
+    const mine = canonicalAgent(by.agent);
+
+    if (mine === null) {
+        warnings.push(
+            `⚠️ Recipient unverifiable: this handoff targets harness "${wantedCanonical}", but this session's own harness was not detected (agent "${by.agent}"). Treat it as addressed elsewhere until your user confirms.`
+        );
+        return "unverifiable";
+    }
+
+    if (mine === wantedCanonical) {
+        return "match";
+    }
+
+    warnings.push(
+        `⚠️ Recipient mismatch: this handoff targets harness "${wantedCanonical}", this session runs "${mine}". ${ANOTHER_HARNESS}`
+    );
+    return "mismatch";
+}
+
+function checkSession(target: HandoffTarget | undefined, by: HandoffEventBy, warnings: string[]): RecipientStatus {
+    const wantedId = target?.sessionId;
+
+    if (wantedId !== undefined && wantedId.trim().length > 0) {
+        if (by.sessionId == null) {
+            warnings.push(
+                `⚠️ Recipient unverifiable: this handoff targets sessionId "${wantedId}", but this session has no sessionId, so the match cannot be checked. Treat it as addressed elsewhere until your user confirms.`
+            );
+            return "unverifiable";
+        }
+
+        if (targetMatchesSession(wantedId, by.sessionId)) {
+            return "match";
+        }
+
+        warnings.push(
+            `⚠️ Recipient mismatch: this handoff targets sessionId "${wantedId}", this session is "${by.sessionId}". ${ANOTHER_SESSION}`
+        );
+        return "mismatch";
+    }
+
+    const wantedName = target?.sessionName;
+
+    if (wantedName === undefined || wantedName.trim().length === 0) {
+        return "not-targeted";
+    }
+
+    if (by.sessionTitle != null && by.sessionTitle === wantedName) {
+        return "match";
+    }
+
+    // Session names are not unique, so a difference never proves the handoff is
+    // for someone else. Say so rather than raising a mismatch nobody can act on.
+    warnings.push(
+        `⚠️ Recipient unverifiable: this handoff targets sessionName "${wantedName}", which is not this session's name (${by.sessionTitle == null ? "unnamed" : `"${by.sessionTitle}"`}). Session names are not unique, so this is a hint, not proof.`
+    );
+    return "unverifiable";
+}
+
+/**
+ * Compare a handoff's intended recipient against the calling session.
+ *
+ * A missing caller identity is reported as unverifiable, never as a mismatch:
+ * "I could not check" and "this is not for you" are different claims, and only
+ * one of them is true when the harness could not be detected.
+ */
+export function recipientCheck({ target, by }: { target?: HandoffTarget; by: HandoffEventBy }): RecipientCheck {
+    const warnings: string[] = [];
+    const agent = checkAgent(target, by, warnings);
+    const session = checkSession(target, by, warnings);
+
+    if (agent === "mismatch" || session === "mismatch") {
+        warnings.push(
+            "If your user explicitly asks you to take it anyway, claim it explicitly (handoff_get with claim: true) and say in a comment why you are working someone else's handoff."
+        );
+    }
+
+    return { agent, session, warnings };
+}
+
+/**
+ * `handoff_list { agent }` — matches the INTENDED RECIPIENT harness only, never
+ * the posting harness. Documented spellings are compared canonically, so
+ * `agent: "claude-code"` finds handoffs stored as `claude`.
+ */
+export function agentFilterMatches(target: HandoffTarget | undefined, query: string): boolean {
+    const stored = target?.agent;
+
+    if (stored === undefined) {
+        return false;
+    }
+
+    const wanted = canonicalAgent(query);
+    const have = canonicalAgent(stored);
+
+    if (wanted !== null || have !== null) {
+        return wanted !== null && have !== null && wanted === have;
+    }
+
+    return stored.trim().toLowerCase() === query.trim().toLowerCase();
+}
+
+/**
+ * `handoff_list { session }` — matches the intended recipient session: the
+ * target sessionId exactly or by leading-segment abbreviation in EITHER
+ * direction (a stored `cd4e9457` and a queried full id name the same session),
+ * or the target sessionName case-insensitively.
+ */
+export function sessionFilterMatches(target: HandoffTarget | undefined, query: string): boolean {
+    const wanted = query.trim();
+
+    if (wanted.length === 0 || target === undefined) {
+        return false;
+    }
+
+    const storedId = target.sessionId;
+
+    if (storedId !== undefined) {
+        if (storedId === wanted || targetMatchesSession(storedId, wanted) || targetMatchesSession(wanted, storedId)) {
+            return true;
+        }
+    }
+
+    const storedName = target.sessionName;
+    return storedName !== undefined && storedName.trim().toLowerCase() === wanted.toLowerCase();
+}

--- a/src/handoff/targeting.ts
+++ b/src/handoff/targeting.ts
@@ -47,7 +47,10 @@ export function canonicalAgent(raw: string | null | undefined): HandoffAgent | n
         return null;
     }
 
-    return AGENT_ALIASES[raw.trim().toLowerCase()] ?? null;
+    const key = raw.trim().toLowerCase();
+
+    // Own-property check: "constructor" or "__proto__" must not read as a harness.
+    return Object.hasOwn(AGENT_ALIASES, key) ? AGENT_ALIASES[key] : null;
 }
 
 export function isKnownAgent(raw: string | null | undefined): boolean {

--- a/src/handoff/types.ts
+++ b/src/handoff/types.ts
@@ -3,6 +3,13 @@ export type HandoffStatus = "open" | "claimed" | "done" | "cancelled";
 export interface HandoffTarget {
     sessionId?: string;
     sessionName?: string;
+    /**
+     * Intended RECIPIENT harness — claude | codex | grok | copilot (see
+     * `src/handoff/targeting.ts`). Never the author's harness: that is
+     * `postedBy.agent` / `postedByContext.agent`, which the fold stamps from the
+     * posting session and which this field must never be confused with.
+     */
+    agent?: string;
 }
 
 export interface HandoffTaskInput {
@@ -113,6 +120,8 @@ export type HandoffEvent =
           ev: "post";
           editId: string;
           title: string;
+          /** Final slug, resolved by the caller (supplied or title-derived) — the fold only copies it. */
+          name?: string;
           description?: string;
           tasks: HandoffTaskInput[];
           target?: HandoffTarget;
@@ -139,6 +148,8 @@ export type HandoffEvent =
     | (HandoffEventBase & {
           ev: "modify_handoff";
           title?: string;
+          /** Replacement slug, already normalized by the caller; null clears it. */
+          name?: string | null;
           description?: string;
           target?: HandoffTarget | null;
           refs?: string[];
@@ -163,6 +174,12 @@ export type HandoffPublicEvent = Omit<HandoffEvent, "editId"> & { outcome?: Fold
 export interface Handoff {
     id: string;
     title: string;
+    /**
+     * Human-readable slug this handoff can also be fetched by. Absent on records
+     * posted before names existed — those stay reachable by id, which is why
+     * nothing here may assume a name is present.
+     */
+    name?: string;
     description?: string;
     status: HandoffStatus;
     tasks: HandoffTask[];
@@ -205,10 +222,13 @@ export interface HandoffActionResult {
 export interface HandoffListRow {
     id: string;
     title: string;
+    name?: string;
     status: HandoffStatus;
     tasks: string;
     progress?: string;
     target?: HandoffTarget;
+    /** Recipient warnings for the LISTING session — absent when there is nothing to say. */
+    warnings?: string[];
     postedBy: { sessionName: string | null };
     claimedBy?: {
         sessionId: string | null;


### PR DESCRIPTION
## What

Handoffs can now be addressed to a **recipient harness** and fetched by a **readable name**, and a session that is not the intended recipient is warned, never blocked.

- **`target.agent`** on `handoff_post` / `modify_handoff`: `claude`, `codex`, `grok`, `copilot`. Spellings are canonicalized (the runtime's `claude-code` and a poster's `claude` are one harness). An undocumented value is stored as given and `info[]` says no warning can fire for it. Author identity stays in `postedBy.agent` / `postedByContext.agent` and is never confused with the recipient.
- **Warnings**: `handoff_get` and `handoff_action` return a top-level `warnings: string[]`; `handoff_list` returns it per row. A mismatch needs two known values on both sides, or an explicit target `sessionId` that differs. A missing caller identity, an undocumented target harness, or a differing `sessionName` are reported as *unverifiable*, never as a mismatch. Nothing blocks: a mismatched session can still claim, check and finish, and the warning stays on the action response.
- **Auto-claim**: a target `sessionId` naming this session still auto-claims, unless `target.agent` names a different harness. Then it does not claim and `info[]` says so.
- **Filters**: `handoff_list { agent, session }` are opt-in and combine; both read the intended recipient, never the poster. The default listing is unchanged and unfiltered.
- **Names**: `handoff_post { name }` is optional and defaults to a slug of the title (lowercase alphanumerics and hyphens, max 60 chars, can never collide with the `h_` id namespace). `handoff_get` / `handoff_action` resolve by name; the `id` field accepts a name too. An id always wins; a unique name resolves; an ambiguous name throws listing every candidate; an id and a name that disagree throw. `modify_handoff { name }` renames, `null` or `""` clears, and a title edit never renames.
- **Storage**: nullable `name` column plus index via `ensureColumn`, so existing databases migrate in place. Legacy records without a target or name keep working by id and warn nobody.
- **Doors**: MCP tool schemas and server instructions, the dev-dashboard HTTP route, and the dashboard handoff tab and dialogs all expose the same fields.

## Why

Handoff `h_dll1tbhu`. A codex task filed from a claude session read as addressed to claude, and users had to copy opaque `h_` ids to hand work over.

## Validation

- `bun run test src/handoff src/claude/mcp src/dev-dashboard/ui/src/components/handoff` → 144 pass, 0 fail.
- `bunx tsgo --noEmit` clean; `bunx biome check` clean on all changed files; `scripts/ci/logging-guard.sh` and `check-package-boundaries.ts` clean.
- Fixtures are invented (`sess-alpha` style ids, documented harness names). No real session or account content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Handoffs can now use readable names, target sessions or harnesses, and filter lists by recipient.
  - Handoff actions provide warnings for recipient mismatches instead of blocking access.
  - Chrome browsing supports persistent profiles through `--user-data-dir`.
  - macOS Mail search supports configurable timeouts and handles large vector searches more reliably.

- **Bug Fixes**
  - Chrome restart guidance now includes both temporary and persistent profile options.
  - Large hybrid Mail searches are capped safely and report applicable warnings.

- **Documentation**
  - Updated handoff, Chrome DevTools, and macOS Mail guidance with the latest behavior and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->